### PR TITLE
feat: deepen apple glass layers with parallax and noise

### DIFF
--- a/frontend/src/components/layout/app-layout.tsx
+++ b/frontend/src/components/layout/app-layout.tsx
@@ -15,6 +15,7 @@ import { useKeyboardShortcut } from '@/hooks/use-keyboard-shortcut';
 import { useEntrancePlayed } from '@/hooks/use-entrance-played';
 import { useKeyChord } from '@/hooks/use-key-chord';
 import type { ChordBinding } from '@/hooks/use-key-chord';
+import { useGlassParallax } from '@/hooks/use-glass-parallax';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 
 function getRouteDepth(pathname: string): number {
@@ -40,6 +41,9 @@ export function AppLayout() {
   const previousDepthRef = useRef(getRouteDepth(location.pathname));
   const { hasPlayed, markPlayed } = useEntrancePlayed();
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const isAppleTheme = theme === 'apple-light' || theme === 'apple-dark';
+
+  useGlassParallax(isAppleTheme);
 
   // Skip entrance on click/keypress
   useEffect(() => {

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@/providers/auth-provider';
 import { useThemeStore } from '@/stores/theme-store';
 import { useUiStore } from '@/stores/ui-store';
 import { cn } from '@/lib/utils';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, type CSSProperties } from 'react';
 import { ConnectionOrb } from '@/components/shared/connection-orb';
 
 const routeLabels: Record<string, string> = {
@@ -33,6 +33,8 @@ export function Header() {
   const hasAnimatedBg = dashboardBackground !== 'none';
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
+  const [headerBlur, setHeaderBlur] = useState(20);
+  const isAppleTheme = theme === 'apple-light' || theme === 'apple-dark';
 
   // Check if the current route is a container detail page
   const containerDetailMatch = location.pathname.match(/^\/containers\/(\d+)\/([a-f0-9]+)$/);
@@ -68,9 +70,29 @@ export function Header() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    if (!isAppleTheme) {
+      setHeaderBlur(20);
+      return;
+    }
+
+    const updateBlur = () => {
+      const minBlur = 20;
+      const maxBlur = 25;
+      const scrollAmount = Math.min(window.scrollY, 200);
+      const nextBlur = minBlur + (scrollAmount / 200) * (maxBlur - minBlur);
+      setHeaderBlur(nextBlur);
+    };
+
+    updateBlur();
+    window.addEventListener('scroll', updateBlur, { passive: true });
+    return () => window.removeEventListener('scroll', updateBlur);
+  }, [isAppleTheme]);
+
   return (
     <header
       data-animated-bg={hasAnimatedBg || undefined}
+      style={{ '--glass-header-blur': `${headerBlur}px` } as CSSProperties}
       className="relative z-40 mx-2 mt-2 flex h-12 shrink-0 items-center justify-between rounded-2xl bg-background/80 backdrop-blur-xl shadow-lg ring-1 ring-black/5 dark:ring-white/10 px-2 md:mx-4 md:mt-4 md:px-4"
     >
       {/* Breadcrumbs */}

--- a/frontend/src/hooks/use-glass-parallax.test.tsx
+++ b/frontend/src/hooks/use-glass-parallax.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { useGlassParallax } from '@/hooks/use-glass-parallax';
+
+function TestHarness({ enabled }: { enabled: boolean }) {
+  useGlassParallax(enabled);
+  return null;
+}
+
+describe('useGlassParallax', () => {
+  const originalMatchMedia = window.matchMedia;
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+  const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      value: 0,
+      configurable: true,
+    });
+
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    window.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+
+    window.cancelAnimationFrame = vi.fn();
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    document.documentElement.style.removeProperty('--glass-bg-shift-x');
+    document.documentElement.style.removeProperty('--glass-bg-shift-y');
+    document.documentElement.style.removeProperty('--glass-card-shift-x');
+    document.documentElement.style.removeProperty('--glass-card-shift-y');
+  });
+
+  it('sets parallax CSS variables when enabled', () => {
+    render(<TestHarness enabled />);
+
+    window.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 100, clientY: 200 })
+    );
+
+    const rootStyle = document.documentElement.style;
+    expect(rootStyle.getPropertyValue('--glass-bg-shift-x')).not.toBe('0px');
+    expect(rootStyle.getPropertyValue('--glass-bg-shift-y')).not.toBe('0px');
+    expect(rootStyle.getPropertyValue('--glass-card-shift-x')).not.toBe('0px');
+    expect(rootStyle.getPropertyValue('--glass-card-shift-y')).not.toBe('0px');
+  });
+
+  it('resets parallax variables when disabled', () => {
+    const { rerender } = render(<TestHarness enabled />);
+
+    window.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 100, clientY: 200 })
+    );
+
+    rerender(<TestHarness enabled={false} />);
+
+    const rootStyle = document.documentElement.style;
+    expect(rootStyle.getPropertyValue('--glass-bg-shift-x')).toBe('0px');
+    expect(rootStyle.getPropertyValue('--glass-bg-shift-y')).toBe('0px');
+    expect(rootStyle.getPropertyValue('--glass-card-shift-x')).toBe('0px');
+    expect(rootStyle.getPropertyValue('--glass-card-shift-y')).toBe('0px');
+  });
+});

