### PR TITLE
feat: implement Catppuccin theme support

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,6 +42,7 @@
 }
 
 @layer base {
+  /* Default Dark Theme */
   .dark {
     --color-background: hsl(240 10% 3.9%);
     --color-foreground: hsl(0 0% 98%);
@@ -75,6 +76,150 @@
     --color-chart-3: hsl(30 80% 55%);
     --color-chart-4: hsl(280 65% 60%);
     --color-chart-5: hsl(340 75% 55%);
+  }
+
+  /* Catppuccin Latte (Light) */
+  .catppuccin-latte {
+    --color-background: #eff1f5; /* Base */
+    --color-foreground: #4c4f69; /* Text */
+    --color-card: #e6e9ef; /* Surface0 */
+    --color-card-foreground: #4c4f69; /* Text */
+    --color-popover: #e6e9ef; /* Surface0 */
+    --color-popover-foreground: #4c4f69; /* Text */
+    --color-primary: #8839ef; /* Mauve */
+    --color-primary-foreground: #eff1f5; /* Base */
+    --color-secondary: #ccd0da; /* Surface1 */
+    --color-secondary-foreground: #4c4f69; /* Text */
+    --color-muted: #bcc0cc; /* Surface2 */
+    --color-muted-foreground: #6c6f85; /* Subtext0 */
+    --color-accent: #1e66f5; /* Blue */
+    --color-accent-foreground: #eff1f5; /* Base */
+    --color-destructive: #d20f39; /* Red */
+    --color-destructive-foreground: #eff1f5; /* Base */
+    --color-border: #ccd0da; /* Surface1 */
+    --color-input: #ccd0da; /* Surface1 */
+    --color-ring: #8839ef; /* Mauve */
+    --color-sidebar-background: #e6e9ef; /* Surface0 */
+    --color-sidebar-foreground: #4c4f69; /* Text */
+    --color-sidebar-primary: #8839ef; /* Mauve */
+    --color-sidebar-primary-foreground: #eff1f5; /* Base */
+    --color-sidebar-accent: #ccd0da; /* Surface1 */
+    --color-sidebar-accent-foreground: #4c4f69; /* Text */
+    --color-sidebar-border: #ccd0da; /* Surface1 */
+    --color-sidebar-ring: #1e66f5; /* Blue */
+    --color-chart-1: #8839ef; /* Mauve */
+    --color-chart-2: #209fb5; /* Sapphire */
+    --color-chart-3: #40a02b; /* Green */
+    --color-chart-4: #fe640b; /* Peach */
+    --color-chart-5: #df8e1d; /* Yellow */
+  }
+
+  /* Catppuccin Frappé (Dark) */
+  .catppuccin-frappe {
+    --color-background: #303446; /* Base */
+    --color-foreground: #c6d0f5; /* Text */
+    --color-card: #414559; /* Surface0 */
+    --color-card-foreground: #c6d0f5; /* Text */
+    --color-popover: #414559; /* Surface0 */
+    --color-popover-foreground: #c6d0f5; /* Text */
+    --color-primary: #ca9ee6; /* Mauve */
+    --color-primary-foreground: #303446; /* Base */
+    --color-secondary: #51576d; /* Surface1 */
+    --color-secondary-foreground: #c6d0f5; /* Text */
+    --color-muted: #626880; /* Surface2 */
+    --color-muted-foreground: #a5adce; /* Subtext0 */
+    --color-accent: #85c1dc; /* Sapphire */
+    --color-accent-foreground: #303446; /* Base */
+    --color-destructive: #e78284; /* Red */
+    --color-destructive-foreground: #303446; /* Base */
+    --color-border: #51576d; /* Surface1 */
+    --color-input: #51576d; /* Surface1 */
+    --color-ring: #ca9ee6; /* Mauve */
+    --color-sidebar-background: #292c3c; /* Mantle */
+    --color-sidebar-foreground: #c6d0f5; /* Text */
+    --color-sidebar-primary: #ca9ee6; /* Mauve */
+    --color-sidebar-primary-foreground: #303446; /* Base */
+    --color-sidebar-accent: #414559; /* Surface0 */
+    --color-sidebar-accent-foreground: #c6d0f5; /* Text */
+    --color-sidebar-border: #414559; /* Surface0 */
+    --color-sidebar-ring: #85c1dc; /* Sapphire */
+    --color-chart-1: #ca9ee6; /* Mauve */
+    --color-chart-2: #85c1dc; /* Sapphire */
+    --color-chart-3: #a6d189; /* Green */
+    --color-chart-4: #ef9f76; /* Peach */
+    --color-chart-5: #e5c890; /* Yellow */
+  }
+
+  /* Catppuccin Macchiato (Dark) */
+  .catppuccin-macchiato {
+    --color-background: #24273a; /* Base */
+    --color-foreground: #cad3f5; /* Text */
+    --color-card: #363a4f; /* Surface0 */
+    --color-card-foreground: #cad3f5; /* Text */
+    --color-popover: #363a4f; /* Surface0 */
+    --color-popover-foreground: #cad3f5; /* Text */
+    --color-primary: #c6a0f6; /* Mauve */
+    --color-primary-foreground: #24273a; /* Base */
+    --color-secondary: #494d64; /* Surface1 */
+    --color-secondary-foreground: #cad3f5; /* Text */
+    --color-muted: #5b6078; /* Surface2 */
+    --color-muted-foreground: #a5adcb; /* Subtext0 */
+    --color-accent: #7dc4e4; /* Sapphire */
+    --color-accent-foreground: #24273a; /* Base */
+    --color-destructive: #ed8796; /* Red */
+    --color-destructive-foreground: #24273a; /* Base */
+    --color-border: #494d64; /* Surface1 */
+    --color-input: #494d64; /* Surface1 */
+    --color-ring: #c6a0f6; /* Mauve */
+    --color-sidebar-background: #1e2030; /* Mantle */
+    --color-sidebar-foreground: #cad3f5; /* Text */
+    --color-sidebar-primary: #c6a0f6; /* Mauve */
+    --color-sidebar-primary-foreground: #24273a; /* Base */
+    --color-sidebar-accent: #363a4f; /* Surface0 */
+    --color-sidebar-accent-foreground: #cad3f5; /* Text */
+    --color-sidebar-border: #363a4f; /* Surface0 */
+    --color-sidebar-ring: #7dc4e4; /* Sapphire */
+    --color-chart-1: #c6a0f6; /* Mauve */
+    --color-chart-2: #7dc4e4; /* Sapphire */
+    --color-chart-3: #a6da95; /* Green */
+    --color-chart-4: #f5a97f; /* Peach */
+    --color-chart-5: #eed49f; /* Yellow */
+  }
+
+  /* Catppuccin Mocha (Darkest) */
+  .catppuccin-mocha {
+    --color-background: #1e1e2e; /* Base */
+    --color-foreground: #cdd6f4; /* Text */
+    --color-card: #313244; /* Surface0 */
+    --color-card-foreground: #cdd6f4; /* Text */
+    --color-popover: #313244; /* Surface0 */
+    --color-popover-foreground: #cdd6f4; /* Text */
+    --color-primary: #cba6f7; /* Mauve */
+    --color-primary-foreground: #1e1e2e; /* Base */
+    --color-secondary: #45475a; /* Surface1 */
+    --color-secondary-foreground: #cdd6f4; /* Text */
+    --color-muted: #585b70; /* Surface2 */
+    --color-muted-foreground: #a6adc8; /* Subtext0 */
+    --color-accent: #74c7ec; /* Sapphire */
+    --color-accent-foreground: #1e1e2e; /* Base */
+    --color-destructive: #f38ba8; /* Red */
+    --color-destructive-foreground: #1e1e2e; /* Base */
+    --color-border: #45475a; /* Surface1 */
+    --color-input: #45475a; /* Surface1 */
+    --color-ring: #cba6f7; /* Mauve */
+    --color-sidebar-background: #181825; /* Mantle */
+    --color-sidebar-foreground: #cdd6f4; /* Text */
+    --color-sidebar-primary: #cba6f7; /* Mauve */
+    --color-sidebar-primary-foreground: #1e1e2e; /* Base */
+    --color-sidebar-accent: #313244; /* Surface0 */
+    --color-sidebar-accent-foreground: #cdd6f4; /* Text */
+    --color-sidebar-border: #313244; /* Surface0 */
+    --color-sidebar-ring: #74c7ec; /* Sapphire */
+    --color-chart-1: #cba6f7; /* Mauve */
+    --color-chart-2: #74c7ec; /* Sapphire */
+    --color-chart-3: #a6e3a1; /* Green */
+    --color-chart-4: #fab387; /* Peach */
+    --color-chart-5: #f9e2af; /* Yellow */
   }
 }
 

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -1,4 +1,16 @@
+import { useThemeStore, themeOptions, type Theme } from '@/stores/theme-store';
+import { Palette, Monitor, Sun, Moon } from 'lucide-react';
+
+function ThemeIcon({ theme }: { theme: Theme }) {
+  if (theme === 'system') return <Monitor className="h-4 w-4" />;
+  if (theme === 'light') return <Sun className="h-4 w-4" />;
+  if (theme.startsWith('catppuccin')) return <Palette className="h-4 w-4" />;
+  return <Moon className="h-4 w-4" />;
+}
+
 export default function SettingsPage() {
+  const { theme, setTheme } = useThemeStore();
+
   return (
     <div className="space-y-6">
       <div>
@@ -7,8 +19,54 @@ export default function SettingsPage() {
           Environment, backup, monitoring, and cache configuration
         </p>
       </div>
-      <div className="rounded-lg border bg-card p-8 text-center text-muted-foreground">
-        Coming soon
+
+      {/* Theme Settings */}
+      <div className="rounded-lg border bg-card p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Palette className="h-5 w-5" />
+          <h2 className="text-xl font-semibold">Appearance</h2>
+        </div>
+        <p className="text-sm text-muted-foreground mb-4">
+          Choose your preferred color theme for the dashboard.
+        </p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+          {themeOptions.map((option) => (
+            <button
+              key={option.value}
+              onClick={() => setTheme(option.value)}
+              className={`flex items-center gap-3 p-4 rounded-lg border text-left transition-colors ${
+                theme === option.value
+                  ? 'border-primary bg-primary/10'
+                  : 'border-border hover:border-primary/50 hover:bg-muted/50'
+              }`}
+            >
+              <div
+                className={`flex items-center justify-center w-10 h-10 rounded-lg ${
+                  theme === option.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground'
+                }`}
+              >
+                <ThemeIcon theme={option.value} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="font-medium truncate">{option.label}</div>
+                <div className="text-xs text-muted-foreground truncate">
+                  {option.description}
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Other Settings - Coming Soon */}
+      <div className="rounded-lg border bg-card p-6">
+        <h2 className="text-xl font-semibold mb-4">Other Settings</h2>
+        <div className="text-center text-muted-foreground py-8">
+          More settings coming soon
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/providers/theme-provider.tsx
+++ b/frontend/src/providers/theme-provider.tsx
@@ -1,24 +1,48 @@
 import { useEffect } from 'react';
 import { useThemeStore } from '@/stores/theme-store';
 
+const ALL_THEME_CLASSES = [
+  'light',
+  'dark',
+  'catppuccin-latte',
+  'catppuccin-frappe',
+  'catppuccin-macchiato',
+  'catppuccin-mocha',
+];
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const { theme, resolvedTheme } = useThemeStore();
+  const { theme, themeClass } = useThemeStore();
 
   useEffect(() => {
     const root = document.documentElement;
-    const resolved = resolvedTheme();
-    root.classList.remove('light', 'dark');
-    root.classList.add(resolved);
-  }, [theme, resolvedTheme]);
+    const currentClass = themeClass();
+
+    // Remove all theme classes
+    ALL_THEME_CLASSES.forEach((cls) => root.classList.remove(cls));
+
+    // Add the current theme class
+    root.classList.add(currentClass);
+
+    // For Catppuccin dark themes, also add 'dark' class for Tailwind dark: variants
+    if (
+      currentClass === 'catppuccin-frappe' ||
+      currentClass === 'catppuccin-macchiato' ||
+      currentClass === 'catppuccin-mocha'
+    ) {
+      root.classList.add('dark');
+    }
+  }, [theme, themeClass]);
 
   useEffect(() => {
     if (theme !== 'system') return;
+
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = () => {
       const root = document.documentElement;
-      root.classList.remove('light', 'dark');
+      ALL_THEME_CLASSES.forEach((cls) => root.classList.remove(cls));
       root.classList.add(mq.matches ? 'dark' : 'light');
     };
+
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
   }, [theme]);

--- a/frontend/src/stores/theme-store.ts
+++ b/frontend/src/stores/theme-store.ts
@@ -1,12 +1,30 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-type Theme = 'dark' | 'light' | 'system';
+export type Theme =
+  | 'system'
+  | 'light'
+  | 'dark'
+  | 'catppuccin-latte'
+  | 'catppuccin-frappe'
+  | 'catppuccin-macchiato'
+  | 'catppuccin-mocha';
+
+export const themeOptions: { value: Theme; label: string; description: string }[] = [
+  { value: 'system', label: 'System', description: 'Follow system preference' },
+  { value: 'light', label: 'Light', description: 'Default light theme' },
+  { value: 'dark', label: 'Dark', description: 'Default dark theme' },
+  { value: 'catppuccin-latte', label: 'Catppuccin Latte', description: 'Warm light pastel theme' },
+  { value: 'catppuccin-frappe', label: 'Catppuccin Frappé', description: 'Medium dark pastel theme' },
+  { value: 'catppuccin-macchiato', label: 'Catppuccin Macchiato', description: 'Darker pastel theme' },
+  { value: 'catppuccin-mocha', label: 'Catppuccin Mocha', description: 'Darkest pastel theme' },
+];
 
 interface ThemeState {
   theme: Theme;
   setTheme: (theme: Theme) => void;
   resolvedTheme: () => 'dark' | 'light';
+  themeClass: () => string;
 }
 
 export const useThemeStore = create<ThemeState>()(
@@ -16,10 +34,24 @@ export const useThemeStore = create<ThemeState>()(
       setTheme: (theme) => set({ theme }),
       resolvedTheme: () => {
         const { theme } = get();
-        if (theme !== 'system') return theme;
-        return window.matchMedia('(prefers-color-scheme: dark)').matches
-          ? 'dark'
-          : 'light';
+        if (theme === 'system') {
+          return window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+        }
+        if (theme === 'light' || theme === 'catppuccin-latte') {
+          return 'light';
+        }
+        return 'dark';
+      },
+      themeClass: () => {
+        const { theme } = get();
+        if (theme === 'system') {
+          return window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+        }
+        return theme;
       },
     }),
     { name: 'theme-preference' }


### PR DESCRIPTION
## Summary
Implement Catppuccin theme support with all four flavors as requested in #28.

## Changes

### Theme Store (`theme-store.ts`)
- Extended `Theme` type with Catppuccin options
- Added `themeOptions` array with labels and descriptions
- Added `themeClass()` function for CSS class management

### CSS (`index.css`)
- Added complete Catppuccin color palettes for all flavors:
  - **Latte** (light) - warm pastel light theme
  - **Frappé** (dark) - medium dark pastel theme
  - **Macchiato** (darker) - darker pastel theme
  - **Mocha** (darkest) - darkest pastel theme
- Mapped all Catppuccin colors to existing CSS variables

### Theme Provider (`theme-provider.tsx`)
- Updated to handle multiple theme classes
- Dark Catppuccin themes also add `dark` class for Tailwind compatibility

### Settings Page (`settings.tsx`)
- Implemented theme selector with visual cards
- Shows all 7 theme options (System, Light, Dark, + 4 Catppuccin)
- Icons indicate theme type (Monitor, Sun, Moon, Palette)

## Test plan
- [x] All themes apply correctly
- [x] Theme persists after page reload
- [x] Dark variants use Tailwind dark: classes
- [x] Charts display with Catppuccin accent colors
- [x] Settings page renders theme selector

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)