### PR TITLE
feat: Predictive Capacity Forecasting with Linear Regression (#104)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -35,6 +35,7 @@ import { userRoutes } from './routes/users.js';
 import { incidentsRoutes } from './routes/incidents.js';
 import { statusPageRoutes } from './routes/status-page.js';
 import { llmRoutes } from './routes/llm.js';
+import { forecastRoutes } from './routes/forecasts.js';
 
 export async function buildApp() {
   const isDev = process.env.NODE_ENV !== 'production';
@@ -94,6 +95,7 @@ export async function buildApp() {
   await app.register(incidentsRoutes);
   await app.register(statusPageRoutes);
   await app.register(llmRoutes);
+  await app.register(forecastRoutes);
 
   // Static files (production only)
   await app.register(staticPlugin);

--- a/backend/src/routes/forecasts.test.ts
+++ b/backend/src/routes/forecasts.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { forecastRoutes } from './forecasts.js';
+
+vi.mock('../config/index.js', () => ({
+  getConfig: vi.fn().mockReturnValue({}),
+}));
+
+const mockGetCapacityForecasts = vi.fn();
+const mockGenerateForecast = vi.fn();
+
+vi.mock('../services/capacity-forecaster.js', () => ({
+  getCapacityForecasts: (...args: unknown[]) => mockGetCapacityForecasts(...args),
+  generateForecast: (...args: unknown[]) => mockGenerateForecast(...args),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe('Forecast Routes', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = Fastify();
+    app.decorate('authenticate', async () => undefined);
+    await app.register(forecastRoutes);
+    await app.ready();
+  });
+
+  it('GET /api/forecasts returns forecast list', async () => {
+    mockGetCapacityForecasts.mockReturnValue([
+      {
+        containerId: 'abc123',
+        containerName: 'web-server',
+        metricType: 'cpu',
+        currentValue: 75,
+        trend: 'increasing',
+        slope: 2.5,
+        r_squared: 0.85,
+        forecast: [],
+        timeToThreshold: 6,
+        confidence: 'high',
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/forecasts',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].trend).toBe('increasing');
+    expect(body[0].timeToThreshold).toBe(6);
+  });
+
+  it('GET /api/forecasts/:containerId returns single forecast', async () => {
+    mockGenerateForecast.mockReturnValue({
+      containerId: 'abc123',
+      containerName: 'web',
+      metricType: 'cpu',
+      currentValue: 60,
+      trend: 'stable',
+      slope: 0.01,
+      r_squared: 0.2,
+      forecast: [],
+      timeToThreshold: null,
+      confidence: 'low',
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/forecasts/abc123?metric=cpu',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.trend).toBe('stable');
+  });
+
+  it('returns error when insufficient data', async () => {
+    mockGenerateForecast.mockReturnValue(null);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/forecasts/nodata',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.error).toBe('Insufficient data for forecast');
+  });
+});

--- a/backend/src/routes/forecasts.ts
+++ b/backend/src/routes/forecasts.ts
@@ -1,0 +1,64 @@
+import { FastifyInstance } from 'fastify';
+import { getCapacityForecasts, generateForecast } from '../services/capacity-forecaster.js';
+
+export async function forecastRoutes(fastify: FastifyInstance) {
+  fastify.get('/api/forecasts', {
+    schema: {
+      tags: ['Forecasts'],
+      summary: 'Get capacity forecasts for all containers',
+      security: [{ bearerAuth: [] }],
+      querystring: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', default: 10 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request) => {
+    const { limit } = request.query as { limit?: number };
+    return getCapacityForecasts(limit ?? 10);
+  });
+
+  fastify.get<{ Params: { containerId: string }; Querystring: { metric?: string; hours?: number } }>(
+    '/api/forecasts/:containerId',
+    {
+      schema: {
+        tags: ['Forecasts'],
+        summary: 'Get capacity forecast for a specific container',
+        security: [{ bearerAuth: [] }],
+        params: {
+          type: 'object',
+          required: ['containerId'],
+          properties: {
+            containerId: { type: 'string' },
+          },
+        },
+        querystring: {
+          type: 'object',
+          properties: {
+            metric: { type: 'string', default: 'cpu' },
+            hours: { type: 'number', default: 24 },
+          },
+        },
+      },
+      preHandler: [fastify.authenticate],
+    },
+    async (request) => {
+      const { containerId } = request.params;
+      const { metric, hours } = request.query;
+      const forecast = generateForecast(
+        containerId,
+        '',
+        metric ?? 'cpu',
+        90,
+        hours ?? 24,
+        hours ?? 24,
+      );
+      if (!forecast) {
+        return { error: 'Insufficient data for forecast' };
+      }
+      return forecast;
+    },
+  );
+}

--- a/backend/src/services/capacity-forecaster.test.ts
+++ b/backend/src/services/capacity-forecaster.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db/sqlite.js', () => {
+  const mockPrepare = vi.fn();
+  return {
+    getDb: vi.fn(() => ({ prepare: mockPrepare })),
+    __mockPrepare: mockPrepare,
+  };
+});
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { linearRegression } from './capacity-forecaster.js';
+
+describe('capacity-forecaster', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('linearRegression', () => {
+    it('returns zero slope for constant data', () => {
+      const points = [
+        { x: 0, y: 50 },
+        { x: 1, y: 50 },
+        { x: 2, y: 50 },
+      ];
+      const result = linearRegression(points);
+      expect(result.slope).toBeCloseTo(0);
+      expect(result.intercept).toBeCloseTo(50);
+    });
+
+    it('returns correct slope for perfectly linear increasing data', () => {
+      const points = [
+        { x: 0, y: 10 },
+        { x: 1, y: 20 },
+        { x: 2, y: 30 },
+        { x: 3, y: 40 },
+      ];
+      const result = linearRegression(points);
+      expect(result.slope).toBeCloseTo(10);
+      expect(result.intercept).toBeCloseTo(10);
+      expect(result.rSquared).toBeCloseTo(1);
+    });
+
+    it('returns negative slope for decreasing data', () => {
+      const points = [
+        { x: 0, y: 100 },
+        { x: 1, y: 80 },
+        { x: 2, y: 60 },
+        { x: 3, y: 40 },
+      ];
+      const result = linearRegression(points);
+      expect(result.slope).toBeCloseTo(-20);
+      expect(result.rSquared).toBeCloseTo(1);
+    });
+
+    it('handles single point', () => {
+      const result = linearRegression([{ x: 0, y: 50 }]);
+      expect(result.slope).toBe(0);
+      expect(result.intercept).toBe(50);
+    });
+
+    it('returns low R² for noisy data', () => {
+      const points = [
+        { x: 0, y: 10 },
+        { x: 1, y: 90 },
+        { x: 2, y: 20 },
+        { x: 3, y: 80 },
+        { x: 4, y: 30 },
+      ];
+      const result = linearRegression(points);
+      expect(result.rSquared).toBeLessThan(0.3);
+    });
+  });
+});

--- a/backend/src/services/capacity-forecaster.ts
+++ b/backend/src/services/capacity-forecaster.ts
@@ -1,0 +1,209 @@
+import { getDb } from '../db/sqlite.js';
+import { createChildLogger } from '../utils/logger.js';
+
+const log = createChildLogger('capacity-forecaster');
+
+export interface ForecastPoint {
+  timestamp: string;
+  value: number;
+  isProjected: boolean;
+}
+
+export interface CapacityForecast {
+  containerId: string;
+  containerName: string;
+  metricType: string;
+  currentValue: number;
+  trend: 'increasing' | 'decreasing' | 'stable';
+  slope: number;
+  r_squared: number;
+  forecast: ForecastPoint[];
+  timeToThreshold: number | null; // hours until threshold is reached, null if stable/decreasing
+  confidence: 'high' | 'medium' | 'low';
+}
+
+/**
+ * Simple linear regression: y = mx + b
+ * Returns slope (m), intercept (b), and R² for goodness of fit.
+ */
+export function linearRegression(
+  points: Array<{ x: number; y: number }>,
+): { slope: number; intercept: number; rSquared: number } {
+  const n = points.length;
+  if (n < 2) return { slope: 0, intercept: points[0]?.y ?? 0, rSquared: 0 };
+
+  let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0, sumY2 = 0;
+  for (const p of points) {
+    sumX += p.x;
+    sumY += p.y;
+    sumXY += p.x * p.y;
+    sumX2 += p.x * p.x;
+    sumY2 += p.y * p.y;
+  }
+
+  const denom = n * sumX2 - sumX * sumX;
+  if (denom === 0) return { slope: 0, intercept: sumY / n, rSquared: 0 };
+
+  const slope = (n * sumXY - sumX * sumY) / denom;
+  const intercept = (sumY - slope * sumX) / n;
+
+  // R² calculation
+  const yMean = sumY / n;
+  let ssTot = 0, ssRes = 0;
+  for (const p of points) {
+    const yPred = slope * p.x + intercept;
+    ssTot += (p.y - yMean) ** 2;
+    ssRes += (p.y - yPred) ** 2;
+  }
+
+  const rSquared = ssTot === 0 ? 0 : 1 - ssRes / ssTot;
+
+  return { slope, intercept, rSquared: Math.max(0, rSquared) };
+}
+
+/**
+ * Get recent metric data points for a container.
+ */
+function getRecentMetrics(
+  containerId: string,
+  metricType: string,
+  hoursBack: number = 24,
+): Array<{ timestamp: string; value: number }> {
+  const db = getDb();
+  return db.prepare(`
+    SELECT timestamp, value FROM metrics
+    WHERE container_id = ? AND metric_type = ?
+      AND timestamp >= datetime('now', ? || ' hours')
+    ORDER BY timestamp ASC
+  `).all(containerId, metricType, `-${hoursBack}`) as Array<{ timestamp: string; value: number }>;
+}
+
+/**
+ * Generate a capacity forecast for a specific container and metric.
+ */
+export function generateForecast(
+  containerId: string,
+  containerName: string,
+  metricType: string,
+  threshold: number = 90,
+  hoursBack: number = 24,
+  hoursForward: number = 24,
+): CapacityForecast | null {
+  const dataPoints = getRecentMetrics(containerId, metricType, hoursBack);
+
+  if (dataPoints.length < 5) return null;
+
+  // Convert timestamps to hours offset from first point
+  const baseTime = new Date(dataPoints[0].timestamp).getTime();
+  const points = dataPoints.map((dp) => ({
+    x: (new Date(dp.timestamp).getTime() - baseTime) / (1000 * 60 * 60),
+    y: dp.value,
+  }));
+
+  const { slope, intercept, rSquared } = linearRegression(points);
+
+  // Determine trend
+  const trend: 'increasing' | 'decreasing' | 'stable' =
+    Math.abs(slope) < 0.1 ? 'stable' : slope > 0 ? 'increasing' : 'decreasing';
+
+  // Confidence based on R² and sample count
+  const confidence: 'high' | 'medium' | 'low' =
+    rSquared > 0.7 && dataPoints.length > 20 ? 'high' :
+    rSquared > 0.4 && dataPoints.length > 10 ? 'medium' : 'low';
+
+  const currentValue = dataPoints[dataPoints.length - 1].value;
+  const lastX = points[points.length - 1].x;
+
+  // Generate forecast points
+  const forecast: ForecastPoint[] = [];
+
+  // Include last few actual data points for context
+  const contextCount = Math.min(5, dataPoints.length);
+  for (let i = dataPoints.length - contextCount; i < dataPoints.length; i++) {
+    forecast.push({
+      timestamp: dataPoints[i].timestamp,
+      value: dataPoints[i].value,
+      isProjected: false,
+    });
+  }
+
+  // Project forward
+  const stepHours = hoursForward / 12; // 12 projected points
+  for (let h = stepHours; h <= hoursForward; h += stepHours) {
+    const projX = lastX + h;
+    const projValue = Math.max(0, Math.min(100, slope * projX + intercept));
+    const projTime = new Date(
+      new Date(dataPoints[dataPoints.length - 1].timestamp).getTime() + h * 60 * 60 * 1000,
+    ).toISOString();
+    forecast.push({ timestamp: projTime, value: projValue, isProjected: true });
+  }
+
+  // Time to threshold (only for increasing metrics approaching a threshold)
+  let timeToThreshold: number | null = null;
+  if (slope > 0 && currentValue < threshold) {
+    const hoursToThreshold = (threshold - currentValue) / slope;
+    if (hoursToThreshold > 0 && hoursToThreshold < 168) { // Within 7 days
+      timeToThreshold = Math.round(hoursToThreshold);
+    }
+  }
+
+  return {
+    containerId,
+    containerName,
+    metricType,
+    currentValue,
+    trend,
+    slope,
+    r_squared: rSquared,
+    forecast,
+    timeToThreshold,
+    confidence,
+  };
+}
+
+/**
+ * Get top containers with concerning capacity trends.
+ */
+export function getCapacityForecasts(
+  limit: number = 10,
+): CapacityForecast[] {
+  const db = getDb();
+
+  // Get unique container IDs with recent metrics
+  const containers = db.prepare(`
+    SELECT DISTINCT container_id, container_name
+    FROM metrics
+    WHERE timestamp >= datetime('now', '-24 hours')
+    GROUP BY container_id
+    HAVING COUNT(*) >= 5
+    ORDER BY container_name ASC
+    LIMIT ?
+  `).all(limit * 2) as Array<{ container_id: string; container_name: string }>;
+
+  const forecasts: CapacityForecast[] = [];
+
+  for (const container of containers) {
+    for (const metricType of ['cpu', 'memory']) {
+      const forecast = generateForecast(
+        container.container_id,
+        container.container_name,
+        metricType,
+      );
+      if (forecast) {
+        forecasts.push(forecast);
+      }
+    }
+  }
+
+  // Sort: increasing trends first, then by time to threshold
+  return forecasts
+    .sort((a, b) => {
+      if (a.trend === 'increasing' && b.trend !== 'increasing') return -1;
+      if (a.trend !== 'increasing' && b.trend === 'increasing') return 1;
+      if (a.timeToThreshold && b.timeToThreshold) return a.timeToThreshold - b.timeToThreshold;
+      if (a.timeToThreshold) return -1;
+      if (b.timeToThreshold) return 1;
+      return 0;
+    })
+    .slice(0, limit);
+}

--- a/frontend/src/hooks/use-forecasts.test.ts
+++ b/frontend/src/hooks/use-forecasts.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: vi.fn().mockResolvedValue([
+      {
+        containerId: 'abc123',
+        containerName: 'web-server',
+        metricType: 'cpu',
+        currentValue: 75,
+        trend: 'increasing',
+        timeToThreshold: 6,
+        confidence: 'high',
+      },
+    ]),
+  },
+}));
+
+import { useForecasts } from './use-forecasts';
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('useForecasts', () => {
+  it('fetches forecast data', async () => {
+    const { result } = renderHook(() => useForecasts(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].trend).toBe('increasing');
+  });
+});

--- a/frontend/src/hooks/use-forecasts.ts
+++ b/frontend/src/hooks/use-forecasts.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export interface ForecastPoint {
+  timestamp: string;
+  value: number;
+  isProjected: boolean;
+}
+
+export interface CapacityForecast {
+  containerId: string;
+  containerName: string;
+  metricType: string;
+  currentValue: number;
+  trend: 'increasing' | 'decreasing' | 'stable';
+  slope: number;
+  r_squared: number;
+  forecast: ForecastPoint[];
+  timeToThreshold: number | null;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export function useForecasts(limit: number = 10) {
+  return useQuery<CapacityForecast[]>({
+    queryKey: ['forecasts', limit],
+    queryFn: () => api.get<CapacityForecast[]>(`/api/forecasts?limit=${limit}`),
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}
+
+export function useContainerForecast(containerId: string, metric: string = 'cpu') {
+  return useQuery<CapacityForecast>({
+    queryKey: ['forecast', containerId, metric],
+    queryFn: () => api.get<CapacityForecast>(`/api/forecasts/${containerId}?metric=${metric}`),
+    staleTime: 5 * 60 * 1000,
+    enabled: !!containerId,
+  });
+}


### PR DESCRIPTION
## Summary
- Linear regression engine for capacity trend analysis on metric history
- API endpoints: `GET /api/forecasts` (all), `GET /api/forecasts/:containerId` (single)
- Trend classification (increasing/decreasing/stable), time-to-threshold estimates
- R² confidence scoring and forecast point generation
- Frontend hook for consuming forecast data

## Test plan
- [x] Backend service tests (5 passing): linearRegression edge cases
- [x] Backend route tests (3 passing): forecast endpoints
- [x] Frontend hook test (1 passing): useForecasts

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)