### PR TITLE
feat: Container comparison view for side-by-side diagnostics

### DIFF
--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -5,7 +5,7 @@ import {
   Ship,
   Layers,
   HeartPulse,
-  ScrollText,
+  GitCompareArrows,
   PackageOpen,
   Network,
   Brain,
@@ -50,6 +50,7 @@ const navigation: NavGroup[] = [
     title: 'Containers',
     items: [
       { label: 'Container Health', to: '/health', icon: HeartPulse },
+      { label: 'Comparison', to: '/comparison', icon: GitCompareArrows },
       { label: 'Image Footprint', to: '/images', icon: PackageOpen },
       { label: 'Network Topology', to: '/topology', icon: Network },
     ],

--- a/frontend/src/hooks/use-container-comparison.test.ts
+++ b/frontend/src/hooks/use-container-comparison.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import { useComparisonMetrics, ComparisonTarget } from './use-container-comparison';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+import { api } from '@/lib/api';
+const mockApi = vi.mocked(api);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useComparisonMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const targets: ComparisonTarget[] = [
+    { containerId: 'abc123', endpointId: 1, name: 'web-1' },
+    { containerId: 'def456', endpointId: 1, name: 'web-2' },
+  ];
+
+  it('should fetch metrics for each target', async () => {
+    mockApi.get.mockResolvedValue({
+      containerId: 'abc123',
+      endpointId: 1,
+      metricType: 'cpu',
+      timeRange: '1h',
+      data: [{ timestamp: '2025-01-01T00:00:00Z', value: 42 }],
+    });
+
+    const { result } = renderHook(
+      () => useComparisonMetrics(targets, 'cpu', '1h'),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockApi.get).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data[0].target.name).toBe('web-1');
+    expect(result.current.data[1].target.name).toBe('web-2');
+  });
+
+  it('should not fetch when fewer than 2 targets', async () => {
+    const singleTarget = [targets[0]];
+
+    renderHook(
+      () => useComparisonMetrics(singleTarget, 'cpu', '1h'),
+      { wrapper: createWrapper() },
+    );
+
+    // Wait a tick — query should NOT fire
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockApi.get).not.toHaveBeenCalled();
+  });
+
+  it('should report isError when a request fails', async () => {
+    mockApi.get
+      .mockResolvedValueOnce({
+        containerId: 'abc123',
+        endpointId: 1,
+        metricType: 'cpu',
+        timeRange: '1h',
+        data: [],
+      })
+      .mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(
+      () => useComparisonMetrics(targets, 'cpu', '1h'),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(true);
+  });
+});

--- a/frontend/src/hooks/use-container-comparison.ts
+++ b/frontend/src/hooks/use-container-comparison.ts
@@ -1,0 +1,50 @@
+import { useQueries } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+interface MetricDataPoint {
+  timestamp: string;
+  value: number;
+}
+
+interface ContainerMetrics {
+  containerId: string;
+  endpointId: number;
+  metricType: string;
+  timeRange: string;
+  data: MetricDataPoint[];
+}
+
+export interface ComparisonTarget {
+  containerId: string;
+  endpointId: number;
+  name: string;
+}
+
+export function useComparisonMetrics(
+  targets: ComparisonTarget[],
+  metricType: string,
+  timeRange: string,
+) {
+  const queries = useQueries({
+    queries: targets.map((target) => ({
+      queryKey: ['metrics', target.endpointId, target.containerId, metricType, timeRange],
+      queryFn: () =>
+        api.get<ContainerMetrics>(
+          `/api/metrics/${target.endpointId}/${target.containerId}`,
+          { params: { metricType, timeRange } },
+        ),
+      enabled: targets.length >= 2,
+    })),
+  });
+
+  const isLoading = queries.some((q) => q.isLoading);
+  const isError = queries.some((q) => q.isError);
+  const data = queries.map((q, i) => ({
+    target: targets[i],
+    metrics: q.data,
+    isLoading: q.isLoading,
+    isError: q.isError,
+  }));
+
+  return { data, isLoading, isError, queries };
+}

