### PR TITLE
Remove unused LLM feedback and add privacy blur to observability

### DIFF
--- a/backend/src/db/migrations/016_drop_llm_feedback.sql
+++ b/backend/src/db/migrations/016_drop_llm_feedback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE llm_traces DROP COLUMN feedback_score;
+ALTER TABLE llm_traces DROP COLUMN feedback_text;

--- a/backend/src/models/api-schemas.ts
+++ b/backend/src/models/api-schemas.ts
@@ -335,6 +335,14 @@ export const LlmTestConnectionBodySchema = z.object({
   ollamaUrl: z.string().optional(),
 });
 
+export const LlmTracesQuerySchema = z.object({
+  limit: z.coerce.number().optional().default(50),
+});
+
+export const LlmStatsQuerySchema = z.object({
+  hours: z.coerce.number().optional().default(24),
+});
+
 // ─── Reports schemas ───────────────────────────────────────────────
 export const ReportsQuerySchema = z.object({
   timeRange: z.enum(['24h', '7d', '30d']).optional(),

--- a/backend/src/routes/llm-observability.test.ts
+++ b/backend/src/routes/llm-observability.test.ts
@@ -1,15 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Fastify from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
 import { llmObservabilityRoutes } from './llm-observability.js';
 
 const mockGetRecentTraces = vi.fn();
 const mockGetLlmStats = vi.fn();
-const mockUpdateFeedback = vi.fn();
 
 vi.mock('../services/llm-trace-store.js', () => ({
   getRecentTraces: (...args: unknown[]) => mockGetRecentTraces(...args),
   getLlmStats: (...args: unknown[]) => mockGetLlmStats(...args),
-  updateFeedback: (...args: unknown[]) => mockUpdateFeedback(...args),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -27,6 +26,7 @@ describe('LLM Observability Routes', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     app = Fastify();
+    app.setValidatorCompiler(validatorCompiler);
     app.decorate('authenticate', async () => undefined);
     await app.register(llmObservabilityRoutes);
     await app.ready();
@@ -50,8 +50,6 @@ describe('LLM Observability Routes', () => {
       totalTokens: 50000,
       avgLatencyMs: 1200,
       errorRate: 2.5,
-      avgFeedbackScore: 4.2,
-      feedbackCount: 30,
       modelBreakdown: [{ model: 'llama3.2', count: 80, tokens: 40000 }],
     });
 
@@ -59,30 +57,6 @@ describe('LLM Observability Routes', () => {
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.totalQueries).toBe(100);
-    expect(body.avgFeedbackScore).toBe(4.2);
-  });
-
-  it('POST /api/llm/feedback updates feedback', async () => {
-    mockUpdateFeedback.mockReturnValue(true);
-
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/llm/feedback',
-      payload: { traceId: 'tr-1', score: 5, text: 'Great answer!' },
-    });
-
-    expect(res.statusCode).toBe(200);
-    expect(res.json().success).toBe(true);
-    expect(mockUpdateFeedback).toHaveBeenCalledWith('tr-1', 5, 'Great answer!');
-  });
-
-  it('POST /api/llm/feedback validates score range', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/llm/feedback',
-      payload: { traceId: 'tr-1', score: 10 },
-    });
-
-    expect(res.statusCode).toBe(400);
+    expect(body.modelBreakdown).toHaveLength(1);
   });
 });

--- a/frontend/src/hooks/use-llm-observability.test.ts
+++ b/frontend/src/hooks/use-llm-observability.test.ts
@@ -12,8 +12,6 @@ vi.mock('@/lib/api', () => ({
           totalTokens: 25000,
           avgLatencyMs: 800,
           errorRate: 1.5,
-          avgFeedbackScore: 3.8,
-          feedbackCount: 10,
           modelBreakdown: [],
         });
       }
@@ -21,7 +19,6 @@ vi.mock('@/lib/api', () => ({
         { id: 1, trace_id: 'tr-1', model: 'llama3.2', total_tokens: 500 },
       ]);
     }),
-    post: vi.fn().mockResolvedValue({ success: true }),
   },
 }));
 

--- a/frontend/src/hooks/use-llm-observability.ts
+++ b/frontend/src/hooks/use-llm-observability.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 
 export interface LlmTrace {
@@ -13,8 +13,6 @@ export interface LlmTrace {
   status: string;
   user_query: string | null;
   response_preview: string | null;
-  feedback_score: number | null;
-  feedback_text: string | null;
   created_at: string;
 }
 
@@ -23,8 +21,6 @@ export interface LlmStats {
   totalTokens: number;
   avgLatencyMs: number;
   errorRate: number;
-  avgFeedbackScore: number | null;
-  feedbackCount: number;
   modelBreakdown: Array<{ model: string; count: number; tokens: number }>;
 }
 
@@ -41,17 +37,5 @@ export function useLlmStats(hours: number = 24) {
     queryKey: ['llm-stats', hours],
     queryFn: () => api.get<LlmStats>(`/api/llm/stats?hours=${hours}`),
     staleTime: 60 * 1000,
-  });
-}
-
-export function useSubmitFeedback() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (data: { traceId: string; score: number; text?: string }) =>
-      api.post('/api/llm/feedback', data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['llm-traces'] });
-      queryClient.invalidateQueries({ queryKey: ['llm-stats'] });
-    },
   });
 }

