### PR TITLE
Replace native selects with Radix UI ThemedSelect

### DIFF
--- a/frontend/src/components/container/container-logs-viewer.tsx
+++ b/frontend/src/components/container/container-logs-viewer.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Download, ScrollText, Clock, Search, AlertTriangle } from 'lucide-react';
 import { useContainerLogs } from '@/hooks/use-container-logs';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 
 export type TailCount = 100 | 500 | 1000 | -1;
@@ -181,20 +182,19 @@ export function ContainerLogsViewer({
         <div className="flex items-center gap-4 flex-wrap">
           {/* Tail Count Selector */}
           <div className="flex items-center gap-2">
-            <label htmlFor="tail-select" className="text-sm font-medium">
+            <label className="text-sm font-medium">
               Tail
             </label>
-            <select
-              id="tail-select"
-              value={tailCount}
-              onChange={(e) => setTailCount(Number(e.target.value) as TailCount)}
-              className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <option value={100}>100 lines</option>
-              <option value={500}>500 lines</option>
-              <option value={1000}>1000 lines</option>
-              <option value={-1}>All lines</option>
-            </select>
+            <ThemedSelect
+              value={String(tailCount)}
+              onValueChange={(val) => setTailCount(Number(val) as TailCount)}
+              options={[
+                { value: '100', label: '100 lines' },
+                { value: '500', label: '500 lines' },
+                { value: '1000', label: '1000 lines' },
+                { value: '-1', label: 'All lines' },
+              ]}
+            />
           </div>
 
           {/* Search Input */}

--- a/frontend/src/components/container/container-metrics-viewer.tsx
+++ b/frontend/src/components/container/container-metrics-viewer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Cpu, HardDrive } from 'lucide-react';
 import { useContainerMetrics } from '@/hooks/use-metrics';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import { MetricsLineChart } from '@/components/charts/metrics-line-chart';
 
 interface ContainerMetricsViewerProps {
@@ -42,21 +43,20 @@ export function ContainerMetricsViewer({
       {/* Time Range Selector */}
       {showTimeRangeSelector && (
         <div className="flex items-center gap-2">
-          <label htmlFor="time-range" className="text-sm font-medium">
+          <label className="text-sm font-medium">
             Time Range
           </label>
-          <select
-            id="time-range"
+          <ThemedSelect
             value={timeRange}
-            onChange={(e) => setTimeRange(e.target.value)}
-            className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <option value="15m">Last 15 minutes</option>
-            <option value="1h">Last 1 hour</option>
-            <option value="6h">Last 6 hours</option>
-            <option value="24h">Last 24 hours</option>
-            <option value="7d">Last 7 days</option>
-          </select>
+            onValueChange={(val) => setTimeRange(val)}
+            options={[
+              { value: '15m', label: 'Last 15 minutes' },
+              { value: '1h', label: 'Last 1 hour' },
+              { value: '6h', label: 'Last 6 hours' },
+              { value: '24h', label: 'Last 24 hours' },
+              { value: '7d', label: 'Last 7 days' },
+            ]}
+          />
         </div>
       )}
 

--- a/frontend/src/components/shared/themed-select.tsx
+++ b/frontend/src/components/shared/themed-select.tsx
@@ -1,0 +1,86 @@
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface ThemedSelectProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  options: SelectOption[];
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+}
+
+export function ThemedSelect({
+  value,
+  onValueChange,
+  options,
+  placeholder = 'Select…',
+  disabled,
+  className,
+  id,
+}: ThemedSelectProps) {
+  return (
+    <SelectPrimitive.Root value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectPrimitive.Trigger
+        id={id}
+        className={cn(
+          'inline-flex h-9 items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs',
+          'ring-offset-background transition-colors',
+          'hover:bg-accent hover:text-accent-foreground',
+          'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          'data-placeholder:text-muted-foreground',
+          className,
+        )}
+      >
+        <SelectPrimitive.Value placeholder={placeholder} />
+        <SelectPrimitive.Icon asChild>
+          <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Content
+          position="popper"
+          sideOffset={4}
+          className={cn(
+            'relative z-50 max-h-72 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md',
+            'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+            'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+            'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2',
+          )}
+        >
+          <SelectPrimitive.Viewport className="p-1">
+            {options.map((opt) => (
+              <SelectPrimitive.Item
+                key={opt.value}
+                value={opt.value}
+                disabled={opt.disabled}
+                className={cn(
+                  'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none',
+                  'focus:bg-accent focus:text-accent-foreground',
+                  'data-disabled:pointer-events-none data-disabled:opacity-50',
+                )}
+              >
+                <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                  <SelectPrimitive.ItemIndicator>
+                    <Check className="h-4 w-4" />
+                  </SelectPrimitive.ItemIndicator>
+                </span>
+                <SelectPrimitive.ItemText>{opt.label}</SelectPrimitive.ItemText>
+              </SelectPrimitive.Item>
+            ))}
+          </SelectPrimitive.Viewport>
+        </SelectPrimitive.Content>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -363,7 +363,6 @@
   & button,
   & a,
   & input,
-  & select,
   & textarea,
   & [role="button"],
   & .bg-card,
@@ -477,8 +476,7 @@ aside[data-animated-bg] nav {
 }
 
 [data-animated-bg] input,
-[data-animated-bg] textarea,
-[data-animated-bg] select {
+[data-animated-bg] textarea {
   background: color-mix(in srgb, var(--color-background) 50%, transparent) !important;
   border-color: color-mix(in srgb, var(--color-border) 40%, transparent) !important;
 }
@@ -561,8 +559,7 @@ aside nav:hover {
 
 .apple-light {
   & input,
-  & textarea,
-  & select {
+  & textarea {
     background: rgba(255, 255, 255, 0.7) !important;
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
@@ -571,8 +568,7 @@ aside nav:hover {
   }
 
   & input:focus,
-  & textarea:focus,
-  & select:focus {
+  & textarea:focus {
     background: rgba(255, 255, 255, 0.9) !important;
     border-color: rgba(99, 102, 241, 0.5) !important;
     box-shadow:
@@ -583,8 +579,7 @@ aside nav:hover {
 
 .apple-dark {
   & input,
-  & textarea,
-  & select {
+  & textarea {
     background: rgba(30, 32, 48, 0.6) !important;
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
@@ -593,8 +588,7 @@ aside nav:hover {
   }
 
   & input:focus,
-  & textarea:focus,
-  & select:focus {
+  & textarea:focus {
     background: rgba(40, 42, 60, 0.8) !important;
     border-color: rgba(129, 140, 248, 0.5) !important;
     box-shadow:

--- a/frontend/src/pages/edge-agent-logs.tsx
+++ b/frontend/src/pages/edge-agent-logs.tsx
@@ -26,6 +26,7 @@ import { AutoRefreshToggle } from '@/components/shared/auto-refresh-toggle';
 import { RefreshButton } from '@/components/shared/refresh-button';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { cn, formatDate } from '@/lib/utils';
+import { ThemedSelect } from '@/components/shared/themed-select';
 
 // Log levels with colors
 const LOG_LEVELS = [
@@ -389,51 +390,41 @@ export default function EdgeAgentLogsPage() {
           {/* Time Range */}
           <div className="flex items-center gap-2">
             <Clock className="h-4 w-4 text-muted-foreground" />
-            <select
+            <ThemedSelect
               value={timeRange}
-              onChange={(e) => setTimeRange(e.target.value)}
-              className="h-10 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            >
-              {TIME_RANGES.map((range) => (
-                <option key={range.value} value={range.value}>
-                  {range.label}
-                </option>
-              ))}
-            </select>
+              onValueChange={(val) => setTimeRange(val)}
+              options={TIME_RANGES.map((range) => ({ value: range.value, label: range.label }))}
+              className="h-10 text-sm"
+            />
           </div>
 
           {/* Level Filter */}
           <div className="flex items-center gap-2">
             <Filter className="h-4 w-4 text-muted-foreground" />
-            <select
-              value={levelFilter}
-              onChange={(e) => setLevelFilter(e.target.value)}
-              className="h-10 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            >
-              {LOG_LEVELS.map((level) => (
-                <option key={level.value} value={level.value}>
-                  {level.label}
-                </option>
-              ))}
-            </select>
+            <ThemedSelect
+              value={levelFilter || '__all__'}
+              onValueChange={(val) => setLevelFilter(val === '__all__' ? '' : val)}
+              options={LOG_LEVELS.map((level) => ({
+                value: level.value || '__all__',
+                label: level.label,
+              }))}
+              className="h-10 text-sm"
+            />
           </div>
 
           {/* Hostname Filter */}
           {hostnames.length > 0 && (
             <div className="flex items-center gap-2">
               <Server className="h-4 w-4 text-muted-foreground" />
-              <select
-                value={hostnameFilter}
-                onChange={(e) => setHostnameFilter(e.target.value)}
-                className="h-10 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-              >
-                <option value="">All Hosts</option>
-                {hostnames.map((host) => (
-                  <option key={host} value={host}>
-                    {host}
-                  </option>
-                ))}
-              </select>
+              <ThemedSelect
+                value={hostnameFilter || '__all__'}
+                onValueChange={(val) => setHostnameFilter(val === '__all__' ? '' : val)}
+                options={[
+                  { value: '__all__', label: 'All Hosts' },
+                  ...hostnames.map((host) => ({ value: host, label: host })),
+                ]}
+                className="h-10 text-sm"
+              />
             </div>
           )}
 

--- a/frontend/src/pages/image-footprint.tsx
+++ b/frontend/src/pages/image-footprint.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { HardDrive, Layers, Tag, AlertTriangle, X, Server, Clock, CheckCircle2, Loader2 } from 'lucide-react';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import { useImages, type DockerImage } from '@/hooks/use-images';
 import { useEndpoints } from '@/hooks/use-endpoints';
 import { useAutoRefresh } from '@/hooks/use-auto-refresh';
@@ -118,18 +119,17 @@ export default function ImageFootprintPage() {
       <div className="flex flex-wrap items-center gap-4">
         <div className="flex items-center gap-2">
           <Server className="h-4 w-4 text-muted-foreground" />
-          <select
-            value={selectedEndpoint ?? ''}
-            onChange={(e) => setSelectedEndpoint(e.target.value ? Number(e.target.value) : undefined)}
-            className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          >
-            <option value="">All Endpoints</option>
-            {endpoints?.map((ep) => (
-              <option key={ep.id} value={ep.id}>
-                {ep.name}
-              </option>
-            ))}
-          </select>
+          <ThemedSelect
+            value={selectedEndpoint !== undefined ? String(selectedEndpoint) : '__all__'}
+            onValueChange={(val) => setSelectedEndpoint(val === '__all__' ? undefined : Number(val))}
+            options={[
+              { value: '__all__', label: 'All Endpoints' },
+              ...(endpoints?.map((ep) => ({
+                value: String(ep.id),
+                label: ep.name,
+              })) ?? []),
+            ]}
+          />
         </div>
 
         {!isLoading && images && (

--- a/frontend/src/pages/llm-assistant.tsx
+++ b/frontend/src/pages/llm-assistant.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Send, X, Trash2, Bot, User, AlertCircle, Copy, Check, ChevronDown } from 'lucide-react';
+import { Send, X, Trash2, Bot, User, AlertCircle, Copy, Check } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
 import { useLlmChat } from '@/hooks/use-llm-chat';
@@ -92,21 +93,15 @@ export default function LlmAssistantPage() {
         <div className="flex items-center gap-3">
           {/* Model Selector */}
           {modelsData && modelsData.models.length > 0 && (
-            <div className="relative">
-              <select
-                value={selectedModel}
-                onChange={(e) => setSelectedModel(e.target.value)}
-                disabled={isStreaming || isSending}
-                className="appearance-none rounded-lg border border-input bg-background pl-3 pr-8 py-2 text-sm font-medium shadow-sm transition-all hover:bg-accent hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-              >
-                {modelsData.models.map((model) => (
-                  <option key={model.name} value={model.name}>
-                    {model.name}
-                  </option>
-                ))}
-              </select>
-              <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            </div>
+            <ThemedSelect
+              value={selectedModel}
+              onValueChange={(val) => setSelectedModel(val)}
+              disabled={isStreaming || isSending}
+              options={modelsData.models.map((model) => ({
+                value: model.name,
+                label: model.name,
+              }))}
+            />
           )}
           <button
             onClick={handleClear}

--- a/frontend/src/pages/log-viewer.tsx
+++ b/frontend/src/pages/log-viewer.tsx
@@ -6,6 +6,7 @@ import { useEndpoints } from '@/hooks/use-endpoints';
 import { useContainers } from '@/hooks/use-containers';
 import { api } from '@/lib/api';
 import { buildRegex, parseLogs, sortByTimestamp, toLocalTimestamp, type LogLevel, type ParsedLogEntry } from '@/lib/log-viewer';
+import { ThemedSelect } from '@/components/shared/themed-select';
 
 const BUFFER_OPTIONS = [500, 1000, 2000] as const;
 const LEVEL_OPTIONS: Array<{ value: LogLevel | 'all'; label: string }> = [
@@ -549,15 +550,15 @@ export default function LogViewerPage() {
         <div className="grid gap-3 lg:grid-cols-4">
           <label className="text-sm">
             <span className="mb-1 block text-muted-foreground">Endpoint</span>
-            <select
-              className="h-9 w-full rounded-md border border-input bg-background px-2"
-              value={selectedEndpoint ?? ''}
-              onChange={(e) => setSelectedEndpoint(Number(e.target.value))}
-            >
-              {endpoints.map((endpoint) => (
-                <option key={endpoint.id} value={endpoint.id}>{endpoint.name}</option>
-              ))}
-            </select>
+            <ThemedSelect
+              className="h-9 w-full"
+              value={selectedEndpoint != null ? String(selectedEndpoint) : '__all__'}
+              onValueChange={(val) => setSelectedEndpoint(val === '__all__' ? undefined : Number(val))}
+              placeholder="Select endpoint..."
+              options={[
+                ...endpoints.map((endpoint) => ({ value: String(endpoint.id), label: endpoint.name })),
+              ]}
+            />
           </label>
 
           <label className="text-sm lg:col-span-2">
@@ -576,15 +577,12 @@ export default function LogViewerPage() {
 
           <label className="text-sm">
             <span className="mb-1 block text-muted-foreground">Level</span>
-            <select
-              className="h-9 w-full rounded-md border border-input bg-background px-2"
+            <ThemedSelect
+              className="h-9 w-full"
               value={level}
-              onChange={(e) => setLevel(e.target.value as LogLevel | 'all')}
-            >
-              {LEVEL_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>{option.label}</option>
-              ))}
-            </select>
+              onValueChange={(val) => setLevel(val as LogLevel | 'all')}
+              options={LEVEL_OPTIONS.map((option) => ({ value: option.value, label: option.label }))}
+            />
           </label>
         </div>
 
@@ -620,17 +618,14 @@ export default function LogViewerPage() {
             <Download className="mr-1 inline h-4 w-4" />
             Export .json
           </button>
-          <label className="ml-auto text-sm">
+          <label className="ml-auto inline-flex items-center text-sm">
             <span className="mr-2 text-muted-foreground">Buffer</span>
-            <select
-              className="h-8 rounded-md border border-input bg-background px-2"
-              value={bufferSize}
-              onChange={(e) => setBufferSize(Number(e.target.value))}
-            >
-              {BUFFER_OPTIONS.map((size) => (
-                <option key={size} value={size}>{size}</option>
-              ))}
-            </select>
+            <ThemedSelect
+              className="h-8"
+              value={String(bufferSize)}
+              onValueChange={(val) => setBufferSize(Number(val))}
+              options={BUFFER_OPTIONS.map((size) => ({ value: String(size), label: String(size) }))}
+            />
           </label>
         </div>
 

--- a/frontend/src/pages/metrics-dashboard.tsx
+++ b/frontend/src/pages/metrics-dashboard.tsx
@@ -16,6 +16,7 @@ import {
   Minus,
   Timer,
 } from 'lucide-react';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import { useEndpoints } from '@/hooks/use-endpoints';
 import { useContainers } from '@/hooks/use-containers';
 import { useContainerMetrics, useAnomalies } from '@/hooks/use-metrics';
@@ -278,37 +279,37 @@ export default function MetricsDashboardPage() {
         {/* Endpoint Selector */}
         <div className="flex items-center gap-2">
           <Server className="h-4 w-4 text-muted-foreground" />
-          <select
-            value={selectedEndpoint ?? ''}
-            onChange={(e) => handleEndpointChange(Number(e.target.value))}
-            className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring"
+          <ThemedSelect
+            value={selectedEndpoint !== null ? String(selectedEndpoint) : '__placeholder__'}
+            onValueChange={(val) => val !== '__placeholder__' && handleEndpointChange(Number(val))}
+            placeholder="Select endpoint..."
             disabled={endpointsLoading}
-          >
-            <option value="">Select endpoint...</option>
-            {endpoints?.map((ep) => (
-              <option key={ep.id} value={ep.id}>
-                {ep.name}
-              </option>
-            ))}
-          </select>
+            options={[
+              { value: '__placeholder__', label: 'Select endpoint...', disabled: true },
+              ...(endpoints?.map((ep) => ({
+                value: String(ep.id),
+                label: ep.name,
+              })) ?? []),
+            ]}
+          />
         </div>
 
         {/* Container Selector */}
         <div className="flex items-center gap-2">
           <Box className="h-4 w-4 text-muted-foreground" />
-          <select
-            value={selectedContainer ?? ''}
-            onChange={(e) => setSelectedContainer(e.target.value)}
-            className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring"
+          <ThemedSelect
+            value={selectedContainer ?? '__placeholder__'}
+            onValueChange={(val) => val !== '__placeholder__' && setSelectedContainer(val)}
+            placeholder="Select container..."
             disabled={!selectedEndpoint || containersLoading}
-          >
-            <option value="">Select container...</option>
-            {containers.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-          </select>
+            options={[
+              { value: '__placeholder__', label: 'Select container...', disabled: true },
+              ...containers.map((c) => ({
+                value: c.id,
+                label: c.name,
+              })),
+            ]}
+          />
         </div>
 
         {/* Time Range Selector */}

--- a/frontend/src/pages/network-topology.tsx
+++ b/frontend/src/pages/network-topology.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { X } from 'lucide-react';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import { useContainers, type Container } from '@/hooks/use-containers';
 import { useNetworks, type Network } from '@/hooks/use-networks';
 import { useEndpoints } from '@/hooks/use-endpoints';
@@ -116,19 +117,18 @@ export default function NetworkTopologyPage() {
           <label htmlFor="endpoint-select" className="text-sm font-medium">
             Endpoint
           </label>
-          <select
+          <ThemedSelect
             id="endpoint-select"
-            value={selectedEndpoint ?? ''}
-            onChange={(e) => setSelectedEndpoint(e.target.value ? Number(e.target.value) : undefined)}
-            className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <option value="">All endpoints</option>
-            {endpoints?.map((ep) => (
-              <option key={ep.id} value={ep.id}>
-                {ep.name} (ID: {ep.id})
-              </option>
-            ))}
-          </select>
+            value={selectedEndpoint !== undefined ? String(selectedEndpoint) : '__all__'}
+            onValueChange={(val) => setSelectedEndpoint(val === '__all__' ? undefined : Number(val))}
+            options={[
+              { value: '__all__', label: 'All endpoints' },
+              ...(endpoints?.map((ep) => ({
+                value: String(ep.id),
+                label: `${ep.name} (ID: ${ep.id})`,
+              })) ?? []),
+            ]}
+          />
         </div>
 
         {containers && networks && (

--- a/frontend/src/pages/packet-capture.tsx
+++ b/frontend/src/pages/packet-capture.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/hooks/use-pcap';
 import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import { ThemedSelect } from '@/components/shared/themed-select';
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
@@ -117,41 +118,37 @@ export default function PacketCapture() {
           {/* Endpoint */}
           <div>
             <label className="mb-1 block text-sm font-medium">Endpoint</label>
-            <select
-              value={selectedEndpoint ?? ''}
-              onChange={(e) => {
-                const val = e.target.value ? Number(e.target.value) : undefined;
-                setSelectedEndpoint(val);
+            <ThemedSelect
+              value={selectedEndpoint != null ? String(selectedEndpoint) : '__all__'}
+              onValueChange={(val) => {
+                const resolved = val === '__all__' ? undefined : Number(val);
+                setSelectedEndpoint(resolved);
                 setSelectedContainer('');
                 setSelectedContainerName('');
               }}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            >
-              <option value="">Select endpoint...</option>
-              {endpoints?.map((ep) => (
-                <option key={ep.id} value={ep.id}>
-                  {ep.name}
-                </option>
-              ))}
-            </select>
+              placeholder="Select endpoint..."
+              options={[
+                { value: '__all__', label: 'Select endpoint...' },
+                ...(endpoints?.map((ep) => ({ value: String(ep.id), label: ep.name })) ?? []),
+              ]}
+              className="w-full text-sm"
+            />
           </div>
 
           {/* Container */}
           <div>
             <label className="mb-1 block text-sm font-medium">Container</label>
-            <select
-              value={selectedContainer}
-              onChange={(e) => handleContainerChange(e.target.value)}
+            <ThemedSelect
+              value={selectedContainer || '__all__'}
+              onValueChange={(val) => handleContainerChange(val === '__all__' ? '' : val)}
               disabled={!selectedEndpoint}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-50"
-            >
-              <option value="">Select container...</option>
-              {runningContainers.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
+              placeholder="Select container..."
+              options={[
+                { value: '__all__', label: 'Select container...' },
+                ...runningContainers.map((c) => ({ value: c.id, label: c.name })),
+              ]}
+              className="w-full text-sm"
+            />
           </div>
 
           {/* BPF Filter */}

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -20,6 +20,7 @@ import { useEndpoints } from '@/hooks/use-endpoints';
 import { MetricsLineChart } from '@/components/charts/metrics-line-chart';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { cn } from '@/lib/utils';
+import { ThemedSelect } from '@/components/shared/themed-select';
 
 const TIME_RANGES = [
   { value: '24h', label: '24 Hours' },
@@ -195,18 +196,15 @@ export default function ReportsPage() {
       <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-card p-4">
         <div className="flex items-center gap-2">
           <Server className="h-4 w-4 text-muted-foreground" />
-          <select
-            value={selectedEndpoint ?? ''}
-            onChange={(e) => setSelectedEndpoint(e.target.value ? Number(e.target.value) : undefined)}
-            className="rounded-md border border-input bg-background px-3 py-2 text-sm"
-          >
-            <option value="">All endpoints</option>
-            {endpoints?.map((ep) => (
-              <option key={ep.id} value={ep.id}>
-                {ep.name}
-              </option>
-            ))}
-          </select>
+          <ThemedSelect
+            value={selectedEndpoint != null ? String(selectedEndpoint) : '__all__'}
+            onValueChange={(val) => setSelectedEndpoint(val === '__all__' ? undefined : Number(val))}
+            options={[
+              { value: '__all__', label: 'All endpoints' },
+              ...(endpoints?.map((ep) => ({ value: String(ep.id), label: ep.name })) ?? []),
+            ]}
+            className="text-sm"
+          />
         </div>
 
         <div className="flex items-center gap-2">

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -32,6 +32,7 @@ import { useCacheStats, useCacheClear } from '@/hooks/use-cache-admin';
 import { useLlmModels, useLlmTestConnection } from '@/hooks/use-llm-models';
 import type { LlmModel } from '@/hooks/use-llm-models';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import { cn, formatBytes } from '@/lib/utils';
 import { toast } from 'sonner';
 import { api } from '@/lib/api';
@@ -434,23 +435,22 @@ export function LlmSettingsSection({ values, originalValues, onChange, disabled 
           </div>
 
           {models.length > 0 ? (
-            <select
+            <ThemedSelect
               id="llm-model-select"
               value={selectedModel}
-              onChange={(e) => onChange('llm.model', e.target.value)}
+              onValueChange={(val) => onChange('llm.model', val)}
               disabled={disabled}
-              className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-            >
-              {models.map((m) => (
-                <option key={m.name} value={m.name}>
-                  {m.name}{m.size ? ` (${formatBytes(m.size)})` : ''}
-                </option>
-              ))}
-              {/* Include current value if not in the models list */}
-              {selectedModel && !models.some((m) => m.name === selectedModel) && (
-                <option value={selectedModel}>{selectedModel}</option>
-              )}
-            </select>
+              options={[
+                ...models.map((m) => ({
+                  value: m.name,
+                  label: `${m.name}${m.size ? ` (${formatBytes(m.size)})` : ''}`,
+                })),
+                ...(selectedModel && !models.some((m) => m.name === selectedModel)
+                  ? [{ value: selectedModel, label: selectedModel }]
+                  : []),
+              ]}
+              className="w-full"
+            />
           ) : (
             <input
               id="llm-model-select"
@@ -751,50 +751,47 @@ export function NotificationHistoryPanel() {
       <div className="border-b p-4">
         <div className="flex flex-wrap items-center gap-3">
           <div className="flex items-center gap-2">
-            <label htmlFor="history-channel-filter" className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               Channel
             </label>
-            <select
-              id="history-channel-filter"
+            <ThemedSelect
               value={channelFilter}
-              onChange={(e) => setChannelFilter(e.target.value as ChannelFilter)}
-              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
-            >
-              <option value="all">All</option>
-              <option value="teams">Teams</option>
-              <option value="email">Email</option>
-            </select>
+              onValueChange={(val) => setChannelFilter(val as ChannelFilter)}
+              options={[
+                { value: 'all', label: 'All' },
+                { value: 'teams', label: 'Teams' },
+                { value: 'email', label: 'Email' },
+              ]}
+            />
           </div>
           <div className="flex items-center gap-2">
-            <label htmlFor="history-status-filter" className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               Status
             </label>
-            <select
-              id="history-status-filter"
+            <ThemedSelect
               value={statusFilter}
-              onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
-              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
-            >
-              <option value="all">All</option>
-              <option value="sent">Sent</option>
-              <option value="failed">Failed</option>
-            </select>
+              onValueChange={(val) => setStatusFilter(val as StatusFilter)}
+              options={[
+                { value: 'all', label: 'All' },
+                { value: 'sent', label: 'Sent' },
+                { value: 'failed', label: 'Failed' },
+              ]}
+            />
           </div>
           <div className="flex items-center gap-2">
-            <label htmlFor="history-date-range-filter" className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               Date Range
             </label>
-            <select
-              id="history-date-range-filter"
+            <ThemedSelect
               value={dateRangeFilter}
-              onChange={(e) => setDateRangeFilter(e.target.value as DateRangeFilter)}
-              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
-            >
-              <option value="24h">Last 24 Hours</option>
-              <option value="7d">Last 7 Days</option>
-              <option value="30d">Last 30 Days</option>
-              <option value="all">All Time</option>
-            </select>
+              onValueChange={(val) => setDateRangeFilter(val as DateRangeFilter)}
+              options={[
+                { value: '24h', label: 'Last 24 Hours' },
+                { value: '7d', label: 'Last 7 Days' },
+                { value: '30d', label: 'Last 30 Days' },
+                { value: 'all', label: 'All Time' },
+              ]}
+            />
           </div>
           <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
             <span className="rounded-full bg-emerald-500/15 px-2 py-1 text-emerald-700 dark:text-emerald-400">Sent: {sentCount}</span>
@@ -930,19 +927,16 @@ export function DefaultLandingPagePreference() {
           Default Landing Page
         </label>
         <div className="flex items-center gap-3">
-          <select
+          <ThemedSelect
             id="default-landing-page"
             value={value}
             disabled={loading || saving}
-            onChange={(e) => setValue(e.target.value)}
-            className="h-9 rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-          >
-            {LANDING_PAGE_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            onValueChange={(val) => setValue(val)}
+            options={LANDING_PAGE_OPTIONS.map((option) => ({
+              value: option.value,
+              label: option.label,
+            }))}
+          />
           <button
             onClick={savePreference}
             disabled={loading || saving}

--- a/frontend/src/pages/trace-explorer.tsx
+++ b/frontend/src/pages/trace-explorer.tsx
@@ -12,7 +12,6 @@ import {
   Filter,
   Layers,
   Timer,
-  Tag,
 } from 'lucide-react';
 import { useTraces, useTrace, useServiceMap, useTraceSummary } from '@/hooks/use-traces';
 import { useAutoRefresh } from '@/hooks/use-auto-refresh';
@@ -22,6 +21,7 @@ import { RefreshButton } from '@/components/shared/refresh-button';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { cn, formatDate } from '@/lib/utils';
+import { ThemedSelect } from '@/components/shared/themed-select';
 
 function formatDuration(ms: number): string {
   if (ms < 1) return '<1ms';
@@ -426,16 +426,15 @@ export default function TraceExplorerPage() {
 
         <div className="flex items-center gap-2">
           <Server className="h-4 w-4 text-muted-foreground" />
-          <select
-            value={serviceFilter}
-            onChange={(e) => setServiceFilter(e.target.value)}
-            className="rounded-md border border-input bg-background px-3 py-2 text-sm"
-          >
-            <option value="">All services</option>
-            {services.map((s) => (
-              <option key={s} value={s}>{s}</option>
-            ))}
-          </select>
+          <ThemedSelect
+            value={serviceFilter || '__all__'}
+            onValueChange={(val) => setServiceFilter(val === '__all__' ? '' : val)}
+            options={[
+              { value: '__all__', label: 'All services' },
+              ...services.map((s) => ({ value: s, label: s })),
+            ]}
+            className="text-sm"
+          />
         </div>
 
         <div className="flex items-center gap-2">

--- a/frontend/src/pages/users.tsx
+++ b/frontend/src/pages/users.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Loader2, ShieldAlert, UserPlus, Users as UsersIcon, Trash2, UserCog } from 'lucide-react';
 import { useAuth } from '@/providers/auth-provider';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import { useCreateUser, useDeleteUser, useUpdateUser, useUsers, type UserRole } from '@/hooks/use-users';
 import { formatDate } from '@/lib/utils';
 
@@ -120,16 +121,16 @@ export default function UsersPage() {
               placeholder="Search username..."
               className="h-8 rounded-md border border-input bg-background px-2 text-sm"
             />
-            <select
+            <ThemedSelect
               value={roleFilter}
-              onChange={(e) => setRoleFilter(e.target.value as 'all' | UserRole)}
-              className="h-8 rounded-md border border-input bg-background px-2 text-sm"
-            >
-              <option value="all">All Roles</option>
-              <option value="admin">Admin</option>
-              <option value="operator">Operator</option>
-              <option value="viewer">Viewer</option>
-            </select>
+              onValueChange={(val) => setRoleFilter(val as 'all' | UserRole)}
+              options={[
+                { value: 'all', label: 'All Roles' },
+                { value: 'admin', label: 'Admin' },
+                { value: 'operator', label: 'Operator' },
+                { value: 'viewer', label: 'Viewer' },
+              ]}
+            />
           </div>
 
           {usersQuery.isLoading ? (
@@ -223,18 +224,19 @@ export default function UsersPage() {
               />
             </label>
 
-            <label className="block">
+            <div className="block">
               <span className="mb-1 block text-muted-foreground">Role</span>
-              <select
+              <ThemedSelect
                 value={form.role}
-                onChange={(e) => setForm((prev) => ({ ...prev, role: e.target.value as UserRole }))}
-                className="h-9 w-full rounded-md border border-input bg-background px-2"
-              >
-                <option value="admin">Admin</option>
-                <option value="operator">Operator</option>
-                <option value="viewer">Viewer</option>
-              </select>
-            </label>
+                onValueChange={(val) => setForm((prev) => ({ ...prev, role: val as UserRole }))}
+                options={[
+                  { value: 'admin', label: 'Admin' },
+                  { value: 'operator', label: 'Operator' },
+                  { value: 'viewer', label: 'Viewer' },
+                ]}
+                className="w-full"
+              />
+            </div>
 
             {errorMessage && <p className="text-xs text-destructive">{errorMessage}</p>}
 

--- a/frontend/src/pages/webhooks.tsx
+++ b/frontend/src/pages/webhooks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Loader2, PlugZap, Plus, TestTube2, Trash2, Activity, Radio, RefreshCw } from 'lucide-react';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import {
   useCreateWebhook,
   useDeleteWebhook,
@@ -186,15 +187,15 @@ export default function WebhooksPage() {
         <section className="rounded-lg border bg-card p-4 lg:col-span-3">
           <div className="mb-4 flex flex-wrap items-center gap-2">
             <label className="text-sm text-muted-foreground">Filter</label>
-            <select
+            <ThemedSelect
               value={filter}
-              onChange={(e) => setFilter(e.target.value as 'all' | 'enabled' | 'disabled')}
-              className="h-8 rounded-md border border-input bg-background px-2 text-sm"
-            >
-              <option value="all">All</option>
-              <option value="enabled">Enabled</option>
-              <option value="disabled">Disabled</option>
-            </select>
+              onValueChange={(val) => setFilter(val as 'all' | 'enabled' | 'disabled')}
+              options={[
+                { value: 'all', label: 'All' },
+                { value: 'enabled', label: 'Enabled' },
+                { value: 'disabled', label: 'Disabled' },
+              ]}
+            />
             <button
               type="button"
               onClick={() => webhooksQuery.refetch()}

--- a/frontend/src/pages/workload-explorer.tsx
+++ b/frontend/src/pages/workload-explorer.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { type ColumnDef } from '@tanstack/react-table';
 import { AlertTriangle, X } from 'lucide-react';
+import { ThemedSelect } from '@/components/shared/themed-select';
 import { useContainers, type Container } from '@/hooks/use-containers';
 import { useEndpoints } from '@/hooks/use-endpoints';
 import { useAutoRefresh } from '@/hooks/use-auto-refresh';
@@ -166,19 +167,18 @@ export default function WorkloadExplorerPage() {
           <label htmlFor="endpoint-select" className="text-sm font-medium">
             Endpoint
           </label>
-          <select
+          <ThemedSelect
             id="endpoint-select"
-            value={selectedEndpoint ?? ''}
-            onChange={(e) => setSelectedEndpoint(e.target.value ? Number(e.target.value) : undefined)}
-            className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <option value="">All endpoints</option>
-            {endpoints?.map((ep) => (
-              <option key={ep.id} value={ep.id}>
-                {ep.name} (ID: {ep.id})
-              </option>
-            ))}
-          </select>
+            value={selectedEndpoint !== undefined ? String(selectedEndpoint) : '__all__'}
+            onValueChange={(val) => setSelectedEndpoint(val === '__all__' ? undefined : Number(val))}
+            options={[
+              { value: '__all__', label: 'All endpoints' },
+              ...(endpoints?.map((ep) => ({
+                value: String(ep.id),
+                label: `${ep.name} (ID: ${ep.id})`,
+              })) ?? []),
+            ]}
+          />
         </div>
 
         {selectedStack && (


### PR DESCRIPTION
## Summary
- Created `ThemedSelect` component using `@radix-ui/react-select` with full theme support, animations, and checkmark indicators
- Replaced all 25+ native `<select>` elements across 15 pages/components with `ThemedSelect`
- Removed orphaned `& select` CSS rules from Apple theme glass inputs and animated background styles

## Motivation
Native HTML `<select>` popups render with browser-default styling that ignores the app's dark theme and glassmorphic design. The Radix-based component renders fully custom dropdowns that respect all themes.

## Files changed
- **New**: `frontend/src/components/shared/themed-select.tsx`
- **Updated**: 15 pages/components replacing `<select>` with `<ThemedSelect>`
- **Updated**: `frontend/src/index.css` — removed orphaned `& select` CSS rules

## Test plan
- [ ] Verify all dropdowns render with themed styling in light and dark modes
- [ ] Verify dropdown popups open/close with animations
- [ ] Verify keyboard navigation works (arrow keys, enter, escape)
- [ ] Test on Apple Light/Dark, Catppuccin, and default themes
- [ ] Verify no native `<select>` elements remain (`grep -r '<select' frontend/src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)