### PR TITLE
Rebuild dummy workload with 26 issue-simulating services

### DIFF
--- a/docker-compose.workload.yml
+++ b/docker-compose.workload.yml
@@ -190,9 +190,14 @@ services:
   # Memory stress: constant ~100MB allocation against 256MB limit
   # Triggers: memory anomaly detection after baseline established
   memory-hog:
-    image: progrium/stress
+    image: alpine:latest
     container_name: memory-hog
-    command: --vm 1 --vm-bytes 100M --vm-hang 0
+    command: >
+      sh -c "
+      echo '[memory-hog] Allocating ~100MB...';
+      dd if=/dev/zero bs=1M count=100 of=/dev/shm/memfill 2>/dev/null;
+      echo '[memory-hog] Holding allocation';
+      while true; do sleep 30; done"
     mem_limit: 256m
     labels:
       app.tier: "test"
@@ -386,23 +391,12 @@ services:
   app-gateway:
     image: nginx:alpine
     container_name: app-gateway
-    command: >
-      sh -c "
-      cat > /etc/nginx/conf.d/default.conf << 'NGINX'
-      server {
-        listen 80;
-        location / {
-          return 200 'gateway ok\n';
-          add_header Content-Type text/plain;
-        }
-        location /api {
-          proxy_pass http://app-api:8000;
-          proxy_connect_timeout 2s;
-          proxy_read_timeout 5s;
-        }
-      }
-      NGINX
-      nginx -g 'daemon off;'"
+    command:
+      - sh
+      - -c
+      - |
+        printf 'server {\n  listen 80;\n  location / {\n    return 200 "gateway ok\\n";\n    add_header Content-Type text/plain;\n  }\n  location /api {\n    proxy_pass http://app-api:8000;\n    proxy_connect_timeout 2s;\n    proxy_read_timeout 5s;\n  }\n}\n' > /etc/nginx/conf.d/default.conf
+        nginx -g 'daemon off;'
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Rebuilt `docker-compose.workload.yml` from 15 generic services to 26 targeted containers
- **12 healthy baseline** services unchanged (web, db, mq, workers, monitoring, staging, dev)
- **10 issue containers** that trigger specific detection capabilities:
  - Anomaly: `memory-hog` (memory spikes), `cpu-burster` (intermittent CPU spikes)
  - Security: `privileged-risk` (3 findings), `network-risk` (3 findings), `no-healthcheck` (1 finding)
  - Health: `health-degrader` (healthy → unhealthy after 2min), `health-flapper` (random toggling)
  - Other: `crash-loop`, `log-spammer`, `stopped-service`
- **4 inter-container traffic** services on `app-frontend-net` / `app-backend-net` for network topology visualization:
  - `app-gateway` (nginx proxy bridging both nets)
  - `app-api` (pings Redis + Postgres)
  - `app-worker-queue` (polls RabbitMQ)
  - `app-cron` (hits gateway periodically)

## Detection Coverage
| Type | Containers | Expected Findings |
|---|---|---|
| Anomaly | memory-hog, cpu-burster | 2 anomaly types (mem + CPU z-score spikes) |
| Security | privileged-risk, network-risk, no-healthcheck | 7 findings total |
| Health | health-degrader, health-flapper | 2 health issues |
| Remediation | crash-loop, health-degrader, health-flapper, memory-hog, stopped-service | 5 suggestions |
| Topology | app-gateway, app-api, app-worker-queue, app-cron | Multi-network bridge |

## Test plan
- [ ] Run `./scripts/deploy-workload.sh start` — stack deploys via Portainer API
- [ ] Run `./scripts/deploy-workload.sh status` — shows 26 containers
- [ ] Wait ~2 min: `health-degrader` transitions to unhealthy
- [ ] Wait ~10 min: CPU/memory anomalies detected after baseline collection
- [ ] Security scanner shows 7 findings across privileged-risk, network-risk, no-healthcheck
- [ ] Network topology shows multi-tier architecture with cross-network connections
- [ ] `docker compose -f docker-compose.workload.yml config --quiet` passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)