### PR TITLE
Implement #151: investigation drill-down detail UI

### DIFF
--- a/frontend/src/hooks/use-investigations.ts
+++ b/frontend/src/hooks/use-investigations.ts
@@ -103,3 +103,19 @@ export function useInvestigations() {
     refetch: query.refetch,
   };
 }
+
+export function useInvestigationDetail(id: string | undefined) {
+  return useQuery<Investigation>({
+    queryKey: ['investigation', id],
+    queryFn: () => api.get<Investigation>(`/api/investigations/${id}`),
+    enabled: Boolean(id),
+  });
+}
+
+export function useInvestigationByInsightId(insightId: string | undefined) {
+  return useQuery<Investigation>({
+    queryKey: ['investigation', 'by-insight', insightId],
+    queryFn: () => api.get<Investigation>(`/api/investigations/by-insight/${insightId}`),
+    enabled: Boolean(insightId),
+  });
+}

--- a/frontend/src/pages/ai-monitor.tsx
+++ b/frontend/src/pages/ai-monitor.tsx
@@ -434,6 +434,14 @@ function InsightCard({
             {investigation && (
               <InvestigationSection investigation={investigation} />
             )}
+            <div className="flex justify-end">
+              <a
+                href={investigation ? `/investigations/${investigation.id}` : `/investigations/insight/${insight.id}`}
+                className="inline-flex items-center gap-1 rounded-md border border-input bg-background px-2.5 py-1 text-xs font-medium hover:bg-accent"
+              >
+                View Investigation Details
+              </a>
+            </div>
 
             {!insight.is_acknowledged && (
               <div className="rounded-md border border-amber-200 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-900/20 p-3">

--- a/frontend/src/pages/investigation-detail.test.tsx
+++ b/frontend/src/pages/investigation-detail.test.tsx
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+
+const mockUseInvestigationDetail = vi.fn();
+const mockUseInvestigationByInsightId = vi.fn();
+
+vi.mock('@/hooks/use-investigations', () => ({
+  safeParseJson: (value: string | null) => {
+    if (!value) return null;
+    return JSON.parse(value);
+  },
+  useInvestigationDetail: (...args: unknown[]) => mockUseInvestigationDetail(...args),
+  useInvestigationByInsightId: (...args: unknown[]) => mockUseInvestigationByInsightId(...args),
+}));
+
+import InvestigationDetailPage from './investigation-detail';
+
+const baseInvestigation = {
+  id: 'inv-1',
+  insight_id: 'insight-1',
+  endpoint_id: 1,
+  container_id: 'container-1',
+  container_name: 'api-1',
+  status: 'complete',
+  evidence_summary: null,
+  root_cause: 'CPU leak in worker process',
+  contributing_factors: JSON.stringify(['High request burst']),
+  severity_assessment: null,
+  recommended_actions: JSON.stringify([{ action: 'Scale replicas', priority: 'high' }]),
+  confidence_score: 0.88,
+  analysis_duration_ms: 3200,
+  llm_model: 'llama3.2',
+  error_message: null,
+  created_at: '2026-02-06T10:00:00.000Z',
+  completed_at: '2026-02-06T10:01:00.000Z',
+};
+
+function renderById() {
+  return render(
+    <MemoryRouter initialEntries={['/investigations/inv-1']}>
+      <Routes>
+        <Route path="/investigations/:id" element={<InvestigationDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function renderByInsight() {
+  return render(
+    <MemoryRouter initialEntries={['/investigations/insight/insight-1']}>
+      <Routes>
+        <Route path="/investigations/insight/:insightId" element={<InvestigationDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('InvestigationDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseInvestigationDetail.mockReturnValue({
+      data: baseInvestigation,
+      isLoading: false,
+      error: null,
+    });
+    mockUseInvestigationByInsightId.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('renders investigation details by investigation id route', () => {
+    renderById();
+
+    expect(screen.getByText('Investigation Detail')).toBeInTheDocument();
+    expect(screen.getByText('CPU leak in worker process')).toBeInTheDocument();
+    expect(screen.getByText('Scale replicas')).toBeInTheDocument();
+    expect(screen.getByText('ID: inv-1')).toBeInTheDocument();
+  });
+
+  it('renders investigation details by insight route', () => {
+    mockUseInvestigationDetail.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    mockUseInvestigationByInsightId.mockReturnValue({
+      data: baseInvestigation,
+      isLoading: false,
+      error: null,
+    });
+
+    renderByInsight();
+
+    expect(screen.getByText('ID: inv-1')).toBeInTheDocument();
+    expect(screen.getByText('High request burst')).toBeInTheDocument();
+  });
+
+  it('renders error state when investigation cannot be loaded', () => {
+    mockUseInvestigationDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Investigation not found'),
+    });
+
+    renderById();
+
+    expect(screen.getByText('Failed to load investigation')).toBeInTheDocument();
+    expect(screen.getByText('Investigation not found')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/investigation-detail.tsx
+++ b/frontend/src/pages/investigation-detail.tsx
@@ -1,0 +1,226 @@
+import { Link, useParams } from 'react-router-dom';
+import { ArrowLeft, Brain, Clock, Database, Layers, Server, AlertTriangle, Loader2 } from 'lucide-react';
+import {
+  safeParseJson,
+  useInvestigationByInsightId,
+  useInvestigationDetail,
+  type RecommendedAction,
+} from '@/hooks/use-investigations';
+import { formatDate } from '@/lib/utils';
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+    gathering: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    analyzing: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+    complete: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+    failed: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  };
+
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[status] ?? styles.pending}`}>
+      {status}
+    </span>
+  );
+}
+
+export default function InvestigationDetailPage() {
+  const { id, insightId } = useParams();
+  const detailQuery = useInvestigationDetail(id);
+  const byInsightQuery = useInvestigationByInsightId(insightId);
+
+  const query = insightId ? byInsightQuery : detailQuery;
+  const investigation = query.data;
+
+  if (query.isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-64 animate-pulse rounded bg-muted" />
+        <div className="h-48 animate-pulse rounded-lg bg-muted" />
+      </div>
+    );
+  }
+
+  if (query.error || !investigation) {
+    const message = query.error instanceof Error ? query.error.message : 'Investigation not found';
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Investigation Detail</h1>
+          <p className="text-muted-foreground">Unable to load the requested investigation.</p>
+        </div>
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6">
+          <p className="font-medium text-destructive">Failed to load investigation</p>
+          <p className="mt-1 text-sm text-muted-foreground">{message}</p>
+          <Link
+            to="/ai-monitor"
+            className="mt-4 inline-flex items-center gap-1 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to AI Monitor
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const contributingFactors = safeParseJson<string[]>(investigation.contributing_factors) ?? [];
+  const recommendedActions = safeParseJson<RecommendedAction[]>(investigation.recommended_actions) ?? [];
+
+  const timeline = [
+    { label: 'Investigation created', time: investigation.created_at, detail: 'Investigation queued from triggering insight.' },
+    ...(investigation.status === 'gathering' ? [{ label: 'Evidence gathering', time: investigation.created_at, detail: 'Collecting logs and metrics for root-cause analysis.' }] : []),
+    ...(investigation.status === 'analyzing' ? [{ label: 'AI analysis started', time: investigation.created_at, detail: 'Analyzing evidence with configured model.' }] : []),
+    ...(investigation.completed_at
+      ? [{ label: 'Investigation completed', time: investigation.completed_at, detail: investigation.status === 'failed' ? 'Analysis failed.' : 'Root cause report generated.' }]
+      : []),
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Investigation Detail</h1>
+          <p className="text-muted-foreground">ID: {investigation.id}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <StatusBadge status={investigation.status} />
+          <Link
+            to="/ai-monitor"
+            className="inline-flex items-center gap-1 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back
+          </Link>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <div className="rounded-lg border bg-card p-4">
+          <div className="flex items-center justify-between text-muted-foreground">
+            <span className="text-sm">Created</span>
+            <Clock className="h-4 w-4" />
+          </div>
+          <p className="mt-2 text-sm font-medium">{formatDate(investigation.created_at)}</p>
+        </div>
+        <div className="rounded-lg border bg-card p-4">
+          <div className="flex items-center justify-between text-muted-foreground">
+            <span className="text-sm">Confidence</span>
+            <Brain className="h-4 w-4" />
+          </div>
+          <p className="mt-2 text-lg font-semibold">
+            {investigation.confidence_score != null ? `${Math.round(investigation.confidence_score * 100)}%` : 'N/A'}
+          </p>
+        </div>
+        <div className="rounded-lg border bg-card p-4">
+          <div className="flex items-center justify-between text-muted-foreground">
+            <span className="text-sm">Duration</span>
+            <Loader2 className="h-4 w-4" />
+          </div>
+          <p className="mt-2 text-lg font-semibold">
+            {investigation.analysis_duration_ms != null ? `${(investigation.analysis_duration_ms / 1000).toFixed(1)}s` : 'N/A'}
+          </p>
+        </div>
+        <div className="rounded-lg border bg-card p-4">
+          <div className="flex items-center justify-between text-muted-foreground">
+            <span className="text-sm">Model</span>
+            <Database className="h-4 w-4" />
+          </div>
+          <p className="mt-2 text-sm font-medium">{investigation.llm_model ?? 'Unknown'}</p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-lg border bg-card p-5">
+          <h2 className="text-lg font-semibold">Timeline</h2>
+          <div className="mt-4 space-y-3">
+            {timeline.map((item, index) => (
+              <div key={`${item.label}-${index}`} className="flex gap-3">
+                <div className="mt-1 h-2 w-2 rounded-full bg-primary" />
+                <div>
+                  <p className="text-sm font-medium">{item.label}</p>
+                  <p className="text-xs text-muted-foreground">{formatDate(item.time)}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">{item.detail}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border bg-card p-5">
+          <h2 className="text-lg font-semibold">Related Artifacts</h2>
+          <div className="mt-4 space-y-2 text-sm">
+            <div className="flex items-center gap-2">
+              <Layers className="h-4 w-4 text-muted-foreground" />
+              <span>Insight ID:</span>
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{investigation.insight_id}</code>
+            </div>
+            {investigation.container_name && (
+              <div className="flex items-center gap-2">
+                <Server className="h-4 w-4 text-muted-foreground" />
+                <span>Container:</span>
+                <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{investigation.container_name}</code>
+              </div>
+            )}
+            {investigation.container_id && (
+              <div className="flex items-center gap-2">
+                <Database className="h-4 w-4 text-muted-foreground" />
+                <span>Container ID:</span>
+                <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{investigation.container_id}</code>
+              </div>
+            )}
+            {investigation.endpoint_id != null && (
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 text-muted-foreground" />
+                <span>Endpoint ID:</span>
+                <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{investigation.endpoint_id}</code>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-card p-5">
+        <h2 className="text-lg font-semibold">Findings</h2>
+        <div className="mt-4 space-y-4">
+          {investigation.root_cause && (
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Root Cause</h3>
+              <p className="mt-1 text-sm">{investigation.root_cause}</p>
+            </div>
+          )}
+          {contributingFactors.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Contributing Factors</h3>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                {contributingFactors.map((factor, idx) => (
+                  <li key={`${factor}-${idx}`}>{factor}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {recommendedActions.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Recommended Actions</h3>
+              <div className="mt-2 space-y-2">
+                {recommendedActions.map((action, idx) => (
+                  <div key={`${action.action}-${idx}`} className="rounded-md border bg-muted/30 p-3">
+                    <p className="text-sm font-medium">{action.action}</p>
+                    <p className="text-xs text-muted-foreground">Priority: {action.priority}</p>
+                    {action.rationale && <p className="mt-1 text-xs text-muted-foreground">{action.rationale}</p>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {investigation.error_message && (
+            <div className="rounded-md border border-red-300 bg-red-50 p-3 dark:border-red-900/40 dark:bg-red-900/20">
+              <p className="text-sm font-medium text-red-700 dark:text-red-400">Investigation Error</p>
+              <p className="text-xs text-red-700/90 dark:text-red-300">{investigation.error_message}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -28,6 +28,7 @@ const ContainerComparison = lazy(() => import('@/pages/container-comparison'));
 const StatusPage = lazy(() => import('@/pages/status-page'));
 const Reports = lazy(() => import('@/pages/reports'));
 const LogViewer = lazy(() => import('@/pages/log-viewer'));
+const InvestigationDetail = lazy(() => import('@/pages/investigation-detail'));
 
 function PageLoader() {
   return (
@@ -81,6 +82,8 @@ export const router = createBrowserRouter([
       { path: 'logs', element: <LazyPage><LogViewer /></LazyPage> },
       { path: 'packet-capture', element: <LazyPage><PacketCapture /></LazyPage> },
       { path: 'reports', element: <LazyPage><Reports /></LazyPage> },
+      { path: 'investigations/:id', element: <LazyPage><InvestigationDetail /></LazyPage> },
+      { path: 'investigations/insight/:insightId', element: <LazyPage><InvestigationDetail /></LazyPage> },
       { path: 'backups', element: <LazyPage><Backups /></LazyPage> },
       { path: 'settings', element: <LazyPage><Settings /></LazyPage> },
     ],


### PR DESCRIPTION
## Summary
- add investigation detail page with timeline, findings, and related artifacts
- add route support for investigation by id and by insight link in frontend/src/router.tsx
- extend investigation hooks with detail and by-insight queries
- add deep-link action from AI Monitor insights to detail routes
- add tests in frontend/src/pages/investigation-detail.test.tsx

## Testing
- npm run test -w frontend -- src/pages/investigation-detail.test.tsx
- npm run test -w frontend -- src/pages/ai-monitor.test.tsx

Closes #151