### PR TITLE
security: pin and refresh Redis/Ollama image tags (#217)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -82,7 +82,7 @@ services:
     #       memory: 256M
 
   ollama:
-    image: ollama/ollama:0.6.5
+    image: ollama/ollama:0.12.10
     restart: unless-stopped
     ports:
       - "11534:11434"
@@ -107,7 +107,7 @@ services:
     #       memory: 2G
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.7-alpine
     restart: unless-stopped
     command: ["redis-server", "--save", "", "--appendonly", "no"]
     healthcheck:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -75,7 +75,7 @@ services:
 
   # Ollama for AI features
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.12.10
     ports:
       - "11434:11434"
     volumes:
@@ -84,7 +84,7 @@ services:
       - dashboard-net
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.7-alpine
     restart: unless-stopped
     command: ["redis-server", "--save", "", "--appendonly", "no"]
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
           memory: 128M
 
   ollama:
-    image: ollama/ollama:0.6.5
+    image: ollama/ollama:0.12.10
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "ollama", "list"]
@@ -99,7 +99,7 @@ services:
       - no-new-privileges:true
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.7-alpine
     restart: unless-stopped
     command: ["redis-server", "--save", "", "--appendonly", "no"]
     healthcheck:


### PR DESCRIPTION
## Summary
- pin Redis images to `redis:7.4.7-alpine`
- pin Ollama images to `ollama/ollama:0.12.10`
- remove floating/broad tags across compose variants for reproducibility and lower drift

## Changes
- `docker-compose.yml`
- `docker-compose.dev.yml`
- `docker-compose.local.yml`

Updated image tags:
- Redis: `redis:7-alpine` -> `redis:7.4.7-alpine`
- Ollama: `ollama/ollama:0.6.5` / `ollama/ollama:latest` -> `ollama/ollama:0.12.10`

## Validation
- verified all compose files now use pinned Redis and Ollama tags

Closes #217