### PR TITLE
fix: revoke JWT access immediately via session checks (#166)

### DIFF
--- a/backend/src/plugins/auth.test.ts
+++ b/backend/src/plugins/auth.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify from 'fastify';
+import authPlugin from './auth.js';
+
+const mockVerifyJwt = vi.fn();
+const mockGetSession = vi.fn();
+
+vi.mock('../utils/crypto.js', () => ({
+  verifyJwt: (...args: unknown[]) => mockVerifyJwt(...args),
+}));
+
+vi.mock('../services/session-store.js', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+describe('auth plugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects missing authorization header', async () => {
+    const app = Fastify();
+    await app.register(authPlugin);
+    app.get('/protected', { preHandler: [app.authenticate] }, async () => ({ ok: true }));
+    await app.ready();
+
+    const res = await app.inject({ method: 'GET', url: '/protected' });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe('Missing or invalid authorization header');
+
+    await app.close();
+  });
+
+  it('rejects token for revoked session', async () => {
+    mockVerifyJwt.mockResolvedValue({
+      sub: 'user-1',
+      username: 'alice',
+      sessionId: 'session-1',
+      role: 'admin',
+    });
+    mockGetSession.mockReturnValue(undefined);
+
+    const app = Fastify();
+    await app.register(authPlugin);
+    app.get('/protected', { preHandler: [app.authenticate] }, async () => ({ ok: true }));
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: { authorization: 'Bearer test-token' },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe('Invalid, expired, or revoked token');
+
+    await app.close();
+  });
+
+  it('rejects token when session identity does not match JWT', async () => {
+    mockVerifyJwt.mockResolvedValue({
+      sub: 'user-1',
+      username: 'alice',
+      sessionId: 'session-1',
+      role: 'admin',
+    });
+    mockGetSession.mockReturnValue({
+      id: 'session-1',
+      user_id: 'user-2',
+      username: 'bob',
+      created_at: '2026-02-07T10:00:00.000Z',
+      expires_at: '2026-02-07T11:00:00.000Z',
+      last_active: '2026-02-07T10:30:00.000Z',
+      is_valid: 1,
+    });
+
+    const app = Fastify();
+    await app.register(authPlugin);
+    app.get('/protected', { preHandler: [app.authenticate] }, async () => ({ ok: true }));
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: { authorization: 'Bearer test-token' },
+    });
+    expect(res.statusCode).toBe(401);
+
+    await app.close();
+  });
+
+  it('accepts token with valid active session', async () => {
+    mockVerifyJwt.mockResolvedValue({
+      sub: 'user-1',
+      username: 'alice',
+      sessionId: 'session-1',
+      role: 'admin',
+    });
+    mockGetSession.mockReturnValue({
+      id: 'session-1',
+      user_id: 'user-1',
+      username: 'alice',
+      created_at: '2026-02-07T10:00:00.000Z',
+      expires_at: '2026-02-07T11:00:00.000Z',
+      last_active: '2026-02-07T10:30:00.000Z',
+      is_valid: 1,
+    });
+
+    const app = Fastify();
+    await app.register(authPlugin);
+    app.get('/protected', { preHandler: [app.authenticate] }, async (request) => ({ user: request.user }));
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: { authorization: 'Bearer test-token' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().user.sub).toBe('user-1');
+    expect(res.json().user.sessionId).toBe('session-1');
+
+    await app.close();
+  });
+});

--- a/backend/src/plugins/socket-io.test.ts
+++ b/backend/src/plugins/socket-io.test.ts
@@ -1,8 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 
+const mockVerifyJwt = vi.fn().mockResolvedValue({ sub: 'u1', username: 'test', sessionId: 's1' });
+const mockGetSession = vi.fn().mockReturnValue({
+  id: 's1',
+  user_id: 'u1',
+  username: 'test',
+  created_at: '2026-02-07T10:00:00.000Z',
+  expires_at: '2026-02-07T11:00:00.000Z',
+  last_active: '2026-02-07T10:30:00.000Z',
+  is_valid: 1,
+});
+
 vi.mock('../utils/crypto.js', () => ({
-  verifyJwt: vi.fn().mockResolvedValue({ sub: 'u1', username: 'test', sessionId: 's1' }),
+  verifyJwt: (...args: unknown[]) => mockVerifyJwt(...args),
+}));
+
+vi.mock('../services/session-store.js', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -15,11 +30,23 @@ vi.mock('../utils/logger.js', () => ({
 }));
 
 import socketIoPlugin from './socket-io.js';
+import { authenticateSocketToken } from './socket-io.js';
 
 describe('socket-io plugin', () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+    mockVerifyJwt.mockResolvedValue({ sub: 'u1', username: 'test', sessionId: 's1' });
+    mockGetSession.mockReturnValue({
+      id: 's1',
+      user_id: 'u1',
+      username: 'test',
+      created_at: '2026-02-07T10:00:00.000Z',
+      expires_at: '2026-02-07T11:00:00.000Z',
+      last_active: '2026-02-07T10:30:00.000Z',
+      is_valid: 1,
+    });
     app = Fastify();
     await app.register(socketIoPlugin);
     await app.ready();
@@ -52,5 +79,24 @@ describe('socket-io plugin', () => {
   it('should set correct transport order', () => {
     const opts = (app.io as unknown as { opts: Record<string, unknown> }).opts;
     expect(opts.transports).toEqual(['websocket', 'polling']);
+  });
+
+  it('authenticateSocketToken rejects missing token', async () => {
+    expect(await authenticateSocketToken(undefined)).toBeNull();
+  });
+
+  it('authenticateSocketToken rejects revoked sessions', async () => {
+    mockGetSession.mockReturnValue(undefined);
+    expect(await authenticateSocketToken('token')).toBeNull();
+  });
+
+  it('authenticateSocketToken rejects mismatched identity', async () => {
+    mockVerifyJwt.mockResolvedValue({ sub: 'u2', username: 'other', sessionId: 's1' });
+    expect(await authenticateSocketToken('token')).toBeNull();
+  });
+
+  it('authenticateSocketToken returns user for active valid session', async () => {
+    const user = await authenticateSocketToken('token');
+    expect(user).toEqual({ sub: 'u1', username: 'test', sessionId: 's1' });
   });
 });


### PR DESCRIPTION
## Summary
- enforce server-side session validation in shared HTTP auth middleware
- enforce the same validation in Socket.IO root and namespace authentication
- reject tokens when session is revoked or identity mismatches session state

## Changes
- backend/src/plugins/auth.ts
  - add authenticateBearerHeader helper
  - validate JWT payload against getSession(payload.sessionId)
  - reject when session missing or JWT subject or username differs from session record
- backend/src/plugins/socket-io.ts
  - add authenticateSocketToken helper
  - apply session validation to root and namespace middleware
- tests
  - backend/src/plugins/auth.test.ts (new): revoked and mismatched session rejection plus valid-session success
  - backend/src/plugins/socket-io.test.ts: socket token/session validation coverage

## Testing
- npm run test -w backend -- src/plugins/auth.test.ts src/plugins/socket-io.test.ts
- npm run typecheck -w backend

Closes #166