### PR TITLE
Use configured Ollama URL/model from settings DB

### DIFF
--- a/backend/src/routes/llm.test.ts
+++ b/backend/src/routes/llm.test.ts
@@ -3,12 +3,16 @@ import Fastify from 'fastify';
 import { validatorCompiler } from 'fastify-type-provider-zod';
 import { llmRoutes } from './llm.js';
 
-// Mock config
-vi.mock('../config/index.js', () => ({
-  getConfig: vi.fn().mockReturnValue({
-    OLLAMA_BASE_URL: 'http://localhost:11434',
-    OLLAMA_MODEL: 'llama3.2',
+// Mock settings-store (getEffectiveLlmConfig)
+vi.mock('../services/settings-store.js', () => ({
+  getEffectiveLlmConfig: vi.fn().mockReturnValue({
+    ollamaUrl: 'http://localhost:11434',
+    model: 'llama3.2',
+    customEnabled: false,
+    customEndpointUrl: undefined,
+    customEndpointToken: undefined,
   }),
+  getSetting: vi.fn().mockReturnValue(undefined),
 }));
 
 // Mock Ollama


### PR DESCRIPTION
## Summary
- Added `getEffectiveLlmConfig()` helper in `settings-store.ts` that reads LLM settings from the DB (`llm.ollama_url`, `llm.model`, `llm.custom_endpoint_enabled`, `llm.custom_endpoint_url`, `llm.custom_endpoint_token`) and falls back to env vars
- Replaced hardcoded `getConfig()` calls with `getEffectiveLlmConfig()` in all 4 LLM consumers: `llm-client.ts`, `llm-chat.ts` socket, and `llm.ts` routes (query, models, test-connection)
- Removed the cached singleton Ollama client so URL changes in Settings take effect immediately without restart
- Updated `llm.test.ts` to mock `getEffectiveLlmConfig` instead of `getConfig`

## Test plan
- [x] `npm run typecheck` — clean
- [x] All 445 backend tests pass (47 test files)
- [ ] Manual: Open LLM Assistant, send a message — response comes from configured Ollama
- [ ] Manual: Change Ollama URL in Settings, save — LLM Assistant uses new URL without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)