### PR TITLE
feat: Add favorite/pinned containers (#90)

### DIFF
--- a/frontend/src/components/shared/favorite-button.tsx
+++ b/frontend/src/components/shared/favorite-button.tsx
@@ -1,0 +1,35 @@
+import { Star } from 'lucide-react';
+import { useFavoritesStore } from '@/stores/favorites-store';
+
+interface FavoriteButtonProps {
+  endpointId: number;
+  containerId: string;
+  className?: string;
+  size?: 'sm' | 'md';
+}
+
+export function FavoriteButton({ endpointId, containerId, className = '', size = 'md' }: FavoriteButtonProps) {
+  const isFavorite = useFavoritesStore(
+    (s) => s.favoriteIds.includes(`${endpointId}:${containerId}`),
+  );
+  const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
+
+  const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        toggleFavorite(endpointId, containerId);
+      }}
+      className={`inline-flex items-center justify-center rounded-md transition-colors hover:bg-accent ${className}`}
+      title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+    >
+      <Star
+        className={`${iconSize} ${isFavorite ? 'fill-amber-400 text-amber-400' : 'text-muted-foreground'}`}
+      />
+    </button>
+  );
+}

--- a/frontend/src/pages/container-detail.tsx
+++ b/frontend/src/pages/container-detail.tsx
@@ -4,6 +4,7 @@ import * as Tabs from '@radix-ui/react-tabs';
 import { useContainerDetail } from '@/hooks/use-container-detail';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { RefreshButton } from '@/components/shared/refresh-button';
+import { FavoriteButton } from '@/components/shared/favorite-button';
 import { ContainerOverview } from '@/components/container/container-overview';
 import { ContainerLogsViewer } from '@/components/container/container-logs-viewer';
 import { ContainerMetricsViewer } from '@/components/container/container-metrics-viewer';
