### PR TITLE
feat: add dummy workload compose for testing dashboard

### DIFF
--- a/docker-compose.workload.yml
+++ b/docker-compose.workload.yml
@@ -1,0 +1,210 @@
+# Dummy workload for testing the AI Portainer Dashboard
+# Run with: docker compose -f docker-compose.workload.yml up -d
+#
+# This creates a variety of containers to simulate a realistic workload:
+# - Web servers (nginx, httpd)
+# - Databases (redis, postgres)
+# - Message queue (rabbitmq)
+# - Monitoring (prometheus)
+# - Various states (healthy, unhealthy, resource-intensive)
+
+services:
+  # === Web Tier ===
+  web-frontend:
+    image: nginx:alpine
+    container_name: web-frontend
+    ports:
+      - "8080:80"
+    labels:
+      app.tier: "web"
+      app.env: "production"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  web-backend-1:
+    image: httpd:alpine
+    container_name: web-backend-1
+    labels:
+      app.tier: "web"
+      app.env: "production"
+      app.role: "backend"
+    healthcheck:
+      test: ["CMD", "httpd", "-t"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  web-backend-2:
+    image: httpd:alpine
+    container_name: web-backend-2
+    labels:
+      app.tier: "web"
+      app.env: "production"
+      app.role: "backend"
+    healthcheck:
+      test: ["CMD", "httpd", "-t"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  # === Database Tier ===
+  db-postgres:
+    image: postgres:16-alpine
+    container_name: db-postgres
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: secret123
+      POSTGRES_DB: appdb
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    labels:
+      app.tier: "database"
+      app.env: "production"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d appdb"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  db-redis:
+    image: redis:7-alpine
+    container_name: db-redis
+    command: redis-server --maxmemory 64mb --maxmemory-policy allkeys-lru
+    labels:
+      app.tier: "cache"
+      app.env: "production"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  # === Message Queue ===
+  mq-rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: mq-rabbitmq
+    ports:
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: admin
+      RABBITMQ_DEFAULT_PASS: admin123
+    labels:
+      app.tier: "messaging"
+      app.env: "production"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_running"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  # === Workers ===
+  worker-1:
+    image: alpine:latest
+    container_name: worker-1
+    command: sh -c "while true; do echo 'Worker 1 processing...'; sleep 10; done"
+    labels:
+      app.tier: "worker"
+      app.env: "production"
+    restart: unless-stopped
+
+  worker-2:
+    image: alpine:latest
+    container_name: worker-2
+    command: sh -c "while true; do echo 'Worker 2 processing...'; sleep 15; done"
+    labels:
+      app.tier: "worker"
+      app.env: "production"
+    restart: unless-stopped
+
+  # === Monitoring ===
+  monitoring-prometheus:
+    image: prom/prometheus:latest
+    container_name: monitoring-prometheus
+    ports:
+      - "9090:9090"
+    labels:
+      app.tier: "monitoring"
+      app.env: "infrastructure"
+    restart: unless-stopped
+
+  # === Staging Environment ===
+  staging-web:
+    image: nginx:alpine
+    container_name: staging-web
+    labels:
+      app.tier: "web"
+      app.env: "staging"
+    restart: unless-stopped
+
+  staging-api:
+    image: httpd:alpine
+    container_name: staging-api
+    labels:
+      app.tier: "api"
+      app.env: "staging"
+    restart: unless-stopped
+
+  # === Development Environment ===
+  dev-web:
+    image: nginx:alpine
+    container_name: dev-web
+    labels:
+      app.tier: "web"
+      app.env: "development"
+    restart: "no"
+
+  # === Intentionally Unhealthy Container (for testing alerts) ===
+  unhealthy-service:
+    image: alpine:latest
+    container_name: unhealthy-service
+    command: sh -c "exit 1"
+    labels:
+      app.tier: "test"
+      app.env: "test"
+    healthcheck:
+      test: ["CMD", "false"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: "no"
+
+  # === Resource Intensive Container (for metrics testing) ===
+  cpu-stress:
+    image: alpine:latest
+    container_name: cpu-stress
+    command: sh -c "while true; do echo 'scale=5000; 4*a(1)' | bc -l > /dev/null 2>&1 || true; sleep 1; done"
+    labels:
+      app.tier: "test"
+      app.env: "test"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 128M
+    restart: unless-stopped
+
+  # === Stopped Container (for state testing) ===
+  stopped-service:
+    image: alpine:latest
+    container_name: stopped-service
+    command: echo "This container exits immediately"
+    labels:
+      app.tier: "test"
+      app.env: "test"
+    restart: "no"
+
+volumes:
+  postgres-data:
+
+networks:
+  default:
+    name: workload-net


### PR DESCRIPTION
## Summary
Add a Docker Compose file with various containers to simulate a realistic environment for testing the dashboard.

## Workload Containers (16 total)

| Container | Image | Purpose |
|-----------|-------|---------|
| web-frontend | nginx:alpine | Frontend web server |
| web-backend-1 | httpd:alpine | Backend server |
| web-backend-2 | httpd:alpine | Backend server (scaled) |
| db-postgres | postgres:16-alpine | Primary database |
| db-redis | redis:7-alpine | Cache layer |
| mq-rabbitmq | rabbitmq:3-management | Message queue |
| worker-1 | alpine | Background worker |
| worker-2 | alpine | Background worker |
| monitoring-prometheus | prom/prometheus | Metrics collection |
| staging-web | nginx:alpine | Staging environment |
| staging-api | httpd:alpine | Staging API |
| dev-web | nginx:alpine | Development environment |
| unhealthy-service | alpine | Intentionally failing (test alerts) |
| cpu-stress | alpine | CPU load generator (test metrics) |
| stopped-service | alpine | Exits immediately (test states) |

## Features Tested
- Multiple container states (running, stopped, unhealthy)
- Health checks
- Resource constraints
- Labels for filtering (app.tier, app.env)
- Various restart policies
- Persistent volumes

## Usage
```bash
# Start workload
docker compose -f docker-compose.workload.yml up -d

# Stop workload
docker compose -f docker-compose.workload.yml down

# Stop and remove volumes
docker compose -f docker-compose.workload.yml down -v
```

## Test plan
- [ ] All containers start successfully
- [ ] Dashboard displays containers with correct states
- [ ] Unhealthy container shows warning in dashboard
- [ ] Metrics visible for running containers

🤖 Generated with [Claude Code](https://claude.ai/code)