### PR TITLE
Remediation: fix stale approvals, rationale visibility, action coverage, and AI discuss flow (#87)

### DIFF
--- a/backend/src/routes/remediation.test.ts
+++ b/backend/src/routes/remediation.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
+import { remediationRoutes } from './remediation.js';
+
+const mockBroadcastActionUpdate = vi.fn();
+const mockRestart = vi.fn();
+const mockStop = vi.fn();
+const mockStart = vi.fn();
+
+let state: { action: any } = {
+  action: null,
+};
+
+vi.mock('../services/audit-logger.js', () => ({
+  writeAuditLog: vi.fn(),
+}));
+
+vi.mock('../sockets/remediation.js', () => ({
+  broadcastActionUpdate: (...args: unknown[]) => mockBroadcastActionUpdate(...args),
+}));
+
+vi.mock('../services/portainer-client.js', () => ({
+  restartContainer: (...args: unknown[]) => mockRestart(...args),
+  stopContainer: (...args: unknown[]) => mockStop(...args),
+  startContainer: (...args: unknown[]) => mockStart(...args),
+}));
+
+vi.mock('../db/sqlite.js', () => ({
+  getDb: () => ({
+    prepare: (query: string) => {
+      if (query.includes('SELECT * FROM actions WHERE id = ?')) {
+        return { get: () => state.action };
+      }
+      if (query.includes('UPDATE actions SET status = \'approved\'')) {
+        return {
+          run: () => {
+            state.action = { ...state.action, status: 'approved' };
+            return { changes: 1 };
+          },
+        };
+      }
+      if (query.includes('UPDATE actions SET status = \'rejected\'')) {
+        return {
+          run: () => {
+            state.action = { ...state.action, status: 'rejected' };
+            return { changes: 1 };
+          },
+        };
+      }
+      if (query.includes('UPDATE actions SET status = \'executing\'')) {
+        return {
+          run: () => {
+            state.action = { ...state.action, status: 'executing' };
+            return { changes: 1 };
+          },
+        };
+      }
+      if (query.includes('UPDATE actions SET status = \'completed\'')) {
+        return {
+          run: () => {
+            state.action = { ...state.action, status: 'completed' };
+            return { changes: 1 };
+          },
+        };
+      }
+      if (query.includes('UPDATE actions SET status = \'failed\'')) {
+        return {
+          run: () => {
+            state.action = { ...state.action, status: 'failed' };
+            return { changes: 1 };
+          },
+        };
+      }
+      if (query.includes('SELECT * FROM actions')) {
+        return { all: () => [] };
+      }
+      if (query.includes('SELECT COUNT(*) as count FROM actions')) {
+        return { get: () => ({ count: 0 }) };
+      }
+      return { run: () => ({ changes: 1 }), get: () => ({ count: 0 }), all: () => [] };
+    },
+  }),
+}));
+
+describe('remediation routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify();
+    app.setValidatorCompiler(validatorCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', () => async () => undefined);
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'operator', sessionId: 's1', role: 'operator' as const };
+    });
+    await app.register(remediationRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.action = {
+      id: 'a1',
+      status: 'pending',
+      endpoint_id: 1,
+      container_id: 'c1',
+      action_type: 'RESTART_CONTAINER',
+    };
+  });
+
+  it('returns 409 on stale approve', async () => {
+    state.action.status = 'approved';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/remediation/actions/a1/approve',
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain('already approved');
+  });
+
+  it('broadcasts update after approve', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/remediation/actions/a1/approve',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockBroadcastActionUpdate).toHaveBeenCalledWith(expect.objectContaining({ status: 'approved' }));
+  });
+});

