### PR TITLE
Fix backend startup by deduplicating pending actions before unique index

### DIFF
--- a/backend/src/db/migrations/020_actions_pending_unique.sql
+++ b/backend/src/db/migrations/020_actions_pending_unique.sql
@@ -1,3 +1,20 @@
+DELETE FROM actions
+WHERE status = 'pending'
+  AND EXISTS (
+    SELECT 1
+    FROM actions newer
+    WHERE newer.status = 'pending'
+      AND newer.container_id = actions.container_id
+      AND newer.action_type = actions.action_type
+      AND (
+        COALESCE(newer.created_at, '') > COALESCE(actions.created_at, '')
+        OR (
+          COALESCE(newer.created_at, '') = COALESCE(actions.created_at, '')
+          AND newer.id > actions.id
+        )
+      )
+  );
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_actions_pending_dedup
   ON actions(container_id, action_type)
   WHERE status = 'pending';

--- a/backend/src/services/remediation-service.ts
+++ b/backend/src/services/remediation-service.ts
@@ -78,7 +78,15 @@ export function suggestAction(
         rationale: pattern.rationale,
       };
 
-      insertAction(action);
+      const inserted = insertAction(action);
+      if (!inserted) {
+        log.debug(
+          { containerId: insight.container_id, actionType: pattern.actionType },
+          'Skipped duplicate pending action due to unique constraint',
+        );
+        return null;
+      }
+
       log.info(
         { actionId, actionType: pattern.actionType, insightId: insight.id },
         'Action suggested',


### PR DESCRIPTION
## Summary
- deduplicate legacy pending actions in migration 020 before creating the partial unique index
- make action insertion resilient to unique constraint races and skip duplicate broadcasts
- add regression tests for migration dedupe and remediation duplicate insert handling

## Validation
- npm run test -w backend -- src/db/sqlite.test.ts src/services/remediation-service.test.ts
- docker compose -f docker-compose.dev.yml up -d --build
- docker compose -f docker-compose.dev.yml ps