### PR TITLE
Add Engine.IO-level JWT verification for Socket.IO

### DIFF
--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -9,6 +9,7 @@ export function getSocket(token: string): Socket {
 
   mainSocket = io(SOCKET_URL, {
     auth: { token },
+    query: { token },
     transports: ['websocket', 'polling'],
     reconnection: true,
     reconnectionAttempts: 10,
@@ -24,6 +25,7 @@ export function getNamespaceSocket(
 ): Socket {
   return io(`${SOCKET_URL}/${namespace}`, {
     auth: { token },
+    query: { token },
     transports: ['websocket', 'polling'],
     reconnection: true,
     reconnectionAttempts: 10,


### PR DESCRIPTION
## Summary
- Adds `allowRequest` callback to reject unauthenticated HTTP requests at the Engine.IO transport level, **before** any session/resource allocation
- Frontend now passes JWT token as `query.token` in addition to `handshake.auth.token` so the transport-level check can verify it
- Existing Socket.IO middleware (Layer 2) remains intact for defence-in-depth

### Defence-in-Depth Architecture
| Layer | Mechanism | Scope | Effect |
|-------|-----------|-------|--------|
| **Layer 1** (new) | `allowRequest` callback | Engine.IO HTTP handshake | Rejects before transport session allocated |
| **Layer 2** (existing) | `io.use()` middleware | Socket.IO protocol | Rejects after transport, before event access |
| **Layer 3** (existing) | Namespace `ns.use()` middleware | Each namespace | Rejects per-namespace |

Closes #309

## Test plan
- [x] New test: rejects requests without token query parameter
- [x] New test: rejects requests with invalid/expired token
- [x] New test: rejects requests with revoked session
- [x] New test: rejects requests with mismatched identity
- [x] New test: accepts requests with valid token and active session
- [x] All 9 existing socket-io tests continue to pass
- [ ] Manual: `curl -s "http://backend:3051/socket.io/?EIO=4&transport=polling"` should return 403 (not a valid session)
- [ ] Manual: verify authenticated frontend Socket.IO connections still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)