### PR TITLE
Add dynamic LLM model scanning and custom endpoint UI

### DIFF
--- a/backend/src/models/api-schemas.ts
+++ b/backend/src/models/api-schemas.ts
@@ -320,6 +320,21 @@ export const CacheInvalidateQuerySchema = z.object({
   resource: z.enum(['endpoints', 'containers', 'images', 'networks', 'stacks']),
 });
 
+// ─── LLM schemas ───────────────────────────────────────────────────
+export const LlmQueryBodySchema = z.object({
+  query: z.string().min(2),
+});
+
+export const LlmModelsQuerySchema = z.object({
+  host: z.string().optional(),
+});
+
+export const LlmTestConnectionBodySchema = z.object({
+  url: z.string().optional(),
+  token: z.string().optional(),
+  ollamaUrl: z.string().optional(),
+});
+
 // ─── Reports schemas ───────────────────────────────────────────────
 export const ReportsQuerySchema = z.object({
   timeRange: z.enum(['24h', '7d', '30d']).optional(),

--- a/frontend/src/hooks/use-llm-models.ts
+++ b/frontend/src/hooks/use-llm-models.ts
@@ -1,22 +1,49 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 
-interface LlmModel {
+export interface LlmModel {
   name: string;
   size?: number;
   modified?: string;
 }
 
-interface LlmModelsResponse {
+export interface LlmModelsResponse {
   models: LlmModel[];
   default: string;
 }
 
-export function useLlmModels() {
+interface LlmTestConnectionRequest {
+  url?: string;
+  token?: string;
+  ollamaUrl?: string;
+}
+
+export interface LlmTestConnectionResponse {
+  ok: boolean;
+  models?: string[];
+  error?: string;
+}
+
+export function useLlmModels(host?: string) {
+  const url = host
+    ? `/api/llm/models?host=${encodeURIComponent(host)}`
+    : '/api/llm/models';
   return useQuery<LlmModelsResponse>({
-    queryKey: ['llm-models'],
-    queryFn: () => api.get<LlmModelsResponse>('/api/llm/models'),
+    queryKey: ['llm-models', host],
+    queryFn: () => api.get<LlmModelsResponse>(url),
     staleTime: 5 * 60 * 1000, // 5 minutes
     retry: 1,
+  });
+}
+
+export function useLlmTestConnection() {
+  const queryClient = useQueryClient();
+
+  return useMutation<LlmTestConnectionResponse, Error, LlmTestConnectionRequest>({
+    mutationFn: (body) =>
+      api.post<LlmTestConnectionResponse>('/api/llm/test-connection', body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['llm-models'] });
+    },
   });
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded 5-model LLM dropdown in Settings with dynamic `LlmSettingsSection` that scans models from the user's configured Ollama server
- Add **Test Connection** button to verify Ollama/custom endpoint connectivity
- Add **Custom API Endpoint** toggle for OpenAI-compatible endpoints (URL + bearer token)
- Fix 500 Internal Server Error on `POST /api/llm/test-connection` and `POST /api/llm/query` caused by plain JSON Schema + Zod validator compiler conflict
- Pass user's configured Ollama URL (from settings) to both Test Connection and Scan Models, enabling external Ollama servers

## Files changed
| File | Change |
|------|--------|
| `backend/src/models/api-schemas.ts` | Add `LlmQueryBodySchema`, `LlmModelsQuerySchema`, `LlmTestConnectionBodySchema` Zod schemas |
| `backend/src/routes/llm.ts` | Use Zod schemas, accept `host` query param on GET models, add `ollamaUrl` support on test-connection |
| `backend/src/routes/llm.test.ts` | Add `validatorCompiler` setup + tests for test-connection endpoint |
| `frontend/src/hooks/use-llm-models.ts` | Add `useLlmTestConnection()` hook, accept optional `host` param in `useLlmModels()` |
| `frontend/src/pages/settings.tsx` | New `LlmSettingsSection` component with model scanning, connection test, custom endpoint UI |
| `frontend/src/pages/settings.test.tsx` | Add 11 tests for `LlmSettingsSection` component |

## Test plan
- [x] Backend: 11 tests pass (`llm.test.ts`)
- [x] Frontend: 13 tests pass (`settings.test.tsx`)
- [x] Full suite: 445 backend + 408 frontend tests pass
- [x] TypeScript: clean typecheck on both workspaces
- [ ] Manual: Open Settings > LLM section, verify models load from configured Ollama URL
- [ ] Manual: Click Test Connection, verify green status for reachable server
- [ ] Manual: Enable Custom Endpoint, enter URL + token, test connection
- [ ] Manual: Select model from dropdown, save, verify persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)