### PR TITLE
feat: add test infrastructure and initial tests

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,21 @@
+FROM node:22-alpine
+
+RUN apk add --no-cache dumb-init
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+ENV NODE_ENV=development
+ENV PORT=3001
+
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --spider --quiet http://127.0.0.1:3001/health || exit 1
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["npx", "tsx", "watch", "src/index.ts"]

--- a/backend/src/models/auth.test.ts
+++ b/backend/src/models/auth.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { LoginRequestSchema } from './auth.js';
+
+describe('LoginRequestSchema', () => {
+  it('should validate a correct login request', () => {
+    const validRequest = {
+      username: 'admin',
+      password: 'password123',
+    };
+
+    const result = LoginRequestSchema.safeParse(validRequest);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.username).toBe('admin');
+      expect(result.data.password).toBe('password123');
+    }
+  });
+
+  it('should reject empty username', () => {
+    const invalidRequest = {
+      username: '',
+      password: 'password123',
+    };
+
+    const result = LoginRequestSchema.safeParse(invalidRequest);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty password', () => {
+    const invalidRequest = {
+      username: 'admin',
+      password: '',
+    };
+
+    const result = LoginRequestSchema.safeParse(invalidRequest);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing fields', () => {
+    const invalidRequest = {
+      username: 'admin',
+    };
+
+    const result = LoginRequestSchema.safeParse(invalidRequest);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject non-string values', () => {
+    const invalidRequest = {
+      username: 123,
+      password: 'password123',
+    };
+
+    const result = LoginRequestSchema.safeParse(invalidRequest);
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+    },
+  },
+});

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ services:
   backend:
     build:
       context: ./backend
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
     command: ["npx", "tsx", "watch", "src/index.ts"]
     ports:
       - "3001:3001"
@@ -37,8 +37,7 @@ services:
   frontend:
     build:
       context: ./frontend
-      dockerfile: Dockerfile
-    command: ["npx", "vite", "--host"]
+      dockerfile: Dockerfile.dev
     ports:
       - "5173:5173"
     environment:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,12 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npx", "vite", "--host"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,8 @@
     "vite": "^6.0.7",
     "vitest": "^3.0.4",
     "@testing-library/react": "^16.1.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "jsdom": "^26.0.0",
     "tailwindcss": "^4.0.0",
     "@tailwindcss/vite": "^4.0.0",
     "eslint": "^9.18.0",

