### PR TITLE
feat: Stack Overview page with filtering capability

### DIFF
--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -3,6 +3,7 @@ import {
   LayoutDashboard,
   Boxes,
   Ship,
+  Layers,
   HeartPulse,
   ScrollText,
   PackageOpen,
@@ -39,6 +40,7 @@ const navigation: NavGroup[] = [
       { label: 'Home', to: '/', icon: LayoutDashboard },
       { label: 'Workload Explorer', to: '/workloads', icon: Boxes },
       { label: 'Fleet Overview', to: '/fleet', icon: Ship },
+      { label: 'Stack Overview', to: '/stacks', icon: Layers },
     ],
   },
   {

--- a/frontend/src/hooks/use-stacks.ts
+++ b/frontend/src/hooks/use-stacks.ts
@@ -1,18 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 
-interface Stack {
+export interface Stack {
   id: number;
   name: string;
   type: number;
   endpointId: number;
-  status: number;
-  creationDate: string;
-  updateDate: string;
-  env?: Array<{
-    name: string;
-    value: string;
-  }>;
+  status: 'active' | 'inactive';
+  createdAt?: number;
+  updatedAt?: number;
+  envCount: number;
 }
 
 export function useStacks() {

--- a/frontend/src/pages/stack-overview.tsx
+++ b/frontend/src/pages/stack-overview.tsx
@@ -1,0 +1,316 @@
+import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { type ColumnDef } from '@tanstack/react-table';
+import { Layers, LayoutGrid, List, AlertTriangle } from 'lucide-react';
+import { useStacks, type Stack } from '@/hooks/use-stacks';
+import { useEndpoints } from '@/hooks/use-endpoints';
+import { useAutoRefresh } from '@/hooks/use-auto-refresh';
+import { DataTable } from '@/components/shared/data-table';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
+import { RefreshButton } from '@/components/shared/refresh-button';
+import { SkeletonCard } from '@/components/shared/loading-skeleton';
+import { cn } from '@/lib/utils';
+
+type ViewMode = 'grid' | 'table';
+
+interface StackWithEndpoint extends Stack {
+  endpointName: string;
+}
+
+function StackCard({ stack, onClick }: { stack: StackWithEndpoint; onClick: () => void }) {
+  const formatDate = (timestamp?: number) => {
+    if (!timestamp) return 'N/A';
+    return new Date(timestamp * 1000).toLocaleDateString();
+  };
+
+  const getStackType = (type: number) => {
+    switch (type) {
+      case 1:
+        return 'Swarm';
+      case 2:
+        return 'Compose';
+      case 3:
+        return 'Kubernetes';
+      default:
+        return `Type ${type}`;
+    }
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      className="w-full rounded-lg border bg-card p-6 shadow-sm text-left transition-colors hover:bg-accent/50 focus:outline-none focus:ring-2 focus:ring-ring"
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div className={cn(
+            'rounded-lg p-2',
+            stack.status === 'active'
+              ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+              : 'bg-gray-100 text-gray-700 dark:bg-gray-900/30 dark:text-gray-400'
+          )}>
+            <Layers className="h-5 w-5" />
+          </div>
+          <div>
+            <h3 className="font-semibold">{stack.name}</h3>
+            <p className="text-xs text-muted-foreground">ID: {stack.id}</p>
+          </div>
+        </div>
+        <StatusBadge status={stack.status} />
+      </div>
+
+      <div className="mt-4 space-y-2">
+        <div>
+          <p className="text-xs text-muted-foreground">Endpoint</p>
+          <p className="mt-1 font-medium text-sm">
+            {stack.endpointName}
+            <span className="ml-2 text-xs text-muted-foreground">(ID: {stack.endpointId})</span>
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <p className="text-xs text-muted-foreground">Type</p>
+            <p className="mt-1 text-sm font-medium">{getStackType(stack.type)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Env Vars</p>
+            <p className="mt-1 text-sm font-medium">{stack.envCount}</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <p className="text-xs text-muted-foreground">Created</p>
+            <p className="mt-1 text-sm">{formatDate(stack.createdAt)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Updated</p>
+            <p className="mt-1 text-sm">{formatDate(stack.updatedAt)}</p>
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export default function StackOverviewPage() {
+  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const navigate = useNavigate();
+
+  const { data: stacks, isLoading: stacksLoading, isError, error, refetch, isFetching } = useStacks();
+  const { data: endpoints, isLoading: endpointsLoading } = useEndpoints();
+  const { interval, setInterval } = useAutoRefresh(30);
+
+  const isLoading = stacksLoading || endpointsLoading;
+
+  const stacksWithEndpoints = useMemo<StackWithEndpoint[]>(() => {
+    if (!stacks || !endpoints) return [];
+    return stacks.map(stack => ({
+      ...stack,
+      endpointName: endpoints.find(ep => ep.id === stack.endpointId)?.name || `Endpoint ${stack.endpointId}`,
+    }));
+  }, [stacks, endpoints]);
+
+  const handleStackClick = (stack: StackWithEndpoint) => {
+    navigate(`/workloads?endpoint=${stack.endpointId}&stack=${encodeURIComponent(stack.name)}`);
+  };
+
+  const getStackType = (type: number) => {
+    switch (type) {
+      case 1:
+        return 'Swarm';
+      case 2:
+        return 'Compose';
+      case 3:
+        return 'Kubernetes';
+      default:
+        return `Type ${type}`;
+    }
+  };
+
+  const formatDate = (timestamp?: number) => {
+    if (!timestamp) return 'N/A';
+    return new Date(timestamp * 1000).toLocaleDateString();
+  };
+
+  const columns: ColumnDef<StackWithEndpoint, unknown>[] = useMemo(() => [
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      cell: ({ row }) => (
+        <div>
+          <span className="font-medium">{row.original.name}</span>
+          <span className="ml-2 text-xs text-muted-foreground">(ID: {row.original.id})</span>
+        </div>
+      ),
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ getValue }) => <StatusBadge status={getValue<string>()} />,
+    },
+    {
+      accessorKey: 'endpointName',
+      header: 'Endpoint',
+      cell: ({ row }) => (
+        <div>
+          <span>{row.original.endpointName}</span>
+          <span className="ml-2 text-xs text-muted-foreground">(ID: {row.original.endpointId})</span>
+        </div>
+      ),
+    },
+    {
+      accessorKey: 'type',
+      header: 'Type',
+      cell: ({ getValue }) => getStackType(getValue<number>()),
+    },
+    {
+      accessorKey: 'envCount',
+      header: 'Env Vars',
+    },
+    {
+      accessorKey: 'createdAt',
+      header: 'Created',
+      cell: ({ getValue }) => formatDate(getValue<number>()),
+    },
+    {
+      accessorKey: 'updatedAt',
+      header: 'Updated',
+      cell: ({ getValue }) => formatDate(getValue<number>()),
+    },
+  ], []);
+
+  if (isError) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Stack Overview</h1>
+          <p className="text-muted-foreground">
+            Monitor all Docker Stacks across your fleet
+          </p>
+        </div>
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
+          <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
+          <p className="mt-4 font-medium text-destructive">Failed to load stacks</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : 'An unexpected error occurred'}
+          </p>
+          <button
+            onClick={() => refetch()}
+            className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const activeCount = stacksWithEndpoints.filter(s => s.status === 'active').length;
+  const inactiveCount = stacksWithEndpoints.filter(s => s.status === 'inactive').length;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Stack Overview</h1>
+          <p className="text-muted-foreground">
+            Monitor all Docker Stacks across your fleet
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <AutoRefreshToggle interval={interval} onIntervalChange={setInterval} />
+          <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
+        </div>
+      </div>
+
+      {/* Summary and View Toggle */}
+      {!isLoading && stacksWithEndpoints.length > 0 && (
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4 text-sm">
+            <span className="text-muted-foreground">
+              {stacksWithEndpoints.length} stack{stacksWithEndpoints.length !== 1 ? 's' : ''}
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="h-2 w-2 rounded-full bg-emerald-500" />
+              {activeCount} active
+            </span>
+            {inactiveCount > 0 && (
+              <span className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
+                <span className="h-2 w-2 rounded-full bg-gray-500" />
+                {inactiveCount} inactive
+              </span>
+            )}
+          </div>
+          <div className="flex items-center rounded-lg border p-1">
+            <button
+              onClick={() => setViewMode('grid')}
+              className={cn(
+                'inline-flex items-center justify-center rounded-md p-2 transition-colors',
+                viewMode === 'grid'
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+              title="Grid view"
+            >
+              <LayoutGrid className="h-4 w-4" />
+            </button>
+            <button
+              onClick={() => setViewMode('table')}
+              className={cn(
+                'inline-flex items-center justify-center rounded-md p-2 transition-colors',
+                viewMode === 'table'
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+              title="Table view"
+            >
+              <List className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <SkeletonCard key={i} className="h-[240px]" />
+          ))}
+        </div>
+      ) : stacksWithEndpoints.length === 0 ? (
+        <div className="rounded-lg border bg-card p-8 text-center">
+          <Layers className="mx-auto h-10 w-10 text-muted-foreground" />
+          <p className="mt-4 font-medium">No stacks found</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            There are no Docker Stacks deployed across your endpoints
+          </p>
+        </div>
+      ) : viewMode === 'grid' ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {stacksWithEndpoints.map((stack) => (
+            <StackCard
+              key={stack.id}
+              stack={stack}
+              onClick={() => handleStackClick(stack)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <DataTable
+            columns={columns}
+            data={stacksWithEndpoints}
+            searchKey="name"
+            searchPlaceholder="Search stacks..."
+            pageSize={15}
+            onRowClick={handleStackClick}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/workload-explorer.tsx
+++ b/frontend/src/pages/workload-explorer.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { type ColumnDef } from '@tanstack/react-table';
-import { Play, Square, RotateCw, AlertTriangle } from 'lucide-react';
+import { Play, Square, RotateCw, AlertTriangle, X } from 'lucide-react';
 import { useContainers, useContainerAction, type Container } from '@/hooks/use-containers';
 import { useEndpoints } from '@/hooks/use-endpoints';
 import { useAutoRefresh } from '@/hooks/use-auto-refresh';
@@ -42,22 +42,45 @@ export default function WorkloadExplorerPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
 
-  // Read endpoint from URL param
+  // Read endpoint and stack from URL params
   const endpointParam = searchParams.get('endpoint');
+  const stackParam = searchParams.get('stack');
   const selectedEndpoint = endpointParam ? Number(endpointParam) : undefined;
+  const selectedStack = stackParam || undefined;
+
+  const setFilters = (endpointId: number | undefined, stackName: string | undefined) => {
+    const params: Record<string, string> = {};
+    if (endpointId !== undefined) {
+      params.endpoint = String(endpointId);
+    }
+    if (stackName) {
+      params.stack = stackName;
+    }
+    setSearchParams(params);
+  };
 
   const setSelectedEndpoint = (endpointId: number | undefined) => {
-    if (endpointId !== undefined) {
-      setSearchParams({ endpoint: String(endpointId) });
-    } else {
-      setSearchParams({});
-    }
+    setFilters(endpointId, selectedStack);
+  };
+
+  const setSelectedStack = (stackName: string | undefined) => {
+    setFilters(selectedEndpoint, stackName);
+  };
+
+  const clearStackFilter = () => {
+    setFilters(selectedEndpoint, undefined);
   };
 
   const { data: endpoints } = useEndpoints();
   const { data: containers, isLoading, isError, error, refetch, isFetching } = useContainers(selectedEndpoint);
   const containerAction = useContainerAction();
   const { interval, setInterval } = useAutoRefresh(30);
+
+  // Filter containers by stack if stack parameter is present
+  const filteredContainers = useMemo(() => {
+    if (!containers || !selectedStack) return containers;
+    return containers.filter(c => c.labels['com.docker.compose.project'] === selectedStack);
+  }, [containers, selectedStack]);
 
   const handleAction = (container: Container, action: ContainerAction) => {
     setPendingAction({ container, action });
@@ -195,27 +218,50 @@ export default function WorkloadExplorerPage() {
         </div>
       </div>
 
-      {/* Endpoint Selector */}
-      <div className="flex items-center gap-4">
-        <label htmlFor="endpoint-select" className="text-sm font-medium">
-          Endpoint
-        </label>
-        <select
-          id="endpoint-select"
-          value={selectedEndpoint ?? ''}
-          onChange={(e) => setSelectedEndpoint(e.target.value ? Number(e.target.value) : undefined)}
-          className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <option value="">All endpoints</option>
-          {endpoints?.map((ep) => (
-            <option key={ep.id} value={ep.id}>
-              {ep.name} (ID: {ep.id})
-            </option>
-          ))}
-        </select>
-        {containers && (
+      {/* Filters */}
+      <div className="flex items-center gap-4 flex-wrap">
+        <div className="flex items-center gap-2">
+          <label htmlFor="endpoint-select" className="text-sm font-medium">
+            Endpoint
+          </label>
+          <select
+            id="endpoint-select"
+            value={selectedEndpoint ?? ''}
+            onChange={(e) => setSelectedEndpoint(e.target.value ? Number(e.target.value) : undefined)}
+            className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="">All endpoints</option>
+            {endpoints?.map((ep) => (
+              <option key={ep.id} value={ep.id}>
+                {ep.name} (ID: {ep.id})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {selectedStack && (
+          <div className="flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 dark:border-blue-900/30 dark:bg-blue-900/20">
+            <span className="text-sm font-medium text-blue-900 dark:text-blue-300">
+              Stack: {selectedStack}
+            </span>
+            <button
+              onClick={clearStackFilter}
+              className="inline-flex items-center justify-center rounded-sm p-0.5 text-blue-700 hover:bg-blue-200 dark:text-blue-400 dark:hover:bg-blue-900/40"
+              title="Clear stack filter"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
+
+        {filteredContainers && (
           <span className="text-sm text-muted-foreground">
-            {containers.length} container{containers.length !== 1 ? 's' : ''}
+            {filteredContainers.length} container{filteredContainers.length !== 1 ? 's' : ''}
+            {selectedStack && containers && filteredContainers.length !== containers.length && (
+              <span className="ml-1">
+                (of {containers.length} total)
+              </span>
+            )}
           </span>
         )}
       </div>
@@ -223,11 +269,11 @@ export default function WorkloadExplorerPage() {
       {/* Container Table */}
       {isLoading ? (
         <SkeletonCard className="h-[500px]" />
-      ) : containers ? (
+      ) : filteredContainers ? (
         <div className="rounded-lg border bg-card p-6 shadow-sm">
           <DataTable
             columns={columns}
-            data={containers}
+            data={filteredContainers}
             searchKey="name"
             searchPlaceholder="Search containers by name..."
             pageSize={15}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -19,6 +19,7 @@ const TraceExplorer = lazy(() => import('@/pages/trace-explorer'));
 const LlmAssistant = lazy(() => import('@/pages/llm-assistant'));
 const EdgeAgentLogs = lazy(() => import('@/pages/edge-agent-logs'));
 const Settings = lazy(() => import('@/pages/settings'));
+const StackOverview = lazy(() => import('@/pages/stack-overview'));
 
 function PageLoader() {
   return (
@@ -46,6 +47,7 @@ export const router = createBrowserRouter([
       { index: true, element: <LazyPage><Home /></LazyPage> },
       { path: 'workloads', element: <LazyPage><WorkloadExplorer /></LazyPage> },
       { path: 'fleet', element: <LazyPage><FleetOverview /></LazyPage> },
+      { path: 'stacks', element: <LazyPage><StackOverview /></LazyPage> },
       { path: 'health', element: <LazyPage><ContainerHealth /></LazyPage> },
       { path: 'container-logs', element: <LazyPage><ContainerLogs /></LazyPage> },
       { path: 'images', element: <LazyPage><ImageFootprint /></LazyPage> },


### PR DESCRIPTION
## Summary
Implements a comprehensive Stack Overview page that displays all Docker Stacks across all Portainer endpoints, with grid/table views, auto-refresh, and intelligent navigation to the Workload Explorer with stack filtering.

## New Features

### 1. Stack Overview Page
- **Grid View**: Responsive 3-column card layout showing stack details
- **Table View**: Searchable, sortable table with 7 columns
- **Auto-refresh**: Configurable auto-refresh with manual refresh button
- **Summary Stats**: Total stacks, active count, inactive count
- **Stack Details**: Name, ID, status, endpoint, type, env vars, creation/update dates
- **Empty State**: Friendly message when no stacks exist
- **Error Handling**: Comprehensive error display with retry functionality

### 2. Stack Filtering in Workload Explorer
- **Stack Parameter**: Support for `?stack=name` URL parameter
- **Smart Filtering**: Filters containers by `com.docker.compose.project` label
- **Visual Indicator**: Blue badge showing active stack filter
- **Clear Filter**: X button to remove stack filter
- **Container Counts**: Shows filtered count and total count
- **State Management**: Filter persists across endpoint changes

### 3. Navigation
- Click a stack → Navigate to `/workloads?endpoint={id}&stack={name}`
- Shows only containers belonging to that specific stack
- Stack filter badge with clear button for easy navigation

## Technical Changes

### Backend
- No backend changes required (uses existing `/api/stacks` endpoint)

### Frontend

**Modified Files:**
- `frontend/src/hooks/use-stacks.ts` - Updated Stack interface to match backend NormalizedStack
- `frontend/src/pages/workload-explorer.tsx` - Added stack filtering logic and UI
- `frontend/src/components/layout/sidebar.tsx` - Added Stack Overview navigation item
- `frontend/src/router.tsx` - Added /stacks route

**New Files:**
- `frontend/src/pages/stack-overview.tsx` - Complete Stack Overview page implementation

## Testing

### Manual Testing Completed
- ✅ Stack Overview page renders correctly
- ✅ Grid and table views work
- ✅ Auto-refresh functionality
- ✅ Stack filtering in Workload Explorer
- ✅ Filter badge and clear button
- ✅ Navigation from Stack Overview to Workload Explorer
- ✅ Empty state displays correctly
- ✅ Error handling with retry

### Test Cases
1. Navigate to `/stacks` - page loads with stack list
2. Click stack card/row - navigates to Workload Explorer with filter
3. Stack filter badge displays correctly
4. Click X button - clears filter and shows all containers
5. Container count shows "X containers (of Y total)" when filtered

## Screenshots
N/A - Local testing confirmed functionality

## Related Issues
- Related to #42 (cache invalidation enhancement)

## Breaking Changes
None

## Migration Guide
No migration needed - this is a new feature

## Checklist
- [x] Code follows project conventions
- [x] All new files created with proper structure
- [x] Existing patterns followed (Fleet Overview as reference)
- [x] Navigation added to sidebar
- [x] Route configured in router
- [x] TypeScript types properly defined
- [x] Error handling implemented
- [x] Loading states implemented
- [x] Empty states implemented
- [x] Auto-refresh functionality added
- [x] Tested locally and working