### PR TITLE
fix: add TypeScript type checking to frontend build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Update build script to run `tsc --noEmit` before `vite build`
- Type errors now fail the build instead of silently shipping to production

## Test plan
- [ ] Introduce a type error in a `.tsx` file
- [ ] Run `npm run build` in frontend directory
- [ ] Verify build fails with type error message
- [ ] Fix the error and verify build succeeds

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)