### PR TITLE
feat: Docker Compose health checks and resource limits

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,14 +27,26 @@ services:
       - METRICS_COLLECTION_INTERVAL_SECONDS=${METRICS_COLLECTION_INTERVAL_SECONDS:-60}
       - CACHE_ENABLED=${CACHE_ENABLED:-true}
       - CACHE_TTL_SECONDS=${CACHE_TTL_SECONDS:-900}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:3051/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     volumes:
       - ./backend/src:/app/src
       - backend-data:/app/data
     depends_on:
       ollama:
-        condition: service_started
+        condition: service_healthy
     networks:
       - dashboard-net
+    # Resource limits commented out for dev — uncomment to test constrained environments
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '1.0'
+    #       memory: 512M
 
   frontend:
     build:
@@ -45,22 +57,47 @@ services:
     environment:
       - VITE_API_URL=http://localhost:3051
       - VITE_SOCKET_URL=http://localhost:3051
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:5273/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     volumes:
       - ./frontend/src:/app/src
       - ./frontend/index.html:/app/index.html
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - dashboard-net
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '0.5'
+    #       memory: 256M
 
   ollama:
     image: ollama/ollama:latest
     ports:
       - "11534:11434"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
     volumes:
       - ollama-data:/root/.ollama
     networks:
       - dashboard-net
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '2.0'
+    #       memory: 4G
+    #     reservations:
+    #       memory: 2G
 
 volumes:
   backend-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,11 +30,24 @@ services:
       - CACHE_ENABLED=${CACHE_ENABLED:-true}
       - CACHE_TTL_SECONDS=${CACHE_TTL_SECONDS:-900}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:3001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     volumes:
       - backend-data:/app/data
     networks:
       - dashboard-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "${BACKEND_CPU_LIMIT:-1.0}"
+          memory: "${BACKEND_MEM_LIMIT:-512M}"
+        reservations:
+          memory: 256M
 
   frontend:
     build:
@@ -42,12 +55,25 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:8080/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     depends_on:
       backend:
         condition: service_healthy
     networks:
       - dashboard-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "${FRONTEND_CPU_LIMIT:-0.5}"
+          memory: "${FRONTEND_MEM_LIMIT:-256M}"
+        reservations:
+          memory: 128M
 
 volumes:
   backend-data:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM node:22-alpine
 
+RUN apk add --no-cache wget
+
 WORKDIR /app
 
 COPY package.json ./


### PR DESCRIPTION
## Summary
- Add health checks to all services in both production and dev compose files
- Add env-configurable resource limits (CPU, memory) for production
- Add `depends_on` with `condition: service_healthy` for startup ordering
- Add `wget` to frontend dev Dockerfile for health check support

Resolves #66

## Test plan
- [ ] Validate compose files: `docker compose config --quiet`
- [ ] Verify health checks: `docker compose ps` shows "healthy"
- [ ] Verify startup ordering respects health dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)