### PR TITLE
perf(api): add cursor-based pagination for audit-log and insights

### DIFF
--- a/backend/src/models/api-schemas.ts
+++ b/backend/src/models/api-schemas.ts
@@ -162,6 +162,7 @@ export const InsightsQuerySchema = z.object({
   acknowledged: z.coerce.boolean().optional(),
   limit: z.coerce.number().default(50),
   offset: z.coerce.number().default(0),
+  cursor: z.string().optional(),
 });
 
 export const InsightIdParamsSchema = z.object({
@@ -229,6 +230,7 @@ export const AuditLogQuerySchema = z.object({
   userId: z.string().optional(),
   limit: z.coerce.number().default(100),
   offset: z.coerce.number().default(0),
+  cursor: z.string().optional(),
 });
 
 // ─── Logs schemas ───────────────────────────────────────────────────

--- a/backend/src/routes/monitoring.test.ts
+++ b/backend/src/routes/monitoring.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+import { monitoringRoutes } from './monitoring.js';
+
+const mockAll = vi.fn().mockReturnValue([]);
+const mockGet = vi.fn().mockReturnValue({ count: 0 });
+const mockRun = vi.fn().mockReturnValue({ changes: 1 });
+
+vi.mock('../db/sqlite.js', () => ({
+  getDb: () => ({
+    prepare: () => ({
+      all: (...args: unknown[]) => mockAll(...args),
+      get: (...args: unknown[]) => mockGet(...args),
+      run: (...args: unknown[]) => mockRun(...args),
+    }),
+  }),
+}));
+
+describe('monitoring insights cursor pagination', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'admin', sessionId: 's1', role: 'admin' as const };
+    });
+    await app.register(monitoringRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockReturnValue({ count: 0 });
+  });
+
+  it('returns hasMore and nextCursor when more items exist', async () => {
+    const rows = [
+      { id: 'i3', severity: 'warning', created_at: '2025-01-03T00:00:00Z' },
+      { id: 'i2', severity: 'info', created_at: '2025-01-02T00:00:00Z' },
+      { id: 'i1', severity: 'critical', created_at: '2025-01-01T00:00:00Z' },
+    ];
+    mockAll.mockReturnValueOnce(rows);
+    mockGet.mockReturnValueOnce({ count: 5 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/monitoring/insights?limit=2',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    const body = response.json();
+    expect(response.statusCode).toBe(200);
+    expect(body.insights).toHaveLength(2);
+    expect(body.hasMore).toBe(true);
+    expect(body.nextCursor).toBe('2025-01-02T00:00:00Z|i2');
+    expect(body.total).toBe(5);
+  });
+
+  it('returns hasMore=false when fewer results than limit', async () => {
+    mockAll.mockReturnValueOnce([
+      { id: 'i1', severity: 'info', created_at: '2025-01-01T00:00:00Z' },
+    ]);
+    mockGet.mockReturnValueOnce({ count: 1 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/monitoring/insights?limit=5',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    const body = response.json();
+    expect(response.statusCode).toBe(200);
+    expect(body.insights).toHaveLength(1);
+    expect(body.hasMore).toBe(false);
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it('accepts cursor for next page', async () => {
+    mockAll.mockReturnValueOnce([]);
+    mockGet.mockReturnValueOnce({ count: 3 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/monitoring/insights?limit=2&cursor=2025-01-02T00:00:00Z|i2',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.hasMore).toBe(false);
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it('keeps backward compatible offset pagination', async () => {
+    mockAll.mockReturnValueOnce([]);
+    mockGet.mockReturnValueOnce({ count: 0 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/monitoring/insights?limit=10&offset=20',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.offset).toBe(20);
+    expect(body.limit).toBe(10);
+    expect(body.total).toBe(0);
+  });
+
+  it('filters by severity with cursor', async () => {
+    mockAll.mockReturnValueOnce([
+      { id: 'i5', severity: 'critical', created_at: '2025-01-05T00:00:00Z' },
+    ]);
+    mockGet.mockReturnValueOnce({ count: 1 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/monitoring/insights?severity=critical&limit=5',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.insights).toHaveLength(1);
+    expect(body.total).toBe(1);
+  });
+
+  it('acknowledges an insight', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/monitoring/insights/i1/acknowledge',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true });
+  });
+});

--- a/backend/src/routes/settings.test.ts
+++ b/backend/src/routes/settings.test.ts
@@ -5,6 +5,9 @@ import { settingsRoutes } from './settings.js';
 
 const mockGetUserDefaultLandingPage = vi.fn();
 const mockSetUserDefaultLandingPage = vi.fn();
+const mockAll = vi.fn().mockReturnValue([]);
+const mockGet = vi.fn().mockReturnValue(undefined);
+const mockRun = vi.fn().mockReturnValue({ changes: 1 });
 
 vi.mock('../services/user-store.js', () => ({
   getUserDefaultLandingPage: (...args: unknown[]) => mockGetUserDefaultLandingPage(...args),
@@ -14,9 +17,9 @@ vi.mock('../services/user-store.js', () => ({
 vi.mock('../db/sqlite.js', () => ({
   getDb: () => ({
     prepare: () => ({
-      all: vi.fn().mockReturnValue([]),
-      get: vi.fn().mockReturnValue(undefined),
-      run: vi.fn().mockReturnValue({ changes: 1 }),
+      all: (...args: unknown[]) => mockAll(...args),
+      get: (...args: unknown[]) => mockGet(...args),
+      run: (...args: unknown[]) => mockRun(...args),
     }),
   }),
 }));
@@ -88,5 +91,103 @@ describe('settings preference routes', () => {
 
     expect(response.statusCode).toBe(400);
     expect(mockSetUserDefaultLandingPage).not.toHaveBeenCalled();
+  });
+});
+
+describe('audit-log cursor pagination', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', () => async () => undefined);
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'admin', sessionId: 's1', role: 'admin' as const };
+    });
+    await app.register(settingsRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns hasMore=true and nextCursor when more items exist', async () => {
+    // Simulate N+1 rows returned (limit=2 → fetch 3 rows)
+    const rows = [
+      { id: 3, action: 'login', created_at: '2025-01-03T00:00:00Z' },
+      { id: 2, action: 'login', created_at: '2025-01-02T00:00:00Z' },
+      { id: 1, action: 'login', created_at: '2025-01-01T00:00:00Z' },
+    ];
+    mockAll.mockReturnValueOnce(rows);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/settings/audit-log?limit=2',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    const body = response.json();
+    expect(response.statusCode).toBe(200);
+    expect(body.entries).toHaveLength(2);
+    expect(body.hasMore).toBe(true);
+    expect(body.nextCursor).toBe('2025-01-02T00:00:00Z|2');
+  });
+
+  it('returns hasMore=false when no more items', async () => {
+    const rows = [
+      { id: 2, action: 'login', created_at: '2025-01-02T00:00:00Z' },
+    ];
+    mockAll.mockReturnValueOnce(rows);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/settings/audit-log?limit=2',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    const body = response.json();
+    expect(response.statusCode).toBe(200);
+    expect(body.entries).toHaveLength(1);
+    expect(body.hasMore).toBe(false);
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it('accepts cursor parameter for next page', async () => {
+    mockAll.mockReturnValueOnce([
+      { id: 1, action: 'login', created_at: '2025-01-01T00:00:00Z' },
+    ]);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/settings/audit-log?limit=2&cursor=2025-01-02T00:00:00Z|2',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    const body = response.json();
+    expect(response.statusCode).toBe(200);
+    expect(body.entries).toHaveLength(1);
+    expect(body.hasMore).toBe(false);
+  });
+
+  it('remains backward compatible with offset pagination', async () => {
+    mockAll.mockReturnValueOnce([]);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/settings/audit-log?limit=10&offset=20',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.offset).toBe(20);
+    expect(body.limit).toBe(10);
   });
 });

--- a/frontend/src/hooks/use-settings.ts
+++ b/frontend/src/hooks/use-settings.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import { toast } from 'sonner';
 
@@ -102,5 +102,29 @@ export function useAuditLog(options?: AuditLogOptions) {
       '/api/settings/audit-log',
       { params: options as Record<string, string | number | boolean | undefined> }
     ),
+  });
+}
+
+interface AuditLogPage {
+  entries: AuditLogEntry[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  limit: number;
+  offset: number;
+}
+
+export function useInfiniteAuditLog(options?: Omit<AuditLogOptions, 'page'>) {
+  return useInfiniteQuery<AuditLogPage>({
+    queryKey: ['settings', 'audit-log', 'infinite', options],
+    queryFn: ({ pageParam }) =>
+      api.get<AuditLogPage>('/api/settings/audit-log', {
+        params: {
+          ...options,
+          cursor: pageParam,
+          limit: options?.limit ?? 100,
+        } as Record<string, string | number | boolean | undefined>,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 }


### PR DESCRIPTION
## Summary
- Adds cursor-based pagination (composite `created_at|id` cursor) to audit-log and monitoring insights endpoints
- Fetches N+1 rows to determine `hasMore` without an extra COUNT query for the cursor path
- Returns `{ nextCursor, hasMore }` alongside existing `offset`/`limit` fields for backward compatibility
- Adds `useInfiniteAuditLog` hook using TanStack Query's `useInfiniteQuery` with `getNextPageParam`

Closes #182

## Test plan
- [x] 4 new tests for audit-log cursor pagination (settings.test.ts)
- [x] 6 new tests for monitoring insights cursor pagination (monitoring.test.ts)
- [ ] Verify existing offset-based calls still work (backward compatible)
- [ ] Test cursor flow: first page → use nextCursor → second page

🤖 Generated with [Claude Code](https://claude.com/claude-code)