### PR TITLE
fix: make login rate limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,7 @@ CACHE_TTL_SECONDS=900
 PORT=3001
 LOG_LEVEL=info
 SQLITE_PATH=./data/dashboard.db
+
+# Rate Limiting
+# Login attempts per minute (default: 5 in production, 30 in development)
+# LOGIN_RATE_LIMIT=30

--- a/backend/src/config/env.schema.ts
+++ b/backend/src/config/env.schema.ts
@@ -41,6 +41,11 @@ export const envSchema = z.object({
   PORT: z.coerce.number().int().min(1).max(65535).default(3001),
   LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),
   SQLITE_PATH: z.string().default('./data/dashboard.db'),
+
+  // Rate Limiting
+  LOGIN_RATE_LIMIT: z.coerce.number().int().min(1).default(
+    process.env.NODE_ENV === 'production' ? 5 : 30
+  ),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -11,6 +11,8 @@ const loginSchema = z.object({
 });
 
 export async function authRoutes(fastify: FastifyInstance) {
+  const config = getConfig();
+
   // Login
   fastify.post('/api/auth/login', {
     schema: {
@@ -39,7 +41,7 @@ export async function authRoutes(fastify: FastifyInstance) {
     },
     config: {
       rateLimit: {
-        max: 5,
+        max: config.LOGIN_RATE_LIMIT,
         timeWindow: '1 minute',
       },
     },
@@ -50,7 +52,6 @@ export async function authRoutes(fastify: FastifyInstance) {
     }
 
     const { username, password } = parsed.data;
-    const config = getConfig();
 
     // Compare against configured credentials
     if (username !== config.DASHBOARD_USERNAME) {


### PR DESCRIPTION
## Summary
- Add `LOGIN_RATE_LIMIT` environment variable to configure login attempts per minute
- Default: 5 in production, 30 in development (based on `NODE_ENV`)
- Document new variable in `.env.example`

## Test plan
- [ ] Verify default rate limit is 30 in development (without `NODE_ENV=production`)
- [ ] Verify rate limit can be overridden via `LOGIN_RATE_LIMIT` env var
- [ ] Verify rate limit is 5 when `NODE_ENV=production` and no override is set

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)