### PR TITLE
Implement #155: logs configuration and connection test UI

### DIFF
--- a/frontend/src/pages/log-viewer-settings.test.tsx
+++ b/frontend/src/pages/log-viewer-settings.test.tsx
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockGet = vi.fn();
+const mockPut = vi.fn();
+const mockPost = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueries: () => [],
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+vi.mock('@/hooks/use-endpoints', () => ({
+  useEndpoints: () => ({ data: [{ id: 1, name: 'Local Docker' }] }),
+}));
+
+vi.mock('@/hooks/use-containers', () => ({
+  useContainers: () => ({ data: [{ id: 'c1', name: 'api', endpointId: 1 }] }),
+}));
+
+import LogViewerPage from './log-viewer';
+
+describe('LogViewerPage logs settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGet.mockImplementation((path: string) => {
+      if (path === '/api/settings') {
+        return Promise.resolve([
+          { key: 'elasticsearch.enabled', value: 'true' },
+          { key: 'elasticsearch.endpoint', value: 'https://logs.example:9200' },
+          { key: 'elasticsearch.api_key', value: 'abc123' },
+          { key: 'elasticsearch.index_pattern', value: 'logs-*' },
+          { key: 'elasticsearch.verify_ssl', value: 'true' },
+        ]);
+      }
+      if (path === '/api/logs/config') {
+        return Promise.resolve({ configured: true, endpoint: 'https://logs.example:9200', indexPattern: 'logs-*' });
+      }
+      return Promise.resolve({});
+    });
+
+    mockPut.mockResolvedValue({});
+    mockPost.mockResolvedValue({ success: true, cluster_name: 'logs-cluster', status: 'green', number_of_nodes: 3 });
+  });
+
+  it('saves logs settings and tests connection', async () => {
+    render(<LogViewerPage />);
+
+    const endpointInput = await screen.findByPlaceholderText('https://logs.internal:9200');
+    fireEvent.change(endpointInput, { target: { value: 'https://logs.internal:9200' } });
+
+    fireEvent.click(screen.getByText('Test Connection'));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/api/logs/test-connection', {
+        endpoint: 'https://logs.internal:9200',
+        apiKey: 'abc123',
+      });
+      expect(screen.getByText('Connection successful')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Save Settings'));
+
+    await waitFor(() => {
+      expect(mockPut).toHaveBeenCalled();
+      expect(screen.getByText('Saved')).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation message for invalid endpoint', async () => {
+    render(<LogViewerPage />);
+
+    const endpointInput = await screen.findByPlaceholderText('https://logs.internal:9200');
+    fireEvent.change(endpointInput, { target: { value: 'not-a-url' } });
+
+    expect(screen.getByText('Enter a valid URL (for example: https://logs.internal:9200)')).toBeInTheDocument();
+    expect(screen.getByText('Test Connection')).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/log-viewer.test.tsx
+++ b/frontend/src/pages/log-viewer.test.tsx
@@ -2,8 +2,26 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import LogViewerPage from './log-viewer';
 
+const mockGet = vi.fn().mockImplementation((path: string) => {
+  if (path === '/api/logs/config') {
+    return Promise.resolve({ configured: false, endpoint: null, indexPattern: null });
+  }
+  if (path === '/api/settings') {
+    return Promise.resolve([]);
+  }
+  return Promise.resolve({});
+});
+
 vi.mock('@tanstack/react-query', () => ({
   useQueries: () => [],
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: vi.fn(),
+    post: vi.fn(),
+  },
 }));
 
 vi.mock('@/hooks/use-endpoints', () => ({
@@ -22,6 +40,7 @@ describe('LogViewerPage', () => {
   it('renders page shell and controls', () => {
     render(<LogViewerPage />);
     expect(screen.getByText('Log Viewer')).toBeInTheDocument();
+    expect(screen.getByText('Logs Settings')).toBeInTheDocument();
     expect(screen.getByText('Regex Search')).toBeInTheDocument();
     expect(screen.getByText('Live Tail ON')).toBeInTheDocument();
     expect(screen.getByText('Select one or more containers to view aggregated logs.')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add Logs Settings panel to log viewer for endpoint/index/api key/SSL configuration
- add inline endpoint validation and safe save flow for elasticsearch.* settings
- add test-connection action wired to /api/logs/test-connection with structured success/failure output
- display current logs configuration state from /api/logs/config
- add frontend tests for new settings behavior and updated page shell assertions

## Testing
- npm run test -w frontend -- src/lib/log-viewer.test.ts src/pages/log-viewer.test.tsx src/pages/log-viewer-settings.test.tsx

Closes #155