### PR TITLE
fix: use shared RefreshButton on packet capture page

### DIFF
--- a/frontend/src/components/shared/refresh-button.test.tsx
+++ b/frontend/src/components/shared/refresh-button.test.tsx
@@ -59,7 +59,7 @@ describe('RefreshButton', () => {
     expect(icon).toHaveClass('animate-spin');
 
     act(() => {
-      vi.advanceTimersByTime(901);
+      vi.advanceTimersByTime(1501);
     });
     expect(icon).not.toHaveClass('animate-spin');
   });

--- a/frontend/src/components/shared/refresh-button.tsx
+++ b/frontend/src/components/shared/refresh-button.tsx
@@ -10,7 +10,7 @@ interface RefreshButtonProps {
 }
 
 export function RefreshButton({ onClick, isLoading, className, onForceRefresh }: RefreshButtonProps) {
-  const MIN_SPIN_MS = 900;
+  const MIN_SPIN_MS = 1500;
   const [showSpin, setShowSpin] = useState(Boolean(isLoading));
   const spinStartedAtRef = useRef(0);
   const stopTimerRef = useRef<number | null>(null);

--- a/frontend/src/pages/packet-capture.tsx
+++ b/frontend/src/pages/packet-capture.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import {
   Radio,
-  RefreshCw,
   Play,
   Square,
   Download,
@@ -18,6 +17,7 @@ import {
   Loader2,
 } from 'lucide-react';
 import { StatusBadge } from '@/components/shared/status-badge';
+import { RefreshButton } from '@/components/shared/refresh-button';
 import { useEndpoints } from '@/hooks/use-endpoints';
 import { useContainers } from '@/hooks/use-containers';
 import { useStacks } from '@/hooks/use-stacks';
@@ -74,7 +74,7 @@ export default function PacketCapture() {
   const { data: endpoints } = useEndpoints();
   const { data: containers } = useContainers(selectedEndpoint);
   const { data: stacks } = useStacks();
-  const { data: capturesData, refetch } = useCaptures({ status: statusFilter });
+  const { data: capturesData, refetch, isFetching } = useCaptures({ status: statusFilter });
   const [expandedAnalysis, setExpandedAnalysis] = useState<Set<string>>(new Set());
   const startCapture = useStartCapture();
   const stopCapture = useStopCapture();
@@ -144,13 +144,7 @@ export default function PacketCapture() {
             Capture network traffic from containers using tcpdump. Download PCAP files for analysis in Wireshark.
           </p>
         </div>
-        <button
-          onClick={() => refetch()}
-          className="inline-flex items-center gap-1 rounded-md border border-input bg-background px-2.5 py-1 text-xs font-medium hover:bg-accent"
-        >
-          <RefreshCw className="h-3.5 w-3.5" />
-          Refresh
-        </button>
+        <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
       </div>
 
       {/* New Capture Form */}


### PR DESCRIPTION
Closes #326

## Summary

- Replaces standalone refresh button on the packet capture page with the shared `RefreshButton` component for consistent pill-style design
- Increases `MIN_SPIN_MS` from 900ms to 1500ms so fast endpoints (like local SQLite) get a satisfying animation duration

## Test plan

- [x] Existing `refresh-button.test.tsx` updated and passing
- [x] Verify refresh button on packet capture page matches style of other pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)