### PR TITLE
perf: pre-compile Zod array schemas (#191)

### DIFF
--- a/backend/src/models/portainer.test.ts
+++ b/backend/src/models/portainer.test.ts
@@ -6,6 +6,8 @@ import {
   ContainerStatsSchema,
   NetworkSchema,
   ImageSchema,
+  EndpointArraySchema,
+  ContainerArraySchema,
 } from './portainer.js';
 
 describe('Portainer Models', () => {
@@ -421,6 +423,30 @@ describe('Portainer Models', () => {
 
       const result = ImageSchema.safeParse(image);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Array Schemas', () => {
+    it('EndpointArraySchema parses array of endpoints', () => {
+      const result = EndpointArraySchema.safeParse([
+        { Id: 1, Name: 'e1', Type: 1, URL: 'tcp://1', Status: 1 },
+        { Id: 2, Name: 'e2', Type: 1, URL: 'tcp://2', Status: 1 },
+      ]);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toHaveLength(2);
+    });
+
+    it('ContainerArraySchema parses array of containers', () => {
+      const result = ContainerArraySchema.safeParse([
+        { Id: 'c1', Names: ['/web'], Image: 'nginx', Created: 1, State: 'running', Status: 'Up' },
+      ]);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toHaveLength(1);
+    });
+
+    it('Array schemas reject non-array input', () => {
+      const result = EndpointArraySchema.safeParse('not an array');
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/backend/src/models/portainer.ts
+++ b/backend/src/models/portainer.ts
@@ -133,6 +133,13 @@ export const ImageSchema = z.object({
   Created: z.number().optional(),
 }).passthrough();
 
+// Pre-compiled array schemas (parsed once at module level for Zod internal caching)
+export const EndpointArraySchema = z.array(EndpointSchema);
+export const ContainerArraySchema = z.array(ContainerSchema);
+export const StackArraySchema = z.array(StackSchema);
+export const NetworkArraySchema = z.array(NetworkSchema);
+export const ImageArraySchema = z.array(ImageSchema);
+
 export type Endpoint = z.infer<typeof EndpointSchema>;
 export type Container = z.infer<typeof ContainerSchema>;
 export type Stack = z.infer<typeof StackSchema>;

--- a/backend/src/services/portainer-client.ts
+++ b/backend/src/services/portainer-client.ts
@@ -3,6 +3,8 @@ import { createChildLogger } from '../utils/logger.js';
 import {
   EndpointSchema, ContainerSchema, StackSchema,
   ContainerStatsSchema, NetworkSchema, ImageSchema,
+  EndpointArraySchema, ContainerArraySchema, StackArraySchema,
+  NetworkArraySchema, ImageArraySchema,
   type Endpoint, type Container, type Stack,
   type ContainerStats, type Network, type DockerImage,
 } from '../models/portainer.js';
@@ -101,7 +103,7 @@ async function portainerFetch<T>(
 // Endpoints
 export async function getEndpoints(): Promise<Endpoint[]> {
   const raw = await portainerFetch<unknown[]>('/api/endpoints');
-  return raw.map((e) => EndpointSchema.parse(e));
+  return EndpointArraySchema.parse(raw);
 }
 
 export async function getEndpoint(id: number): Promise<Endpoint> {
@@ -114,7 +116,7 @@ export async function getContainers(endpointId: number, all = true): Promise<Con
   const raw = await portainerFetch<unknown[]>(
     `/api/endpoints/${endpointId}/docker/containers/json?all=${all}`,
   );
-  return raw.map((c) => ContainerSchema.parse(c));
+  return ContainerArraySchema.parse(raw);
 }
 
 export async function getContainer(endpointId: number, containerId: string): Promise<Container> {
@@ -180,7 +182,7 @@ export async function getContainerStats(endpointId: number, containerId: string)
 // Stacks
 export async function getStacks(): Promise<Stack[]> {
   const raw = await portainerFetch<unknown[]>('/api/stacks');
-  return raw.map((s) => StackSchema.parse(s));
+  return StackArraySchema.parse(raw);
 }
 
 export async function getStack(id: number): Promise<Stack> {
@@ -193,7 +195,7 @@ export async function getNetworks(endpointId: number): Promise<Network[]> {
   const raw = await portainerFetch<unknown[]>(
     `/api/endpoints/${endpointId}/docker/networks`,
   );
-  return raw.map((n) => NetworkSchema.parse(n));
+  return NetworkArraySchema.parse(raw);
 }
 
 // Images
@@ -201,7 +203,7 @@ export async function getImages(endpointId: number): Promise<DockerImage[]> {
   const raw = await portainerFetch<unknown[]>(
     `/api/endpoints/${endpointId}/docker/images/json`,
   );
-  return raw.map((i) => ImageSchema.parse(i));
+  return ImageArraySchema.parse(raw);
 }
 
 // Exec (for packet capture and other read-only operations)


### PR DESCRIPTION
## Summary
- Add pre-compiled array schemas (`EndpointArraySchema`, `ContainerArraySchema`, `StackArraySchema`, `NetworkArraySchema`, `ImageArraySchema`) at module level in `portainer.ts`
- Update `portainer-client.ts` to use single `.parse()` on full arrays instead of per-item `.map(item => Schema.parse(item))`
- Add 3 tests for array schema validation

## Test plan
- [x] All 23 portainer model tests pass
- [x] Array schemas correctly parse valid arrays
- [x] Array schemas reject non-array input

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)