### PR TITLE
Fix security issues in notification settings and delivery (#96)

### DIFF
--- a/frontend/src/pages/settings.test.tsx
+++ b/frontend/src/pages/settings.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { NotificationTestButtons } from './settings';
+
+const mockPost = vi.fn();
+const mockSuccess = vi.fn();
+const mockError = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockSuccess(...args),
+    error: (...args: unknown[]) => mockError(...args),
+  },
+}));
+
+describe('Settings notification test actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows success toast when API returns success true', async () => {
+    mockPost.mockResolvedValue({ success: true });
+
+    render(<NotificationTestButtons />);
+    fireEvent.click(screen.getByRole('button', { name: /test teams/i }));
+
+    await waitFor(() => {
+      expect(mockSuccess).toHaveBeenCalledWith('Test teams notification sent successfully');
+    });
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it('shows error toast when API returns success false', async () => {
+    mockPost.mockResolvedValue({ success: false, error: 'Webhook URL not configured' });
+
+    render(<NotificationTestButtons />);
+    fireEvent.click(screen.getByRole('button', { name: /test teams/i }));
+
+    await waitFor(() => {
+      expect(mockError).toHaveBeenCalledWith('Failed to send test teams notification: Webhook URL not configured');
+    });
+    expect(mockSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -270,7 +270,7 @@ function SettingsSection({
   );
 }
 
-function NotificationTestButtons() {
+export function NotificationTestButtons() {
   const [testingTeams, setTestingTeams] = useState(false);
   const [testingEmail, setTestingEmail] = useState(false);
 
@@ -278,8 +278,12 @@ function NotificationTestButtons() {
     const setTesting = channel === 'teams' ? setTestingTeams : setTestingEmail;
     setTesting(true);
     try {
-      await api.post('/api/notifications/test', { channel });
-      toast.success(`Test ${channel} notification sent successfully`);
+      const result = await api.post<{ success: boolean; error?: string }>('/api/notifications/test', { channel });
+      if (result.success) {
+        toast.success(`Test ${channel} notification sent successfully`);
+      } else {
+        toast.error(`Failed to send test ${channel} notification: ${result.error || 'Unknown error'}`);
+      }
     } catch (err) {
       toast.error(`Failed to send test ${channel} notification: ${err instanceof Error ? err.message : 'Unknown error'}`);
     } finally {


### PR DESCRIPTION
## Summary
- harden Teams webhook validation to trusted Office domains over HTTPS
- block private/local SMTP hosts and ignore DB SMTP host/user/password overrides
- handle failed notification test API responses in UI with explicit error toasts
- add backend/frontend regression tests for these paths

Closes #96