### PR TITLE
fix: use tar.gz filename schema for Portainer backup routes

### DIFF
--- a/backend/src/models/api-schemas.ts
+++ b/backend/src/models/api-schemas.ts
@@ -205,6 +205,12 @@ export const FilenameParamsSchema = z.object({
     .regex(/^[A-Za-z0-9._-]+\.db$/, 'filename must be a .db file without path separators'),
 });
 
+export const PortainerBackupFilenameParamsSchema = z.object({
+  filename: z
+    .string()
+    .regex(/^[A-Za-z0-9._-]+\.tar\.gz$/, 'filename must be a .tar.gz file without path separators'),
+});
+
 // ─── Settings schemas ───────────────────────────────────────────────
 export const SettingsQuerySchema = z.object({
   category: z.string().optional(),

--- a/backend/src/routes/portainer-backup.test.ts
+++ b/backend/src/routes/portainer-backup.test.ts
@@ -209,17 +209,16 @@ describe('portainer-backup routes', () => {
     });
 
     it('returns 400 for path traversal attempt', async () => {
-      mockGetPortainerBackupPath.mockImplementationOnce(() => {
-        throw new Error('Invalid backup filename: path traversal detected');
-      });
-
       const response = await app.inject({
         method: 'GET',
         url: '/api/portainer-backup/..%2F..%2Fetc%2Fpasswd',
       });
 
       expect(response.statusCode).toBe(400);
-      expect(response.json()).toEqual({ error: 'Invalid filename' });
+      expect(response.json()).toMatchObject({
+        error: 'Bad Request',
+        message: expect.stringContaining('filename must be a .tar.gz file'),
+      });
     });
   });
 

--- a/backend/src/routes/portainer-backup.ts
+++ b/backend/src/routes/portainer-backup.ts
@@ -9,7 +9,7 @@ import {
   getPortainerBackupPath,
   deletePortainerBackup,
 } from '../services/portainer-backup.js';
-import { FilenameParamsSchema } from '../models/api-schemas.js';
+import { PortainerBackupFilenameParamsSchema } from '../models/api-schemas.js';
 
 const log = createChildLogger('portainer-backup-route');
 
@@ -69,7 +69,7 @@ export async function portainerBackupRoutes(fastify: FastifyInstance) {
       tags: ['Portainer Backup'],
       summary: 'Download a Portainer backup file',
       security: [{ bearerAuth: [] }],
-      params: FilenameParamsSchema,
+      params: PortainerBackupFilenameParamsSchema,
     },
     preHandler: [fastify.authenticate],
   }, async (request, reply) => {
@@ -98,7 +98,7 @@ export async function portainerBackupRoutes(fastify: FastifyInstance) {
       tags: ['Portainer Backup'],
       summary: 'Delete a Portainer backup file',
       security: [{ bearerAuth: [] }],
-      params: FilenameParamsSchema,
+      params: PortainerBackupFilenameParamsSchema,
     },
     preHandler: [fastify.authenticate],
   }, async (request, reply) => {


### PR DESCRIPTION
## Summary
- Fixes 5 failing backend tests in `portainer-backup.test.ts` from PR #242
- `FilenameParamsSchema` only allowed `.db` files, but Portainer backups are `.tar.gz` — Fastify rejected every backup filename with 400 before the route handler ran
- Added `PortainerBackupFilenameParamsSchema` with `.tar.gz` regex and updated the portainer-backup routes to use it
- Updated path traversal test to expect Fastify's schema validation error format

## Test plan
- [ ] CI pipeline passes (all 5 previously failing tests should now pass)
- [ ] `backup.ts` (dashboard DB backup) still uses the original `.db`-only schema — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)