### PR TITLE
feat: Add cache invalidation mechanism with force refresh UI

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -24,6 +24,7 @@ import { logsRoutes } from './routes/logs.js';
 import { imagesRoutes } from './routes/images.js';
 import { networksRoutes } from './routes/networks.js';
 import { searchRoutes } from './routes/search.js';
+import { cacheAdminRoutes } from './routes/cache-admin.js';
 
 export async function buildApp() {
   const isDev = process.env.NODE_ENV !== 'production';
@@ -72,6 +73,7 @@ export async function buildApp() {
   await app.register(imagesRoutes);
   await app.register(networksRoutes);
   await app.register(searchRoutes);
+  await app.register(cacheAdminRoutes);
 
   // Static files (production only)
   await app.register(staticPlugin);

--- a/backend/src/routes/cache-admin.test.ts
+++ b/backend/src/routes/cache-admin.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { cacheAdminRoutes } from './cache-admin.js';
+
+vi.mock('../services/portainer-cache.js', () => ({
+  cache: {
+    getStats: vi.fn(),
+    getEntries: vi.fn(),
+    clear: vi.fn(),
+    invalidatePattern: vi.fn(),
+  },
+}));
+
+vi.mock('../services/audit-logger.js', () => ({
+  writeAuditLog: vi.fn(),
+}));
+
+import { cache } from '../services/portainer-cache.js';
+import { writeAuditLog } from '../services/audit-logger.js';
+
+const mockCache = vi.mocked(cache);
+const mockWriteAuditLog = vi.mocked(writeAuditLog);
+
+describe('Cache Admin Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    app.decorate('authenticate', async () => undefined);
+    await app.register(cacheAdminRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/admin/cache/stats', () => {
+    it('returns cache statistics and entries', async () => {
+      mockCache.getStats.mockReturnValue({
+        size: 5,
+        hits: 100,
+        misses: 20,
+        hitRate: '83.3%',
+      });
+      mockCache.getEntries.mockReturnValue([
+        { key: 'endpoints', expiresIn: 120 },
+        { key: 'containers:1', expiresIn: 45 },
+      ]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/admin/cache/stats',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.size).toBe(5);
+      expect(body.hits).toBe(100);
+      expect(body.misses).toBe(20);
+      expect(body.hitRate).toBe('83.3%');
+      expect(body.entries).toHaveLength(2);
+      expect(body.entries[0].key).toBe('endpoints');
+    });
+  });
+
+  describe('POST /api/admin/cache/clear', () => {
+    it('clears cache and writes audit log', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/admin/cache/clear',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(mockCache.clear).toHaveBeenCalledTimes(1);
+      expect(mockWriteAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'cache.clear',
+          target_type: 'cache',
+          target_id: '*',
+        }),
+      );
+    });
+  });
+
+  describe('POST /api/admin/cache/invalidate', () => {
+    it('invalidates cache pattern and writes audit log', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/admin/cache/invalidate?resource=containers',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(body.resource).toBe('containers');
+      expect(mockCache.invalidatePattern).toHaveBeenCalledWith('containers');
+      expect(mockWriteAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'cache.invalidate',
+          target_type: 'cache',
+          target_id: 'containers',
+        }),
+      );
+    });
+
+    it('rejects invalid resource with 400', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/admin/cache/invalidate?resource=invalid',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('rejects missing resource param with 400', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/admin/cache/invalidate',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+});

