### PR TITLE
feat: add dummy workload compose and Portainer deploy script

### DIFF
--- a/docker-compose.workload.yml
+++ b/docker-compose.workload.yml
@@ -1,0 +1,210 @@
+# Dummy workload for testing the AI Portainer Dashboard
+# Run with: docker compose -f docker-compose.workload.yml up -d
+#
+# This creates a variety of containers to simulate a realistic workload:
+# - Web servers (nginx, httpd)
+# - Databases (redis, postgres)
+# - Message queue (rabbitmq)
+# - Monitoring (prometheus)
+# - Various states (healthy, unhealthy, resource-intensive)
+
+services:
+  # === Web Tier ===
+  web-frontend:
+    image: nginx:alpine
+    container_name: web-frontend
+    ports:
+      - "8080:80"
+    labels:
+      app.tier: "web"
+      app.env: "production"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  web-backend-1:
+    image: httpd:alpine
+    container_name: web-backend-1
+    labels:
+      app.tier: "web"
+      app.env: "production"
+      app.role: "backend"
+    healthcheck:
+      test: ["CMD", "httpd", "-t"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  web-backend-2:
+    image: httpd:alpine
+    container_name: web-backend-2
+    labels:
+      app.tier: "web"
+      app.env: "production"
+      app.role: "backend"
+    healthcheck:
+      test: ["CMD", "httpd", "-t"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  # === Database Tier ===
+  db-postgres:
+    image: postgres:16-alpine
+    container_name: db-postgres
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: secret123
+      POSTGRES_DB: appdb
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    labels:
+      app.tier: "database"
+      app.env: "production"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d appdb"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  db-redis:
+    image: redis:7-alpine
+    container_name: db-redis
+    command: redis-server --maxmemory 64mb --maxmemory-policy allkeys-lru
+    labels:
+      app.tier: "cache"
+      app.env: "production"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  # === Message Queue ===
+  mq-rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: mq-rabbitmq
+    ports:
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: admin
+      RABBITMQ_DEFAULT_PASS: admin123
+    labels:
+      app.tier: "messaging"
+      app.env: "production"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_running"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  # === Workers ===
+  worker-1:
+    image: alpine:latest
+    container_name: worker-1
+    command: sh -c "while true; do echo 'Worker 1 processing...'; sleep 10; done"
+    labels:
+      app.tier: "worker"
+      app.env: "production"
+    restart: unless-stopped
+
+  worker-2:
+    image: alpine:latest
+    container_name: worker-2
+    command: sh -c "while true; do echo 'Worker 2 processing...'; sleep 15; done"
+    labels:
+      app.tier: "worker"
+      app.env: "production"
+    restart: unless-stopped
+
+  # === Monitoring ===
+  monitoring-prometheus:
+    image: prom/prometheus:latest
+    container_name: monitoring-prometheus
+    ports:
+      - "9090:9090"
+    labels:
+      app.tier: "monitoring"
+      app.env: "infrastructure"
+    restart: unless-stopped
+
+  # === Staging Environment ===
+  staging-web:
+    image: nginx:alpine
+    container_name: staging-web
+    labels:
+      app.tier: "web"
+      app.env: "staging"
+    restart: unless-stopped
+
+  staging-api:
+    image: httpd:alpine
+    container_name: staging-api
+    labels:
+      app.tier: "api"
+      app.env: "staging"
+    restart: unless-stopped
+
+  # === Development Environment ===
+  dev-web:
+    image: nginx:alpine
+    container_name: dev-web
+    labels:
+      app.tier: "web"
+      app.env: "development"
+    restart: "no"
+
+  # === Intentionally Unhealthy Container (for testing alerts) ===
+  unhealthy-service:
+    image: alpine:latest
+    container_name: unhealthy-service
+    command: sh -c "exit 1"
+    labels:
+      app.tier: "test"
+      app.env: "test"
+    healthcheck:
+      test: ["CMD", "false"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: "no"
+
+  # === Resource Intensive Container (for metrics testing) ===
+  cpu-stress:
+    image: alpine:latest
+    container_name: cpu-stress
+    command: sh -c "while true; do echo 'scale=5000; 4*a(1)' | bc -l > /dev/null 2>&1 || true; sleep 1; done"
+    labels:
+      app.tier: "test"
+      app.env: "test"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 128M
+    restart: unless-stopped
+
+  # === Stopped Container (for state testing) ===
+  stopped-service:
+    image: alpine:latest
+    container_name: stopped-service
+    command: echo "This container exits immediately"
+    labels:
+      app.tier: "test"
+      app.env: "test"
+    restart: "no"
+
+volumes:
+  postgres-data:
+
+networks:
+  default:
+    name: workload-net

--- a/scripts/deploy-workload.sh
+++ b/scripts/deploy-workload.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Deploy dummy workload stack to Portainer
+# Usage: ./scripts/deploy-workload.sh [start|stop|status]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load environment variables
+if [ -f "$PROJECT_DIR/.env" ]; then
+  export $(grep -v '^#' "$PROJECT_DIR/.env" | xargs)
+fi
+
+PORTAINER_URL="${PORTAINER_API_URL:-http://localhost:9000}"
+API_KEY="${PORTAINER_API_KEY}"
+STACK_NAME="dummy-workload"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.workload.yml"
+
+if [ -z "$API_KEY" ]; then
+  echo "Error: PORTAINER_API_KEY not set in .env file"
+  exit 1
+fi
+
+# Get endpoint ID (assumes first endpoint)
+get_endpoint_id() {
+  curl -s -H "X-API-Key: $API_KEY" "$PORTAINER_URL/api/endpoints" | jq -r '.[0].Id'
+}
+
+# Get stack ID by name
+get_stack_id() {
+  curl -s -H "X-API-Key: $API_KEY" "$PORTAINER_URL/api/stacks" | \
+    jq -r ".[] | select(.Name == \"$STACK_NAME\") | .Id"
+}
+
+# Check if Portainer is available
+check_portainer() {
+  if ! curl -s -f "$PORTAINER_URL/api/status" > /dev/null 2>&1; then
+    echo "Error: Cannot connect to Portainer at $PORTAINER_URL"
+    exit 1
+  fi
+}
+
+# Deploy stack
+deploy_stack() {
+  check_portainer
+
+  ENDPOINT_ID=$(get_endpoint_id)
+  if [ -z "$ENDPOINT_ID" ] || [ "$ENDPOINT_ID" == "null" ]; then
+    echo "Error: No endpoints found in Portainer"
+    exit 1
+  fi
+
+  EXISTING_STACK_ID=$(get_stack_id)
+
+  if [ -n "$EXISTING_STACK_ID" ] && [ "$EXISTING_STACK_ID" != "null" ]; then
+    echo "Stack '$STACK_NAME' already exists (ID: $EXISTING_STACK_ID)"
+    echo "Starting existing stack..."
+
+    RESULT=$(curl -s -X POST \
+      -H "X-API-Key: $API_KEY" \
+      "$PORTAINER_URL/api/stacks/$EXISTING_STACK_ID/start?endpointId=$ENDPOINT_ID")
+
+    if echo "$RESULT" | jq -e '.message' > /dev/null 2>&1; then
+      # Check if it's just "already running"
+      MSG=$(echo "$RESULT" | jq -r '.message')
+      if [[ "$MSG" == *"already running"* ]] || [[ "$MSG" == *"active"* ]]; then
+        echo "Stack is already running"
+      else
+        echo "Warning: $MSG"
+      fi
+    else
+      echo "Stack started successfully"
+    fi
+  else
+    echo "Creating new stack '$STACK_NAME'..."
+
+    STACK_CONTENT=$(cat "$COMPOSE_FILE")
+
+    RESULT=$(curl -s -X POST \
+      -H "X-API-Key: $API_KEY" \
+      -H "Content-Type: application/json" \
+      "$PORTAINER_URL/api/stacks/create/standalone/string?endpointId=$ENDPOINT_ID" \
+      -d "$(jq -n --arg name "$STACK_NAME" --arg content "$STACK_CONTENT" \
+        '{Name: $name, StackFileContent: $content}')")
+
+    if echo "$RESULT" | jq -e '.Id' > /dev/null 2>&1; then
+      STACK_ID=$(echo "$RESULT" | jq -r '.Id')
+      echo "Stack created successfully (ID: $STACK_ID)"
+    else
+      echo "Error: $(echo "$RESULT" | jq -r '.message // .details // "Unknown error"')"
+      exit 1
+    fi
+  fi
+}
+
+# Stop stack
+stop_stack() {
+  check_portainer
+
+  ENDPOINT_ID=$(get_endpoint_id)
+  STACK_ID=$(get_stack_id)
+
+  if [ -z "$STACK_ID" ] || [ "$STACK_ID" == "null" ]; then
+    echo "Stack '$STACK_NAME' not found"
+    exit 0
+  fi
+
+  echo "Stopping stack '$STACK_NAME' (ID: $STACK_ID)..."
+
+  RESULT=$(curl -s -X POST \
+    -H "X-API-Key: $API_KEY" \
+    "$PORTAINER_URL/api/stacks/$STACK_ID/stop?endpointId=$ENDPOINT_ID")
+
+  if echo "$RESULT" | jq -e '.message' > /dev/null 2>&1; then
+    MSG=$(echo "$RESULT" | jq -r '.message')
+    if [[ "$MSG" == *"already"* ]] || [[ "$MSG" == *"inactive"* ]]; then
+      echo "Stack is already stopped"
+    else
+      echo "Warning: $MSG"
+    fi
+  else
+    echo "Stack stopped successfully"
+  fi
+}
+
+# Delete stack
+delete_stack() {
+  check_portainer
+
+  ENDPOINT_ID=$(get_endpoint_id)
+  STACK_ID=$(get_stack_id)
+
+  if [ -z "$STACK_ID" ] || [ "$STACK_ID" == "null" ]; then
+    echo "Stack '$STACK_NAME' not found"
+    exit 0
+  fi
+
+  echo "Deleting stack '$STACK_NAME' (ID: $STACK_ID)..."
+
+  curl -s -X DELETE \
+    -H "X-API-Key: $API_KEY" \
+    "$PORTAINER_URL/api/stacks/$STACK_ID?endpointId=$ENDPOINT_ID" > /dev/null
+
+  echo "Stack deleted successfully"
+}
+
+# Show stack status
+show_status() {
+  check_portainer
+
+  STACK_ID=$(get_stack_id)
+
+  if [ -z "$STACK_ID" ] || [ "$STACK_ID" == "null" ]; then
+    echo "Stack '$STACK_NAME' not found in Portainer"
+    exit 0
+  fi
+
+  STACK_INFO=$(curl -s -H "X-API-Key: $API_KEY" "$PORTAINER_URL/api/stacks/$STACK_ID")
+
+  echo "Stack: $STACK_NAME"
+  echo "ID: $STACK_ID"
+  echo "Status: $(echo "$STACK_INFO" | jq -r 'if .Status == 1 then "Active" else "Inactive" end')"
+
+  # Count containers
+  ENDPOINT_ID=$(get_endpoint_id)
+  CONTAINERS=$(curl -s -H "X-API-Key: $API_KEY" \
+    "$PORTAINER_URL/api/endpoints/$ENDPOINT_ID/docker/containers/json?all=true" | \
+    jq "[.[] | select(.Labels[\"com.docker.compose.project\"] == \"$STACK_NAME\")] | length")
+
+  echo "Containers: $CONTAINERS"
+}
+
+# Main
+case "${1:-start}" in
+  start|deploy)
+    deploy_stack
+    ;;
+  stop)
+    stop_stack
+    ;;
+  delete|remove)
+    delete_stack
+    ;;
+  status)
+    show_status
+    ;;
+  restart)
+    stop_stack
+    sleep 2
+    deploy_stack
+    ;;
+  *)
+    echo "Usage: $0 [start|stop|delete|status|restart]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
Add a dummy workload compose file and a shell script to deploy it as a managed Portainer stack.