@@ -108,7 +109,10 @@ export default function ContainerDetailPage() {
             <ArrowLeft className="h-4 w-4" />
           </button>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">{container.name}</h1>
+            <div className="flex items-center gap-2">
+              <h1 className="text-3xl font-bold tracking-tight">{container.name}</h1>
+              <FavoriteButton endpointId={parsedEndpointId} containerId={containerId} />
+            </div>
             <p className="text-muted-foreground">
               {container.id.slice(0, 12)} • {container.endpointName}
             </p>

--- a/frontend/src/pages/workload-explorer.tsx
+++ b/frontend/src/pages/workload-explorer.tsx
@@ -9,6 +9,7 @@ import { DataTable } from '@/components/shared/data-table';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
 import { RefreshButton } from '@/components/shared/refresh-button';
+import { FavoriteButton } from '@/components/shared/favorite-button';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { formatDate, truncate } from '@/lib/utils';
 
@@ -63,12 +64,15 @@ export default function WorkloadExplorerPage() {
       cell: ({ row, getValue }) => {
         const container = row.original;
         return (
-          <button
-            onClick={() => navigate(`/containers/${container.endpointId}/${container.id}`)}
-            className="inline-flex items-center rounded-lg bg-primary/10 px-3 py-1 text-sm font-medium text-primary transition-all duration-200 hover:bg-primary/20 hover:shadow-sm hover:ring-1 hover:ring-primary/20"
-          >
-            {truncate(getValue<string>(), 45)}
-          </button>
+          <div className="flex items-center gap-1">
+            <FavoriteButton size="sm" endpointId={container.endpointId} containerId={container.id} />
+            <button
+              onClick={() => navigate(`/containers/${container.endpointId}/${container.id}`)}
+              className="inline-flex items-center rounded-lg bg-primary/10 px-3 py-1 text-sm font-medium text-primary transition-all duration-200 hover:bg-primary/20 hover:shadow-sm hover:ring-1 hover:ring-primary/20"
+            >
+              {truncate(getValue<string>(), 45)}
+            </button>
+          </div>
         );
       },
     },

--- a/frontend/src/stores/favorites-store.test.ts
+++ b/frontend/src/stores/favorites-store.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useFavoritesStore } from './favorites-store';
+
+describe('useFavoritesStore', () => {
+  beforeEach(() => {
+    useFavoritesStore.setState({ favoriteIds: [] });
+  });
+
+  describe('initial state', () => {
+    it('should have empty favoriteIds by default', () => {
+      const state = useFavoritesStore.getState();
+      expect(state.favoriteIds).toEqual([]);
+    });
+  });
+
+  describe('toggleFavorite', () => {
+    it('should add a favorite when not present', () => {
+      const { toggleFavorite } = useFavoritesStore.getState();
+
+      toggleFavorite(1, 'abc123');
+
+      expect(useFavoritesStore.getState().favoriteIds).toEqual(['1:abc123']);
+    });
+
+    it('should remove a favorite when already present', () => {
+      const { toggleFavorite } = useFavoritesStore.getState();
+
+      toggleFavorite(1, 'abc123');
+      toggleFavorite(1, 'abc123');
+
+      expect(useFavoritesStore.getState().favoriteIds).toEqual([]);
+    });
+
+    it('should handle multiple favorites', () => {
+      const { toggleFavorite } = useFavoritesStore.getState();
+
+      toggleFavorite(1, 'abc');
+      toggleFavorite(2, 'def');
+      toggleFavorite(1, 'ghi');
+
+      expect(useFavoritesStore.getState().favoriteIds).toEqual([
+        '1:abc',
+        '2:def',
+        '1:ghi',
+      ]);
+    });
+
+    it('should only remove the toggled favorite', () => {
+      const { toggleFavorite } = useFavoritesStore.getState();
+
+      toggleFavorite(1, 'abc');
+      toggleFavorite(2, 'def');
+      toggleFavorite(1, 'abc');
+
+      expect(useFavoritesStore.getState().favoriteIds).toEqual(['2:def']);
+    });
+  });
+
+  describe('isFavorite', () => {
+    it('should return false when not favorited', () => {
+      const { isFavorite } = useFavoritesStore.getState();
+      expect(isFavorite(1, 'abc')).toBe(false);
+    });
+
+    it('should return true when favorited', () => {
+      const { toggleFavorite } = useFavoritesStore.getState();
+      toggleFavorite(1, 'abc');
+
+      const { isFavorite } = useFavoritesStore.getState();
+      expect(isFavorite(1, 'abc')).toBe(true);
+    });
+
+    it('should return false after un-favoriting', () => {
+      const { toggleFavorite } = useFavoritesStore.getState();
+      toggleFavorite(1, 'abc');
+      toggleFavorite(1, 'abc');
+
+      const { isFavorite } = useFavoritesStore.getState();
+      expect(isFavorite(1, 'abc')).toBe(false);
+    });
+  });
+
+  describe('removeFavorite', () => {
+    it('should remove a specific favorite', () => {
+      const { toggleFavorite } = useFavoritesStore.getState();
+      toggleFavorite(1, 'abc');
+      toggleFavorite(2, 'def');
+
+      const { removeFavorite } = useFavoritesStore.getState();
+      removeFavorite(1, 'abc');
+
+      expect(useFavoritesStore.getState().favoriteIds).toEqual(['2:def']);
+    });
+
+    it('should be a no-op when favorite does not exist', () => {
+      const { toggleFavorite } = useFavoritesStore.getState();
+      toggleFavorite(1, 'abc');
+
+      const { removeFavorite } = useFavoritesStore.getState();
+      removeFavorite(99, 'nonexistent');
+
+      expect(useFavoritesStore.getState().favoriteIds).toEqual(['1:abc']);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('should remove all favorites', () => {
+      const { toggleFavorite } = useFavoritesStore.getState();
+      toggleFavorite(1, 'a');
+      toggleFavorite(2, 'b');
+      toggleFavorite(3, 'c');
+
+      const { clearAll } = useFavoritesStore.getState();
+      clearAll();
+
+      expect(useFavoritesStore.getState().favoriteIds).toEqual([]);
+    });
+
+    it('should work when already empty', () => {
+      const { clearAll } = useFavoritesStore.getState();
+      clearAll();
+
+      expect(useFavoritesStore.getState().favoriteIds).toEqual([]);
+    });
+
+    it('should allow adding favorites again after clearing', () => {
+      const { toggleFavorite, clearAll } = useFavoritesStore.getState();
+
+      toggleFavorite(1, 'abc');
+      clearAll();
+      toggleFavorite(2, 'def');
+
+      expect(useFavoritesStore.getState().favoriteIds).toEqual(['2:def']);
+    });
+  });
+});

--- a/frontend/src/stores/favorites-store.ts
+++ b/frontend/src/stores/favorites-store.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+function toKey(endpointId: number, containerId: string): string {
+  return `${endpointId}:${containerId}`;
+}
+
+interface FavoritesState {
+  favoriteIds: string[];
+  toggleFavorite: (endpointId: number, containerId: string) => void;
+  removeFavorite: (endpointId: number, containerId: string) => void;
+  isFavorite: (endpointId: number, containerId: string) => boolean;
+  clearAll: () => void;
+}
+
+export const useFavoritesStore = create<FavoritesState>()(
+  persist(
+    (set, get) => ({
+      favoriteIds: [],
+      toggleFavorite: (endpointId, containerId) =>
+        set((state) => {
+          const key = toKey(endpointId, containerId);
+          const exists = state.favoriteIds.includes(key);
+          return {
+            favoriteIds: exists
+              ? state.favoriteIds.filter((id) => id !== key)
+              : [...state.favoriteIds, key],
+          };
+        }),
+      removeFavorite: (endpointId, containerId) =>
+        set((state) => {
+          const key = toKey(endpointId, containerId);
+          return { favoriteIds: state.favoriteIds.filter((id) => id !== key) };
+        }),
+      isFavorite: (endpointId, containerId) => {
+        const key = toKey(endpointId, containerId);
+        return get().favoriteIds.includes(key);
+      },
+      clearAll: () => set({ favoriteIds: [] }),
+    }),
+    {
+      name: 'container-favorites',
+      partialize: (state) => ({ favoriteIds: state.favoriteIds }),
+    },
+  ),
+);


### PR DESCRIPTION
* feat(frontend): Implement keyboard shortcuts for power user navigation

This commit implements keyboard shortcuts for power user navigation as requested in issue #37.

Changes include:
- Created a  custom hook to handle global keyboard events.
- Integrated the  hook into  to enable navigation to main sections and toggle the command palette using keyboard shortcuts.
- Added  mock in  to fix failing tests related to Zustand persistence.
- Updated  with a new section detailing the available keyboard shortcuts.

* feat(frontend): Add favorite/pinned containers with localStorage persistence

Add star/favorite toggle to container lists and detail views, persist favorites in localStorage via Zustand, and show a "Pinned Favorites" section on the Home dashboard.

Closes #39



---------