### PR TITLE
feat: outbound webhooks and event API (#61)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -28,6 +28,7 @@ import { searchRoutes } from './routes/search.js';
 import { notificationRoutes } from './routes/notifications.js';
 import { cacheAdminRoutes } from './routes/cache-admin.js';
 import { pcapRoutes } from './routes/pcap.js';
+import { webhookRoutes } from './routes/webhooks.js';
 
 export async function buildApp() {
   const isDev = process.env.NODE_ENV !== 'production';
@@ -80,6 +81,7 @@ export async function buildApp() {
   await app.register(notificationRoutes);
   await app.register(cacheAdminRoutes);
   await app.register(pcapRoutes);
+  await app.register(webhookRoutes);
 
   // Static files (production only)
   await app.register(staticPlugin);

--- a/backend/src/config/env.schema.ts
+++ b/backend/src/config/env.schema.ts
@@ -73,6 +73,11 @@ export const envSchema = z.object({
   EMAIL_NOTIFICATIONS_ENABLED: z.coerce.boolean().default(false),
   EMAIL_RECIPIENTS: z.string().default(''),
 
+  // Webhooks
+  WEBHOOKS_ENABLED: z.coerce.boolean().default(false),
+  WEBHOOKS_MAX_RETRIES: z.coerce.number().int().min(0).max(10).default(5),
+  WEBHOOKS_RETRY_INTERVAL_SECONDS: z.coerce.number().int().min(10).default(60),
+
   // Rate Limiting
   LOGIN_RATE_LIMIT: z.coerce.number().int().min(1).default(
     process.env.NODE_ENV === 'production' ? 5 : 30

--- a/backend/src/db/migrations/011_webhooks.sql
+++ b/backend/src/db/migrations/011_webhooks.sql
@@ -1,0 +1,32 @@
+-- Outbound webhooks configuration
+CREATE TABLE IF NOT EXISTS webhooks (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  url TEXT NOT NULL,
+  secret TEXT NOT NULL,
+  events TEXT NOT NULL DEFAULT '["insight.created"]',
+  enabled INTEGER NOT NULL DEFAULT 1,
+  description TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Webhook delivery log for tracking and retry
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id TEXT PRIMARY KEY,
+  webhook_id TEXT NOT NULL REFERENCES webhooks(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  http_status INTEGER,
+  response_body TEXT,
+  attempt INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 5,
+  next_retry_at TEXT,
+  delivered_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_webhook_id ON webhook_deliveries(webhook_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON webhook_deliveries(status);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_next_retry ON webhook_deliveries(status, next_retry_at);

--- a/backend/src/routes/webhooks.test.ts
+++ b/backend/src/routes/webhooks.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import { webhookRoutes } from './webhooks.js';
+
+vi.mock('../services/webhook-service.js', () => ({
+  createWebhook: vi.fn(),
+  listWebhooks: vi.fn(),
+  getWebhookById: vi.fn(),
+  updateWebhook: vi.fn(),
+  deleteWebhook: vi.fn(),
+  getDeliveriesForWebhook: vi.fn(),
+  signPayload: vi.fn(() => 'mockedsignature'),
+}));
+
+vi.mock('../services/event-bus.js', () => ({
+  onEvent: vi.fn(() => vi.fn()),
+  emitEvent: vi.fn(),
+}));
+
+import {
+  createWebhook,
+  listWebhooks,
+  getWebhookById,
+  updateWebhook,
+  deleteWebhook,
+  getDeliveriesForWebhook,
+} from '../services/webhook-service.js';
+
+const mockCreateWebhook = vi.mocked(createWebhook);
+const mockListWebhooks = vi.mocked(listWebhooks);
+const mockGetWebhookById = vi.mocked(getWebhookById);
+const mockUpdateWebhook = vi.mocked(updateWebhook);
+const mockDeleteWebhook = vi.mocked(deleteWebhook);
+const mockGetDeliveries = vi.mocked(getDeliveriesForWebhook);
+
+async function buildTestApp() {
+  const app = Fastify();
+  app.decorate('authenticate', async () => undefined);
+  await app.register(webhookRoutes);
+  return app;
+}
+
+describe('webhookRoutes', () => {
+  let app: Awaited<ReturnType<typeof buildTestApp>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('GET /api/webhooks', () => {
+    it('should list webhooks with masked secrets', async () => {
+      mockListWebhooks.mockReturnValue([
+        {
+          id: 'wh-1',
+          name: 'Test Hook',
+          url: 'https://example.com/hook',
+          secret: 'abcdefghijklmnop1234567890',
+          events: '["insight.created"]',
+          enabled: 1,
+          description: null,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+      ]);
+
+      const res = await app.inject({ method: 'GET', url: '/api/webhooks' });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body).toHaveLength(1);
+      expect(body[0].name).toBe('Test Hook');
+      expect(body[0].secret).toBe('abcdefgh...');
+      expect(body[0].events).toEqual(['insight.created']);
+    });
+  });
+
+  describe('POST /api/webhooks', () => {
+    it('should create a webhook', async () => {
+      mockCreateWebhook.mockReturnValue({
+        id: 'wh-new',
+        name: 'New Hook',
+        url: 'https://example.com/hook',
+        secret: '1234567890abcdef',
+        events: '["*"]',
+        enabled: 1,
+        description: null,
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/webhooks',
+        payload: {
+          name: 'New Hook',
+          url: 'https://example.com/hook',
+          events: ['*'],
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(mockCreateWebhook).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'New Hook', url: 'https://example.com/hook' }),
+      );
+    });
+
+    it('should reject invalid event types', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/webhooks',
+        payload: {
+          name: 'Bad Hook',
+          url: 'https://example.com/hook',
+          events: ['invalid.event.type'],
+        },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('GET /api/webhooks/:id', () => {
+    it('should return 404 for non-existent webhook', async () => {
+      mockGetWebhookById.mockReturnValue(undefined);
+
+      const res = await app.inject({ method: 'GET', url: '/api/webhooks/non-existent' });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('should return webhook details', async () => {
+      mockGetWebhookById.mockReturnValue({
+        id: 'wh-1',
+        name: 'Test',
+        url: 'https://example.com/hook',
+        secret: 'secretvalue123456',
+        events: '["insight.created"]',
+        enabled: 1,
+        description: 'Test webhook',
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/api/webhooks/wh-1' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().name).toBe('Test');
+    });
+  });
+
+  describe('PATCH /api/webhooks/:id', () => {
+    it('should update a webhook', async () => {
+      mockUpdateWebhook.mockReturnValue({
+        id: 'wh-1',
+        name: 'Updated',
+        url: 'https://example.com/hook',
+        secret: 'secretvalue123456',
+        events: '["*"]',
+        enabled: 1,
+        description: null,
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/webhooks/wh-1',
+        payload: { name: 'Updated' },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().name).toBe('Updated');
+    });
+
+    it('should return 404 for non-existent webhook', async () => {
+      mockUpdateWebhook.mockReturnValue(undefined);
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/webhooks/non-existent',
+        payload: { name: 'Updated' },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/webhooks/:id', () => {
+    it('should delete a webhook', async () => {
+      mockDeleteWebhook.mockReturnValue(true);
+
+      const res = await app.inject({ method: 'DELETE', url: '/api/webhooks/wh-1' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().success).toBe(true);
+    });
+
+    it('should return 404 for non-existent webhook', async () => {
+      mockDeleteWebhook.mockReturnValue(false);
+
+      const res = await app.inject({ method: 'DELETE', url: '/api/webhooks/non-existent' });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('GET /api/webhooks/:id/deliveries', () => {
+    it('should return delivery history', async () => {
+      mockGetWebhookById.mockReturnValue({
+        id: 'wh-1',
+        name: 'Test',
+        url: 'https://example.com/hook',
+        secret: 'secret',
+        events: '["*"]',
+        enabled: 1,
+        description: null,
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      });
+
+      mockGetDeliveries.mockReturnValue({
+        deliveries: [
+          {
+            id: 'del-1',
+            webhook_id: 'wh-1',
+            event_type: 'insight.created',
+            payload: '{}',
+            status: 'delivered',
+            http_status: 200,
+            response_body: null,
+            attempt: 1,
+            max_attempts: 5,
+            next_retry_at: null,
+            delivered_at: '2025-01-01T00:00:00Z',
+            created_at: '2025-01-01T00:00:00Z',
+          },
+        ],
+        total: 1,
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/api/webhooks/wh-1/deliveries' });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.deliveries).toHaveLength(1);
+      expect(body.total).toBe(1);
+    });
+  });
+
+  describe('GET /api/webhooks/event-types', () => {
+    it('should list available event types', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/webhooks/event-types' });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.length).toBeGreaterThan(0);
+      expect(body[0]).toHaveProperty('type');
+      expect(body[0]).toHaveProperty('description');
+    });
+  });
+});

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -1,0 +1,330 @@
+import { FastifyInstance } from 'fastify';
+import {
+  createWebhook,
+  listWebhooks,
+  getWebhookById,
+  updateWebhook,
+  deleteWebhook,
+  getDeliveriesForWebhook,
+  signPayload,
+  type Webhook,
+} from '../services/webhook-service.js';
+import { emitEvent } from '../services/event-bus.js';
+import { onEvent, type WebhookEvent } from '../services/event-bus.js';
+
+const VALID_EVENT_TYPES = [
+  'insight.created',
+  'anomaly.detected',
+  'container.state_change',
+  'remediation.requested',
+  'remediation.approved',
+  'remediation.rejected',
+  'remediation.completed',
+  '*',
+];
+
+function sanitizeWebhook(webhook: Webhook) {
+  return {
+    ...webhook,
+    secret: webhook.secret.slice(0, 8) + '...',
+    events: JSON.parse(webhook.events),
+  };
+}
+
+export async function webhookRoutes(fastify: FastifyInstance) {
+  // List all webhooks
+  fastify.get('/api/webhooks', {
+    schema: {
+      tags: ['Webhooks'],
+      summary: 'List all configured webhooks',
+      security: [{ bearerAuth: [] }],
+    },
+    preHandler: [fastify.authenticate],
+  }, async () => {
+    const webhooks = listWebhooks();
+    return webhooks.map(sanitizeWebhook);
+  });
+
+  // Create a webhook
+  fastify.post('/api/webhooks', {
+    schema: {
+      tags: ['Webhooks'],
+      summary: 'Create a new webhook',
+      security: [{ bearerAuth: [] }],
+      body: {
+        type: 'object',
+        required: ['name', 'url', 'events'],
+        properties: {
+          name: { type: 'string', minLength: 1, maxLength: 100 },
+          url: { type: 'string', format: 'uri' },
+          secret: { type: 'string' },
+          events: { type: 'array', items: { type: 'string' }, minItems: 1 },
+          enabled: { type: 'boolean' },
+          description: { type: 'string', maxLength: 500 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const body = request.body as {
+      name: string;
+      url: string;
+      secret?: string;
+      events: string[];
+      enabled?: boolean;
+      description?: string;
+    };
+
+    // Validate event types
+    for (const evt of body.events) {
+      if (!VALID_EVENT_TYPES.includes(evt) && !evt.endsWith('.*')) {
+        return reply.status(400).send({ error: `Invalid event type: ${evt}` });
+      }
+    }
+
+    const webhook = createWebhook(body);
+    return reply.status(201).send(sanitizeWebhook(webhook));
+  });
+
+  // Get a single webhook
+  fastify.get('/api/webhooks/:id', {
+    schema: {
+      tags: ['Webhooks'],
+      summary: 'Get webhook details',
+      security: [{ bearerAuth: [] }],
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const webhook = getWebhookById(id);
+    if (!webhook) return reply.status(404).send({ error: 'Webhook not found' });
+    return sanitizeWebhook(webhook);
+  });
+
+  // Update a webhook
+  fastify.patch('/api/webhooks/:id', {
+    schema: {
+      tags: ['Webhooks'],
+      summary: 'Update a webhook',
+      security: [{ bearerAuth: [] }],
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string' } },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', minLength: 1, maxLength: 100 },
+          url: { type: 'string', format: 'uri' },
+          secret: { type: 'string' },
+          events: { type: 'array', items: { type: 'string' }, minItems: 1 },
+          enabled: { type: 'boolean' },
+          description: { type: 'string', maxLength: 500 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const body = request.body as {
+      name?: string;
+      url?: string;
+      secret?: string;
+      events?: string[];
+      enabled?: boolean;
+      description?: string;
+    };
+
+    if (body.events) {
+      for (const evt of body.events) {
+        if (!VALID_EVENT_TYPES.includes(evt) && !evt.endsWith('.*')) {
+          return reply.status(400).send({ error: `Invalid event type: ${evt}` });
+        }
+      }
+    }
+
+    const webhook = updateWebhook(id, body);
+    if (!webhook) return reply.status(404).send({ error: 'Webhook not found' });
+    return sanitizeWebhook(webhook);
+  });
+
+  // Delete a webhook
+  fastify.delete('/api/webhooks/:id', {
+    schema: {
+      tags: ['Webhooks'],
+      summary: 'Delete a webhook',
+      security: [{ bearerAuth: [] }],
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const deleted = deleteWebhook(id);
+    if (!deleted) return reply.status(404).send({ error: 'Webhook not found' });
+    return { success: true };
+  });
+
+  // Get delivery history for a webhook
+  fastify.get('/api/webhooks/:id/deliveries', {
+    schema: {
+      tags: ['Webhooks'],
+      summary: 'Get webhook delivery history',
+      security: [{ bearerAuth: [] }],
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string' } },
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', default: 50 },
+          offset: { type: 'number', default: 0 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const { limit = 50, offset = 0 } = request.query as { limit?: number; offset?: number };
+
+    const webhook = getWebhookById(id);
+    if (!webhook) return reply.status(404).send({ error: 'Webhook not found' });
+
+    return getDeliveriesForWebhook(id, limit, offset);
+  });
+
+  // Send a test event to a webhook
+  fastify.post('/api/webhooks/:id/test', {
+    schema: {
+      tags: ['Webhooks'],
+      summary: 'Send a test event to a webhook',
+      security: [{ bearerAuth: [] }],
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const webhook = getWebhookById(id);
+    if (!webhook) return reply.status(404).send({ error: 'Webhook not found' });
+
+    const testPayload = JSON.stringify({
+      type: 'webhook.test',
+      timestamp: new Date().toISOString(),
+      data: {
+        message: 'This is a test event from AI Portainer Dashboard',
+        webhookId: id,
+        webhookName: webhook.name,
+      },
+    });
+
+    const signature = signPayload(testPayload, webhook.secret);
+
+    try {
+      const response = await fetch(webhook.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Signature': `sha256=${signature}`,
+          'X-Webhook-Event': 'webhook.test',
+          'X-Webhook-Delivery': crypto.randomUUID(),
+          'User-Agent': 'AI-Portainer-Dashboard/1.0',
+        },
+        body: testPayload,
+        signal: AbortSignal.timeout(10000),
+      });
+
+      const body = await response.text().catch(() => '');
+
+      return {
+        success: response.ok,
+        httpStatus: response.status,
+        responseBody: body.slice(0, 500),
+      };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  });
+
+  // SSE event stream
+  fastify.get('/api/events/stream', {
+    schema: {
+      tags: ['Events'],
+      summary: 'Server-Sent Events stream of dashboard events',
+      security: [{ bearerAuth: [] }],
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    reply.raw.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+
+    reply.raw.write(':ok\n\n');
+
+    const handler = (event: WebhookEvent) => {
+      reply.raw.write(`event: ${event.type}\n`);
+      reply.raw.write(`data: ${JSON.stringify(event)}\n\n`);
+    };
+
+    const unsubscribe = onEvent(handler);
+
+    // Heartbeat to keep connection alive
+    const heartbeat = setInterval(() => {
+      reply.raw.write(':heartbeat\n\n');
+    }, 30000);
+
+    request.raw.on('close', () => {
+      unsubscribe();
+      clearInterval(heartbeat);
+    });
+  });
+
+  // Get available event types
+  fastify.get('/api/webhooks/event-types', {
+    schema: {
+      tags: ['Webhooks'],
+      summary: 'List available webhook event types',
+      security: [{ bearerAuth: [] }],
+    },
+    preHandler: [fastify.authenticate],
+  }, async () => {
+    return VALID_EVENT_TYPES.map((type) => ({
+      type,
+      description: getEventTypeDescription(type),
+    }));
+  });
+}
+
+function getEventTypeDescription(type: string): string {
+  const descriptions: Record<string, string> = {
+    'insight.created': 'A new monitoring insight was generated',
+    'anomaly.detected': 'An anomaly was detected in container metrics',
+    'container.state_change': 'A container changed state (started, stopped, etc.)',
+    'remediation.requested': 'A remediation action was requested',
+    'remediation.approved': 'A remediation action was approved',
+    'remediation.rejected': 'A remediation action was rejected',
+    'remediation.completed': 'A remediation action was completed',
+    '*': 'All events',
+  };
+  return descriptions[type] || type;
+}

--- a/backend/src/services/event-bus.test.ts
+++ b/backend/src/services/event-bus.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { emitEvent, onEvent, getEmitter } from './event-bus.js';
+
+describe('event-bus', () => {
+  it('should emit and receive events', () => {
+    const handler = vi.fn();
+    const unsub = onEvent(handler);
+
+    emitEvent({
+      type: 'insight.created',
+      timestamp: new Date().toISOString(),
+      data: { test: true },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'insight.created' }),
+    );
+
+    unsub();
+  });
+
+  it('should unsubscribe properly', () => {
+    const handler = vi.fn();
+    const unsub = onEvent(handler);
+
+    unsub();
+
+    emitEvent({
+      type: 'test.event',
+      timestamp: new Date().toISOString(),
+      data: {},
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('should support multiple listeners', () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+
+    const unsub1 = onEvent(handler1);
+    const unsub2 = onEvent(handler2);
+
+    emitEvent({
+      type: 'multi.test',
+      timestamp: new Date().toISOString(),
+      data: {},
+    });
+
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledTimes(1);
+
+    unsub1();
+    unsub2();
+  });
+
+  it('should expose the emitter', () => {
+    const emitter = getEmitter();
+    expect(emitter).toBeDefined();
+    expect(typeof emitter.on).toBe('function');
+    expect(typeof emitter.emit).toBe('function');
+  });
+});

--- a/backend/src/services/event-bus.ts
+++ b/backend/src/services/event-bus.ts
@@ -1,0 +1,29 @@
+import { EventEmitter } from 'node:events';
+import { createChildLogger } from '../utils/logger.js';
+
+const log = createChildLogger('event-bus');
+
+export interface WebhookEvent {
+  type: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+
+const emitter = new EventEmitter();
+emitter.setMaxListeners(50);
+
+export function emitEvent(event: WebhookEvent): void {
+  log.debug({ eventType: event.type }, 'Event emitted');
+  emitter.emit('event', event);
+}
+
+export function onEvent(handler: (event: WebhookEvent) => void): () => void {
+  emitter.on('event', handler);
+  return () => {
+    emitter.off('event', handler);
+  };
+}
+
+export function getEmitter(): EventEmitter {
+  return emitter;
+}

--- a/backend/src/services/webhook-service.test.ts
+++ b/backend/src/services/webhook-service.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { signPayload } from './webhook-service.js';
+
+// In-memory store for the mock DB
+const webhookStore: Map<string, Record<string, unknown>> = new Map();
+const deliveryStore: Map<string, Record<string, unknown>> = new Map();
+
+vi.mock('../db/sqlite.js', () => {
+  const mockDb = {
+    prepare: vi.fn((sql: string) => ({
+      run: vi.fn((...args: unknown[]) => {
+        if (sql.includes('INSERT INTO webhooks')) {
+          const row = {
+            id: args[0],
+            name: args[1],
+            url: args[2],
+            secret: args[3],
+            events: args[4],
+            enabled: args[5],
+            description: args[6],
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          };
+          webhookStore.set(row.id as string, row);
+          return { changes: 1 };
+        }
+        if (sql.includes('INSERT INTO webhook_deliveries')) {
+          const row = {
+            id: args[0],
+            webhook_id: args[1],
+            event_type: args[2],
+            payload: args[3],
+            status: 'pending',
+            attempt: 0,
+            max_attempts: 5,
+            created_at: new Date().toISOString(),
+          };
+          deliveryStore.set(row.id as string, row);
+          return { changes: 1 };
+        }
+        if (sql.includes('DELETE FROM webhooks')) {
+          const deleted = webhookStore.delete(args[0] as string);
+          return { changes: deleted ? 1 : 0 };
+        }
+        if (sql.includes('UPDATE webhooks')) {
+          return { changes: 1 };
+        }
+        return { changes: 0 };
+      }),
+      get: vi.fn((...args: unknown[]) => {
+        if (sql.includes('FROM webhooks WHERE id')) {
+          return webhookStore.get(args[0] as string) ?? undefined;
+        }
+        if (sql.includes('COUNT(*)')) {
+          return { count: deliveryStore.size };
+        }
+        return undefined;
+      }),
+      all: vi.fn(() => {
+        if (sql.includes('FROM webhooks')) return [...webhookStore.values()];
+        if (sql.includes('FROM webhook_deliveries')) return [...deliveryStore.values()];
+        return [];
+      }),
+    })),
+  };
+  return { getDb: vi.fn(() => mockDb) };
+});
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('./event-bus.js', () => ({
+  onEvent: vi.fn(() => vi.fn()),
+  emitEvent: vi.fn(),
+}));
+
+import {
+  createWebhook,
+  listWebhooks,
+  deleteWebhook,
+  createDelivery,
+  startWebhookListener,
+  stopWebhookListener,
+} from './webhook-service.js';
+
+describe('webhook-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webhookStore.clear();
+    deliveryStore.clear();
+  });
+
+  describe('signPayload', () => {
+    it('should produce a deterministic HMAC-SHA256 signature', () => {
+      const payload = '{"type":"test"}';
+      const secret = 'my-secret';
+      const sig1 = signPayload(payload, secret);
+      const sig2 = signPayload(payload, secret);
+      expect(sig1).toBe(sig2);
+      expect(sig1).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('should produce different signatures for different secrets', () => {
+      const payload = '{"type":"test"}';
+      const sig1 = signPayload(payload, 'secret-a');
+      const sig2 = signPayload(payload, 'secret-b');
+      expect(sig1).not.toBe(sig2);
+    });
+  });
+
+  describe('createWebhook', () => {
+    it('should create a webhook with generated secret', () => {
+      const webhook = createWebhook({
+        name: 'Test Webhook',
+        url: 'https://example.com/hook',
+        events: ['insight.created'],
+      });
+
+      expect(webhook).toBeDefined();
+      expect(webhook.name).toBe('Test Webhook');
+      expect(webhook.url).toBe('https://example.com/hook');
+      expect(webhook.secret).toBeTruthy();
+    });
+
+    it('should create a webhook with custom secret', () => {
+      const webhook = createWebhook({
+        name: 'Custom Secret',
+        url: 'https://example.com/hook',
+        events: ['*'],
+        secret: 'my-custom-secret',
+      });
+
+      expect(webhook).toBeDefined();
+      expect(webhook.secret).toBe('my-custom-secret');
+    });
+  });
+
+  describe('listWebhooks', () => {
+    it('should return all webhooks', () => {
+      createWebhook({ name: 'Hook 1', url: 'https://a.com/h', events: ['*'] });
+      createWebhook({ name: 'Hook 2', url: 'https://b.com/h', events: ['*'] });
+
+      const webhooks = listWebhooks();
+      expect(webhooks).toHaveLength(2);
+    });
+  });
+
+  describe('deleteWebhook', () => {
+    it('should delete an existing webhook', () => {
+      const webhook = createWebhook({ name: 'To Delete', url: 'https://x.com/h', events: ['*'] });
+      const result = deleteWebhook(webhook.id);
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-existent webhook', () => {
+      const result = deleteWebhook('non-existent-id');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createDelivery', () => {
+    it('should create a delivery record', () => {
+      const webhook = createWebhook({ name: 'Delivery Test', url: 'https://x.com/h', events: ['*'] });
+      const event = { type: 'insight.created', timestamp: new Date().toISOString(), data: { test: true } };
+      const deliveryId = createDelivery(webhook.id, event);
+      expect(deliveryId).toBeTruthy();
+      expect(typeof deliveryId).toBe('string');
+    });
+  });
+
+  describe('startWebhookListener / stopWebhookListener', () => {
+    it('should start and stop without errors', () => {
+      expect(() => startWebhookListener()).not.toThrow();
+      expect(() => stopWebhookListener()).not.toThrow();
+    });
+  });
+});

--- a/backend/src/services/webhook-service.ts
+++ b/backend/src/services/webhook-service.ts
@@ -1,0 +1,300 @@
+import crypto from 'node:crypto';
+import { getDb } from '../db/sqlite.js';
+import { createChildLogger } from '../utils/logger.js';
+import { onEvent, type WebhookEvent } from './event-bus.js';
+
+const log = createChildLogger('webhook-service');
+
+export interface Webhook {
+  id: string;
+  name: string;
+  url: string;
+  secret: string;
+  events: string;
+  enabled: number;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WebhookDelivery {
+  id: string;
+  webhook_id: string;
+  event_type: string;
+  payload: string;
+  status: string;
+  http_status: number | null;
+  response_body: string | null;
+  attempt: number;
+  max_attempts: number;
+  next_retry_at: string | null;
+  delivered_at: string | null;
+  created_at: string;
+}
+
+export interface CreateWebhookInput {
+  name: string;
+  url: string;
+  secret?: string;
+  events: string[];
+  enabled?: boolean;
+  description?: string;
+}
+
+export interface UpdateWebhookInput {
+  name?: string;
+  url?: string;
+  secret?: string;
+  events?: string[];
+  enabled?: boolean;
+  description?: string;
+}
+
+function generateSecret(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+export function signPayload(payload: string, secret: string): string {
+  return crypto.createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+// --- CRUD ---
+
+export function createWebhook(input: CreateWebhookInput): Webhook {
+  const db = getDb();
+  const id = crypto.randomUUID();
+  const secret = input.secret || generateSecret();
+  const events = JSON.stringify(input.events);
+
+  db.prepare(`
+    INSERT INTO webhooks (id, name, url, secret, events, enabled, description)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(id, input.name, input.url, secret, events, input.enabled !== false ? 1 : 0, input.description ?? null);
+
+  return getWebhookById(id)!;
+}
+
+export function getWebhookById(id: string): Webhook | undefined {
+  const db = getDb();
+  return db.prepare('SELECT * FROM webhooks WHERE id = ?').get(id) as Webhook | undefined;
+}
+
+export function listWebhooks(): Webhook[] {
+  const db = getDb();
+  return db.prepare('SELECT * FROM webhooks ORDER BY created_at DESC').all() as Webhook[];
+}
+
+export function updateWebhook(id: string, input: UpdateWebhookInput): Webhook | undefined {
+  const db = getDb();
+  const existing = getWebhookById(id);
+  if (!existing) return undefined;
+
+  const updates: string[] = [];
+  const values: unknown[] = [];
+
+  if (input.name !== undefined) { updates.push('name = ?'); values.push(input.name); }
+  if (input.url !== undefined) { updates.push('url = ?'); values.push(input.url); }
+  if (input.secret !== undefined) { updates.push('secret = ?'); values.push(input.secret); }
+  if (input.events !== undefined) { updates.push('events = ?'); values.push(JSON.stringify(input.events)); }
+  if (input.enabled !== undefined) { updates.push('enabled = ?'); values.push(input.enabled ? 1 : 0); }
+  if (input.description !== undefined) { updates.push('description = ?'); values.push(input.description); }
+
+  if (updates.length === 0) return existing;
+
+  updates.push("updated_at = datetime('now')");
+  values.push(id);
+
+  db.prepare(`UPDATE webhooks SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+  return getWebhookById(id);
+}
+
+export function deleteWebhook(id: string): boolean {
+  const db = getDb();
+  const result = db.prepare('DELETE FROM webhooks WHERE id = ?').run(id);
+  return result.changes > 0;
+}
+
+// --- Delivery ---
+
+function getBackoffDelay(attempt: number): number {
+  // Exponential backoff: 10s, 30s, 90s, 270s, 810s
+  return Math.min(10 * Math.pow(3, attempt), 3600) * 1000;
+}
+
+export function createDelivery(webhookId: string, event: WebhookEvent): string {
+  const db = getDb();
+  const id = crypto.randomUUID();
+  const payload = JSON.stringify(event);
+
+  db.prepare(`
+    INSERT INTO webhook_deliveries (id, webhook_id, event_type, payload, status, attempt, max_attempts)
+    VALUES (?, ?, ?, ?, 'pending', 0, 5)
+  `).run(id, webhookId, event.type, payload);
+
+  return id;
+}
+
+export async function deliverWebhook(deliveryId: string): Promise<boolean> {
+  const db = getDb();
+  const delivery = db.prepare('SELECT * FROM webhook_deliveries WHERE id = ?').get(deliveryId) as WebhookDelivery | undefined;
+  if (!delivery) return false;
+
+  const webhook = getWebhookById(delivery.webhook_id);
+  if (!webhook) {
+    db.prepare("UPDATE webhook_deliveries SET status = 'failed' WHERE id = ?").run(deliveryId);
+    return false;
+  }
+
+  const signature = signPayload(delivery.payload, webhook.secret);
+  const attempt = delivery.attempt + 1;
+
+  try {
+    const response = await fetch(webhook.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Webhook-Signature': `sha256=${signature}`,
+        'X-Webhook-Event': delivery.event_type,
+        'X-Webhook-Delivery': deliveryId,
+        'User-Agent': 'AI-Portainer-Dashboard/1.0',
+      },
+      body: delivery.payload,
+      signal: AbortSignal.timeout(10000),
+    });
+
+    const responseBody = await response.text().catch(() => '');
+
+    if (response.ok) {
+      db.prepare(`
+        UPDATE webhook_deliveries
+        SET status = 'delivered', http_status = ?, response_body = ?, attempt = ?, delivered_at = datetime('now')
+        WHERE id = ?
+      `).run(response.status, responseBody.slice(0, 1000), attempt, deliveryId);
+      log.info({ deliveryId, webhookId: webhook.id, status: response.status }, 'Webhook delivered');
+      return true;
+    }
+
+    // Failed but retryable
+    if (attempt < delivery.max_attempts) {
+      const delayMs = getBackoffDelay(attempt);
+      const nextRetry = new Date(Date.now() + delayMs).toISOString();
+      db.prepare(`
+        UPDATE webhook_deliveries
+        SET status = 'retrying', http_status = ?, response_body = ?, attempt = ?, next_retry_at = ?
+        WHERE id = ?
+      `).run(response.status, responseBody.slice(0, 1000), attempt, nextRetry, deliveryId);
+      log.warn({ deliveryId, attempt, nextRetry, httpStatus: response.status }, 'Webhook delivery failed, will retry');
+    } else {
+      db.prepare(`
+        UPDATE webhook_deliveries
+        SET status = 'failed', http_status = ?, response_body = ?, attempt = ?
+        WHERE id = ?
+      `).run(response.status, responseBody.slice(0, 1000), attempt, deliveryId);
+      log.error({ deliveryId, attempt, httpStatus: response.status }, 'Webhook delivery permanently failed');
+    }
+    return false;
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+
+    if (attempt < delivery.max_attempts) {
+      const delayMs = getBackoffDelay(attempt);
+      const nextRetry = new Date(Date.now() + delayMs).toISOString();
+      db.prepare(`
+        UPDATE webhook_deliveries
+        SET status = 'retrying', response_body = ?, attempt = ?, next_retry_at = ?
+        WHERE id = ?
+      `).run(errorMsg.slice(0, 1000), attempt, nextRetry, deliveryId);
+      log.warn({ deliveryId, attempt, err: errorMsg }, 'Webhook delivery error, will retry');
+    } else {
+      db.prepare(`
+        UPDATE webhook_deliveries
+        SET status = 'failed', response_body = ?, attempt = ?
+        WHERE id = ?
+      `).run(errorMsg.slice(0, 1000), attempt, deliveryId);
+      log.error({ deliveryId, attempt, err: errorMsg }, 'Webhook delivery permanently failed');
+    }
+    return false;
+  }
+}
+
+export function getPendingRetries(): WebhookDelivery[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT * FROM webhook_deliveries
+    WHERE status = 'retrying' AND next_retry_at <= datetime('now')
+    ORDER BY next_retry_at ASC
+    LIMIT 50
+  `).all() as WebhookDelivery[];
+}
+
+export function getDeliveriesForWebhook(webhookId: string, limit = 50, offset = 0): { deliveries: WebhookDelivery[]; total: number } {
+  const db = getDb();
+  const deliveries = db.prepare(`
+    SELECT * FROM webhook_deliveries WHERE webhook_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?
+  `).all(webhookId, limit, offset) as WebhookDelivery[];
+
+  const total = db.prepare('SELECT COUNT(*) as count FROM webhook_deliveries WHERE webhook_id = ?').get(webhookId) as { count: number };
+
+  return { deliveries, total: total.count };
+}
+
+// --- Dispatch engine ---
+
+export async function dispatchEvent(event: WebhookEvent): Promise<void> {
+  const webhooks = listWebhooks().filter((w) => w.enabled);
+
+  for (const webhook of webhooks) {
+    const subscribedEvents: string[] = JSON.parse(webhook.events);
+    const matches = subscribedEvents.some((pattern) => {
+      if (pattern === '*') return true;
+      if (pattern.endsWith('.*')) {
+        const prefix = pattern.slice(0, -2);
+        return event.type.startsWith(prefix + '.');
+      }
+      return pattern === event.type;
+    });
+
+    if (!matches) continue;
+
+    const deliveryId = createDelivery(webhook.id, event);
+
+    // Fire and forget the delivery — errors are caught inside deliverWebhook
+    deliverWebhook(deliveryId).catch((err) => {
+      log.error({ err, deliveryId }, 'Unexpected error in webhook delivery');
+    });
+  }
+}
+
+export async function processRetries(): Promise<number> {
+  const pending = getPendingRetries();
+  let processed = 0;
+
+  for (const delivery of pending) {
+    await deliverWebhook(delivery.id);
+    processed++;
+  }
+
+  return processed;
+}
+
+// --- Event listener ---
+
+let unsubscribe: (() => void) | null = null;
+
+export function startWebhookListener(): void {
+  if (unsubscribe) return;
+  unsubscribe = onEvent((event) => {
+    dispatchEvent(event).catch((err) => {
+      log.error({ err, eventType: event.type }, 'Failed to dispatch webhook event');
+    });
+  });
+  log.info('Webhook event listener started');
+}
+
+export function stopWebhookListener(): void {
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = null;
+    log.info('Webhook event listener stopped');
+  }
+}

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -21,6 +21,7 @@ import {
   EyeOff,
   Bell,
   Send,
+  Webhook,
 } from 'lucide-react';
 import { useThemeStore, themeOptions, type Theme } from '@/stores/theme-store';
 import { useSettings, useUpdateSetting } from '@/hooks/use-settings';
@@ -72,6 +73,11 @@ const DEFAULT_SETTINGS = {
     { key: 'oidc.redirect_uri', label: 'Redirect URI', description: 'Callback URL (e.g., http://localhost:5173/auth/callback)', type: 'string', defaultValue: '' },
     { key: 'oidc.scopes', label: 'Scopes', description: 'Space-separated OIDC scopes to request', type: 'string', defaultValue: 'openid profile email' },
     { key: 'oidc.local_auth_enabled', label: 'Keep Local Auth Enabled', description: 'Allow username/password login alongside SSO', type: 'boolean', defaultValue: 'true' },
+  ],
+  webhooks: [
+    { key: 'webhooks.enabled', label: 'Enable Webhooks', description: 'Enable outbound webhook event delivery', type: 'boolean', defaultValue: 'false' },
+    { key: 'webhooks.max_retries', label: 'Max Retries', description: 'Maximum delivery attempts for failed webhooks', type: 'number', defaultValue: '5', min: 0, max: 10 },
+    { key: 'webhooks.retry_interval', label: 'Retry Interval', description: 'Seconds between webhook retry checks', type: 'number', defaultValue: '60', min: 10, max: 600 },
   ],
   elasticsearch: [
     { key: 'elasticsearch.enabled', label: 'Enable Elasticsearch', description: 'Enable Elasticsearch/Kibana integration for edge agent logs', type: 'boolean', defaultValue: 'false' },
@@ -374,6 +380,7 @@ export default function SettingsPage() {
       'notifications.smtp_user',
       'notifications.smtp_password',
       'notifications.email_recipients',
+      'webhooks.enabled',
     ];
     return restartKeys.some(
       (key) => editedValues[key] !== originalValues[key]
@@ -622,6 +629,19 @@ export default function SettingsPage() {
 
       {/* Notification Test Buttons */}
       <NotificationTestButtons />
+
+      {/* Webhooks Settings */}
+      <SettingsSection
+        title="Webhooks"
+        icon={<Webhook className="h-5 w-5" />}
+        category="webhooks"
+        settings={DEFAULT_SETTINGS.webhooks}
+        values={editedValues}
+        originalValues={originalValues}
+        onChange={handleChange}
+        requiresRestart
+        disabled={isSaving}
+      />
 
       {/* Cache Settings */}
       <SettingsSection


### PR DESCRIPTION
## Summary

- **Webhook Management**: Full CRUD API for configuring outbound webhooks with HMAC-SHA256 signed payloads
- **Event Bus**: Internal pub/sub system that emits events from monitoring insights, anomaly detection, and remediation actions
- **SSE Stream**: Server-Sent Events endpoint (`GET /api/events/stream`) for real-time event consumption
- **Delivery Engine**: Automatic dispatch with exponential backoff retries (up to 5 attempts), delivery logging, and status tracking
- **Frontend Settings**: New Webhooks settings section in the Settings page for enabling/configuring webhook behavior

### Event Types
`insight.created`, `anomaly.detected`, `container.state_change`, `remediation.requested/approved/rejected/completed`, `*` (wildcard)

### New Files
- `backend/src/db/migrations/011_webhooks.sql` - webhooks + webhook_deliveries tables
- `backend/src/services/event-bus.ts` - Internal event emitter
- `backend/src/services/webhook-service.ts` - CRUD, HMAC signing, dispatch, retry
- `backend/src/routes/webhooks.ts` - REST endpoints + SSE stream
- Tests: 24 new backend tests (event-bus, webhook-service, webhook routes)

### Modified Files
- `backend/src/config/env.schema.ts` - Added `WEBHOOKS_ENABLED`, `WEBHOOKS_MAX_RETRIES`, `WEBHOOKS_RETRY_INTERVAL_SECONDS`
- `backend/src/app.ts` - Register webhook routes
- `backend/src/scheduler/setup.ts` - Webhook listener startup + retry scheduler
- `backend/src/services/monitoring-service.ts` - Emit events on insight creation
- `backend/src/services/remediation-service.ts` - Emit events on action status changes
- `frontend/src/pages/settings.tsx` - Webhooks settings section

Resolves #61

## Test plan
- [x] 247 backend tests passing (24 new)
- [x] 170 frontend tests passing
- [x] TypeScript strict mode passes both workspaces
- [ ] Manual: Create webhook via API, verify delivery with HMAC signature
- [ ] Manual: Connect to SSE stream, verify events appear in real-time
- [ ] Manual: Test retry behavior with unreachable webhook URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)