--- a/frontend/src/pages/container-comparison.test.tsx
+++ b/frontend/src/pages/container-comparison.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { createElement } from 'react';
+import ContainerComparison from './container-comparison';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+vi.mock('@/hooks/use-auto-refresh', () => ({
+  useAutoRefresh: () => ({
+    interval: 30,
+    setInterval: vi.fn(),
+    enabled: true,
+    toggle: vi.fn(),
+    options: [0, 15, 30, 60, 120, 300],
+  }),
+}));
+
+vi.mock('recharts', () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) =>
+    createElement('div', { 'data-testid': 'line-chart' }, children),
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) =>
+    createElement('div', null, children),
+}));
+
+import { api } from '@/lib/api';
+const mockApi = vi.mocked(api);
+
+const mockContainers = [
+  {
+    id: 'abc123',
+    name: 'web-app-1',
+    image: 'nginx:latest',
+    state: 'running',
+    status: 'Up 2 hours',
+    endpointId: 1,
+    endpointName: 'prod-1',
+    ports: [],
+    created: 1700000000,
+    labels: { 'com.docker.compose.service': 'web' },
+    networks: ['bridge'],
+    healthStatus: 'healthy',
+  },
+  {
+    id: 'def456',
+    name: 'web-app-2',
+    image: 'nginx:latest',
+    state: 'running',
+    status: 'Up 3 hours',
+    endpointId: 1,
+    endpointName: 'prod-1',
+    ports: [],
+    created: 1700000100,
+    labels: { 'com.docker.compose.service': 'web', 'version': '2.0' },
+    networks: ['bridge', 'backend'],
+    healthStatus: 'unhealthy',
+  },
+  {
+    id: 'ghi789',
+    name: 'api-server',
+    image: 'node:20',
+    state: 'exited',
+    status: 'Exited (0)',
+    endpointId: 2,
+    endpointName: 'staging',
+    ports: [],
+    created: 1699999900,
+    labels: {},
+    networks: [],
+  },
+];
+
+function createWrapper(initialEntries = ['/comparison']) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(MemoryRouter, { initialEntries }, children),
+    );
+}
+
+describe('ContainerComparison', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.get.mockResolvedValue(mockContainers);
+  });
+
+  it('should render the page header', async () => {
+    render(createElement(ContainerComparison), { wrapper: createWrapper() });
+
+    expect(screen.getByText('Container Comparison')).toBeInTheDocument();
+    expect(
+      screen.getByText('Compare metrics, configuration, and status across containers'),
+    ).toBeInTheDocument();
+  });
+
+  it('should show "Add container" button', async () => {
+    render(createElement(ContainerComparison), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Add container')).toBeInTheDocument();
+    });
+  });
+
+  it('should show info message when fewer than 2 containers selected', async () => {
+    render(createElement(ContainerComparison), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Select at least 2 containers to compare/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show container search dropdown when clicking Add', async () => {
+    render(createElement(ContainerComparison), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Add container')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Add container'));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search containers...')).toBeInTheDocument();
+    });
+  });
+
+  it('should show containers in search dropdown', async () => {
+    render(createElement(ContainerComparison), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Add container')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Add container'));
+
+    await waitFor(() => {
+      expect(screen.getByText('web-app-1')).toBeInTheDocument();
+      expect(screen.getByText('web-app-2')).toBeInTheDocument();
+      expect(screen.getByText('api-server')).toBeInTheDocument();
+    });
+  });
+
+  it('should filter containers by search text', async () => {
+    render(createElement(ContainerComparison), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Add container')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Add container'));
+
+    const searchInput = screen.getByPlaceholderText('Search containers...');
+    fireEvent.change(searchInput, { target: { value: 'api' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('api-server')).toBeInTheDocument();
+      expect(screen.queryByText('web-app-1')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/container-comparison.tsx
+++ b/frontend/src/pages/container-comparison.tsx
@@ -1,0 +1,577 @@
+import { useState, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { Plus, X, GitCompareArrows, BarChart3, Info, Clock } from 'lucide-react';
+import { useContainers, Container } from '@/hooks/use-containers';
+import { useComparisonMetrics, ComparisonTarget } from '@/hooks/use-container-comparison';
+import { formatDate, cn } from '@/lib/utils';
+import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
+import { RefreshButton } from '@/components/shared/refresh-button';
+import { useAutoRefresh } from '@/hooks/use-auto-refresh';
+import { useForceRefresh } from '@/hooks/use-force-refresh';
+
+const CHART_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444'];
+const TIME_RANGES = ['15m', '1h', '6h', '24h', '7d'] as const;
+const MAX_CONTAINERS = 4;
+
+function ContainerSelector({
+  containers,
+  selected,
+  onAdd,
+  onRemove,
+}: {
+  containers: Container[];
+  selected: ComparisonTarget[];
+  onAdd: (c: Container) => void;
+  onRemove: (containerId: string) => void;
+}) {
+  const [search, setSearch] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const selectedIds = new Set(selected.map((s) => s.containerId));
+  const filtered = containers.filter(
+    (c) =>
+      !selectedIds.has(c.id) &&
+      (c.name.toLowerCase().includes(search.toLowerCase()) ||
+        c.image.toLowerCase().includes(search.toLowerCase()) ||
+        c.endpointName.toLowerCase().includes(search.toLowerCase())),
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {selected.map((target, i) => (
+          <div
+            key={target.containerId}
+            className="flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm"
+            style={{ borderColor: CHART_COLORS[i] }}
+          >
+            <div
+              className="h-3 w-3 rounded-full"
+              style={{ backgroundColor: CHART_COLORS[i] }}
+            />
+            <span className="font-medium">{target.name}</span>
+            <button
+              onClick={() => onRemove(target.containerId)}
+              className="ml-1 rounded p-0.5 hover:bg-muted"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        ))}
+
+        {selected.length < MAX_CONTAINERS && (
+          <div className="relative">
+            <button
+              onClick={() => setOpen(!open)}
+              className="flex items-center gap-1.5 rounded-lg border border-dashed px-3 py-1.5 text-sm text-muted-foreground hover:border-primary hover:text-foreground transition-colors"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Add container
+            </button>
+
+            {open && (
+              <div className="absolute left-0 top-full z-50 mt-1 w-80 rounded-lg border bg-popover shadow-lg">
+                <div className="p-2">
+                  <input
+                    type="text"
+                    placeholder="Search containers..."
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none focus:ring-1 focus:ring-primary"
+                    autoFocus
+                  />
+                </div>
+                <ul className="max-h-48 overflow-y-auto p-1">
+                  {filtered.length === 0 ? (
+                    <li className="px-3 py-2 text-sm text-muted-foreground">
+                      No containers found
+                    </li>
+                  ) : (
+                    filtered.slice(0, 20).map((c) => (
+                      <li key={c.id}>
+                        <button
+                          onClick={() => {
+                            onAdd(c);
+                            setOpen(false);
+                            setSearch('');
+                          }}
+                          className="flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-sm hover:bg-accent text-left"
+                        >
+                          <div className="flex-1 min-w-0">
+                            <div className="truncate font-medium">{c.name}</div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              {c.image} &middot; {c.endpointName}
+                            </div>
+                          </div>
+                          <span
+                            className={cn(
+                              'shrink-0 rounded-full px-1.5 py-0.5 text-xs',
+                              c.state === 'running'
+                                ? 'bg-emerald-500/10 text-emerald-500'
+                                : 'bg-gray-500/10 text-gray-500',
+                            )}
+                          >
+                            {c.state}
+                          </span>
+                        </button>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {selected.length < 2 && (
+        <p className="text-sm text-muted-foreground flex items-center gap-1.5">
+          <Info className="h-3.5 w-3.5" />
+          Select at least 2 containers to compare (max {MAX_CONTAINERS})
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ComparisonChart({
+  targets,
+  metricType,
+  timeRange,
+  label,
+  unit,
+}: {
+  targets: ComparisonTarget[];
+  metricType: string;
+  timeRange: string;
+  label: string;
+  unit: string;
+}) {
+  const { data, isLoading } = useComparisonMetrics(targets, metricType, timeRange);
+
+  // Merge all time series by timestamp
+  const merged = useMemo(() => {
+    const timeMap = new Map<string, Record<string, number>>();
+
+    data.forEach(({ target, metrics }) => {
+      metrics?.data.forEach((point) => {
+        const existing = timeMap.get(point.timestamp) || {};
+        existing[target.containerId] = point.value;
+        timeMap.set(point.timestamp, existing);
+      });
+    });
+
+    return Array.from(timeMap.entries())
+      .map(([timestamp, values]) => ({ timestamp, ...values }))
+      .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  }, [data]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[300px] items-center justify-center text-muted-foreground">
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary" />
+      </div>
+    );
+  }
+
+  if (merged.length === 0) {
+    return (
+      <div className="flex h-[300px] items-center justify-center text-muted-foreground">
+        No {label.toLowerCase()} data available for the selected time range
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={merged} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <XAxis
+          dataKey="timestamp"
+          tick={{ fontSize: 11 }}
+          tickFormatter={(v) => formatDate(v)}
+        />
+        <YAxis
+          tick={{ fontSize: 11 }}
+          tickFormatter={(v) => `${v}${unit}`}
+        />
+        <Tooltip
+          labelFormatter={(v) => formatDate(v as string)}
+          formatter={(value: number, name: string) => {
+            const target = targets.find((t) => t.containerId === name);
+            return [`${value.toFixed(1)}${unit}`, target?.name || name];
+          }}
+        />
+        <Legend
+          formatter={(value: string) => {
+            const target = targets.find((t) => t.containerId === value);
+            return target?.name || value;
+          }}
+        />
+        {targets.map((target, i) => (
+          <Line
+            key={target.containerId}
+            type="monotone"
+            dataKey={target.containerId}
+            name={target.containerId}
+            stroke={CHART_COLORS[i]}
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 4 }}
+            connectNulls
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+function SummaryTable({ containers }: { containers: Container[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="pb-2 pr-4 font-medium text-muted-foreground">Attribute</th>
+            {containers.map((c, i) => (
+              <th key={c.id} className="pb-2 pr-4 font-medium">
+                <div className="flex items-center gap-2">
+                  <div
+                    className="h-2.5 w-2.5 rounded-full"
+                    style={{ backgroundColor: CHART_COLORS[i] }}
+                  />
+                  {c.name}
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          <tr>
+            <td className="py-2 pr-4 text-muted-foreground">State</td>
+            {containers.map((c) => (
+              <td key={c.id} className="py-2 pr-4">
+                <span
+                  className={cn(
+                    'rounded-full px-2 py-0.5 text-xs font-medium',
+                    c.state === 'running'
+                      ? 'bg-emerald-500/10 text-emerald-500'
+                      : c.state === 'exited'
+                        ? 'bg-red-500/10 text-red-500'
+                        : 'bg-gray-500/10 text-gray-500',
+                  )}
+                >
+                  {c.state}
+                </span>
+              </td>
+            ))}
+          </tr>
+          <tr>
+            <td className="py-2 pr-4 text-muted-foreground">Status</td>
+            {containers.map((c) => (
+              <td key={c.id} className="py-2 pr-4">{c.status}</td>
+            ))}
+          </tr>
+          <tr>
+            <td className="py-2 pr-4 text-muted-foreground">Image</td>
+            {containers.map((c) => (
+              <td key={c.id} className="py-2 pr-4">
+                <span className="font-mono text-xs">{c.image}</span>
+              </td>
+            ))}
+          </tr>
+          <tr>
+            <td className="py-2 pr-4 text-muted-foreground">Endpoint</td>
+            {containers.map((c) => (
+              <td key={c.id} className="py-2 pr-4">{c.endpointName}</td>
+            ))}
+          </tr>
+          <tr>
+            <td className="py-2 pr-4 text-muted-foreground">Health</td>
+            {containers.map((c) => (
+              <td key={c.id} className="py-2 pr-4">
+                {c.healthStatus ? (
+                  <span
+                    className={cn(
+                      'rounded-full px-2 py-0.5 text-xs font-medium',
+                      c.healthStatus === 'healthy'
+                        ? 'bg-emerald-500/10 text-emerald-500'
+                        : 'bg-red-500/10 text-red-500',
+                    )}
+                  >
+                    {c.healthStatus}
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </td>
+            ))}
+          </tr>
+          <tr>
+            <td className="py-2 pr-4 text-muted-foreground">Networks</td>
+            {containers.map((c) => (
+              <td key={c.id} className="py-2 pr-4">
+                {c.networks.length > 0 ? c.networks.join(', ') : '—'}
+              </td>
+            ))}
+          </tr>
+          <tr>
+            <td className="py-2 pr-4 text-muted-foreground">Created</td>
+            {containers.map((c) => (
+              <td key={c.id} className="py-2 pr-4">
+                {formatDate(new Date(c.created * 1000).toISOString())}
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ConfigDiff({ containers }: { containers: Container[] }) {
+  // Collect all unique label keys
+  const allLabelKeys = Array.from(
+    new Set(containers.flatMap((c) => Object.keys(c.labels))),
+  ).sort();
+
+  if (allLabelKeys.length === 0) {
+    return (
+      <div className="flex h-32 items-center justify-center text-muted-foreground">
+        No labels to compare
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="pb-2 pr-4 font-medium text-muted-foreground">Label</th>
+            {containers.map((c, i) => (
+              <th key={c.id} className="pb-2 pr-4 font-medium">
+                <div className="flex items-center gap-2">
+                  <div
+                    className="h-2.5 w-2.5 rounded-full"
+                    style={{ backgroundColor: CHART_COLORS[i] }}
+                  />
+                  {c.name}
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {allLabelKeys.map((key) => {
+            const values = containers.map((c) => c.labels[key] || '');
+            const allSame = values.every((v) => v === values[0]);
+
+            return (
+              <tr key={key} className={allSame ? '' : 'bg-yellow-500/5'}>
+                <td className="py-1.5 pr-4 font-mono text-xs text-muted-foreground">
+                  {key}
+                </td>
+                {values.map((val, i) => (
+                  <td
+                    key={containers[i].id}
+                    className={cn(
+                      'py-1.5 pr-4 font-mono text-xs',
+                      !allSame && val ? 'text-yellow-600 dark:text-yellow-400 font-medium' : '',
+                    )}
+                  >
+                    {val || <span className="text-muted-foreground">—</span>}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function ContainerComparison() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [tab, setTab] = useState<'metrics' | 'config' | 'summary'>('metrics');
+  const [timeRange, setTimeRange] = useState<string>('1h');
+  const { interval, setInterval } = useAutoRefresh(30);
+
+  const { data: allContainers = [], isFetching, refetch } = useContainers();
+  const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', refetch);
+
+  // Parse selected containers from URL params
+  const selected = useMemo<ComparisonTarget[]>(() => {
+    const ids = searchParams.get('containers')?.split(',').filter(Boolean) || [];
+    return ids
+      .map((encoded) => {
+        const [endpointId, containerId] = encoded.split(':');
+        const container = allContainers.find((c) => c.id === containerId);
+        return container
+          ? { containerId: container.id, endpointId: Number(endpointId), name: container.name }
+          : null;
+      })
+      .filter((t): t is ComparisonTarget => t !== null)
+      .slice(0, MAX_CONTAINERS);
+  }, [searchParams, allContainers]);
+
+  const selectedContainers = useMemo(
+    () =>
+      selected
+        .map((t) => allContainers.find((c) => c.id === t.containerId))
+        .filter((c): c is Container => c !== undefined),
+    [selected, allContainers],
+  );
+
+  function updateUrl(targets: ComparisonTarget[]) {
+    const param = targets.map((t) => `${t.endpointId}:${t.containerId}`).join(',');
+    setSearchParams(param ? { containers: param } : {});
+  }
+
+  function handleAdd(c: Container) {
+    const newTarget: ComparisonTarget = {
+      containerId: c.id,
+      endpointId: c.endpointId,
+      name: c.name,
+    };
+    updateUrl([...selected, newTarget]);
+  }
+
+  function handleRemove(containerId: string) {
+    updateUrl(selected.filter((t) => t.containerId !== containerId));
+  }
+
+  const tabs = [
+    { key: 'metrics' as const, label: 'Metrics', icon: BarChart3 },
+    { key: 'config' as const, label: 'Configuration', icon: GitCompareArrows },
+    { key: 'summary' as const, label: 'Summary', icon: Info },
+  ];
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Container Comparison</h1>
+          <p className="text-muted-foreground">
+            Compare metrics, configuration, and status across containers
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <AutoRefreshToggle interval={interval} onIntervalChange={setInterval} />
+          <RefreshButton
+            onClick={() => refetch()}
+            onForceRefresh={forceRefresh}
+            isLoading={isFetching || isForceRefreshing}
+          />
+        </div>
+      </div>
+
+      {/* Container Selector */}
+      <div className="rounded-lg border bg-card p-4">
+        <ContainerSelector
+          containers={allContainers}
+          selected={selected}
+          onAdd={handleAdd}
+          onRemove={handleRemove}
+        />
+      </div>
+
+      {/* Tabs & Content */}
+      {selected.length >= 2 && (
+        <>
+          <div className="flex items-center justify-between">
+            <div className="flex gap-1 rounded-lg border p-1">
+              {tabs.map(({ key, label, icon: Icon }) => (
+                <button
+                  key={key}
+                  onClick={() => setTab(key)}
+                  className={cn(
+                    'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                    tab === key
+                      ? 'bg-primary text-primary-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {tab === 'metrics' && (
+              <div className="flex items-center gap-1.5">
+                <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+                <div className="flex gap-1 rounded-lg border p-1">
+                  {TIME_RANGES.map((tr) => (
+                    <button
+                      key={tr}
+                      onClick={() => setTimeRange(tr)}
+                      className={cn(
+                        'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+                        timeRange === tr
+                          ? 'bg-primary text-primary-foreground'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      {tr}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Tab Content */}
+          {tab === 'metrics' && (
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="rounded-lg border bg-card p-4">
+                <h3 className="mb-3 text-sm font-medium">CPU Usage</h3>
+                <ComparisonChart
+                  targets={selected}
+                  metricType="cpu"
+                  timeRange={timeRange}
+                  label="CPU"
+                  unit="%"
+                />
+              </div>
+              <div className="rounded-lg border bg-card p-4">
+                <h3 className="mb-3 text-sm font-medium">Memory Usage</h3>
+                <ComparisonChart
+                  targets={selected}
+                  metricType="memory"
+                  timeRange={timeRange}
+                  label="Memory"
+                  unit="%"
+                />
+              </div>
+            </div>
+          )}
+
+          {tab === 'config' && (
+            <div className="rounded-lg border bg-card p-4">
+              <h3 className="mb-3 text-sm font-medium">Label Comparison</h3>
+              <ConfigDiff containers={selectedContainers} />
+            </div>
+          )}
+
+          {tab === 'summary' && (
+            <div className="rounded-lg border bg-card p-4">
+              <h3 className="mb-3 text-sm font-medium">Status Summary</h3>
+              <SummaryTable containers={selectedContainers} />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -22,6 +22,7 @@ const Settings = lazy(() => import('@/pages/settings'));
 const StackOverview = lazy(() => import('@/pages/stack-overview'));
 const ContainerDetail = lazy(() => import('@/pages/container-detail'));
 const PacketCapture = lazy(() => import('@/pages/packet-capture'));
+const ContainerComparison = lazy(() => import('@/pages/container-comparison'));
 
 function PageLoader() {
   return (
@@ -57,6 +58,7 @@ export const router = createBrowserRouter([
       { path: 'stacks', element: <LazyPage><StackOverview /></LazyPage> },
       { path: 'containers/:endpointId/:containerId', element: <LazyPage><ContainerDetail /></LazyPage> },
       { path: 'health', element: <LazyPage><ContainerHealth /></LazyPage> },
+      { path: 'comparison', element: <LazyPage><ContainerComparison /></LazyPage> },
       { path: 'images', element: <LazyPage><ImageFootprint /></LazyPage> },
       { path: 'topology', element: <LazyPage><NetworkTopology /></LazyPage> },
       { path: 'ai-monitor', element: <LazyPage><AiMonitor /></LazyPage> },


### PR DESCRIPTION
## Summary
- Adds a new Container Comparison page (`/comparison`) that lets users select 2-4 containers and view overlaid metrics, label diffs, and status summaries side-by-side
- Selection is persisted in URL query params (`?containers=1:abc,1:def`) making comparisons shareable
- Sidebar entry added under the "Containers" navigation group with `GitCompareArrows` icon

Resolves #57

## Changes
- **New**: `frontend/src/pages/container-comparison.tsx` — Main page with selector, metrics overlay, config diff, and summary tabs
- **New**: `frontend/src/hooks/use-container-comparison.ts` — Hook using `useQueries` to fetch metrics for multiple containers in parallel
- **New**: `frontend/src/pages/container-comparison.test.tsx` — 6 page-level tests (rendering, search, filtering)
- **New**: `frontend/src/hooks/use-container-comparison.test.ts` — 3 hook tests (parallel fetch, error handling, disabled state)
- **Modified**: `frontend/src/router.tsx` — Added lazy-loaded comparison route
- **Modified**: `frontend/src/components/layout/sidebar.tsx` — Added "Comparison" nav item

## Test plan
- [x] All 170 frontend tests pass (161 existing + 9 new)
- [x] All 247 backend tests pass (unchanged)
- [x] TypeScript strict mode passes for both workspaces
- [x] ESLint passes for both workspaces
- [ ] Verify page loads at `/comparison`
- [ ] Select 2 containers and verify overlaid CPU/Memory charts render
- [ ] Switch to Configuration tab and verify label diff highlighting
- [ ] Switch to Summary tab and verify status comparison table
- [ ] Verify URL updates with container IDs and is shareable
- [ ] Verify time range selector updates chart data

> **Note:** This PR targets `dev`. Issue #57 will auto-close when `dev` is merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)