### PR TITLE
perf(frontend): optimize TanStack Query cache and add prefetching

### DIFF
--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -29,6 +29,7 @@ import {
 import { useUiStore } from '@/stores/ui-store';
 import { useThemeStore } from '@/stores/theme-store';
 import { useRemediationActions } from '@/hooks/use-remediation';
+import { usePrefetch } from '@/hooks/use-prefetch';
 import { cn } from '@/lib/utils';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 
@@ -168,6 +169,17 @@ export function Sidebar() {
   const reducedMotion = useReducedMotion();
   const navRef = useRef<HTMLElement>(null);
   const hasAnimatedBg = dashboardBackground !== 'none';
+  const { prefetchContainers, prefetchEndpoints, prefetchDashboard, prefetchImages, prefetchStacks } = usePrefetch();
+
+  const prefetchMap: Record<string, (() => void) | undefined> = {
+    '/': prefetchDashboard,
+    '/workloads': prefetchContainers,
+    '/fleet': prefetchEndpoints,
+    '/stacks': prefetchStacks,
+    '/health': prefetchContainers,
+    '/comparison': prefetchContainers,
+    '/images': prefetchImages,
+  };
 
   return (
     <aside
@@ -265,6 +277,8 @@ export function Sidebar() {
                           )
                         }
                         title={sidebarCollapsed ? item.label : undefined}
+                        onMouseEnter={prefetchMap[item.to]}
+                        onFocus={prefetchMap[item.to]}
                       >
                         {({ isActive }) => (
                           <>

--- a/frontend/src/hooks/use-backups.ts
+++ b/frontend/src/hooks/use-backups.ts
@@ -24,6 +24,7 @@ export function useBackups() {
   return useQuery<BackupListResponse>({
     queryKey: backupQueryKey,
     queryFn: () => api.get<BackupListResponse>('/api/backup'),
+    staleTime: 60 * 1000,
   });
 }
 

--- a/frontend/src/hooks/use-images.ts
+++ b/frontend/src/hooks/use-images.ts
@@ -21,5 +21,6 @@ export function useImages(endpointId?: number) {
         : '/api/images';
       return api.get<DockerImage[]>(path);
     },
+    staleTime: 5 * 60 * 1000,
   });
 }

--- a/frontend/src/hooks/use-networks.ts
+++ b/frontend/src/hooks/use-networks.ts
@@ -22,5 +22,6 @@ export function useNetworks(endpointId?: number) {
         : '/api/networks';
       return api.get<Network[]>(path);
     },
+    staleTime: 5 * 60 * 1000,
   });
 }

--- a/frontend/src/hooks/use-prefetch.test.ts
+++ b/frontend/src/hooks/use-prefetch.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePrefetch } from './use-prefetch';
+
+const mockPrefetchQuery = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ prefetchQuery: mockPrefetchQuery }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: { get: vi.fn(() => Promise.resolve([])) },
+}));
+
+describe('usePrefetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return prefetch functions', () => {
+    const { result } = renderHook(() => usePrefetch());
+
+    expect(result.current.prefetchContainers).toBeTypeOf('function');
+    expect(result.current.prefetchEndpoints).toBeTypeOf('function');
+    expect(result.current.prefetchDashboard).toBeTypeOf('function');
+    expect(result.current.prefetchImages).toBeTypeOf('function');
+    expect(result.current.prefetchStacks).toBeTypeOf('function');
+  });
+
+  it('should call prefetchQuery with correct key for containers', () => {
+    const { result } = renderHook(() => usePrefetch());
+    result.current.prefetchContainers();
+
+    expect(mockPrefetchQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['containers', undefined],
+        staleTime: 30_000,
+      }),
+    );
+  });
+
+  it('should call prefetchQuery with correct key for endpoints', () => {
+    const { result } = renderHook(() => usePrefetch());
+    result.current.prefetchEndpoints();
+
+    expect(mockPrefetchQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['endpoints'],
+        staleTime: 60_000,
+      }),
+    );
+  });
+
+  it('should call prefetchQuery with correct key for images', () => {
+    const { result } = renderHook(() => usePrefetch());
+    result.current.prefetchImages();
+
+    expect(mockPrefetchQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['images', undefined],
+        staleTime: 5 * 60_000,
+      }),
+    );
+  });
+
+  it('should call prefetchQuery with correct key for stacks', () => {
+    const { result } = renderHook(() => usePrefetch());
+    result.current.prefetchStacks();
+
+    expect(mockPrefetchQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['stacks'],
+        staleTime: 5 * 60_000,
+      }),
+    );
+  });
+
+  it('should call prefetchQuery with correct key for dashboard', () => {
+    const { result } = renderHook(() => usePrefetch());
+    result.current.prefetchDashboard();
+
+    expect(mockPrefetchQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['dashboard', 'summary'],
+        staleTime: 30_000,
+      }),
+    );
+  });
+});

