### PR TITLE
Use container names in remediation UI

### DIFF
--- a/frontend/src/pages/remediation.test.tsx
+++ b/frontend/src/pages/remediation.test.tsx
@@ -76,10 +76,12 @@ describe('RemediationPage', () => {
     vi.clearAllMocks();
   });
 
-  it('shows container name as primary label and keeps id de-emphasized', () => {
+  it('shows container name and hides action/container ids from row display', () => {
     renderPage();
     expect(screen.getByText('api-service')).toBeInTheDocument();
-    expect(screen.getByText('ID: containe')).toBeInTheDocument();
+    expect(screen.queryByText('ID: containe')).not.toBeInTheDocument();
+    expect(screen.queryByText('action-1')).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'ID' })).not.toBeInTheDocument();
   });
 
   it('renders structured remediation analysis from rationale JSON', () => {

--- a/frontend/src/pages/remediation.tsx
+++ b/frontend/src/pages/remediation.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   AlertTriangle,
-  Shield,
   CheckCircle2,
   XCircle,
   Play,
@@ -225,12 +224,6 @@ function ActionRow({
   return (
     <tr className="border-b transition-colors hover:bg-muted/30">
       <td className="p-4">
-        <div className="flex items-center gap-2">
-          <Shield className="h-4 w-4 text-primary" />
-          <span className="font-mono text-xs">{action.id.slice(0, 8)}</span>
-        </div>
-      </td>
-      <td className="p-4">
         <span className="font-medium">
           {ACTION_TYPE_LABELS[actionType] || actionType}
         </span>
@@ -238,14 +231,9 @@ function ActionRow({
       <td className="p-4">
         <div className="flex items-center gap-2">
           <Box className="h-4 w-4 text-muted-foreground" />
-          <div>
-            <p className="font-medium">{containerName}</p>
-            {containerId && (
-              <p className="font-mono text-[11px] text-muted-foreground">
-                ID: {containerId.slice(0, 8)}
-              </p>
-            )}
-          </div>
+          <p className="font-medium" title={containerId ? `Container ID: ${containerId}` : undefined}>
+            {containerName}
+          </p>
         </div>
       </td>
       <td className="p-4">
@@ -602,7 +590,7 @@ export default function RemediationPage() {
         <SkeletonCard className="h-[400px]" />
       ) : actions.length === 0 ? (
         <div className="rounded-lg border border-dashed bg-muted/20 p-12 text-center">
-          <Shield className="mx-auto h-12 w-12 text-muted-foreground" />
+          <Box className="mx-auto h-12 w-12 text-muted-foreground" />
           <h3 className="mt-4 text-lg font-semibold">No remediation actions</h3>
           <p className="mt-2 text-sm text-muted-foreground">
             {statusFilter === 'all'
@@ -616,7 +604,6 @@ export default function RemediationPage() {
             <table className="w-full">
               <thead>
                 <tr className="border-b bg-muted/50">
-                  <th className="p-4 text-left text-sm font-medium text-muted-foreground">ID</th>
                   <th className="p-4 text-left text-sm font-medium text-muted-foreground">Action Type</th>
                   <th className="p-4 text-left text-sm font-medium text-muted-foreground">Container</th>
                   <th className="p-4 text-left text-sm font-medium text-muted-foreground">Status</th>


### PR DESCRIPTION
## Summary
- show `container_name` as the primary container identifier in remediation rows
- keep a short container ID subtitle for disambiguation
- update the "Discuss with AI" prompt to lead with container name context
- update remediation page tests to verify container-name-first rendering and prompt content

## Testing
- npm run test -w frontend -- src/pages/remediation.test.tsx

Fixes #362