--- a/frontend/src/pages/llm-observability.test.tsx
+++ b/frontend/src/pages/llm-observability.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -25,8 +25,6 @@ const mockStats = {
   totalTokens: 58300,
   avgLatencyMs: 1250,
   errorRate: 0.03,
-  avgFeedbackScore: 4.2,
-  feedbackCount: 27,
   modelBreakdown: [
     { model: 'llama3.2', count: 120, tokens: 48000 },
     { model: 'mistral', count: 22, tokens: 10300 },
@@ -46,8 +44,6 @@ const mockTraces = [
     status: 'success',
     user_query: 'What containers are using the most memory?',
     response_preview: 'Based on the metrics...',
-    feedback_score: 4,
-    feedback_text: null,
     created_at: '2025-01-15 10:30:00',
   },
   {
@@ -62,8 +58,6 @@ const mockTraces = [
     status: 'error',
     user_query: 'Show CPU anomalies',
     response_preview: null,
-    feedback_score: null,
-    feedback_text: null,
     created_at: '2025-01-15 10:25:00',
   },
 ];
@@ -72,7 +66,6 @@ const mockTraces = [
 vi.mock('@/hooks/use-llm-observability', () => ({
   useLlmTraces: vi.fn().mockReturnValue({ data: [], isLoading: false, refetch: vi.fn() }),
   useLlmStats: vi.fn().mockReturnValue({ data: null, isLoading: false, refetch: vi.fn() }),
-  useSubmitFeedback: vi.fn().mockReturnValue({ mutate: vi.fn() }),
 }));
 
 vi.mock('@/hooks/use-auto-refresh', () => ({
@@ -97,7 +90,7 @@ describe('LlmObservabilityPage', () => {
   it('renders the page title and subtitle', () => {
     renderPage();
     expect(screen.getByText('LLM Observability')).toBeTruthy();
-    expect(screen.getByText('Monitor LLM usage, performance, and feedback')).toBeTruthy();
+    expect(screen.getByText('Monitor LLM usage and performance')).toBeTruthy();
   });
 
   it('shows empty state when no traces exist', () => {
@@ -135,19 +128,6 @@ describe('LlmObservabilityPage', () => {
     expect(screen.getByText('mistral')).toBeTruthy();
   });
 
-  it('renders feedback summary with score', () => {
-    vi.mocked(useLlmStats).mockReturnValue({
-      data: mockStats,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmStats>);
-
-    renderPage();
-    expect(screen.getByText('Feedback Summary')).toBeTruthy();
-    expect(screen.getByText('4.2')).toBeTruthy();
-    expect(screen.getByText('/ 5')).toBeTruthy();
-  });
-
   it('renders traces table with data', () => {
     vi.mocked(useLlmStats).mockReturnValue({
       data: mockStats,
@@ -165,6 +145,28 @@ describe('LlmObservabilityPage', () => {
     expect(screen.getByText('Show CPU anomalies')).toBeTruthy();
     expect(screen.getByText('success')).toBeTruthy();
     expect(screen.getByText('error')).toBeTruthy();
+  });
+
+  it('blurs query column by default and reveals on toggle', () => {
+    vi.mocked(useLlmTraces).mockReturnValue({
+      data: mockTraces,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as ReturnType<typeof useLlmTraces>);
+
+    renderPage();
+    const queryCell = screen.getByText('What containers are using the most memory?');
+
+    // Privacy mode is ON by default — cell should have blur class
+    expect(queryCell.closest('td')?.className).toContain('blur-sm');
+
+    // Click the Privacy toggle button to reveal
+    fireEvent.click(screen.getByText('Privacy'));
+    expect(queryCell.closest('td')?.className).not.toContain('blur-sm');
+
+    // Click again to re-blur
+    fireEvent.click(screen.getByText('Privacy'));
+    expect(queryCell.closest('td')?.className).toContain('blur-sm');
   });
 
   it('renders skeleton cards during loading', () => {


### PR DESCRIPTION
## Summary
- Removes the entire unused LLM feedback system (endpoint, DB columns, UI) — it was dead code with no way to submit feedback
- Fixes `schema.safeParse is not a function` 500 error on `/api/llm/traces` by converting plain JSON schemas to Zod
- Adds a privacy toggle (on by default) that blurs user queries in the traces table, with hover-to-reveal

## Test plan
- [x] Backend observability route tests pass (2 tests)
- [x] Frontend observability page tests pass (7 tests)
- [x] Frontend hook tests pass (2 tests)
- [ ] Verify LLM Observability page loads with traces visible
- [ ] Verify Privacy toggle blurs/reveals query column
- [ ] Verify migration 016 drops feedback columns cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)