## Files Added

### `docker-compose.workload.yml`
16 containers simulating a production environment:
- **Web tier**: nginx frontend, 2x httpd backends
- **Database**: PostgreSQL, Redis
- **Messaging**: RabbitMQ with management UI
- **Workers**: 2 background processors
- **Monitoring**: Prometheus
- **Staging/Dev**: Additional environments
- **Test**: Unhealthy, CPU stress, stopped containers

### `scripts/deploy-workload.sh`
Shell script to manage the workload as a Portainer stack via API:

```bash
./scripts/deploy-workload.sh start   # Deploy/start stack
./scripts/deploy-workload.sh stop    # Stop stack
./scripts/deploy-workload.sh status  # Show stack info
./scripts/deploy-workload.sh delete  # Remove stack
./scripts/deploy-workload.sh restart # Stop + start
```

The script reads `PORTAINER_API_URL` and `PORTAINER_API_KEY` from `.env`.

## Why a script instead of just docker-compose?
Running `docker compose up` directly creates containers that Portainer sees as "standalone" - not as a managed stack. Using the Portainer API creates a proper stack that:
- Appears in Portainer's Stacks UI
- Can be managed (start/stop/update) from Portainer
- Shows as a logical grouping in the dashboard

## Test plan
- [x] Script deploys stack successfully
- [x] Stack appears in Portainer UI
- [x] Containers visible in AI Dashboard
- [x] Start/stop/status commands work

🤖 Generated with [Claude Code](https://claude.ai/code)