### PR TITLE
feat: virtual scrolling for data tables (#82)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-tooltip": "^1.1.6",
     "@tanstack/react-query": "^5.64.1",
     "@tanstack/react-table": "^8.20.6",
+    "@tanstack/react-virtual": "^3.11.2",
     "@xyflow/react": "^12.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/src/components/shared/data-table.test.tsx
+++ b/frontend/src/components/shared/data-table.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DataTable } from './data-table';
+import type { ColumnDef } from '@tanstack/react-table';
+
+// Mock @tanstack/react-virtual
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: vi.fn(({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: Math.min(count, 30) }, (_, i) => ({
+        index: i,
+        start: i * 48,
+        end: (i + 1) * 48,
+        size: 48,
+        key: i,
+      })),
+    getTotalSize: () => count * 48,
+    measureElement: vi.fn(),
+  })),
+}));
+
+interface TestRow {
+  id: number;
+  name: string;
+  status: string;
+}
+
+const testColumns: ColumnDef<TestRow, any>[] = [
+  { accessorKey: 'id', header: 'ID' },
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'status', header: 'Status' },
+];
+
+function makeRows(count: number): TestRow[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    name: `container-${i + 1}`,
+    status: i % 2 === 0 ? 'running' : 'stopped',
+  }));
+}
+
+describe('DataTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('pagination mode (small datasets)', () => {
+    it('renders table with data', () => {
+      const data = makeRows(5);
+      render(<DataTable columns={testColumns} data={data} />);
+
+      expect(screen.getByText('ID')).toBeInTheDocument();
+      expect(screen.getByText('Name')).toBeInTheDocument();
+      expect(screen.getByText('Status')).toBeInTheDocument();
+      expect(screen.getByText('container-1')).toBeInTheDocument();
+      expect(screen.getByText('container-5')).toBeInTheDocument();
+    });
+
+    it('shows pagination when data exceeds page size', () => {
+      const data = makeRows(25);
+      render(<DataTable columns={testColumns} data={data} pageSize={10} />);
+
+      expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+      expect(screen.getByText(/25 total/)).toBeInTheDocument();
+    });
+
+    it('hides pagination when data fits in one page', () => {
+      const data = makeRows(5);
+      render(<DataTable columns={testColumns} data={data} pageSize={10} />);
+
+      expect(screen.queryByText(/Page/)).not.toBeInTheDocument();
+    });
+
+    it('navigates between pages', () => {
+      const data = makeRows(25);
+      render(<DataTable columns={testColumns} data={data} pageSize={10} />);
+
+      expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+
+      const nextButton = screen.getAllByRole('button').find(
+        (btn) => !btn.hasAttribute('disabled') && btn.querySelector('svg')
+      );
+      // Find the next page button (second pagination button)
+      const buttons = screen.getAllByRole('button');
+      const nextBtn = buttons[buttons.length - 1]; // last button is next
+      fireEvent.click(nextBtn);
+
+      expect(screen.getByText(/Page 2 of 3/)).toBeInTheDocument();
+    });
+
+    it('shows empty state when no data', () => {
+      render(<DataTable columns={testColumns} data={[]} />);
+      expect(screen.getByText('No results.')).toBeInTheDocument();
+    });
+
+    it('renders search input when searchKey provided', () => {
+      render(
+        <DataTable
+          columns={testColumns}
+          data={makeRows(5)}
+          searchKey="name"
+          searchPlaceholder="Search containers..."
+        />
+      );
+
+      expect(screen.getByPlaceholderText('Search containers...')).toBeInTheDocument();
+    });
+
+    it('filters data with search', () => {
+      const data = makeRows(5);
+      render(
+        <DataTable columns={testColumns} data={data} searchKey="name" />
+      );
+
+      const searchInput = screen.getByPlaceholderText('Filter...');
+      fireEvent.change(searchInput, { target: { value: 'container-1' } });
+
+      expect(screen.getByText('container-1')).toBeInTheDocument();
+      expect(screen.queryByText('container-2')).not.toBeInTheDocument();
+    });
+
+    it('calls onRowClick when a row is clicked', () => {
+      const onClick = vi.fn();
+      const data = makeRows(3);
+      render(
+        <DataTable columns={testColumns} data={data} onRowClick={onClick} />
+      );
+
+      fireEvent.click(screen.getByText('container-2'));
+      expect(onClick).toHaveBeenCalledWith(data[1]);
+    });
+
+    it('does not render virtual scroll container in pagination mode', () => {
+      render(<DataTable columns={testColumns} data={makeRows(10)} />);
+      expect(screen.queryByTestId('virtual-scroll-container')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('virtual scrolling mode (large datasets)', () => {
+    it('auto-enables virtual scrolling for data > 50 rows', () => {
+      render(<DataTable columns={testColumns} data={makeRows(100)} />);
+
+      expect(screen.getByTestId('virtual-scroll-container')).toBeInTheDocument();
+      expect(screen.queryByText(/Page/)).not.toBeInTheDocument();
+    });
+
+    it('shows total count in virtual mode', () => {
+      render(<DataTable columns={testColumns} data={makeRows(100)} />);
+
+      expect(screen.getByTestId('virtual-row-count')).toHaveTextContent('100 total');
+    });
+
+    it('shows filtered count when search is active', () => {
+      render(
+        <DataTable columns={testColumns} data={makeRows(100)} searchKey="name" />
+      );
+
+      const searchInput = screen.getByPlaceholderText('Filter...');
+      fireEvent.change(searchInput, { target: { value: 'container-1' } });
+
+      // Will show "X of 100 match" format
+      expect(screen.getByTestId('virtual-row-count')).toHaveTextContent(/of 100/);
+    });
+
+    it('renders sticky header in virtual mode', () => {
+      render(<DataTable columns={testColumns} data={makeRows(100)} />);
+
+      const thead = screen.getByTestId('virtual-scroll-container').querySelector('thead');
+      expect(thead?.className).toContain('sticky');
+    });
+
+    it('has keyboard navigation support', () => {
+      render(<DataTable columns={testColumns} data={makeRows(100)} />);
+
+      const scrollContainer = screen.getByTestId('virtual-scroll-container');
+      expect(scrollContainer).toHaveAttribute('tabindex', '0');
+    });
+
+    it('has accessible role and label', () => {
+      render(<DataTable columns={testColumns} data={makeRows(100)} />);
+
+      const scrollContainer = screen.getByTestId('virtual-scroll-container');
+      expect(scrollContainer).toHaveAttribute('role', 'grid');
+      expect(scrollContainer).toHaveAttribute('aria-label', 'Data table with virtual scrolling');
+    });
+
+    it('can be forced with virtualScrolling prop', () => {
+      render(
+        <DataTable columns={testColumns} data={makeRows(5)} virtualScrolling={true} />
+      );
+
+      expect(screen.getByTestId('virtual-scroll-container')).toBeInTheDocument();
+    });
+
+    it('can be disabled with virtualScrolling=false', () => {
+      render(
+        <DataTable columns={testColumns} data={makeRows(100)} virtualScrolling={false} />
+      );
+
+      expect(screen.queryByTestId('virtual-scroll-container')).not.toBeInTheDocument();
+    });
+
+    it('renders rows from virtualizer', () => {
+      render(<DataTable columns={testColumns} data={makeRows(100)} />);
+
+      // Our mock virtualizer returns first 30 items
+      expect(screen.getByText('container-1')).toBeInTheDocument();
+      expect(screen.getByText('container-30')).toBeInTheDocument();
+    });
+
+    it('sets max-height on scroll container', () => {
+      render(<DataTable columns={testColumns} data={makeRows(100)} />);
+
+      const scrollContainer = screen.getByTestId('virtual-scroll-container');
+      expect(scrollContainer.style.maxHeight).toBe('600px');
+    });
+
+    it('shows empty state in virtual mode with no matching data', () => {
+      render(
+        <DataTable columns={testColumns} data={makeRows(100)} searchKey="name" />
+      );
+
+      const searchInput = screen.getByPlaceholderText('Filter...');
+      fireEvent.change(searchInput, { target: { value: 'nonexistent-xyz' } });
+
+      expect(screen.getByText('No results.')).toBeInTheDocument();
+    });
+
+    it('does not show scroll-to-top by default', () => {
+      render(<DataTable columns={testColumns} data={makeRows(100)} />);
+      expect(screen.queryByTestId('scroll-to-top')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('sorting', () => {
+    it('renders sort icons on sortable columns', () => {
+      render(<DataTable columns={testColumns} data={makeRows(5)} />);
+
+      // Each column header should have an ArrowUpDown icon
+      const headers = screen.getAllByRole('columnheader');
+      headers.forEach((header) => {
+        expect(header.querySelector('svg')).toBeInTheDocument();
+      });
+    });
+
+    it('toggles sorting when clicking column header', () => {
+      render(<DataTable columns={testColumns} data={makeRows(5)} />);
+
+      const nameHeader = screen.getByText('Name').closest('th');
+      expect(nameHeader).toBeInTheDocument();
+      fireEvent.click(nameHeader!);
+
+      // Table should still be rendered (sorting changes row order)
+      expect(screen.getByText('container-1')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/shared/data-table.tsx
+++ b/frontend/src/components/shared/data-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import {
   useReactTable,
   getCoreRowModel,
@@ -9,9 +9,17 @@ import {
   type ColumnDef,
   type SortingState,
   type ColumnFiltersState,
+  type Row,
 } from '@tanstack/react-table';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { cn } from '@/lib/utils';
-import { ArrowUpDown, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ArrowUpDown, ChevronLeft, ChevronRight, ArrowUp } from 'lucide-react';
+
+const ROW_HEIGHT = 48;
+const OVERSCAN = 10;
+const VIRTUAL_THRESHOLD = 50;
+const SCROLL_CONTAINER_HEIGHT = 600;
+const SCROLL_TO_TOP_THRESHOLD = 20;
 
 interface DataTableProps<T> {
   columns: ColumnDef<T, any>[];
@@ -20,6 +28,7 @@ interface DataTableProps<T> {
   searchPlaceholder?: string;
   pageSize?: number;
   onRowClick?: (row: T) => void;
+  virtualScrolling?: boolean;
 }
 
 export function DataTable<T>({
@@ -29,9 +38,14 @@ export function DataTable<T>({
   searchPlaceholder = 'Filter...',
   pageSize = 10,
   onRowClick,
+  virtualScrolling,
 }: DataTableProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [showScrollTop, setShowScrollTop] = useState(false);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const useVirtual = virtualScrolling ?? data.length > VIRTUAL_THRESHOLD;
 
   const table = useReactTable({
     data,
@@ -39,109 +53,239 @@ export function DataTable<T>({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
+    ...(useVirtual ? {} : { getPaginationRowModel: getPaginationRowModel() }),
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     state: { sorting, columnFilters },
-    initialState: { pagination: { pageSize } },
+    ...(useVirtual ? {} : { initialState: { pagination: { pageSize } } }),
   });
+
+  const { rows } = table.getRowModel();
+
+  const virtualizer = useVirtualizer({
+    count: useVirtual ? rows.length : 0,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: OVERSCAN,
+    enabled: useVirtual,
+  });
+
+  const handleScroll = useCallback(() => {
+    if (!scrollContainerRef.current || !useVirtual) return;
+    const scrollTop = scrollContainerRef.current.scrollTop;
+    setShowScrollTop(scrollTop > ROW_HEIGHT * SCROLL_TO_TOP_THRESHOLD);
+  }, [useVirtual]);
+
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el || !useVirtual) return;
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [handleScroll, useVirtual]);
+
+  const scrollToTop = useCallback(() => {
+    scrollContainerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!useVirtual || !scrollContainerRef.current) return;
+      if (e.key === 'j') {
+        scrollContainerRef.current.scrollBy({ top: ROW_HEIGHT, behavior: 'smooth' });
+      } else if (e.key === 'k') {
+        scrollContainerRef.current.scrollBy({ top: -ROW_HEIGHT, behavior: 'smooth' });
+      }
+    },
+    [useVirtual]
+  );
+
+  const filteredCount = rows.length;
+  const totalCount = data.length;
+  const searchValue = searchKey
+    ? (table.getColumn(searchKey)?.getFilterValue() as string) ?? ''
+    : '';
+  const isFiltered = searchValue.length > 0;
+
+  const renderRow = (row: Row<T>) => (
+    <tr
+      key={row.id}
+      className={cn(
+        'border-b transition-colors duration-200 hover:bg-muted/30',
+        onRowClick && 'cursor-pointer'
+      )}
+      onClick={() => onRowClick?.(row.original)}
+    >
+      {row.getVisibleCells().map((cell) => (
+        <td
+          key={cell.id}
+          style={{ width: cell.column.getSize() !== 150 ? cell.column.getSize() : undefined }}
+          className="px-4 py-3 align-middle"
+        >
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </td>
+      ))}
+    </tr>
+  );
+
+  const renderHeader = () => (
+    <thead className={cn('[&_tr]:border-b', useVirtual && 'sticky top-0 z-10 bg-card')}>
+      {table.getHeaderGroups().map((headerGroup) => (
+        <tr key={headerGroup.id} className="border-b transition-colors hover:bg-muted/50">
+          {headerGroup.headers.map((header) => (
+            <th
+              key={header.id}
+              style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}
+              className={cn(
+                'h-10 px-4 text-left align-middle font-medium text-muted-foreground',
+                header.column.getCanSort() && 'cursor-pointer select-none'
+              )}
+              onClick={header.column.getToggleSortingHandler()}
+            >
+              <div className="flex items-center gap-2">
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(header.column.columnDef.header, header.getContext())}
+                {header.column.getCanSort() && (
+                  <ArrowUpDown className="h-4 w-4" />
+                )}
+              </div>
+            </th>
+          ))}
+        </tr>
+      ))}
+    </thead>
+  );
 
   return (
     <div className="space-y-4">
-      {searchKey && (
-        <input
-          type="text"
-          placeholder={searchPlaceholder}
-          value={(table.getColumn(searchKey)?.getFilterValue() as string) ?? ''}
-          onChange={(e) => table.getColumn(searchKey)?.setFilterValue(e.target.value)}
-          className="w-full max-w-sm rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        />
-      )}
-
-      <div className="rounded-md border">
-        <table className="w-full caption-bottom text-sm">
-          <thead className="[&_tr]:border-b">
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id} className="border-b transition-colors hover:bg-muted/50">
-                {headerGroup.headers.map((header) => (
-                  <th
-                    key={header.id}
-                    style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}
-                    className={cn(
-                      'h-10 px-4 text-left align-middle font-medium text-muted-foreground',
-                      header.column.getCanSort() && 'cursor-pointer select-none'
-                    )}
-                    onClick={header.column.getToggleSortingHandler()}
-                  >
-                    <div className="flex items-center gap-2">
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(header.column.columnDef.header, header.getContext())}
-                      {header.column.getCanSort() && (
-                        <ArrowUpDown className="h-4 w-4" />
-                      )}
-                    </div>
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          <tbody className="[&_tr:last-child]:border-0">
-            {table.getRowModel().rows.length ? (
-              table.getRowModel().rows.map((row) => (
-                <tr
-                  key={row.id}
-                  className={cn(
-                    'border-b transition-colors duration-200 hover:bg-muted/30',
-                    onRowClick && 'cursor-pointer'
-                  )}
-                  onClick={() => onRowClick?.(row.original)}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <td
-                      key={cell.id}
-                      style={{ width: cell.column.getSize() !== 150 ? cell.column.getSize() : undefined }}
-                      className="px-4 py-3 align-middle"
-                    >
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </td>
-                  ))}
-                </tr>
-              ))
-            ) : (
-              <tr>
-                <td colSpan={columns.length} className="h-24 text-center text-muted-foreground">
-                  No results.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+      <div className="flex items-center justify-between gap-4">
+        {searchKey && (
+          <input
+            type="text"
+            placeholder={searchPlaceholder}
+            value={searchValue}
+            onChange={(e) => table.getColumn(searchKey)?.setFilterValue(e.target.value)}
+            className="w-full max-w-sm rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        )}
+        {useVirtual && (
+          <p className="shrink-0 text-sm text-muted-foreground" data-testid="virtual-row-count">
+            {isFiltered
+              ? `${filteredCount} of ${totalCount} match${filteredCount !== 1 ? '' : 'es'}`
+              : `${totalCount} total`}
+          </p>
+        )}
       </div>
 
-      {table.getPageCount() > 1 && (
-        <div className="flex items-center justify-between">
-          <p className="text-sm text-muted-foreground">
-            Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
-            {' '}({data.length} total)
-          </p>
-          <div className="flex items-center gap-2">
-            <button
-              className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-            <button
-              className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </button>
+      {useVirtual ? (
+        <div className="relative rounded-md border">
+          <div
+            ref={scrollContainerRef}
+            className="overflow-auto"
+            style={{ maxHeight: SCROLL_CONTAINER_HEIGHT }}
+            tabIndex={0}
+            onKeyDown={handleKeyDown}
+            role="grid"
+            aria-label="Data table with virtual scrolling"
+            data-testid="virtual-scroll-container"
+          >
+            <table className="w-full caption-bottom text-sm">
+              {renderHeader()}
+              <tbody className="[&_tr:last-child]:border-0">
+                {rows.length ? (
+                  <>
+                    {virtualizer.getVirtualItems().length > 0 && (
+                      <tr>
+                        <td
+                          colSpan={columns.length}
+                          style={{ height: virtualizer.getVirtualItems()[0]?.start ?? 0, padding: 0 }}
+                        />
+                      </tr>
+                    )}
+                    {virtualizer.getVirtualItems().map((virtualRow) => {
+                      const row = rows[virtualRow.index];
+                      return renderRow(row);
+                    })}
+                    {virtualizer.getVirtualItems().length > 0 && (
+                      <tr>
+                        <td
+                          colSpan={columns.length}
+                          style={{
+                            height:
+                              virtualizer.getTotalSize() -
+                              (virtualizer.getVirtualItems().at(-1)?.end ?? 0),
+                            padding: 0,
+                          }}
+                        />
+                      </tr>
+                    )}
+                  </>
+                ) : (
+                  <tr>
+                    <td colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                      No results.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
           </div>
+
+          {showScrollTop && (
+            <button
+              onClick={scrollToTop}
+              className="absolute bottom-4 right-4 inline-flex h-8 w-8 items-center justify-center rounded-full border bg-background shadow-md transition-opacity hover:bg-accent"
+              aria-label="Scroll to top"
+              data-testid="scroll-to-top"
+            >
+              <ArrowUp className="h-4 w-4" />
+            </button>
+          )}
         </div>
+      ) : (
+        <>
+          <div className="rounded-md border">
+            <table className="w-full caption-bottom text-sm">
+              {renderHeader()}
+              <tbody className="[&_tr:last-child]:border-0">
+                {table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row) => renderRow(row))
+                ) : (
+                  <tr>
+                    <td colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                      No results.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {table.getPageCount() > 1 && (
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+                {' '}({data.length} total)
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
+                  onClick={() => table.previousPage()}
+                  disabled={!table.getCanPreviousPage()}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </button>
+                <button
+                  className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
+                  onClick={() => table.nextPage()}
+                  disabled={!table.getCanNextPage()}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds `@tanstack/react-virtual` for virtual scrolling in data tables
- Auto-switches between pagination (≤50 rows) and virtual scrolling (>50 rows)
- Sticky table headers remain visible during scroll
- j/k keyboard navigation for row-by-row scrolling
- Scroll-to-top floating button after scrolling 20+ rows
- Progressive count display: "X of Y match" when filtering, "Y total" otherwise
- Explicit `virtualScrolling` prop for manual override
- Fully backward compatible — all 4 existing DataTable consumers work unchanged

## Acceptance Criteria
- [x] Data tables use virtual scrolling instead of pagination (for large datasets)
- [x] Only visible rows + overscan buffer (10) are rendered in DOM
- [x] Smooth scrolling with consistent 48px row height
- [x] Sticky table headers during scroll
- [x] Total and visible count shown in header
- [x] Scroll-to-top button appears after scrolling > 20 rows
- [x] Search/filter works with virtual scroll (client-side filtering)
- [x] Row height consistent (no layout shifts during scroll)
- [x] Keyboard navigation (j/k) works with virtual scroll
- [x] Accessible: role="grid", aria-label, tabIndex

## Test plan
- [x] 23 new tests covering pagination mode, virtual mode, sorting, filtering, keyboard nav, accessibility
- [x] All 250 frontend tests pass
- [x] All 320 backend tests pass
- [x] TypeScript strict mode — no errors
- [x] ESLint — no warnings

## Files changed
- `frontend/package.json` — added `@tanstack/react-virtual`
- `frontend/src/components/shared/data-table.tsx` — enhanced with virtual scrolling
- `frontend/src/components/shared/data-table.test.tsx` — new test file (23 tests)

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)