--- a/frontend/src/hooks/use-glass-parallax.ts
+++ b/frontend/src/hooks/use-glass-parallax.ts
@@ -1,0 +1,82 @@
+import { useEffect } from 'react';
+
+const MAX_BACKGROUND_SHIFT = 5;
+const MAX_CARD_SHIFT = 1;
+
+function setGlassParallaxVariables({
+  bgX,
+  bgY,
+  cardX,
+  cardY,
+}: {
+  bgX: string;
+  bgY: string;
+  cardX: string;
+  cardY: string;
+}) {
+  const root = document.documentElement;
+  root.style.setProperty('--glass-bg-shift-x', bgX);
+  root.style.setProperty('--glass-bg-shift-y', bgY);
+  root.style.setProperty('--glass-card-shift-x', cardX);
+  root.style.setProperty('--glass-card-shift-y', cardY);
+}
+
+export function useGlassParallax(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) {
+      setGlassParallaxVariables({
+        bgX: '0px',
+        bgY: '0px',
+        cardX: '0px',
+        cardY: '0px',
+      });
+      return;
+    }
+
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const isCoarsePointer = window.matchMedia('(pointer: coarse)').matches;
+    const isTouchDevice = navigator.maxTouchPoints > 0;
+
+    if (prefersReducedMotion || isCoarsePointer || isTouchDevice) {
+      setGlassParallaxVariables({
+        bgX: '0px',
+        bgY: '0px',
+        cardX: '0px',
+        cardY: '0px',
+      });
+      return;
+    }
+
+    let frame = 0;
+
+    const handleMove = (event: MouseEvent) => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        const xRatio = event.clientX / window.innerWidth - 0.5;
+        const yRatio = event.clientY / window.innerHeight - 0.5;
+        const bgX = `${(-xRatio * MAX_BACKGROUND_SHIFT).toFixed(2)}px`;
+        const bgY = `${(-yRatio * MAX_BACKGROUND_SHIFT).toFixed(2)}px`;
+        const cardX = `${(-xRatio * MAX_CARD_SHIFT).toFixed(2)}px`;
+        const cardY = `${(-yRatio * MAX_CARD_SHIFT).toFixed(2)}px`;
+
+        setGlassParallaxVariables({ bgX, bgY, cardX, cardY });
+        frame = 0;
+      });
+    };
+
+    window.addEventListener('mousemove', handleMove, { passive: true });
+
+    return () => {
+      window.removeEventListener('mousemove', handleMove);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+      setGlassParallaxVariables({
+        bgX: '0px',
+        bgY: '0px',
+        cardX: '0px',
+        cardY: '0px',
+      });
+    };
+  }, [enabled]);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -461,10 +461,44 @@
    GLASSMORPHISM UI - FUTURISTIC DESIGN SYSTEM
    ============================================ */
 
