### PR TITLE
fix: add admin role checks to high-impact mutation endpoints (#168)

### DIFF
--- a/backend/src/routes/backup.ts
+++ b/backend/src/routes/backup.ts
@@ -118,7 +118,7 @@ export async function backupRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       params: FilenameParamsSchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { filename } = request.params as { filename: string };
     const config = getConfig();
@@ -159,7 +159,7 @@ export async function backupRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       params: FilenameParamsSchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { filename } = request.params as { filename: string };
     const backupDir = getBackupDir();

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -64,7 +64,7 @@ export async function webhookRoutes(fastify: FastifyInstance) {
         },
       },
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const body = request.body as {
       name: string;
@@ -129,7 +129,7 @@ export async function webhookRoutes(fastify: FastifyInstance) {
         },
       },
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const body = request.body as {
@@ -166,7 +166,7 @@ export async function webhookRoutes(fastify: FastifyInstance) {
         properties: { id: { type: 'string' } },
       },
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const deleted = deleteWebhook(id);
@@ -216,7 +216,7 @@ export async function webhookRoutes(fastify: FastifyInstance) {
         properties: { id: { type: 'string' } },
       },
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const webhook = getWebhookById(id);


### PR DESCRIPTION
## Summary
- add admin role gates to backup restore/delete endpoints
- add admin role gates to webhook create/update/delete/test endpoints
- add regression tests proving low-privilege users are rejected

## Changes
- backend/src/routes/backup.ts
  - requireRole("admin") on restore and delete routes
- backend/src/routes/webhooks.ts
  - requireRole("admin") on create, update, delete, and test routes
- backend/src/routes/backup.test.ts
  - add authorization tests for non-admin restore/delete rejection
- backend/src/routes/webhooks.test.ts
  - add authorization tests for non-admin create/update/delete/test rejection

## Testing
- npm run test -w backend -- src/routes/backup.test.ts src/routes/webhooks.test.ts
- npm run typecheck -w backend

Closes #168