--- a/frontend/src/components/shared/kpi-card.test.tsx
+++ b/frontend/src/components/shared/kpi-card.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { KpiCard } from './kpi-card';
+
+describe('KpiCard', () => {
+  it('should render label and value', () => {
+    render(<KpiCard label="Total Containers" value={42} />);
+
+    expect(screen.getByText('Total Containers')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('should render string values', () => {
+    render(<KpiCard label="Status" value="Healthy" />);
+
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Healthy')).toBeInTheDocument();
+  });
+
+  it('should render trend indicator when provided', () => {
+    render(<KpiCard label="CPU Usage" value="45%" trend="up" trendValue="+5%" />);
+
+    expect(screen.getByText('+5%')).toBeInTheDocument();
+  });
+
+  it('should apply up trend styling', () => {
+    render(<KpiCard label="Metric" value={100} trend="up" trendValue="+10" />);
+
+    const trendElement = screen.getByText('+10');
+    expect(trendElement).toHaveClass('text-emerald-600');
+  });
+
+  it('should apply down trend styling', () => {
+    render(<KpiCard label="Metric" value={100} trend="down" trendValue="-10" />);
+
+    const trendElement = screen.getByText('-10');
+    expect(trendElement).toHaveClass('text-red-600');
+  });
+
+  it('should apply neutral trend styling', () => {
+    render(<KpiCard label="Metric" value={100} trend="neutral" trendValue="0" />);
+
+    const trendElement = screen.getByText('0');
+    expect(trendElement).toHaveClass('text-muted-foreground');
+  });
+
+  it('should render icon when provided', () => {
+    const TestIcon = () => <span data-testid="test-icon">Icon</span>;
+    render(<KpiCard label="With Icon" value={50} icon={<TestIcon />} />);
+
+    expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(
+      <KpiCard label="Custom" value={1} className="custom-class" />
+    );
+
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('should not render trend when not provided', () => {
+    render(<KpiCard label="No Trend" value={100} />);
+
+    // The trend container should not be present
+    const element = screen.getByText('100');
+    expect(element.parentElement?.querySelector('.text-emerald-600')).toBeNull();
+    expect(element.parentElement?.querySelector('.text-red-600')).toBeNull();
+  });
+});

--- a/frontend/src/components/shared/status-badge.test.tsx
+++ b/frontend/src/components/shared/status-badge.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusBadge } from './status-badge';
+
+describe('StatusBadge', () => {
+  it('should render the status text', () => {
+    render(<StatusBadge status="running" />);
+    expect(screen.getByText('running')).toBeInTheDocument();
+  });
+
+  it('should apply running status colors', () => {
+    render(<StatusBadge status="running" />);
+    const badge = screen.getByText('running');
+    expect(badge).toHaveClass('bg-emerald-100');
+  });
+
+  it('should apply stopped status colors', () => {
+    render(<StatusBadge status="stopped" />);
+    const badge = screen.getByText('stopped');
+    expect(badge).toHaveClass('bg-red-100');
+  });
+
+  it('should apply paused status colors', () => {
+    render(<StatusBadge status="paused" />);
+    const badge = screen.getByText('paused');
+    expect(badge).toHaveClass('bg-amber-100');
+  });
+
+  it('should apply unknown status colors for unrecognized status', () => {
+    render(<StatusBadge status="custom-status" />);
+    const badge = screen.getByText('custom-status');
+    expect(badge).toHaveClass('bg-gray-100');
+  });
+
+  it('should apply custom className', () => {
+    render(<StatusBadge status="running" className="custom-class" />);
+    const badge = screen.getByText('running');
+    expect(badge).toHaveClass('custom-class');
+  });
+
+  it('should render various status types correctly', () => {
+    const statuses = ['healthy', 'unhealthy', 'pending', 'completed', 'failed', 'warning', 'critical'];
+
+    statuses.forEach((status) => {
+      const { unmount } = render(<StatusBadge status={status} />);
+      expect(screen.getByText(status)).toBeInTheDocument();
+      unmount();
+    });
+  });
+});

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes, formatDuration, truncate, cn } from './utils';
+
+describe('formatBytes', () => {
+  it('should return "0 B" for 0 bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('should format bytes correctly', () => {
+    expect(formatBytes(500)).toBe('500 B');
+  });
+
+  it('should format kilobytes correctly', () => {
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('should format megabytes correctly', () => {
+    expect(formatBytes(1048576)).toBe('1 MB');
+    expect(formatBytes(1572864)).toBe('1.5 MB');
+  });
+
+  it('should format gigabytes correctly', () => {
+    expect(formatBytes(1073741824)).toBe('1 GB');
+  });
+
+  it('should respect decimal parameter', () => {
+    expect(formatBytes(1536, 2)).toBe('1.5 KB');
+    expect(formatBytes(1536, 0)).toBe('2 KB');
+  });
+});
+
+describe('formatDuration', () => {
+  it('should format milliseconds', () => {
+    expect(formatDuration(500)).toBe('500ms');
+    expect(formatDuration(999)).toBe('999ms');
+  });
+
+  it('should format seconds', () => {
+    expect(formatDuration(1000)).toBe('1.0s');
+    expect(formatDuration(5500)).toBe('5.5s');
+    expect(formatDuration(59999)).toBe('60.0s');
+  });
+
+  it('should format minutes', () => {
+    expect(formatDuration(60000)).toBe('1.0m');
+    expect(formatDuration(90000)).toBe('1.5m');
+    expect(formatDuration(300000)).toBe('5.0m');
+  });
+});
+
+describe('truncate', () => {
+  it('should not truncate strings shorter than length', () => {
+    expect(truncate('hello', 10)).toBe('hello');
+  });
+
+  it('should not truncate strings equal to length', () => {
+    expect(truncate('hello', 5)).toBe('hello');
+  });
+
+  it('should truncate strings longer than length', () => {
+    expect(truncate('hello world', 5)).toBe('hello...');
+  });
+
+  it('should handle empty strings', () => {
+    expect(truncate('', 5)).toBe('');
+  });
+});
+
+describe('cn', () => {
+  it('should merge class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('should handle conditional classes', () => {
+    expect(cn('foo', false && 'bar', 'baz')).toBe('foo baz');
+  });
+
+  it('should merge tailwind classes correctly', () => {
+    expect(cn('p-4', 'p-2')).toBe('p-2');
+    expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+  });
+
+  it('should handle undefined and null', () => {
+    expect(cn('foo', undefined, null, 'bar')).toBe('foo bar');
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- Add development Dockerfiles for backend and frontend with full dev dependencies
- Configure Vitest for both backend and frontend
- Add React Testing Library setup for component testing
- Create initial test suite with 38 passing tests

## Changes
### Dev Infrastructure
- `backend/Dockerfile.dev` - Node image with all dependencies for dev/testing
- `frontend/Dockerfile.dev` - Node image with Vite dev server
- Updated `docker-compose.dev.yml` to use dev Dockerfiles

### Test Configuration
- `backend/vitest.config.ts` - Vitest config for Node environment
- `frontend/vitest.config.ts` - Vitest config with jsdom for React
- `frontend/vitest.setup.ts` - React Testing Library setup
- Added `@testing-library/jest-dom` and `jsdom` to frontend

### Initial Tests (38 total)
| File | Tests | Coverage |
|------|-------|----------|
| `backend/src/models/auth.test.ts` | 5 | Zod schema validation |
| `frontend/src/lib/utils.test.ts` | 17 | formatBytes, formatDuration, truncate, cn |
| `frontend/src/components/shared/status-badge.test.tsx` | 7 | Component rendering & styling |
| `frontend/src/components/shared/kpi-card.test.tsx` | 9 | Component with trends & icons |

## Test plan
- [x] Backend tests pass: `docker compose -f docker-compose.dev.yml exec backend npm test`
- [x] Frontend tests pass: `docker compose -f docker-compose.dev.yml exec frontend npm test`

🤖 Generated with [Claude Code](https://claude.ai/code)