+@property --glass-mesh-drift-x {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+@property --glass-mesh-drift-y {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+@keyframes apple-mesh-drift {
+  0% {
+    --glass-mesh-drift-x: -4px;
+    --glass-mesh-drift-y: -6px;
+  }
+  50% {
+    --glass-mesh-drift-x: 4px;
+    --glass-mesh-drift-y: 6px;
+  }
+  100% {
+    --glass-mesh-drift-x: -4px;
+    --glass-mesh-drift-y: -6px;
+  }
+}
+
 /* ====== GRADIENT MESH BACKGROUNDS ====== */
 
 /* Light theme - soft pastel gradient mesh */
 .apple-light {
+  --glass-bg-shift-x: 0px;
+  --glass-bg-shift-y: 0px;
+  --glass-card-shift-x: 0px;
+  --glass-card-shift-y: 0px;
+  --glass-header-blur: 20px;
+  --glass-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.4'/%3E%3C/svg%3E");
+  --glass-noise-opacity: 0.04;
   background:
     radial-gradient(ellipse at 0% 0%, rgba(99, 102, 241, 0.15) 0%, transparent 50%),
     radial-gradient(ellipse at 100% 0%, rgba(236, 72, 153, 0.12) 0%, transparent 50%),
@@ -472,11 +506,21 @@
     radial-gradient(ellipse at 0% 100%, rgba(139, 92, 246, 0.12) 0%, transparent 50%),
     linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
   background-attachment: fixed;
+  background-position: calc(50% + var(--glass-bg-shift-x) + var(--glass-mesh-drift-x))
+    calc(50% + var(--glass-bg-shift-y) + var(--glass-mesh-drift-y));
   min-height: 100vh;
+  animation: apple-mesh-drift 24s ease-in-out infinite;
 }
 
 /* Dark theme - deep space gradient with subtle aurora */
 .apple-dark {
+  --glass-bg-shift-x: 0px;
+  --glass-bg-shift-y: 0px;
+  --glass-card-shift-x: 0px;
+  --glass-card-shift-y: 0px;
+  --glass-header-blur: 20px;
+  --glass-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.4'/%3E%3C/svg%3E");
+  --glass-noise-opacity: 0.035;
   background:
     radial-gradient(ellipse at 20% 20%, rgba(99, 102, 241, 0.2) 0%, transparent 40%),
     radial-gradient(ellipse at 80% 20%, rgba(139, 92, 246, 0.15) 0%, transparent 40%),
@@ -484,7 +528,17 @@
     radial-gradient(ellipse at 20% 80%, rgba(236, 72, 153, 0.1) 0%, transparent 40%),
     linear-gradient(180deg, #0f0f1a 0%, #0a0a12 50%, #050508 100%);
   background-attachment: fixed;
+  background-position: calc(50% + var(--glass-bg-shift-x) + var(--glass-mesh-drift-x))
+    calc(50% + var(--glass-bg-shift-y) + var(--glass-mesh-drift-y));
   min-height: 100vh;
+  animation: apple-mesh-drift 26s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .apple-light,
+  .apple-dark {
+    animation: none;
+  }
 }
 
 /* ====== GLOBAL TRANSITIONS ====== */
@@ -517,6 +571,9 @@
     backdrop-filter: blur(20px) saturate(180%);
     -webkit-backdrop-filter: blur(20px) saturate(180%);
     border: 1px solid rgba(255, 255, 255, 0.5) !important;
+    contain: paint;
+    transform: translate3d(var(--glass-card-shift-x, 0px), var(--glass-card-shift-y, 0px), 0);
+    will-change: transform;
     box-shadow:
       0 8px 32px rgba(99, 102, 241, 0.08),
       0 4px 16px rgba(0, 0, 0, 0.04),
@@ -529,7 +586,11 @@
       0 12px 40px rgba(99, 102, 241, 0.12),
       0 8px 24px rgba(0, 0, 0, 0.06),
       inset 0 1px 0 rgba(255, 255, 255, 0.9);
-    transform: translateY(-2px);
+    transform: translate3d(
+      var(--glass-card-shift-x, 0px),
+      calc(var(--glass-card-shift-y, 0px) - 2px),
+      0
+    );
   }
 }
 
@@ -537,10 +598,13 @@
 .apple-dark {
   & .bg-card,
   & .rounded-lg.border.bg-card {
-    background: rgba(30, 32, 48, 0.5) !important;
+    background: rgba(30, 32, 48, 0.6) !important;
     backdrop-filter: blur(20px) saturate(180%);
     -webkit-backdrop-filter: blur(20px) saturate(180%);
-    border: 1px solid rgba(148, 163, 184, 0.12) !important;
+    border: 1px solid rgba(148, 163, 184, 0.16) !important;
+    contain: paint;
+    transform: translate3d(var(--glass-card-shift-x, 0px), var(--glass-card-shift-y, 0px), 0);
+    will-change: transform;
     box-shadow:
       0 8px 32px rgba(0, 0, 0, 0.3),
       0 4px 16px rgba(99, 102, 241, 0.05),
@@ -549,12 +613,16 @@
 
   & .bg-card:hover {
     background: rgba(40, 42, 60, 0.6) !important;
-    border-color: rgba(129, 140, 248, 0.2) !important;
+    border-color: rgba(129, 140, 248, 0.24) !important;
     box-shadow:
       0 16px 48px rgba(0, 0, 0, 0.4),
       0 8px 24px rgba(129, 140, 248, 0.08),
       inset 0 1px 0 rgba(255, 255, 255, 0.08);
-    transform: translateY(-2px);
+    transform: translate3d(
+      var(--glass-card-shift-x, 0px),
+      calc(var(--glass-card-shift-y, 0px) - 2px),
+      0
+    );
   }
 }
 
@@ -564,10 +632,11 @@
   & [data-sidebar],
   & .bg-sidebar-background,
   & aside {
-    background: rgba(255, 255, 255, 0.7) !important;
-    backdrop-filter: blur(24px) saturate(180%);
-    -webkit-backdrop-filter: blur(24px) saturate(180%);
-    border-right: 1px solid rgba(255, 255, 255, 0.5) !important;
+    background: rgba(255, 255, 255, 0.5) !important;
+    backdrop-filter: blur(30px) saturate(170%);
+    -webkit-backdrop-filter: blur(30px) saturate(170%);
+    border-right: 1px solid rgba(255, 255, 255, 0.6) !important;
+    box-shadow: 0 20px 50px rgba(99, 102, 241, 0.12);
   }
 }
 
@@ -575,11 +644,72 @@
   & [data-sidebar],
   & .bg-sidebar-background,
   & aside {
-    background: rgba(15, 15, 25, 0.75) !important;
-    backdrop-filter: blur(24px) saturate(180%);
-    -webkit-backdrop-filter: blur(24px) saturate(180%);
-    border-right: 1px solid rgba(148, 163, 184, 0.08) !important;
+    background: rgba(15, 15, 25, 0.5) !important;
+    backdrop-filter: blur(30px) saturate(170%);
+    -webkit-backdrop-filter: blur(30px) saturate(170%);
+    border-right: 1px solid rgba(148, 163, 184, 0.18) !important;
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.45);
   }
