### PR TITLE
perf(frontend): add Core Web Vitals monitoring (LCP, INP, CLS, TTFB)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "socket.io-client": "^4.8.1",
     "sonner": "^1.7.2",
     "tailwind-merge": "^2.6.0",
+    "web-vitals": "^5.1.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/frontend/src/lib/web-vitals.test.ts
+++ b/frontend/src/lib/web-vitals.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockOnCLS = vi.fn();
+const mockOnINP = vi.fn();
+const mockOnLCP = vi.fn();
+const mockOnTTFB = vi.fn();
+
+vi.mock('web-vitals', () => ({
+  onCLS: (...args: unknown[]) => mockOnCLS(...args),
+  onINP: (...args: unknown[]) => mockOnINP(...args),
+  onLCP: (...args: unknown[]) => mockOnLCP(...args),
+  onTTFB: (...args: unknown[]) => mockOnTTFB(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('reportWebVitals', () => {
+  it('registers all four web vital handlers', async () => {
+    const { reportWebVitals } = await import('./web-vitals');
+    const handler = vi.fn();
+    await reportWebVitals(handler);
+
+    expect(mockOnCLS).toHaveBeenCalledWith(handler);
+    expect(mockOnINP).toHaveBeenCalledWith(handler);
+    expect(mockOnLCP).toHaveBeenCalledWith(handler);
+    expect(mockOnTTFB).toHaveBeenCalledWith(handler);
+  });
+
+  it('uses default handler when no callback provided', async () => {
+    const { reportWebVitals } = await import('./web-vitals');
+    await reportWebVitals();
+
+    expect(mockOnCLS).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockOnINP).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockOnLCP).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockOnTTFB).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('default handler logs metric in dev mode', async () => {
+    const { reportWebVitals } = await import('./web-vitals');
+    await reportWebVitals();
+
+    // Get the handler that was passed to onCLS
+    const handler = mockOnCLS.mock.calls[0][0];
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    handler({ name: 'CLS', value: 0.05, rating: 'good' });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[Web Vitals] CLS: 0.05 (good)'),
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/frontend/src/lib/web-vitals.ts
+++ b/frontend/src/lib/web-vitals.ts
@@ -1,0 +1,23 @@
+import type { Metric } from 'web-vitals';
+
+type ReportHandler = (metric: Metric) => void;
+
+const isDev = import.meta.env.DEV;
+
+const defaultHandler: ReportHandler = (metric) => {
+  if (isDev) {
+    const color = metric.rating === 'good' ? '\x1b[32m' : metric.rating === 'needs-improvement' ? '\x1b[33m' : '\x1b[31m';
+    // eslint-disable-next-line no-console
+    console.log(
+      `${color}[Web Vitals] ${metric.name}: ${Math.round(metric.value * 100) / 100} (${metric.rating})\x1b[0m`,
+    );
+  }
+};
+
+export async function reportWebVitals(onReport: ReportHandler = defaultHandler) {
+  const { onCLS, onINP, onLCP, onTTFB } = await import('web-vitals');
+  onCLS(onReport);
+  onINP(onReport);
+  onLCP(onReport);
+  onTTFB(onReport);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { reportWebVitals } from './lib/web-vitals';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
@@ -8,3 +9,5 @@ createRoot(document.getElementById('root')!).render(
     <App />
   </StrictMode>
 );
+
+reportWebVitals();

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "socket.io-client": "^4.8.1",
         "sonner": "^1.7.2",
         "tailwind-merge": "^2.6.0",
+        "web-vitals": "^5.1.0",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -12292,6 +12293,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",


### PR DESCRIPTION
## Summary
- Installs `web-vitals` library and creates `lib/web-vitals.ts` module
- Measures all 4 Core Web Vitals: LCP, INP, CLS, TTFB
- Logs color-coded metrics to console in development (green=good, yellow=needs-improvement, red=poor)
- Supports custom report handler for production analytics integration
- Uses dynamic `import('web-vitals')` for tree-shaking

Closes #184

## Test plan
- [x] 3 tests: handler registration, default handler, console logging
- [ ] Open dev dashboard in browser and verify metrics appear in console
- [ ] Verify no runtime errors in production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)