### PR TITLE
Implement #153: monitoring insight acknowledgement in UI

### DIFF
--- a/frontend/src/pages/ai-monitor.test.tsx
+++ b/frontend/src/pages/ai-monitor.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const mockAcknowledgeInsight = vi.fn();
+
+const baseInsights = [
+  {
+    id: 'insight-1',
+    endpoint_id: 1,
+    endpoint_name: 'local',
+    container_id: 'container-1',
+    container_name: 'api-1',
+    severity: 'warning' as const,
+    category: 'anomaly:cpu',
+    title: 'CPU trend spike',
+    description: 'CPU utilization increased quickly over 5 minutes.',
+    suggested_action: 'Inspect workload pressure.',
+    is_acknowledged: 0,
+    created_at: '2026-02-06T10:00:00.000Z',
+  },
+  {
+    id: 'insight-2',
+    endpoint_id: 1,
+    endpoint_name: 'local',
+    container_id: 'container-2',
+    container_name: 'worker-2',
+    severity: 'info' as const,
+    category: 'anomaly:memory',
+    title: 'Memory is stable',
+    description: 'No immediate action required.',
+    suggested_action: null,
+    is_acknowledged: 1,
+    created_at: '2026-02-06T10:01:00.000Z',
+  },
+];
+
+const mockUseMonitoring = vi.fn();
+
+vi.mock('@/hooks/use-monitoring', () => ({
+  useMonitoring: () => mockUseMonitoring(),
+}));
+
+vi.mock('@/hooks/use-investigations', () => ({
+  safeParseJson: () => [],
+  useInvestigations: () => ({
+    getInvestigationForInsight: () => undefined,
+  }),
+}));
+
+vi.mock('@/hooks/use-incidents', () => ({
+  useIncidents: () => ({ data: { incidents: [], counts: { active: 0 } } }),
+  useResolveIncident: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/hooks/use-auto-refresh', () => ({
+  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn() }),
+}));
+
+import AiMonitorPage from './ai-monitor';
+
+describe('AiMonitorPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMonitoring.mockReturnValue({
+      insights: baseInsights,
+      isLoading: false,
+      error: null,
+      subscribedSeverities: new Set(['critical', 'warning', 'info']),
+      subscribeSeverity: vi.fn(),
+      unsubscribeSeverity: vi.fn(),
+      acknowledgeInsight: mockAcknowledgeInsight,
+      acknowledgeError: null,
+      isAcknowledging: false,
+      acknowledgingInsightId: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it('acknowledges an unacknowledged insight from the insight card', () => {
+    render(<AiMonitorPage />);
+
+    fireEvent.click(screen.getByText('CPU trend spike'));
+    fireEvent.click(screen.getByRole('button', { name: 'Acknowledge' }));
+
+    expect(mockAcknowledgeInsight).toHaveBeenCalledWith('insight-1');
+  });
+
+  it('filters to only unacknowledged insights', () => {
+    render(<AiMonitorPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unacknowledged' }));
+
+    expect(screen.getByText('CPU trend spike')).toBeInTheDocument();
+    expect(screen.queryByText('Memory is stable')).not.toBeInTheDocument();
+  });
+
+  it('renders acknowledge error message when mutation fails', () => {
+    mockUseMonitoring.mockReturnValue({
+      insights: baseInsights,
+      isLoading: false,
+      error: null,
+      subscribedSeverities: new Set(['critical', 'warning', 'info']),
+      subscribeSeverity: vi.fn(),
+      unsubscribeSeverity: vi.fn(),
+      acknowledgeInsight: mockAcknowledgeInsight,
+      acknowledgeError: new Error('Failed to acknowledge insight'),
+      isAcknowledging: false,
+      acknowledgingInsightId: null,
+      refetch: vi.fn(),
+    });
+
+    render(<AiMonitorPage />);
+    fireEvent.click(screen.getByText('CPU trend spike'));
+
+    expect(screen.getByText('Failed to acknowledge insight')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ai-monitor.tsx
+++ b/frontend/src/pages/ai-monitor.tsx
@@ -47,6 +47,9 @@ interface InsightCardProps {
     created_at: string;
   };
   investigation?: Investigation;
+  onAcknowledge: (insightId: string) => void;
+  isAcknowledging: boolean;
+  acknowledgeErrorMessage?: string;
 }
 
 function SeverityBadge({ severity }: { severity: Severity }) {
@@ -331,7 +334,13 @@ function IncidentCard({ incident, onResolve }: { incident: Incident; onResolve: 
   );
 }
 
-function InsightCard({ insight, investigation }: InsightCardProps) {
+function InsightCard({
+  insight,
+  investigation,
+  onAcknowledge,
+  isAcknowledging,
+  acknowledgeErrorMessage,
+}: InsightCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   const categoryIcon = {
@@ -426,6 +435,42 @@ function InsightCard({ insight, investigation }: InsightCardProps) {
               <InvestigationSection investigation={investigation} />
             )}
 
+            {!insight.is_acknowledged && (
+              <div className="rounded-md border border-amber-200 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-900/20 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-xs text-amber-800 dark:text-amber-200">
+                    Mark this insight as acknowledged to reduce noise during triage.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => onAcknowledge(insight.id)}
+                    disabled={isAcknowledging}
+                    className={cn(
+                      'inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+                      isAcknowledging
+                        ? 'bg-muted text-muted-foreground cursor-not-allowed'
+                        : 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400 dark:hover:bg-emerald-900/50'
+                    )}
+                  >
+                    {isAcknowledging ? (
+                      <>
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        Acknowledging...
+                      </>
+                    ) : (
+                      <>
+                        <CheckCircle2 className="h-3 w-3" />
+                        Acknowledge
+                      </>
+                    )}
+                  </button>
+                </div>
+                {acknowledgeErrorMessage && (
+                  <p className="mt-2 text-xs text-red-700 dark:text-red-300">{acknowledgeErrorMessage}</p>
+                )}
+              </div>
+            )}
+
             {(insight.endpoint_name || insight.container_name) && (
               <div>
                 <h4 className="text-sm font-medium mb-2">Resource Details</h4>
@@ -476,6 +521,7 @@ function InsightCard({ insight, investigation }: InsightCardProps) {
 
 export default function AiMonitorPage() {
   const [severityFilter, setSeverityFilter] = useState<'all' | Severity>('all');
+  const [acknowledgementFilter, setAcknowledgementFilter] = useState<'all' | 'unacknowledged'>('all');
   const { interval, setInterval } = useAutoRefresh(30);
 
   const {
@@ -485,6 +531,9 @@ export default function AiMonitorPage() {
     subscribedSeverities,
     subscribeSeverity,
     unsubscribeSeverity,
+    acknowledgeInsight,
+    acknowledgeError,
+    acknowledgingInsightId,
     refetch,
   } = useMonitoring();
 
@@ -494,9 +543,16 @@ export default function AiMonitorPage() {
 
   // Filter insights by severity
   const filteredInsights = useMemo(() => {
-    if (severityFilter === 'all') return insights;
-    return insights.filter((i) => i.severity === severityFilter);
-  }, [insights, severityFilter]);
+    const bySeverity = severityFilter === 'all'
+      ? insights
+      : insights.filter((i) => i.severity === severityFilter);
+
+    if (acknowledgementFilter === 'unacknowledged') {
+      return bySeverity.filter((i) => !i.is_acknowledged);
+    }
+
+    return bySeverity;
+  }, [acknowledgementFilter, insights, severityFilter]);
 
   // Stats
   const stats = useMemo(() => ({
@@ -624,7 +680,7 @@ export default function AiMonitorPage() {
       </div>
 
       {/* Severity Filter Tabs */}
-      <div className="flex items-center gap-1 overflow-x-auto rounded-lg border bg-card p-1">
+      <div className="flex flex-wrap items-center gap-2 overflow-x-auto rounded-lg border bg-card p-1">
         <button
           onClick={() => setSeverityFilter('all')}
           className={cn(
@@ -682,6 +738,29 @@ export default function AiMonitorPage() {
             </button>
           );
         })}
+        <div className="mx-1 hidden h-6 w-px bg-border sm:block" />
+        <button
+          onClick={() => setAcknowledgementFilter('all')}
+          className={cn(
+            'rounded-md px-3 py-2 text-sm font-medium transition-colors whitespace-nowrap',
+            acknowledgementFilter === 'all'
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+          )}
+        >
+          All Statuses
+        </button>
+        <button
+          onClick={() => setAcknowledgementFilter('unacknowledged')}
+          className={cn(
+            'rounded-md px-3 py-2 text-sm font-medium transition-colors whitespace-nowrap',
+            acknowledgementFilter === 'unacknowledged'
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+          )}
+        >
+          Unacknowledged
+        </button>
       </div>
 
       {/* Active Incidents */}
@@ -714,9 +793,11 @@ export default function AiMonitorPage() {
           <Activity className="mx-auto h-12 w-12 text-muted-foreground" />
           <h3 className="mt-4 text-lg font-semibold">No insights</h3>
           <p className="mt-2 text-sm text-muted-foreground">
-            {severityFilter === 'all'
-              ? 'AI monitoring has not generated any insights yet. Check back soon.'
-              : `No ${severityFilter} insights found. Try a different filter.`}
+            {acknowledgementFilter === 'unacknowledged'
+              ? 'No unacknowledged insights match the current filters.'
+              : severityFilter === 'all'
+                ? 'AI monitoring has not generated any insights yet. Check back soon.'
+                : `No ${severityFilter} insights found. Try a different filter.`}
           </p>
           {!subscribedSeverities.has(severityFilter as Severity) && severityFilter !== 'all' && (
             <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
@@ -731,6 +812,9 @@ export default function AiMonitorPage() {
               key={insight.id}
               insight={insight}
               investigation={getInvestigationForInsight(insight.id)}
+              onAcknowledge={acknowledgeInsight}
+              isAcknowledging={acknowledgingInsightId === insight.id}
+              acknowledgeErrorMessage={acknowledgeError instanceof Error ? acknowledgeError.message : undefined}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add optimistic acknowledge mutation in frontend/src/hooks/use-monitoring.ts
- add acknowledge action and unacknowledged filter in frontend/src/pages/ai-monitor.tsx
- add regression tests for acknowledge action, filtering, and error rendering in frontend/src/pages/ai-monitor.test.tsx

## Testing
- npm run test -w frontend -- src/pages/ai-monitor.test.tsx
- npm run typecheck -w frontend (fails on existing unrelated frontend/src/pages/settings.tsx api.patch typing issue)

Closes #153