### PR TITLE
fix: normalize session expiry comparisons in sqlite (#169)

### DIFF
--- a/backend/src/services/session-store.test.ts
+++ b/backend/src/services/session-store.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config/index.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    SQLITE_PATH: ':memory:',
+  }),
+}));
+
+async function setupSessionsTable() {
+  const { getDb } = await import('../db/sqlite.js');
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      username TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      last_active TEXT NOT NULL,
+      is_valid INTEGER NOT NULL DEFAULT 1
+    )
+  `);
+  db.exec('DELETE FROM sessions');
+  return db;
+}
+
+describe('session-store expiration semantics', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../db/sqlite.js');
+    closeDb();
+    vi.useRealTimers();
+  });
+
+  it('does not return expired sessions with ISO timestamps', async () => {
+    const db = await setupSessionsTable();
+    db.prepare(`
+      INSERT INTO sessions (id, user_id, username, created_at, expires_at, last_active, is_valid)
+      VALUES (?, ?, ?, ?, ?, ?, 1)
+    `).run(
+      'expired-session',
+      'user-1',
+      'alice',
+      '2026-02-07T09:00:00.000Z',
+      '2026-02-07T09:30:00.000Z',
+      '2026-02-07T09:15:00.000Z',
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-07T10:00:00.000Z'));
+
+    const { getSession } = await import('./session-store.js');
+    expect(getSession('expired-session')).toBeUndefined();
+  });
+
+  it('treats session expiring exactly at now as expired', async () => {
+    const db = await setupSessionsTable();
+    db.prepare(`
+      INSERT INTO sessions (id, user_id, username, created_at, expires_at, last_active, is_valid)
+      VALUES (?, ?, ?, ?, ?, ?, 1)
+    `).run(
+      'boundary-session',
+      'user-2',
+      'bob',
+      '2026-02-07T09:00:00.000Z',
+      '2026-02-07T10:00:00.000Z',
+      '2026-02-07T09:55:00.000Z',
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-07T10:00:00.000Z'));
+
+    const { getSession } = await import('./session-store.js');
+    expect(getSession('boundary-session')).toBeUndefined();
+  });
+
+  it('cleans expired and invalid sessions while preserving active ones', async () => {
+    const db = await setupSessionsTable();
+    db.prepare(`
+      INSERT INTO sessions (id, user_id, username, created_at, expires_at, last_active, is_valid)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'expired-valid',
+      'user-1',
+      'alice',
+      '2026-02-07T09:00:00.000Z',
+      '2026-02-07T09:30:00.000Z',
+      '2026-02-07T09:15:00.000Z',
+      1,
+    );
+    db.prepare(`
+      INSERT INTO sessions (id, user_id, username, created_at, expires_at, last_active, is_valid)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'future-invalid',
+      'user-2',
+      'bob',
+      '2026-02-07T09:00:00.000Z',
+      '2026-02-07T11:30:00.000Z',
+      '2026-02-07T09:15:00.000Z',
+      0,
+    );
+    db.prepare(`
+      INSERT INTO sessions (id, user_id, username, created_at, expires_at, last_active, is_valid)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'future-valid',
+      'user-3',
+      'carol',
+      '2026-02-07T09:00:00.000Z',
+      '2026-02-07T11:30:00.000Z',
+      '2026-02-07T09:15:00.000Z',
+      1,
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-07T10:00:00.000Z'));
+
+    const { cleanExpiredSessions } = await import('./session-store.js');
+    expect(cleanExpiredSessions()).toBe(2);
+
+    const remaining = db.prepare('SELECT id FROM sessions ORDER BY id').all() as Array<{ id: string }>;
+    expect(remaining).toEqual([{ id: 'future-valid' }]);
+  });
+});

--- a/backend/src/services/session-store.ts
+++ b/backend/src/services/session-store.ts
@@ -39,7 +39,7 @@ export function createSession(userId: string, username: string): Session {
 
 export function getSession(sessionId: string): Session | undefined {
   return prepareStmt(
-    'SELECT * FROM sessions WHERE id = ? AND is_valid = 1 AND expires_at > datetime(?)'
+    'SELECT * FROM sessions WHERE id = ? AND is_valid = 1 AND unixepoch(expires_at) > unixepoch(?)'
   ).get(sessionId, new Date().toISOString()) as Session | undefined;
 }
 
@@ -62,7 +62,7 @@ export function refreshSession(sessionId: string): Session | undefined {
 
 export function cleanExpiredSessions(): number {
   const result = prepareStmt(
-    'DELETE FROM sessions WHERE expires_at < datetime(?) OR is_valid = 0'
+    'DELETE FROM sessions WHERE unixepoch(expires_at) < unixepoch(?) OR is_valid = 0'
   ).run(new Date().toISOString());
   return result.changes;
 }


### PR DESCRIPTION
Summary
- fix session validity and cleanup comparisons to use unixepoch on both sides
- prevents mixed-format datetime string comparisons from allowing expired sessions to appear valid
- keeps existing ISO8601 session storage while enforcing correct temporal semantics

Changes
- update getSession query in backend/src/services/session-store.ts
- update cleanExpiredSessions query in backend/src/services/session-store.ts
- add regression tests in backend/src/services/session-store.test.ts for expired ISO sessions, exact boundary expiry, and cleanup correctness

Testing
- npm run test -w backend -- src/services/session-store.test.ts
- npm run test -w backend -- src/db/sqlite.test.ts

Closes #169