### PR TITLE
feat: optimistic UI updates for instant feedback

### DIFF
--- a/frontend/src/components/shared/refresh-button.test.tsx
+++ b/frontend/src/components/shared/refresh-button.test.tsx
@@ -19,29 +19,29 @@ describe('RefreshButton', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should be disabled when isLoading is true', () => {
+  it('should show Updating text when isLoading is true', () => {
     const onClick = vi.fn();
     render(<RefreshButton onClick={onClick} isLoading={true} />);
 
     const button = screen.getByRole('button');
-    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent('Updating...');
   });
 
-  it('should not be disabled when isLoading is false', () => {
+  it('should show Refresh text when isLoading is false', () => {
     const onClick = vi.fn();
     render(<RefreshButton onClick={onClick} isLoading={false} />);
 
     const button = screen.getByRole('button');
-    expect(button).not.toBeDisabled();
+    expect(button).toHaveTextContent('Refresh');
   });
 
-  it('should not call onClick when disabled', () => {
+  it('should still be clickable when loading (optimistic)', () => {
     const onClick = vi.fn();
     render(<RefreshButton onClick={onClick} isLoading={true} />);
 
     fireEvent.click(screen.getByRole('button'));
 
-    expect(onClick).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it('should apply spin animation to icon when loading', () => {
@@ -68,12 +68,12 @@ describe('RefreshButton', () => {
     expect(button).toHaveClass('custom-class');
   });
 
-  it('should render with opacity when disabled', () => {
+  it('should render with relative class for loading indicator', () => {
     const onClick = vi.fn();
     render(<RefreshButton onClick={onClick} isLoading={true} />);
 
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('disabled:opacity-50');
+    expect(button).toHaveClass('relative');
   });
 
   it('should handle multiple clicks when not loading', () => {
@@ -138,7 +138,7 @@ describe('RefreshButton', () => {
       expect(onClick).not.toHaveBeenCalled();
     });
 
-    it('should disable both buttons when loading', () => {
+    it('should show Updating text in split mode when loading', () => {
       const onClick = vi.fn();
       const onForceRefresh = vi.fn();
       render(
@@ -146,8 +146,7 @@ describe('RefreshButton', () => {
       );
 
       const buttons = screen.getAllByRole('button');
-      expect(buttons[0]).toBeDisabled();
-      expect(buttons[1]).toBeDisabled();
+      expect(buttons[0]).toHaveTextContent('Updating...');
     });
 
     it('should still call onClick on first button in split mode', () => {

--- a/frontend/src/components/shared/refresh-button.tsx
+++ b/frontend/src/components/shared/refresh-button.tsx
@@ -13,14 +13,13 @@ export function RefreshButton({ onClick, isLoading, className, onForceRefresh }:
     return (
       <button
         onClick={onClick}
-        disabled={isLoading}
         className={cn(
-          'inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50',
+          'relative inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent',
           className
         )}
       >
         <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
-        Refresh
+        {isLoading ? 'Updating...' : 'Refresh'}
       </button>
     );
   }
@@ -29,17 +28,15 @@ export function RefreshButton({ onClick, isLoading, className, onForceRefresh }:
     <div className={cn('inline-flex items-center', className)}>
       <button
         onClick={onClick}
-        disabled={isLoading}
-        className="inline-flex items-center gap-2 rounded-l-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
+        className="inline-flex items-center gap-2 rounded-l-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent"
       >
         <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
-        Refresh
+        {isLoading ? 'Updating...' : 'Refresh'}
       </button>
       <button
         onClick={onForceRefresh}
-        disabled={isLoading}
         title="Force refresh (bypass backend cache)"
-        className="inline-flex items-center rounded-r-md border border-l-0 border-input bg-background px-2 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
+        className="inline-flex items-center rounded-r-md border border-l-0 border-input bg-background px-2 py-2 text-sm font-medium hover:bg-accent"
       >
         <Zap className="h-4 w-4" />
       </button>

--- a/frontend/src/providers/query-provider.tsx
+++ b/frontend/src/providers/query-provider.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, keepPreviousData } from '@tanstack/react-query';
 import { useState } from 'react';
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
@@ -11,6 +11,7 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             gcTime: 5 * 60 * 1000,
             retry: 2,
             refetchOnWindowFocus: true,
+            placeholderData: keepPreviousData,
           },
           mutations: {
             retry: 0,


### PR DESCRIPTION
## Summary
- Added `keepPreviousData` as global query default to prevent skeleton flash during refetch
- Implemented optimistic update pattern in `useUpdateSetting()` with `onMutate`/`onError`/`onSettled`
- RefreshButton now stays clickable during loading, shows "Updating..." text

## Test plan
- [ ] Verify settings updates feel instant (no loading state visible)
- [ ] Verify failed updates roll back to previous value with error toast
- [ ] Verify RefreshButton shows "Updating..." while loading
- [ ] Run `npm run test -w frontend` — all tests pass

Resolves #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)