### PR TITLE
[L1] BPF Filter Regex Allows Shell Operator Characters (CVSS 2.0)

### DIFF
--- a/backend/src/models/pcap.test.ts
+++ b/backend/src/models/pcap.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { StartCaptureRequestSchema } from './pcap.js';
+
+describe('StartCaptureRequestSchema filter validation', () => {
+  const basePayload = {
+    endpointId: 1,
+    containerId: 'container-1',
+    containerName: 'api',
+  };
+
+  it('accepts normal BPF syntax without shell operators', () => {
+    const result = StartCaptureRequestSchema.safeParse({
+      ...basePayload,
+      filter: 'tcp and port 443',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects ampersand shell operators in filter input', () => {
+    const result = StartCaptureRequestSchema.safeParse({
+      ...basePayload,
+      filter: 'tcp && port 443',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects pipe shell operators in filter input', () => {
+    const result = StartCaptureRequestSchema.safeParse({
+      ...basePayload,
+      filter: 'tcp | port 443',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/models/pcap.ts
+++ b/backend/src/models/pcap.ts
@@ -34,7 +34,7 @@ export const CaptureSchema = z.object({
 export type Capture = z.infer<typeof CaptureSchema>;
 
 // BPF filter regex: only allow safe characters (prevents shell injection)
-const BPF_FILTER_REGEX = /^[a-zA-Z0-9\s.:()/\-!=<>&|]+$/;
+const BPF_FILTER_REGEX = /^[a-zA-Z0-9\s.:()/\-!=<>]+$/;
 
 export const StartCaptureRequestSchema = z.object({
   endpointId: z.number().int().positive(),


### PR DESCRIPTION
## Summary
Security/vulnerability remediation for issue #270.

## Tracking
Fixes #270
Related: #273