### PR TITLE
fix(auth): preserve session across reload

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -14,6 +14,7 @@ describe('ApiClient', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     api.setToken(null);
+    window.localStorage.removeItem('auth_token');
   });
 
   afterEach(() => {
@@ -149,6 +150,22 @@ describe('ApiClient', () => {
   });
 
   describe('authentication', () => {
+    it('should hydrate token from localStorage on client initialization', async () => {
+      window.localStorage.setItem('auth_token', 'persisted-token');
+      vi.resetModules();
+      const { api: freshApi } = await import('./api');
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await freshApi.get('/api/protected');
+
+      const headers = mockFetch.mock.calls[0][1]?.headers as Headers;
+      expect(headers.get('Authorization')).toBe('Bearer persisted-token');
+    });
+
     it('should include Authorization header when token is set', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 const API_BASE = import.meta.env.VITE_API_URL || '';
+const AUTH_TOKEN_KEY = 'auth_token';
 
 function describeHttpError(status: number): string {
   switch (status) {
@@ -15,6 +16,18 @@ interface RequestOptions extends RequestInit {
 
 class ApiClient {
   private token: string | null = null;
+
+  constructor() {
+    this.token = this.readStoredToken();
+  }
+
+  private readStoredToken(): string | null {
+    try {
+      return window.localStorage.getItem(AUTH_TOKEN_KEY);
+    } catch {
+      return null;
+    }
+  }
 
   setToken(token: string | null) {
     this.token = token;

--- a/frontend/src/providers/auth-provider.tsx
+++ b/frontend/src/providers/auth-provider.tsx
@@ -64,13 +64,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [username, setUsername] = useState<string | null>(() => getStoredAuth().username);
   const [role, setRole] = useState<UserRole>(() => getStoredAuth().role);
 
-  // Initialize API client with stored token on mount
-  useEffect(() => {
-    if (token) {
-      api.setToken(token);
-    }
-  }, []);
-
   const login = useCallback(async (user: string, password: string) => {
     const data = await api.post<{ token: string; username: string; defaultLandingPage?: string }>(
       '/api/auth/login',


### PR DESCRIPTION
## Summary
- hydrate API auth token synchronously from localStorage during ApiClient construction
- remove mount-only token hydration effect in AuthProvider
- add regression test to ensure first request after reload includes Authorization header

## Testing
- npm run test -w frontend -- src/lib/api.test.ts

Closes #340