### PR TITLE
Implement #152: notification history timeline UI

### DIFF
--- a/frontend/src/pages/settings-notification-history.test.tsx
+++ b/frontend/src/pages/settings-notification-history.test.tsx
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockGet = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+import { NotificationHistoryPanel } from './settings';
+
+describe('NotificationHistoryPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGet.mockResolvedValue({
+      entries: [
+        {
+          id: 1,
+          channel: 'teams',
+          event_type: 'anomaly_detected',
+          title: 'CPU Spike',
+          body: 'High CPU observed on api-1',
+          severity: 'warning',
+          status: 'sent',
+          error: null,
+          container_name: 'api-1',
+          created_at: new Date().toISOString(),
+        },
+        {
+          id: 2,
+          channel: 'email',
+          event_type: 'incident_summary',
+          title: 'Delivery Failure',
+          body: 'SMTP connection failed',
+          severity: 'critical',
+          status: 'failed',
+          error: 'SMTP timeout',
+          container_name: null,
+          created_at: new Date().toISOString(),
+        },
+      ],
+      total: 2,
+      limit: 200,
+      offset: 0,
+    });
+  });
+
+  it('loads and renders notification history entries', async () => {
+    render(<NotificationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/api/notifications/history', {
+        params: { limit: 200, offset: 0, channel: undefined },
+      });
+    });
+
+    expect(screen.getByText('CPU Spike')).toBeInTheDocument();
+    expect(screen.getByText('Delivery Failure')).toBeInTheDocument();
+  });
+
+  it('filters entries by status', async () => {
+    render(<NotificationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CPU Spike')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'failed' } });
+
+    expect(screen.queryByText('CPU Spike')).not.toBeInTheDocument();
+    expect(screen.getByText('Delivery Failure')).toBeInTheDocument();
+  });
+
+  it('shows error state when history request fails', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Request failed'));
+
+    render(<NotificationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load notification history')).toBeInTheDocument();
+      expect(screen.getByText('Request failed')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -335,6 +335,235 @@ export function NotificationTestButtons() {
   );
 }
 
+interface NotificationHistoryEntry {
+  id: number;
+  channel: 'teams' | 'email';
+  event_type: string;
+  title: string;
+  body: string;
+  severity: string;
+  status: 'sent' | 'failed';
+  error: string | null;
+  container_name: string | null;
+  created_at: string;
+}
+
+interface NotificationHistoryResponse {
+  entries: NotificationHistoryEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+type ChannelFilter = 'all' | 'teams' | 'email';
+type StatusFilter = 'all' | 'sent' | 'failed';
+type DateRangeFilter = 'all' | '24h' | '7d' | '30d';
+
+export function NotificationHistoryPanel() {
+  const [entries, setEntries] = useState<NotificationHistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [channelFilter, setChannelFilter] = useState<ChannelFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [dateRangeFilter, setDateRangeFilter] = useState<DateRangeFilter>('7d');
+
+  const fetchHistory = async (channel: ChannelFilter) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params: Record<string, string | number | undefined> = {
+        limit: 200,
+        offset: 0,
+        channel: channel === 'all' ? undefined : channel,
+      };
+      const response = await api.get<NotificationHistoryResponse>('/api/notifications/history', { params });
+      setEntries(response.entries);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load notification history');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchHistory(channelFilter);
+  }, [channelFilter]);
+
+  const filteredEntries = useMemo(() => {
+    const now = Date.now();
+
+    return entries.filter((entry) => {
+      if (statusFilter !== 'all' && entry.status !== statusFilter) {
+        return false;
+      }
+
+      if (dateRangeFilter !== 'all') {
+        const createdAt = new Date(entry.created_at).getTime();
+        const ageMs = now - createdAt;
+        const thresholds: Record<Exclude<DateRangeFilter, 'all'>, number> = {
+          '24h': 24 * 60 * 60 * 1000,
+          '7d': 7 * 24 * 60 * 60 * 1000,
+          '30d': 30 * 24 * 60 * 60 * 1000,
+        };
+        if (ageMs > thresholds[dateRangeFilter]) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [dateRangeFilter, entries, statusFilter]);
+
+  const sentCount = filteredEntries.filter((entry) => entry.status === 'sent').length;
+  const failedCount = filteredEntries.filter((entry) => entry.status === 'failed').length;
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b p-4">
+        <div className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          <h2 className="text-lg font-semibold">Notification History</h2>
+        </div>
+        <button
+          type="button"
+          onClick={() => void fetchHistory(channelFilter)}
+          disabled={loading}
+          className="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent disabled:opacity-50"
+        >
+          {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+          Refresh
+        </button>
+      </div>
+
+      <div className="border-b p-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2">
+            <label htmlFor="history-channel-filter" className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Channel
+            </label>
+            <select
+              id="history-channel-filter"
+              value={channelFilter}
+              onChange={(e) => setChannelFilter(e.target.value as ChannelFilter)}
+              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
+            >
+              <option value="all">All</option>
+              <option value="teams">Teams</option>
+              <option value="email">Email</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label htmlFor="history-status-filter" className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Status
+            </label>
+            <select
+              id="history-status-filter"
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
+            >
+              <option value="all">All</option>
+              <option value="sent">Sent</option>
+              <option value="failed">Failed</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label htmlFor="history-date-range-filter" className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Date Range
+            </label>
+            <select
+              id="history-date-range-filter"
+              value={dateRangeFilter}
+              onChange={(e) => setDateRangeFilter(e.target.value as DateRangeFilter)}
+              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
+            >
+              <option value="24h">Last 24 Hours</option>
+              <option value="7d">Last 7 Days</option>
+              <option value="30d">Last 30 Days</option>
+              <option value="all">All Time</option>
+            </select>
+          </div>
+          <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="rounded-full bg-emerald-500/15 px-2 py-1 text-emerald-700 dark:text-emerald-400">Sent: {sentCount}</span>
+            <span className="rounded-full bg-red-500/15 px-2 py-1 text-red-700 dark:text-red-400">Failed: {failedCount}</span>
+          </div>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="p-4">
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4">
+            <p className="font-medium text-destructive">Failed to load notification history</p>
+            <p className="mt-1 text-sm text-muted-foreground">{error}</p>
+          </div>
+        </div>
+      ) : loading ? (
+        <div className="space-y-2 p-4">
+          <div className="h-10 animate-pulse rounded bg-muted" />
+          <div className="h-10 animate-pulse rounded bg-muted" />
+          <div className="h-10 animate-pulse rounded bg-muted" />
+        </div>
+      ) : filteredEntries.length === 0 ? (
+        <div className="p-8 text-center">
+          <p className="text-sm font-medium">No notification history found</p>
+          <p className="mt-1 text-sm text-muted-foreground">Try adjusting channel, status, or date filters.</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[900px] text-sm">
+            <thead>
+              <tr className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-2.5 font-medium">Time</th>
+                <th className="px-4 py-2.5 font-medium">Channel</th>
+                <th className="px-4 py-2.5 font-medium">Status</th>
+                <th className="px-4 py-2.5 font-medium">Event</th>
+                <th className="px-4 py-2.5 font-medium">Message</th>
+                <th className="px-4 py-2.5 font-medium">Error</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredEntries.map((entry) => (
+                <tr key={entry.id} className="border-b last:border-0">
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {new Date(entry.created_at).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="inline-flex rounded-full bg-muted px-2 py-1 text-xs capitalize">
+                      {entry.channel}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={cn(
+                        'inline-flex rounded-full px-2 py-1 text-xs font-medium',
+                        entry.status === 'sent'
+                          ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
+                          : 'bg-red-500/15 text-red-700 dark:text-red-400'
+                      )}
+                    >
+                      {entry.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <p className="font-medium">{entry.title}</p>
+                    <p className="text-xs text-muted-foreground">{entry.event_type}</p>
+                  </td>
+                  <td className="max-w-[380px] px-4 py-3 text-xs text-muted-foreground">
+                    <p className="line-clamp-2">{entry.body}</p>
+                  </td>
+                  <td className="max-w-[280px] px-4 py-3 text-xs text-red-700 dark:text-red-400">
+                    {entry.error ?? 'None'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function DefaultLandingPagePreference() {
   const [value, setValue] = useState('/');
   const [loading, setLoading] = useState(true);
@@ -734,6 +963,9 @@ export default function SettingsPage() {
 
       {/* Notification Test Buttons */}
       <NotificationTestButtons />
+
+      {/* Notification History */}
+      <NotificationHistoryPanel />
 
       {/* Webhooks Settings */}
       <SettingsSection


### PR DESCRIPTION
## Summary
- add Notification History panel in settings with channel/status/date range filters
- add refresh, loading, empty, and error states for notification history
- add sent/failed summary counters and tabular event rendering
- add tests in frontend/src/pages/settings-notification-history.test.tsx

## Testing
- npm run test -w frontend -- src/pages/settings.test.tsx src/pages/settings-notification-history.test.tsx

Closes #152