### PR TITLE
Workload explorer: align image, endpoint, and network panes

### DIFF
--- a/frontend/src/components/container/container-overview.tsx
+++ b/frontend/src/components/container/container-overview.tsx
@@ -51,7 +51,7 @@ interface ContainerOverviewProps {
 
 export function ContainerOverview({ container }: ContainerOverviewProps) {
   const ports = container.ports || [];
-  const networks = Object.keys(container.networks || {});
+  const networks = container.networks || [];
   const labels = container.labels || {};
   const labelEntries = Object.entries(labels);
 
@@ -106,36 +106,58 @@ export function ContainerOverview({ container }: ContainerOverviewProps) {
         </div>
       </div>
 
-      {/* Image Information Card */}
-      <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-          <HardDrive className="h-5 w-5" />
-          Image Information
-        </h3>
-        <div className="space-y-2">
-          <div>
-            <p className="text-xs text-muted-foreground">Full Image</p>
-            <p className="text-sm font-mono">{container.image}</p>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Image Information Card */}
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+            <HardDrive className="h-5 w-5" />
+            Image Information
+          </h3>
+          <div className="space-y-2">
+            <div>
+              <p className="text-xs text-muted-foreground">Full Image</p>
+              <p className="text-sm font-mono">{container.image}</p>
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Endpoint Information Card */}
-      <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-          <Server className="h-5 w-5" />
-          Endpoint Information
-        </h3>
-        <div className="space-y-2">
-          <div>
-            <p className="text-xs text-muted-foreground">Name</p>
-            <p className="text-sm font-medium">{container.endpointName}</p>
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">ID</p>
-            <p className="text-sm font-mono">{container.endpointId}</p>
+        {/* Endpoint Information Card */}
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+            <Server className="h-5 w-5" />
+            Endpoint Information
+          </h3>
+          <div className="space-y-2">
+            <div>
+              <p className="text-xs text-muted-foreground">Name</p>
+              <p className="text-sm font-medium">{container.endpointName}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">ID</p>
+              <p className="text-sm font-mono">{container.endpointId}</p>
+            </div>
           </div>
         </div>
+
+        {/* Networks Card */}
+        {networks.length > 0 && (
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+              <Network className="h-5 w-5" />
+              Networks
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {networks.map((network) => (
+                <span
+                  key={network}
+                  className="inline-flex items-center rounded-md bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                >
+                  {network}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Port Mappings Card */}
@@ -166,26 +188,6 @@ export function ContainerOverview({ container }: ContainerOverviewProps) {
                 ))}
               </tbody>
             </table>
-          </div>
-        </div>
-      )}
-
-      {/* Networks Card */}
-      {networks.length > 0 && (
-        <div className="rounded-lg border bg-card p-6 shadow-sm">
-          <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-            <Network className="h-5 w-5" />
-            Networks
-          </h3>
-          <div className="flex flex-wrap gap-2">
-            {networks.map((network) => (
-              <span
-                key={network}
-                className="inline-flex items-center rounded-md bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
-              >
-                {network}
-              </span>
-            ))}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- place Image Information, Endpoint Information, and Networks cards in one responsive row grid on large screens
- keep single-column layout on smaller screens
- use the container's network names directly when rendering network chips

## Testing
- npm run test -w frontend -- container-overview.test.tsx