--- a/backend/src/services/remediation-service.test.ts
+++ b/backend/src/services/remediation-service.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockInsertAction = vi.fn();
+const mockGetAction = vi.fn();
+const mockUpdateActionStatus = vi.fn();
+const mockRestart = vi.fn();
+const mockStart = vi.fn();
+const mockStop = vi.fn();
+const mockBroadcastNewAction = vi.fn();
+
+vi.mock('uuid', () => ({
+  v4: () => 'action-123',
+}));
+
+vi.mock('./actions-store.js', () => ({
+  insertAction: (...args: unknown[]) => mockInsertAction(...args),
+  getAction: (...args: unknown[]) => mockGetAction(...args),
+  updateActionStatus: (...args: unknown[]) => mockUpdateActionStatus(...args),
+}));
+
+vi.mock('./portainer-client.js', () => ({
+  restartContainer: (...args: unknown[]) => mockRestart(...args),
+  startContainer: (...args: unknown[]) => mockStart(...args),
+  stopContainer: (...args: unknown[]) => mockStop(...args),
+}));
+
+vi.mock('./event-bus.js', () => ({
+  emitEvent: vi.fn(),
+}));
+
+vi.mock('../sockets/remediation.js', () => ({
+  broadcastNewAction: (...args: unknown[]) => mockBroadcastNewAction(...args),
+}));
+
+import { suggestAction, executeAction } from './remediation-service.js';
+
+describe('remediation-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps OOM insights to STOP_CONTAINER and broadcasts', () => {
+    const result = suggestAction({
+      id: 'insight-1',
+      title: 'OOM detected',
+      description: 'out of memory',
+      suggested_action: '',
+      container_id: 'container-1',
+      container_name: 'api',
+      endpoint_id: 1,
+    } as any);
+
+    expect(result).toEqual({ actionId: 'action-123', actionType: 'STOP_CONTAINER' });
+    expect(mockInsertAction).toHaveBeenCalledWith(expect.objectContaining({ action_type: 'STOP_CONTAINER' }));
+    expect(mockBroadcastNewAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('executes START_CONTAINER action path', async () => {
+    mockGetAction.mockReturnValue({
+      id: 'action-1',
+      endpoint_id: 1,
+      container_id: 'c1',
+      action_type: 'START_CONTAINER',
+      status: 'approved',
+    });
+    mockUpdateActionStatus.mockReturnValue(true);
+
+    const ok = await executeAction('action-1');
+    expect(ok).toBe(true);
+    expect(mockStart).toHaveBeenCalledWith(1, 'c1');
+  });
+});

--- a/backend/src/sockets/remediation.ts
+++ b/backend/src/sockets/remediation.ts
@@ -3,8 +3,10 @@ import { getDb } from '../db/sqlite.js';
 import { createChildLogger } from '../utils/logger.js';
 
 const log = createChildLogger('socket:remediation');
+let remediationNamespace: Namespace | null = null;
 
 export function setupRemediationNamespace(ns: Namespace) {
+  remediationNamespace = ns;
   ns.on('connection', (socket) => {
     const userId = socket.data.user?.sub || 'unknown';
     log.info({ userId }, 'Remediation client connected');
@@ -36,12 +38,12 @@ export function setupRemediationNamespace(ns: Namespace) {
   });
 }
 
-// Call this when action status changes
-export function broadcastActionUpdate(ns: Namespace, action: Record<string, unknown>) {
-  ns.emit('actions:updated', action);
+export function broadcastActionUpdate(action: Record<string, unknown>) {
+  if (!remediationNamespace) return;
+  remediationNamespace.emit('actions:updated', action);
 }
 
-// Call this when new action is suggested
-export function broadcastNewAction(ns: Namespace, action: Record<string, unknown>) {
-  ns.emit('actions:new', action);
+export function broadcastNewAction(action: Record<string, unknown>) {
+  if (!remediationNamespace) return;
+  remediationNamespace.emit('actions:new', action);
 }

--- a/frontend/src/hooks/use-remediation.ts
+++ b/frontend/src/hooks/use-remediation.ts
@@ -8,7 +8,7 @@ interface RemediationAction {
   status: 'pending' | 'approved' | 'rejected' | 'executing' | 'completed' | 'failed';
   containerId: string;
   endpointId: number;
-  description: string;
+  rationale: string;
   suggestedBy: string;
   createdAt: string;
   updatedAt: string;
@@ -40,6 +40,13 @@ export function useApproveAction() {
       });
     },
     onError: (error) => {
+      queryClient.invalidateQueries({ queryKey: ['remediation', 'actions'] });
+      if (error.message.toLowerCase().includes('already')) {
+        toast.error('Action state changed', {
+          description: `${error.message} The list has been refreshed.`,
+        });
+        return;
+      }
       toast.error('Failed to approve action', {
         description: error.message,
       });
@@ -61,6 +68,13 @@ export function useRejectAction() {
       });
     },
     onError: (error) => {
+      queryClient.invalidateQueries({ queryKey: ['remediation', 'actions'] });
+      if (error.message.toLowerCase().includes('already')) {
+        toast.error('Action state changed', {
+          description: `${error.message} The list has been refreshed.`,
+        });
+        return;
+      }
       toast.error('Failed to reject action', {
         description: error.message,
       });
@@ -82,6 +96,13 @@ export function useExecuteAction() {
       });
     },
     onError: (error) => {
+      queryClient.invalidateQueries({ queryKey: ['remediation', 'actions'] });
+      if (error.message.toLowerCase().includes('already')) {
+        toast.error('Action state changed', {
+          description: `${error.message} The list has been refreshed.`,
+        });
+        return;
+      }
       toast.error('Failed to execute action', {
         description: error.message,
       });

--- a/frontend/src/pages/llm-assistant.test.tsx
+++ b/frontend/src/pages/llm-assistant.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 // Mock modules before importing component
 vi.mock('@/hooks/use-llm-chat', () => ({
@@ -34,12 +35,14 @@ import LlmAssistantPage from './llm-assistant';
 import { useLlmChat } from '@/hooks/use-llm-chat';
 import { useLlmModels } from '@/hooks/use-llm-models';
 
-function renderPage() {
+function renderPage(initialEntry: string = '/assistant', state?: Record<string, unknown>) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <QueryClientProvider client={qc}>
-      <LlmAssistantPage />
-    </QueryClientProvider>,
+    <MemoryRouter initialEntries={[{ pathname: initialEntry, state }]}>
+      <QueryClientProvider client={qc}>
+        <LlmAssistantPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
   );
 }
 
@@ -127,6 +130,12 @@ describe('LlmAssistantPage', () => {
 
     renderPage();
     expect(screen.getByText('Stop generating')).toBeTruthy();
+  });
+
+  it('prefills input when opened from remediation context', () => {
+    renderPage('/assistant', { prefillPrompt: 'Explain this remediation action' });
+    const input = screen.getByPlaceholderText('Ask about your infrastructure...') as HTMLInputElement;
+    expect(input.value).toBe('Explain this remediation action');
   });
 });
 

--- a/frontend/src/pages/llm-assistant.tsx
+++ b/frontend/src/pages/llm-assistant.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Send, X, Trash2, Bot, User, AlertCircle, Copy, Check, ChevronDown } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
@@ -8,6 +9,8 @@ import { useLlmModels } from '@/hooks/use-llm-models';
 import 'highlight.js/styles/tokyo-night-dark.css';
 
 export default function LlmAssistantPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
   const [input, setInput] = useState('');
   const [isSending, setIsSending] = useState(false);
   const [selectedModel, setSelectedModel] = useState<string>('');
@@ -15,6 +18,13 @@ export default function LlmAssistantPage() {
   const inputRef = useRef<HTMLInputElement>(null);
   const { messages, isStreaming, currentResponse, sendMessage, cancelGeneration, clearHistory } = useLlmChat();
   const { data: modelsData } = useLlmModels();
+
+  useEffect(() => {
+    const state = location.state as { prefillPrompt?: string } | null;
+    if (!state?.prefillPrompt) return;
+    setInput(state.prefillPrompt);
+    navigate(location.pathname, { replace: true, state: null });
+  }, [location.pathname, location.state, navigate]);
 
   // Set default model when models load
   useEffect(() => {

--- a/frontend/src/pages/remediation.test.tsx
+++ b/frontend/src/pages/remediation.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import RemediationPage from './remediation';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/hooks/use-remediation', () => ({
+  useRemediationActions: () => ({
+    data: [{
+      id: 'action-1',
+      action_type: 'STOP_CONTAINER',
+      status: 'pending',
+      container_id: 'container-1',
+      endpoint_id: 1,
+      rationale: 'Container is consuming too many resources',
+      suggested_by: 'AI Monitor',
+      created_at: '2026-02-06T00:00:00Z',
+    }],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+  useApproveAction: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useRejectAction: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useExecuteAction: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+}));
+
+vi.mock('@/hooks/use-auto-refresh', () => ({
+  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn() }),
+}));
+
+vi.mock('@/providers/socket-provider', () => ({
+  useSockets: () => ({
+    remediationSocket: { on: vi.fn(), off: vi.fn() },
+  }),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <RemediationPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('RemediationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows rationale and routes Discuss with AI with context', () => {
+    renderPage();
+    expect(screen.getByText('Container is consuming too many resources')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Discuss with AI/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/assistant', expect.objectContaining({
+      state: expect.objectContaining({
+        source: 'remediation',
+        actionId: 'action-1',
+      }),
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- return 409 stale-state responses for approve/reject/execute with actionable refresh guidance
- wire remediation socket broadcasts so action state/new suggestions sync in real time
- expand remediation suggestions beyond restart-only (add STOP/START patterns) and execute these action types
- display AI rationale directly in remediation table and add Discuss with AI action on each row
- prefill LLM assistant input with remediation context via navigation state
- add backend/frontend regression tests for stale handling, action mapping, rationale display, and AI handoff

Closes #87