### PR TITLE
fix: block path traversal in backup filename routes (#165)

### DIFF
--- a/backend/src/models/api-schemas.ts
+++ b/backend/src/models/api-schemas.ts
@@ -200,7 +200,9 @@ export const TraceIdParamsSchema = z.object({
 
 // ─── Backup schemas ─────────────────────────────────────────────────
 export const FilenameParamsSchema = z.object({
-  filename: z.string(),
+  filename: z
+    .string()
+    .regex(/^[A-Za-z0-9._-]+\.db$/, 'filename must be a .db file without path separators'),
 });
 
 // ─── Settings schemas ───────────────────────────────────────────────

--- a/backend/src/routes/backup.test.ts
+++ b/backend/src/routes/backup.test.ts
@@ -95,4 +95,31 @@ describe('backup routes', () => {
     expect(response.statusCode).toBe(404);
     expect(response.json()).toEqual({ error: 'Backup not found' });
   });
+
+  it('rejects traversal attempts on download endpoint', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/backup/..%2F..%2Fetc%2Fpasswd',
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects traversal attempts on restore endpoint', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/backup/..%2F..%2Fetc%2Fpasswd/restore',
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects traversal attempts on delete endpoint', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/api/backup/..%2F..%2Fetc%2Fpasswd',
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
 });

--- a/backend/src/routes/backup.ts
+++ b/backend/src/routes/backup.ts
@@ -16,6 +16,17 @@ function getBackupDir() {
   return dir;
 }
 
+function resolveBackupFilePath(backupDir: string, filename: string): string | null {
+  const resolvedBackupDir = path.resolve(backupDir);
+  const filePath = path.resolve(backupDir, filename);
+
+  if (!filePath.startsWith(`${resolvedBackupDir}${path.sep}`)) {
+    return null;
+  }
+
+  return filePath;
+}
+
 export async function backupRoutes(fastify: FastifyInstance) {
   // Create backup
   fastify.post('/api/backup', {
@@ -83,7 +94,11 @@ export async function backupRoutes(fastify: FastifyInstance) {
   }, async (request, reply) => {
     const { filename } = request.params as { filename: string };
     const backupDir = getBackupDir();
-    const filePath = path.join(backupDir, filename);
+    const filePath = resolveBackupFilePath(backupDir, filename);
+
+    if (!filePath) {
+      return reply.code(400).send({ error: 'Invalid backup filename' });
+    }
 
     if (!fs.existsSync(filePath)) {
       return reply.code(404).send({ error: 'Backup not found' });
@@ -109,7 +124,11 @@ export async function backupRoutes(fastify: FastifyInstance) {
     const config = getConfig();
     const db = getDb();
     const backupDir = getBackupDir();
-    const filePath = path.join(backupDir, filename);
+    const filePath = resolveBackupFilePath(backupDir, filename);
+
+    if (!filePath) {
+      return reply.code(400).send({ error: 'Invalid backup filename' });
+    }
 
     if (!fs.existsSync(filePath)) {
       return reply.code(404).send({ error: 'Backup not found' });
@@ -144,7 +163,11 @@ export async function backupRoutes(fastify: FastifyInstance) {
   }, async (request, reply) => {
     const { filename } = request.params as { filename: string };
     const backupDir = getBackupDir();
-    const filePath = path.join(backupDir, filename);
+    const filePath = resolveBackupFilePath(backupDir, filename);
+
+    if (!filePath) {
+      return reply.code(400).send({ error: 'Invalid backup filename' });
+    }
 
     if (!fs.existsSync(filePath)) {
       return reply.code(404).send({ error: 'Backup not found' });


### PR DESCRIPTION
## Summary
- prevent path traversal in backup download, restore, and delete endpoints
- constrain backup filename params to safe .db filenames with no path separators
- add regression tests for encoded slash traversal attempts

## Changes
- backend/src/routes/backup.ts
  - add resolved backup path containment check via path.resolve
  - reject invalid/traversal filenames with 400 before filesystem operations
- backend/src/models/api-schemas.ts
  - tighten FilenameParamsSchema to safe .db filename regex
- backend/src/routes/backup.test.ts
  - add traversal regression tests for GET, POST restore, and DELETE endpoints

## Testing
- npm run test -w backend -- src/routes/backup.test.ts
- npm run typecheck -w backend

Closes #165