+}
+
+/* ====== NOISE TEXTURE OVERLAY ====== */
+
+.apple-light :where(
+  .bg-card,
+  .rounded-lg.border.bg-card,
+  header,
+  nav:not(aside nav),
+  [data-sidebar],
+  .bg-sidebar-background,
+  aside,
+  .bg-popover,
+  [data-radix-popper-content-wrapper] > div
+),
+.apple-dark :where(
+  .bg-card,
+  .rounded-lg.border.bg-card,
+  header,
+  nav:not(aside nav),
+  [data-sidebar],
+  .bg-sidebar-background,
+  aside,
+  .bg-popover,
+  [data-radix-popper-content-wrapper] > div
+) {
+  position: relative;
+  overflow: hidden;
+}
+
+.apple-light :where(
+  .bg-card,
+  .rounded-lg.border.bg-card,
+  header,
+  nav:not(aside nav),
+  [data-sidebar],
+  .bg-sidebar-background,
+  aside,
+  .bg-popover,
+  [data-radix-popper-content-wrapper] > div
+)::after,
+.apple-dark :where(
+  .bg-card,
+  .rounded-lg.border.bg-card,
+  header,
+  nav:not(aside nav),
+  [data-sidebar],
+  .bg-sidebar-background,
+  aside,
+  .bg-popover,
+  [data-radix-popper-content-wrapper] > div
+)::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: var(--glass-noise);
+  background-size: 160px 160px;
+  opacity: var(--glass-noise-opacity);
+  mix-blend-mode: soft-light;
+  pointer-events: none;
 }
 
 /* ====== ANIMATED BACKGROUND — GLASS OVERRIDE ====== */
