### PR TITLE
fix: add auth headers to streamOllamaRawCall fallback

### DIFF
--- a/backend/src/sockets/llm-chat.test.ts
+++ b/backend/src/sockets/llm-chat.test.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { isRecoverableToolCallParseError, formatChatContext } from './llm-chat.js';
+import { isRecoverableToolCallParseError, formatChatContext, getAuthHeaders } from './llm-chat.js';
+
+describe('getAuthHeaders', () => {
+  it('returns empty object when token is undefined', () => {
+    expect(getAuthHeaders(undefined)).toEqual({});
+  });
+
+  it('returns empty object when token is empty string', () => {
+    expect(getAuthHeaders('')).toEqual({});
+  });
+
+  it('returns Bearer header for simple token', () => {
+    expect(getAuthHeaders('my-secret-token')).toEqual({
+      Authorization: 'Bearer my-secret-token',
+    });
+  });
+
+  it('returns Basic header for username:password format', () => {
+    const result = getAuthHeaders('admin:secret123');
+    const expected = Buffer.from('admin:secret123').toString('base64');
+    expect(result).toEqual({
+      Authorization: `Basic ${expected}`,
+    });
+  });
+});
 
 describe('isRecoverableToolCallParseError', () => {
   it('returns true for known tool-call parser failures', () => {

--- a/backend/src/sockets/llm-chat.ts
+++ b/backend/src/sockets/llm-chat.ts
@@ -19,7 +19,7 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
-function getAuthHeaders(token: string | undefined): Record<string, string> {
+export function getAuthHeaders(token: string | undefined): Record<string, string> {
   if (!token) return {};
 
   // Check if token is in username:password format (Basic auth)
@@ -267,7 +267,10 @@ async function streamOllamaRawCall(
   const baseUrl = llmConfig.ollamaUrl.replace(/\/$/, '');
   const response = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...getAuthHeaders(llmConfig.customEndpointToken),
+    },
     body: JSON.stringify({
       model: selectedModel,
       messages,


### PR DESCRIPTION
## Summary
- Fixes `streamOllamaRawCall` sending requests to Ollama `/api/chat` without `Authorization` headers when `OLLAMA_BEARER_TOKEN` is configured
- Spreads `getAuthHeaders(llmConfig.customEndpointToken)` into the fetch headers, consistent with `streamLlmCall`
- Exports `getAuthHeaders` for testability and adds unit tests covering Bearer and Basic auth formats

Closes #324

## Test plan
- [x] Unit tests for `getAuthHeaders()` (undefined, empty, Bearer token, Basic auth)
- [x] All 11 existing + new tests passing
- [x] TypeScript typecheck passes
- [ ] Manual: Configure `OLLAMA_BEARER_TOKEN`, place authenticating proxy in front of Ollama, trigger tool-call parse error fallback → verify auth header is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)