--- a/backend/src/routes/cache-admin.ts
+++ b/backend/src/routes/cache-admin.ts
@@ -1,0 +1,90 @@
+import { FastifyInstance } from 'fastify';
+import { cache } from '../services/portainer-cache.js';
+import { writeAuditLog } from '../services/audit-logger.js';
+
+const VALID_RESOURCES = ['endpoints', 'containers', 'images', 'networks', 'stacks'] as const;
+type CacheResource = (typeof VALID_RESOURCES)[number];
+
+export async function cacheAdminRoutes(fastify: FastifyInstance) {
+  // Get cache stats + entries
+  fastify.get('/api/admin/cache/stats', {
+    schema: {
+      tags: ['Cache Admin'],
+      summary: 'Get cache statistics and active entries',
+      security: [{ bearerAuth: [] }],
+    },
+    preHandler: [fastify.authenticate],
+  }, async () => {
+    return {
+      ...cache.getStats(),
+      entries: cache.getEntries(),
+    };
+  });
+
+  // Clear entire cache
+  fastify.post('/api/admin/cache/clear', {
+    schema: {
+      tags: ['Cache Admin'],
+      summary: 'Clear all cache entries',
+      security: [{ bearerAuth: [] }],
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request) => {
+    cache.clear();
+
+    writeAuditLog({
+      user_id: request.user?.sub,
+      username: request.user?.username,
+      action: 'cache.clear',
+      target_type: 'cache',
+      target_id: '*',
+      request_id: request.requestId,
+      ip_address: request.ip,
+    });
+
+    return { success: true };
+  });
+
+  // Invalidate cache by resource pattern
+  fastify.post('/api/admin/cache/invalidate', {
+    schema: {
+      tags: ['Cache Admin'],
+      summary: 'Invalidate cache entries matching a resource pattern',
+      security: [{ bearerAuth: [] }],
+      querystring: {
+        type: 'object',
+        required: ['resource'],
+        properties: {
+          resource: { type: 'string', enum: [...VALID_RESOURCES] },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const { resource } = request.query as { resource?: string };
+
+    if (!resource) {
+      return reply.status(400).send({ error: 'Missing required query parameter: resource' });
+    }
+
+    if (!VALID_RESOURCES.includes(resource as CacheResource)) {
+      return reply.status(400).send({
+        error: `Invalid resource: ${resource}. Must be one of: ${VALID_RESOURCES.join(', ')}`,
+      });
+    }
+
+    cache.invalidatePattern(resource);
+
+    writeAuditLog({
+      user_id: request.user?.sub,
+      username: request.user?.username,
+      action: 'cache.invalidate',
+      target_type: 'cache',
+      target_id: resource,
+      request_id: request.requestId,
+      ip_address: request.ip,
+    });
+
+    return { success: true, resource };
+  });
+}

--- a/backend/src/services/portainer-cache.ts
+++ b/backend/src/services/portainer-cache.ts
@@ -47,6 +47,19 @@ class TtlCache {
     }
   }
 
+  getEntries(): Array<{ key: string; expiresIn: number }> {
+    const now = Date.now();
+    const entries: Array<{ key: string; expiresIn: number }> = [];
+    for (const [key, entry] of this.store.entries()) {
+      if (now > entry.expiresAt) {
+        this.store.delete(key);
+        continue;
+      }
+      entries.push({ key, expiresIn: Math.round((entry.expiresAt - now) / 1000) });
+    }
+    return entries;
+  }
+
   clear(): void {
     this.store.clear();
     log.info('Cache cleared');

--- a/frontend/src/components/shared/refresh-button.test.tsx
+++ b/frontend/src/components/shared/refresh-button.test.tsx
@@ -107,4 +107,59 @@ describe('RefreshButton', () => {
     expect(icon).toHaveClass('h-4');
     expect(icon).toHaveClass('w-4');
   });
+
+  describe('split-button (with onForceRefresh)', () => {
+    it('should render single button when no onForceRefresh', () => {
+      const onClick = vi.fn();
+      render(<RefreshButton onClick={onClick} />);
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons).toHaveLength(1);
+    });
+
+    it('should render two buttons when onForceRefresh provided', () => {
+      const onClick = vi.fn();
+      const onForceRefresh = vi.fn();
+      render(<RefreshButton onClick={onClick} onForceRefresh={onForceRefresh} />);
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons).toHaveLength(2);
+    });
+
+    it('should call onForceRefresh (not onClick) when force refresh button clicked', () => {
+      const onClick = vi.fn();
+      const onForceRefresh = vi.fn();
+      render(<RefreshButton onClick={onClick} onForceRefresh={onForceRefresh} />);
+
+      const buttons = screen.getAllByRole('button');
+      fireEvent.click(buttons[1]); // second button is force refresh
+
+      expect(onForceRefresh).toHaveBeenCalledTimes(1);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('should disable both buttons when loading', () => {
+      const onClick = vi.fn();
+      const onForceRefresh = vi.fn();
+      render(
+        <RefreshButton onClick={onClick} onForceRefresh={onForceRefresh} isLoading={true} />
+      );
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons[0]).toBeDisabled();
+      expect(buttons[1]).toBeDisabled();
+    });
+
+    it('should still call onClick on first button in split mode', () => {
+      const onClick = vi.fn();
+      const onForceRefresh = vi.fn();
+      render(<RefreshButton onClick={onClick} onForceRefresh={onForceRefresh} />);
+
+      const buttons = screen.getAllByRole('button');
+      fireEvent.click(buttons[0]);
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(onForceRefresh).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/components/shared/refresh-button.tsx
+++ b/frontend/src/components/shared/refresh-button.tsx
@@ -1,24 +1,48 @@
-import { RefreshCw } from 'lucide-react';
+import { RefreshCw, Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface RefreshButtonProps {
   onClick: () => void;
   isLoading?: boolean;
   className?: string;
+  onForceRefresh?: () => void;
 }
 
-export function RefreshButton({ onClick, isLoading, className }: RefreshButtonProps) {
+export function RefreshButton({ onClick, isLoading, className, onForceRefresh }: RefreshButtonProps) {
+  if (!onForceRefresh) {
+    return (
+      <button
+        onClick={onClick}
+        disabled={isLoading}
+        className={cn(
+          'inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50',
+          className
+        )}
+      >
+        <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
+        Refresh
+      </button>
+    );
+  }
+
   return (
-    <button
-      onClick={onClick}
-      disabled={isLoading}
-      className={cn(
-        'inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50',
-        className
-      )}
-    >
-      <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
-      Refresh
-    </button>
+    <div className={cn('inline-flex items-center', className)}>
+      <button
+        onClick={onClick}
+        disabled={isLoading}
+        className="inline-flex items-center gap-2 rounded-l-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
+      >
+        <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
+        Refresh
+      </button>
+      <button
+        onClick={onForceRefresh}
+        disabled={isLoading}
+        title="Force refresh (bypass backend cache)"
+        className="inline-flex items-center rounded-r-md border border-l-0 border-input bg-background px-2 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
+      >
+        <Zap className="h-4 w-4" />
+      </button>
+    </div>
   );
 }

--- a/frontend/src/hooks/use-cache-admin.ts
+++ b/frontend/src/hooks/use-cache-admin.ts
@@ -1,0 +1,34 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+interface CacheEntry {
+  key: string;
+  expiresIn: number;
+}
+
+interface CacheStats {
+  size: number;
+  hits: number;
+  misses: number;
+  hitRate: string;
+  entries: CacheEntry[];
+}
+
+export function useCacheStats() {
+  return useQuery<CacheStats>({
+    queryKey: ['admin', 'cache', 'stats'],
+    queryFn: () => api.get<CacheStats>('/api/admin/cache/stats'),
+    refetchInterval: 10_000,
+  });
+}
+
+export function useCacheClear() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => api.post('/api/admin/cache/clear'),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'cache', 'stats'] });
+    },
+  });
+}

--- a/frontend/src/hooks/use-force-refresh.test.ts
+++ b/frontend/src/hooks/use-force-refresh.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useForceRefresh } from './use-force-refresh';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    request: vi.fn(),
+  },
+}));
+
+import { api } from '@/lib/api';
+
+const mockApi = vi.mocked(api);
+
+describe('useForceRefresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls invalidate endpoint then refetch', async () => {
+    mockApi.request.mockResolvedValue({ success: true });
+    const refetch = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useForceRefresh('containers', refetch));
+
+    await act(async () => {
+      await result.current.forceRefresh();
+    });
+
+    expect(mockApi.request).toHaveBeenCalledWith('/api/admin/cache/invalidate', {
+      method: 'POST',
+      params: { resource: 'containers' },
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('still refetches if invalidation fails', async () => {
+    mockApi.request.mockRejectedValue(new Error('Network error'));
+    const refetch = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useForceRefresh('endpoints', refetch));
+
+    await act(async () => {
+      await result.current.forceRefresh();
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks isForceRefreshing loading state', async () => {
+    let resolveRefetch: () => void;
+    const refetchPromise = new Promise<void>((resolve) => {
+      resolveRefetch = resolve;
+    });
+    mockApi.request.mockResolvedValue({ success: true });
+    const refetch = vi.fn().mockReturnValue(refetchPromise);
+
+    const { result } = renderHook(() => useForceRefresh('stacks', refetch));
+
+    expect(result.current.isForceRefreshing).toBe(false);
+
+    let forceRefreshPromise: Promise<void>;
+    act(() => {
+      forceRefreshPromise = result.current.forceRefresh();
+    });
+
+    // Wait for microtasks to flush (the invalidate .catch() resolves)
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isForceRefreshing).toBe(true);
+
+    await act(async () => {
+      resolveRefetch!();
+      await forceRefreshPromise!;
+    });
+
+    expect(result.current.isForceRefreshing).toBe(false);
+  });
+});

--- a/frontend/src/hooks/use-force-refresh.ts
+++ b/frontend/src/hooks/use-force-refresh.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+import { api } from '@/lib/api';
+
+type CacheResource = 'endpoints' | 'containers' | 'images' | 'networks' | 'stacks';
+
+export function useForceRefresh(resource: CacheResource, refetch: () => Promise<unknown>) {
+  const [isForceRefreshing, setIsForceRefreshing] = useState(false);
+
+  const forceRefresh = useCallback(async () => {
+    setIsForceRefreshing(true);
+    try {
+      await api.request('/api/admin/cache/invalidate', {
+        method: 'POST',
+        params: { resource },
+      }).catch(() => {
+        // swallow invalidation errors - still refetch below
+      });
+      await refetch();
+    } finally {
+      setIsForceRefreshing(false);
+    }
+  }, [resource, refetch]);
+
+  return { forceRefresh, isForceRefreshing };
+}

--- a/frontend/src/pages/container-detail.tsx
+++ b/frontend/src/pages/container-detail.tsx
@@ -4,6 +4,7 @@ import * as Tabs from '@radix-ui/react-tabs';
 import { useContainerDetail } from '@/hooks/use-container-detail';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { RefreshButton } from '@/components/shared/refresh-button';
+import { useForceRefresh } from '@/hooks/use-force-refresh';
 import { FavoriteButton } from '@/components/shared/favorite-button';
 import { ContainerOverview } from '@/components/container/container-overview';
 import { ContainerLogsViewer } from '@/components/container/container-logs-viewer';
@@ -27,6 +28,7 @@ export default function ContainerDetailPage() {
     refetch,
     isFetching
   } = useContainerDetail(parsedEndpointId!, containerId!);
+  const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', refetch);
 
   // Handle tab change
   const handleTabChange = (value: string) => {
@@ -118,7 +120,7 @@ export default function ContainerDetailPage() {
             </p>
           </div>
         </div>
-        <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
+        <RefreshButton onClick={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
       </div>
 
       {/* Tabs */}

--- a/frontend/src/pages/container-health.tsx
+++ b/frontend/src/pages/container-health.tsx
@@ -16,6 +16,7 @@ import { useAutoRefresh } from '@/hooks/use-auto-refresh';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
 import { RefreshButton } from '@/components/shared/refresh-button';
+import { useForceRefresh } from '@/hooks/use-force-refresh';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 
 interface HealthStats {
@@ -125,6 +126,7 @@ function UnhealthyContainerRow({ container, onClick }: UnhealthyContainerRowProp
 export default function ContainerHealthPage() {
   const navigate = useNavigate();
   const { data: containers, isLoading, isError, error, refetch, isFetching } = useContainers();
+  const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', refetch);
   const { interval, setInterval } = useAutoRefresh(30);
 
   const stats = useMemo(() => {
@@ -202,7 +204,7 @@ export default function ContainerHealthPage() {
         </div>
         <div className="flex items-center gap-2">
           <AutoRefreshToggle interval={interval} onIntervalChange={setInterval} />
-          <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
+          <RefreshButton onClick={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
         </div>
       </div>
 

--- a/frontend/src/pages/fleet-overview.tsx
+++ b/frontend/src/pages/fleet-overview.tsx
@@ -8,6 +8,7 @@ import { DataTable } from '@/components/shared/data-table';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
 import { RefreshButton } from '@/components/shared/refresh-button';
+import { useForceRefresh } from '@/hooks/use-force-refresh';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { cn } from '@/lib/utils';
 
@@ -89,6 +90,7 @@ export default function FleetOverviewPage() {
   const navigate = useNavigate();
 
   const { data: endpoints, isLoading, isError, error, refetch, isFetching } = useEndpoints();
+  const { forceRefresh, isForceRefreshing } = useForceRefresh('endpoints', refetch);
   const { interval, setInterval } = useAutoRefresh(30);
 
   const handleEndpointClick = (endpointId: number) => {
@@ -200,7 +202,7 @@ export default function FleetOverviewPage() {
         </div>
         <div className="flex items-center gap-2">
           <AutoRefreshToggle interval={interval} onIntervalChange={setInterval} />
-          <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
+          <RefreshButton onClick={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
         </div>
       </div>
 

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -11,6 +11,7 @@ import { StatusBadge } from '@/components/shared/status-badge';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
 import { RefreshButton } from '@/components/shared/refresh-button';
+import { useForceRefresh } from '@/hooks/use-force-refresh';
 import { FavoriteButton } from '@/components/shared/favorite-button';
 import { ContainerStatePie } from '@/components/charts/container-state-pie';
 import { EndpointStatusBar } from '@/components/charts/endpoint-status-bar';
@@ -21,6 +22,7 @@ import { formatDate, truncate } from '@/lib/utils';
 export default function HomePage() {
   const navigate = useNavigate();
   const { data, isLoading, isError, error, refetch, isFetching } = useDashboard();
+  const { forceRefresh, isForceRefreshing } = useForceRefresh('endpoints', refetch);
   const { interval, setInterval } = useAutoRefresh(30);
   const favoriteIds = useFavoritesStore((s) => s.favoriteIds);
   const { data: allContainers } = useContainers();
@@ -143,7 +145,7 @@ export default function HomePage() {
         </div>
         <div className="flex items-center gap-2">
           <AutoRefreshToggle interval={interval} onIntervalChange={setInterval} />
-          <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
+          <RefreshButton onClick={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
         </div>
       </div>
 

--- a/frontend/src/pages/image-footprint.tsx
+++ b/frontend/src/pages/image-footprint.tsx
@@ -7,6 +7,7 @@ import { ImageTreemap } from '@/components/charts/image-treemap';
 import { ImageSunburst } from '@/components/charts/image-sunburst';
 import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
 import { RefreshButton } from '@/components/shared/refresh-button';
+import { useForceRefresh } from '@/hooks/use-force-refresh';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { formatBytes } from '@/lib/utils';
 import { cn } from '@/lib/utils';
@@ -17,6 +18,7 @@ export default function ImageFootprintPage() {
 
   const { data: endpoints } = useEndpoints();
   const { data: images, isLoading, isError, error, refetch, isFetching } = useImages(selectedEndpoint);
+  const { forceRefresh, isForceRefreshing } = useForceRefresh('images', refetch);
   const { interval, setInterval } = useAutoRefresh(60);
 
   const stats = useMemo(() => {
@@ -92,7 +94,7 @@ export default function ImageFootprintPage() {
         </div>
         <div className="flex items-center gap-2">
           <AutoRefreshToggle interval={interval} onIntervalChange={setInterval} />
-          <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
+          <RefreshButton onClick={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
         </div>
       </div>
 

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react';
 import { useThemeStore, themeOptions, type Theme } from '@/stores/theme-store';
 import { useSettings, useUpdateSetting } from '@/hooks/use-settings';
+import { useCacheStats, useCacheClear } from '@/hooks/use-cache-admin';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
@@ -254,6 +255,8 @@ export default function SettingsPage() {
   const { theme, setTheme } = useThemeStore();
   const { data: settingsData, isLoading, isError, error, refetch } = useSettings();
   const updateSetting = useUpdateSetting();
+  const { data: cacheStats } = useCacheStats();
+  const cacheClear = useCacheClear();
 
   // Local state for edited values
   const [editedValues, setEditedValues] = useState<Record<string, string>>({});
@@ -551,6 +554,68 @@ export default function SettingsPage() {
         onChange={handleChange}
         disabled={isSaving}
       />
+
+      {/* Cache Status */}
+      <div className="rounded-lg border bg-card">
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div className="flex items-center gap-2">
+            <Database className="h-5 w-5" />
+            <h2 className="text-lg font-semibold">Cache Status</h2>
+          </div>
+          <button
+            onClick={() => cacheClear.mutate()}
+            disabled={cacheClear.isPending}
+            className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent disabled:opacity-50"
+          >
+            {cacheClear.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3.5 w-3.5" />
+            )}
+            Clear All Cache
+          </button>
+        </div>
+        <div className="p-4 space-y-4">
+          <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-lg bg-muted/50 p-4">
+              <p className="text-xs text-muted-foreground">Entries</p>
+              <p className="text-2xl font-bold mt-1">{cacheStats?.size ?? 0}</p>
+            </div>
+            <div className="rounded-lg bg-muted/50 p-4">
+              <p className="text-xs text-muted-foreground">Hits</p>
+              <p className="text-2xl font-bold mt-1">{cacheStats?.hits ?? 0}</p>
+            </div>
+            <div className="rounded-lg bg-muted/50 p-4">
+              <p className="text-xs text-muted-foreground">Misses</p>
+              <p className="text-2xl font-bold mt-1">{cacheStats?.misses ?? 0}</p>
+            </div>
+            <div className="rounded-lg bg-muted/50 p-4">
+              <p className="text-xs text-muted-foreground">Hit Rate</p>
+              <p className="text-2xl font-bold mt-1">{cacheStats?.hitRate ?? 'N/A'}</p>
+            </div>
+          </div>
+          {cacheStats?.entries && cacheStats.entries.length > 0 && (
+            <div className="rounded-lg border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="text-left p-3 font-medium">Cache Key</th>
+                    <th className="text-right p-3 font-medium">Expires In</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {cacheStats.entries.map((entry) => (
+                    <tr key={entry.key} className="border-b last:border-0">
+                      <td className="p-3 font-mono text-xs">{entry.key}</td>
+                      <td className="p-3 text-right text-muted-foreground">{entry.expiresIn}s</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
 
       {/* LLM Settings */}
       <SettingsSection

--- a/frontend/src/pages/stack-overview.tsx
+++ b/frontend/src/pages/stack-overview.tsx
@@ -9,6 +9,7 @@ import { DataTable } from '@/components/shared/data-table';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
 import { RefreshButton } from '@/components/shared/refresh-button';
+import { useForceRefresh } from '@/hooks/use-force-refresh';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { cn } from '@/lib/utils';
 
@@ -100,6 +101,7 @@ export default function StackOverviewPage() {
   const navigate = useNavigate();
 
   const { data: stacks, isLoading: stacksLoading, isError, error, refetch, isFetching } = useStacks();
+  const { forceRefresh, isForceRefreshing } = useForceRefresh('stacks', refetch);
   const { data: endpoints, isLoading: endpointsLoading } = useEndpoints();
   const { interval, setInterval } = useAutoRefresh(30);
 
@@ -223,7 +225,7 @@ export default function StackOverviewPage() {
         </div>
         <div className="flex items-center gap-2">
           <AutoRefreshToggle interval={interval} onIntervalChange={setInterval} />
-          <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
+          <RefreshButton onClick={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
         </div>
       </div>
 

--- a/frontend/src/pages/workload-explorer.tsx
+++ b/frontend/src/pages/workload-explorer.tsx
@@ -9,6 +9,7 @@ import { DataTable } from '@/components/shared/data-table';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
 import { RefreshButton } from '@/components/shared/refresh-button';
+import { useForceRefresh } from '@/hooks/use-force-refresh';
 import { FavoriteButton } from '@/components/shared/favorite-button';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { formatDate, truncate } from '@/lib/utils';
@@ -48,6 +49,7 @@ export default function WorkloadExplorerPage() {
 
   const { data: endpoints } = useEndpoints();
   const { data: containers, isLoading, isError, error, refetch, isFetching } = useContainers(selectedEndpoint);
+  const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', refetch);
   const { interval, setInterval } = useAutoRefresh(30);
 
   // Filter containers by stack if stack parameter is present
@@ -154,7 +156,7 @@ export default function WorkloadExplorerPage() {
         </div>
         <div className="flex items-center gap-2">
           <AutoRefreshToggle interval={interval} onIntervalChange={setInterval} />
-          <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
+          <RefreshButton onClick={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- **Backend**: 3 new auth-protected cache admin endpoints (`GET /api/admin/cache/stats`, `POST /api/admin/cache/clear`, `POST /api/admin/cache/invalidate?resource=X`) with audit logging
- **Frontend**: "Force Refresh" split-button on 7 pages that invalidates backend cache before refetching, plus a Cache Status card in Settings showing live KPIs (entries, hits, misses, hit rate) and active cache entries table
- **Backward compatible**: `RefreshButton` renders identically when `onForceRefresh` is not provided

Closes #42

## Changes

### New files (5)
| File | Purpose |
|---|---|
| `backend/src/routes/cache-admin.ts` | Cache admin endpoints |
| `backend/src/routes/cache-admin.test.ts` | 5 backend tests |
| `frontend/src/hooks/use-force-refresh.ts` | Hook to invalidate + refetch |
| `frontend/src/hooks/use-force-refresh.test.ts` | 3 frontend tests |
| `frontend/src/hooks/use-cache-admin.ts` | `useCacheStats` + `useCacheClear` hooks |

### Modified files (12)
| File | Change |
|---|---|
| `backend/src/services/portainer-cache.ts` | Added `getEntries()` to `TtlCache` |
| `backend/src/app.ts` | Register `cacheAdminRoutes` |
| `frontend/src/components/shared/refresh-button.tsx` | Split-button with optional `onForceRefresh` |
| `frontend/src/components/shared/refresh-button.test.tsx` | 5 new split-button tests |
| `frontend/src/pages/settings.tsx` | Cache Status card with KPIs and entries table |
| 7 pages (`home`, `fleet-overview`, `container-detail`, `container-health`, `workload-explorer`, `stack-overview`, `image-footprint`) | Force refresh integration (~3 lines each) |

## Test plan
- [x] Backend typecheck passes
- [x] Frontend typecheck passes
- [x] Backend tests pass (147 total, 5 new cache-admin tests)
- [x] Frontend tests pass (151 total, 8 new tests for refresh-button + use-force-refresh)
- [x] Lint passes for both workspaces
- [ ] Manual: verify split-button appears on pages with Zap icon
- [ ] Manual: verify force refresh invalidates cache and refetches fresh data
- [ ] Manual: verify Cache Status card in Settings shows live stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)