--- a/frontend/src/hooks/use-prefetch.ts
+++ b/frontend/src/hooks/use-prefetch.ts
@@ -1,0 +1,59 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { api } from '@/lib/api';
+
+/**
+ * Prefetch common data on hover/focus of navigation links to eliminate
+ * loading spinners when navigating between pages.
+ */
+export function usePrefetch() {
+  const queryClient = useQueryClient();
+
+  const prefetchContainers = useCallback(() => {
+    queryClient.prefetchQuery({
+      queryKey: ['containers', undefined],
+      queryFn: () => api.get('/api/containers'),
+      staleTime: 30 * 1000,
+    });
+  }, [queryClient]);
+
+  const prefetchEndpoints = useCallback(() => {
+    queryClient.prefetchQuery({
+      queryKey: ['endpoints'],
+      queryFn: () => api.get('/api/endpoints'),
+      staleTime: 60 * 1000,
+    });
+  }, [queryClient]);
+
+  const prefetchDashboard = useCallback(() => {
+    queryClient.prefetchQuery({
+      queryKey: ['dashboard', 'summary'],
+      queryFn: () => api.get('/api/dashboard/summary'),
+      staleTime: 30 * 1000,
+    });
+  }, [queryClient]);
+
+  const prefetchImages = useCallback(() => {
+    queryClient.prefetchQuery({
+      queryKey: ['images', undefined],
+      queryFn: () => api.get('/api/images'),
+      staleTime: 5 * 60 * 1000,
+    });
+  }, [queryClient]);
+
+  const prefetchStacks = useCallback(() => {
+    queryClient.prefetchQuery({
+      queryKey: ['stacks'],
+      queryFn: () => api.get('/api/stacks'),
+      staleTime: 5 * 60 * 1000,
+    });
+  }, [queryClient]);
+
+  return {
+    prefetchContainers,
+    prefetchEndpoints,
+    prefetchDashboard,
+    prefetchImages,
+    prefetchStacks,
+  };
+}

--- a/frontend/src/hooks/use-settings.ts
+++ b/frontend/src/hooks/use-settings.ts
@@ -44,6 +44,7 @@ export function useSettings(category?: string) {
       const params: Record<string, string | undefined> = { category };
       return api.get<Setting[]>('/api/settings', { params });
     },
+    staleTime: 5 * 60 * 1000,
   });
 }
 

--- a/frontend/src/hooks/use-stacks.ts
+++ b/frontend/src/hooks/use-stacks.ts
@@ -16,5 +16,6 @@ export function useStacks() {
   return useQuery<Stack[]>({
     queryKey: ['stacks'],
     queryFn: () => api.get<Stack[]>('/api/stacks'),
+    staleTime: 5 * 60 * 1000,
   });
 }

--- a/frontend/src/providers/query-provider.test.tsx
+++ b/frontend/src/providers/query-provider.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { QueryProvider } from './query-provider';
+
+function Inspector() {
+  const client = useQueryClient();
+  const defaults = client.getDefaultOptions();
+  return <pre data-testid="defaults">{JSON.stringify(defaults)}</pre>;
+}
+
+describe('QueryProvider', () => {
+  it('should set correct default query options', () => {
+    const { getByTestId } = render(
+      <QueryProvider>
+        <Inspector />
+      </QueryProvider>,
+    );
+
+    const defaults = JSON.parse(getByTestId('defaults').textContent ?? '{}');
+
+    expect(defaults.queries.staleTime).toBe(30_000);
+    expect(defaults.queries.gcTime).toBe(600_000);
+    expect(defaults.queries.retry).toBe(2);
+    expect(defaults.queries.refetchOnWindowFocus).toBe(true);
+    expect(defaults.queries.refetchOnReconnect).toBe('always');
+  });
+
+  it('should set correct default mutation options', () => {
+    const { getByTestId } = render(
+      <QueryProvider>
+        <Inspector />
+      </QueryProvider>,
+    );
+
+    const defaults = JSON.parse(getByTestId('defaults').textContent ?? '{}');
+    expect(defaults.mutations.retry).toBe(0);
+  });
+});

--- a/frontend/src/providers/query-provider.tsx
+++ b/frontend/src/providers/query-provider.tsx
@@ -8,9 +8,10 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
         defaultOptions: {
           queries: {
             staleTime: 30 * 1000,
-            gcTime: 5 * 60 * 1000,
+            gcTime: 10 * 60 * 1000,
             retry: 2,
             refetchOnWindowFocus: true,
+            refetchOnReconnect: 'always',
             placeholderData: keepPreviousData,
           },
           mutations: {


### PR DESCRIPTION
## Summary
- Increase `gcTime` from 5min to 10min to retain cached data longer across navigation
- Add `refetchOnReconnect: 'always'` to ensure data freshness after network reconnection
- Set 5min `staleTime` for infrequently-changing data (images, stacks, networks, settings)
- Set 1min `staleTime` for backups
- Add `usePrefetch` hook for route-level data prefetching on hover/focus
- Integrate prefetch triggers in sidebar navigation links

## Test plan
- [x] New `use-prefetch.test.ts` — 6 tests covering all prefetch functions
- [x] New `query-provider.test.tsx` — 2 tests verifying default config values
- [x] TypeScript passes `--noEmit` with no errors
- [ ] Manual: Navigate between pages — cached data loads instantly
- [ ] Manual: Hover over sidebar links — check Network tab for prefetch requests

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)