### PR TITLE
fix: prevent unhandled promise rejection crash in cache scheduler

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,11 @@ import { ensureModel } from './services/llm-client.js';
 
 const log = createChildLogger('server');
 
+// Safety net: log unhandled rejections instead of crashing the process
+process.on('unhandledRejection', (reason) => {
+  log.error({ err: reason }, 'Unhandled promise rejection (process kept alive)');
+});
+
 async function main() {
   const config = getConfig();
   const app = await buildApp();


### PR DESCRIPTION
## Summary
- Restructure `cachedFetch()` to use explicit resolve/reject with self-contained try/catch, preventing unhandled promise rejections when the Portainer API is unreachable during scheduled cache refreshes
- Add global `process.on('unhandledRejection')` safety net in server entry point to log and survive any future unhandled rejections
- Add test verifying in-flight map cleanup and re-fetch after completion

## Root Cause
The `cachedFetch()` function used an immediately-invoked async function (IIFE) whose promise was stored in an `inFlight` map for stampede prevention. When the fetcher rejected (e.g., Portainer unreachable), the IIFE promise had no `.catch()` handler attached, causing Node.js to treat it as an unhandled rejection and crash the entire process.

## Changes
- **`portainer-cache.ts`**: Replace IIFE pattern with explicit `new Promise` + deferred resolve/reject. All errors are caught in a try/catch and forwarded via `reject()`, eliminating the unhandled rejection vector
- **`index.ts`**: Add `process.on('unhandledRejection')` safety net that logs errors instead of crashing
- **`portainer-cache.test.ts`**: Add test for in-flight map cleanup after promise completion

## Test plan
- [x] All 541 backend tests pass (60 files)
- [x] TypeScript typecheck clean
- [x] Verify backend survives Portainer API being unreachable during cache refresh
- [x] Verify cache refresh retries on next scheduled interval

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)