### PR TITLE
Fix AI Assistant suggested questions to run on click

### DIFF
--- a/frontend/src/pages/llm-assistant.test.tsx
+++ b/frontend/src/pages/llm-assistant.test.tsx
@@ -140,6 +140,25 @@ describe('LlmAssistantPage', () => {
     const input = screen.getByPlaceholderText('Ask about your infrastructure...') as HTMLInputElement;
     expect(input.value).toBe('Explain this remediation action');
   });
+
+  it('sends suggested question immediately when clicked', () => {
+    const sendMessage = vi.fn();
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      sendMessage,
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Show me all running containers' }));
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith('Show me all running containers', undefined, 'llama3.2');
+  });
 });
 
 describe('normalizeMarkdown', () => {

--- a/frontend/src/pages/llm-assistant.tsx
+++ b/frontend/src/pages/llm-assistant.tsx
@@ -76,6 +76,14 @@ export default function LlmAssistantPage() {
     setInput('');
   }, [input, isStreaming, isSending, sendMessage, selectedModel]);
 
+  const handleSuggestedQuestionClick = useCallback((suggestion: string) => {
+    if (isStreaming || isSending) return;
+
+    setIsSending(true);
+    sendMessage(suggestion, undefined, selectedModel || undefined);
+    setInput('');
+  }, [isStreaming, isSending, sendMessage, selectedModel]);
+
   const handleClear = () => {
     if (window.confirm('Clear all chat history?')) {
       clearHistory();
@@ -149,8 +157,9 @@ export default function LlmAssistantPage() {
                   ].map((suggestion, i) => (
                     <button
                       key={i}
-                      onClick={() => setInput(suggestion)}
-                      className="rounded-lg border border-border/50 bg-background/50 px-4 py-3 text-sm text-left hover:bg-accent hover:border-border transition-colors"
+                      onClick={() => handleSuggestedQuestionClick(suggestion)}
+                      disabled={isStreaming || isSending}
+                      className="rounded-lg border border-border/50 bg-background/50 px-4 py-3 text-sm text-left hover:bg-accent hover:border-border transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {suggestion}
                     </button>


### PR DESCRIPTION
## Summary
- send suggested AI Assistant prompts immediately when clicked on the welcome screen
- prevent duplicate sends by disabling suggested prompt buttons while sending/streaming
- add a regression test verifying click-to-send behavior with selected model

## Testing
- npx vitest run src/pages/llm-assistant.test.tsx (from frontend/)

Fixes #235