### PR TITLE
fix: secure settings API and redact secret keys (#167)

### DIFF
--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -13,6 +13,9 @@ import { getUserDefaultLandingPage, setUserDefaultLandingPage } from '../service
 const SENSITIVE_KEYS = new Set([
   'notifications.smtp_password',
   'notifications.teams_webhook_url',
+  'oidc.client_secret',
+  'elasticsearch.api_key',
+  'llm.custom_endpoint_token',
 ]);
 
 const REDACTED = '••••••••';
@@ -28,11 +31,32 @@ const LANDING_PAGE_OPTIONS = new Set([
 
 function redactSensitive(rows: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
   return rows.map((row) => {
-    if (typeof row.key === 'string' && SENSITIVE_KEYS.has(row.key) && row.value) {
+    if (
+      typeof row.key === 'string'
+      && isSensitiveSettingKey(row.key)
+      && row.value
+    ) {
       return { ...row, value: REDACTED };
     }
     return row;
   });
+}
+
+function isSensitiveSettingKey(key: string): boolean {
+  if (SENSITIVE_KEYS.has(key)) return true;
+
+  const keyLower = key.toLowerCase();
+  return (
+    keyLower.endsWith('_password')
+    || keyLower.endsWith('_secret')
+    || keyLower.endsWith('_token')
+    || keyLower.endsWith('_api_key')
+    || keyLower.endsWith('.password')
+    || keyLower.endsWith('.secret')
+    || keyLower.endsWith('.token')
+    || keyLower.endsWith('.api_key')
+    || keyLower.endsWith('.webhook_url')
+  );
 }
 
 export async function settingsRoutes(fastify: FastifyInstance) {
@@ -81,7 +105,7 @@ export async function settingsRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       querystring: SettingsQuerySchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request) => {
     const { category } = request.query as { category?: string };
     const db = getDb();
@@ -124,7 +148,7 @@ export async function settingsRoutes(fastify: FastifyInstance) {
       ip_address: request.ip,
     });
 
-    const responseValue = SENSITIVE_KEYS.has(key) ? REDACTED : value;
+    const responseValue = isSensitiveSettingKey(key) ? REDACTED : value;
     return { success: true, key, value: responseValue };
   });
 


### PR DESCRIPTION
## Summary
- restrict GET /api/settings to admin role
- expand redaction to cover secret-bearing settings including OIDC and Elasticsearch credentials
- keep sensitive values masked in setting update responses

## Changes
- backend/src/routes/settings.ts
  - GET /api/settings now requires admin role
  - add broader sensitive-key detection and redaction
  - redact sensitive values in PUT /api/settings/:key response
- backend/src/routes/settings.test.ts
  - add regression test for non-admin access being blocked
  - add regression test for admin response redaction of sensitive keys

## Testing
- npm run test -w backend -- src/routes/settings.test.ts
- npm run typecheck -w backend

Closes #167