### PR TITLE
perf(docker): optimize Dockerfiles for faster builds and smaller images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+.git
+.github
+*.md
+!README.md
+.env
+.env.*
+*.log
+dist
+.vscode
+.idea
+coverage
+.nyc_output
+*.tsbuildinfo
+research-speed.md

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+*.log
+*.tsbuildinfo

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,20 +1,20 @@
 FROM node:22-alpine AS builder
 
 WORKDIR /app
-COPY package.json ./
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci
 COPY tsconfig.json ./
 COPY src/ src/
 RUN npm run build
 
 FROM node:22-alpine AS runtime
 
-RUN apk add --no-cache dumb-init wget
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup -u 1001
+RUN apk add --no-cache dumb-init wget && \
+    addgroup -S appgroup && adduser -S appuser -G appgroup -u 1001
 
 WORKDIR /app
-COPY --from=builder /app/package.json ./
-RUN npm install --omit=dev
+COPY --from=builder /app/package.json /app/package-lock.json ./
+RUN npm ci --omit=dev
 COPY --from=builder /app/dist/ dist/
 COPY --from=builder /app/src/db/migrations/ dist/db/migrations/
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+*.log
+*.tsbuildinfo

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,9 +4,11 @@ ARG VITE_API_URL=""
 ARG VITE_SOCKET_URL=""
 
 WORKDIR /app
-COPY package.json ./
-RUN npm install
-COPY . .
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY index.html vite.config.ts tsconfig.json tsconfig.node.json components.json ./
+COPY public/ public/
+COPY src/ src/
 ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_SOCKET_URL=$VITE_SOCKET_URL
 RUN npm run build
@@ -18,11 +20,8 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup -u 1001
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
 
-RUN chown -R appuser:appgroup /usr/share/nginx/html \
-    && chown -R appuser:appgroup /var/cache/nginx \
-    && chown -R appuser:appgroup /var/log/nginx \
-    && touch /tmp/nginx.pid \
-    && chown appuser:appgroup /tmp/nginx.pid
+RUN chown -R appuser:appgroup /usr/share/nginx/html /var/cache/nginx /var/log/nginx \
+    && touch /tmp/nginx.pid && chown appuser:appgroup /tmp/nginx.pid
 
 USER appuser
 


### PR DESCRIPTION
## Summary
- Uses `npm ci` instead of `npm install` for deterministic, faster dependency installation
- Copies `package-lock.json` in both backend and frontend build stages
- Replaces `COPY . .` in frontend with explicit file copies for better Docker layer caching
- Merges multiple `RUN` layers to reduce image layer count
- Adds `.dockerignore` files (root, backend, frontend) to exclude unnecessary files from build context

Closes #185

## Test plan
- [ ] Verify backend Docker image builds successfully: `docker build -t test-backend backend/`
- [ ] Verify frontend Docker image builds successfully: `docker build -t test-frontend frontend/`
- [ ] Verify `docker compose -f docker-compose.dev.yml up` works
- [ ] Confirm layer caching works — second build should be faster when only src/ changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)