@@ -738,10 +868,10 @@ aside nav:hover {
 .apple-light {
   & .bg-popover,
   & [data-radix-popper-content-wrapper] > div {
-    background: rgba(255, 255, 255, 0.85) !important;
-    backdrop-filter: blur(24px) saturate(200%);
-    -webkit-backdrop-filter: blur(24px) saturate(200%);
-    border: 1px solid rgba(255, 255, 255, 0.6) !important;
+    background: rgba(255, 255, 255, 0.8) !important;
+    backdrop-filter: blur(10px) saturate(160%);
+    -webkit-backdrop-filter: blur(10px) saturate(160%);
+    border: 1px solid rgba(255, 255, 255, 0.65) !important;
     box-shadow:
       0 24px 48px rgba(0, 0, 0, 0.12),
       0 12px 24px rgba(99, 102, 241, 0.08);
@@ -751,10 +881,10 @@ aside nav:hover {
 .apple-dark {
   & .bg-popover,
   & [data-radix-popper-content-wrapper] > div {
-    background: rgba(20, 22, 35, 0.85) !important;
-    backdrop-filter: blur(24px) saturate(200%);
-    -webkit-backdrop-filter: blur(24px) saturate(200%);
-    border: 1px solid rgba(148, 163, 184, 0.12) !important;
+    background: rgba(20, 22, 35, 0.8) !important;
+    backdrop-filter: blur(10px) saturate(160%);
+    -webkit-backdrop-filter: blur(10px) saturate(160%);
+    border: 1px solid rgba(148, 163, 184, 0.2) !important;
     box-shadow:
       0 24px 48px rgba(0, 0, 0, 0.5),
       0 12px 24px rgba(129, 140, 248, 0.05);
@@ -882,20 +1012,50 @@ aside nav:hover {
 .apple-light {
   & header,
   & nav:not(aside nav) {
-    background: rgba(255, 255, 255, 0.7) !important;
-    backdrop-filter: blur(20px) saturate(180%);
-    -webkit-backdrop-filter: blur(20px) saturate(180%);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.5) !important;
+    background: rgba(255, 255, 255, 0.5) !important;
+    backdrop-filter: blur(var(--glass-header-blur, 20px)) saturate(170%);
+    -webkit-backdrop-filter: blur(var(--glass-header-blur, 20px)) saturate(170%);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.6) !important;
+    box-shadow: 0 16px 40px rgba(15, 23, 42, 0.1);
   }
 }
 
 .apple-dark {
   & header,
   & nav:not(aside nav) {
-    background: rgba(15, 15, 25, 0.75) !important;
-    backdrop-filter: blur(20px) saturate(180%);
-    -webkit-backdrop-filter: blur(20px) saturate(180%);
-    border-bottom: 1px solid rgba(148, 163, 184, 0.1) !important;
+    background: rgba(15, 15, 25, 0.5) !important;
+    backdrop-filter: blur(var(--glass-header-blur, 20px)) saturate(170%);
+    -webkit-backdrop-filter: blur(var(--glass-header-blur, 20px)) saturate(170%);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2) !important;
+    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.45);
+  }
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .apple-light :where(
+    .bg-card,
+    .rounded-lg.border.bg-card,
+    header,
+    nav:not(aside nav),
+    [data-sidebar],
+    .bg-sidebar-background,
+    aside,
+    .bg-popover,
+    [data-radix-popper-content-wrapper] > div
+  ),
+  .apple-dark :where(
+    .bg-card,
+    .rounded-lg.border.bg-card,
+    header,
+    nav:not(aside nav),
+    [data-sidebar],
+    .bg-sidebar-background,
+    aside,
+    .bg-popover,
+    [data-radix-popper-content-wrapper] > div
+  ) {
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
   }
 }
 

--- a/frontend/src/pages/llm-assistant.tsx
+++ b/frontend/src/pages/llm-assistant.tsx
@@ -26,7 +26,15 @@ export default function LlmAssistantPage() {
   const [selectedModel, setSelectedModel] = useState<string>('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const { messages, isStreaming, currentResponse, activeToolCalls, sendMessage, cancelGeneration, clearHistory } = useLlmChat();
+  const {
+    messages,
+    isStreaming,
+    currentResponse,
+    activeToolCalls = [],
+    sendMessage,
+    cancelGeneration,
+    clearHistory,
+  } = useLlmChat();
   const { data: modelsData } = useLlmModels();
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Increase visual depth and polish for the Apple glass themes by adding multi-layer blur, subtle parallax, animated mesh drift, and noise texture to make glass surfaces feel more realistic and premium.  
- Keep effects performant and accessible by respecting `prefers-reduced-motion`, disabling parallax on coarse/touch pointers, and providing a graceful `@supports` fallback for browsers without `backdrop-filter`.  
- Fix a runtime/test flake in the LLM assistant where `activeToolCalls` could be undefined and cause rendering errors during streaming.

### Description
- Add a new parallax hook at `frontend/src/hooks/use-glass-parallax.ts` which animates CSS variables for background and card shifts and disables itself on touch/coarse/prefers-reduced-motion.  
- Extend Apple theme CSS in `frontend/src/index.css` with `@property` declarations, `apple-mesh-drift` keyframes, CSS variables, noise-image overlay, layered blur/opacity tweaks (sidebar/header/cards/popovers), `will-change/contain` hints, and `@supports` fallbacks.  
- Wire the parallax hook into the layout via `frontend/src/components/layout/app-layout.tsx` and add a scroll-driven dynamic header blur in `frontend/src/components/layout/header.tsx` exposed as `--glass-header-blur`.  
- Harden the LLM assistant rendering by defaulting `activeToolCalls` to an empty array in `frontend/src/pages/llm-assistant.tsx` to avoid undefined-length errors.  
- Add unit tests for the parallax behavior at `frontend/src/hooks/use-glass-parallax.test.tsx`.

### Testing
- Ran frontend unit tests with `npm run test -w frontend` (Vitest) and all frontend tests passed: 65 test files, 503 tests — status: succeeded.  
- Added and executed `frontend/src/hooks/use-glass-parallax.test.tsx` which passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987226a54b08333b38668087fbf8010)