### PR TITLE
Backend performance hardening: concurrency, SWR cache, parallel fetches, error handling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "nodemailer": "^8.0.0",
     "ollama": "^0.5.12",
     "openid-client": "^6.1.0",
+    "p-limit": "^3.1.0",
     "pg": "^8.18.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",

--- a/backend/src/config/env.schema.ts
+++ b/backend/src/config/env.schema.ts
@@ -20,6 +20,8 @@ export const envSchema = z.object({
   PORTAINER_API_URL: z.string().url().default('http://localhost:9000'),
   PORTAINER_API_KEY: z.string().min(1).default(''),
   PORTAINER_VERIFY_SSL: z.coerce.boolean().default(true),
+  PORTAINER_CONCURRENCY: z.coerce.number().int().min(1).max(50).default(10),
+  PORTAINER_MAX_CONNECTIONS: z.coerce.number().int().min(1).max(100).default(20),
 
   // Ollama
   OLLAMA_BASE_URL: z.string().url().default('http://host.docker.internal:11434'),

--- a/backend/src/routes/monitoring.ts
+++ b/backend/src/routes/monitoring.ts
@@ -8,6 +8,9 @@ import {
   DEFAULT_SECURITY_AUDIT_IGNORE_PATTERNS,
   SECURITY_AUDIT_IGNORE_KEY,
 } from '../services/security-audit.js';
+import { createChildLogger } from '../utils/logger.js';
+
+const log = createChildLogger('route:monitoring');
 
 export async function monitoringRoutes(fastify: FastifyInstance) {
   fastify.get('/api/monitoring/insights', {
@@ -18,7 +21,7 @@ export async function monitoringRoutes(fastify: FastifyInstance) {
       querystring: InsightsQuerySchema,
     },
     preHandler: [fastify.authenticate],
-  }, async (request) => {
+  }, async (request, reply) => {
     const { severity, acknowledged, limit = 50, offset = 0, cursor } = request.query as {
       severity?: string;
       acknowledged?: boolean;
@@ -27,66 +30,72 @@ export async function monitoringRoutes(fastify: FastifyInstance) {
       cursor?: string;
     };
 
-    const db = getDb();
-    const filterConditions: string[] = [];
-    const filterParams: unknown[] = [];
+    try {
+      const db = getDb();
+      const filterConditions: string[] = [];
+      const filterParams: unknown[] = [];
 
-    if (severity) {
-      filterConditions.push('severity = ?');
-      filterParams.push(severity);
+      if (severity) {
+        filterConditions.push('severity = ?');
+        filterParams.push(severity);
+      }
+      if (acknowledged !== undefined) {
+        filterConditions.push('is_acknowledged = ?');
+        filterParams.push(acknowledged ? 1 : 0);
+      }
+
+      const filterWhere = filterConditions.length > 0
+        ? `WHERE ${filterConditions.join(' AND ')}`
+        : '';
+
+      // Build full conditions including cursor
+      const conditions = [...filterConditions];
+      const params = [...filterParams];
+
+      if (cursor) {
+        const [cursorDate, cursorId] = cursor.split('|');
+        conditions.push('(created_at < ? OR (created_at = ? AND id < ?))');
+        params.push(cursorDate, cursorDate, cursorId);
+      }
+
+      const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+      // Fetch N+1 to determine hasMore
+      const fetchLimit = limit + 1;
+      const insights = cursor
+        ? db.prepare(`
+            SELECT * FROM insights ${where}
+            ORDER BY created_at DESC, id DESC LIMIT ?
+          `).all(...params, fetchLimit) as Array<Record<string, unknown>>
+        : db.prepare(`
+            SELECT * FROM insights ${where}
+            ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
+          `).all(...params, fetchLimit, offset) as Array<Record<string, unknown>>;
+
+      const total = db.prepare(`
+        SELECT COUNT(*) as count FROM insights ${filterWhere}
+      `).get(...filterParams) as { count: number };
+
+      const hasMore = insights.length > limit;
+      const items = hasMore ? insights.slice(0, limit) : insights;
+      const lastItem = items[items.length - 1];
+      const nextCursor = hasMore && lastItem
+        ? `${lastItem.created_at}|${lastItem.id}`
+        : null;
+
+      return {
+        insights: items,
+        total: total.count,
+        limit,
+        offset,
+        nextCursor,
+        hasMore,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err }, 'Failed to query insights');
+      return reply.code(500).send({ error: 'Failed to query insights', details: msg });
     }
-    if (acknowledged !== undefined) {
-      filterConditions.push('is_acknowledged = ?');
-      filterParams.push(acknowledged ? 1 : 0);
-    }
-
-    const filterWhere = filterConditions.length > 0
-      ? `WHERE ${filterConditions.join(' AND ')}`
-      : '';
-
-    // Build full conditions including cursor
-    const conditions = [...filterConditions];
-    const params = [...filterParams];
-
-    if (cursor) {
-      const [cursorDate, cursorId] = cursor.split('|');
-      conditions.push('(created_at < ? OR (created_at = ? AND id < ?))');
-      params.push(cursorDate, cursorDate, cursorId);
-    }
-
-    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-
-    // Fetch N+1 to determine hasMore
-    const fetchLimit = limit + 1;
-    const insights = cursor
-      ? db.prepare(`
-          SELECT * FROM insights ${where}
-          ORDER BY created_at DESC, id DESC LIMIT ?
-        `).all(...params, fetchLimit) as Array<Record<string, unknown>>
-      : db.prepare(`
-          SELECT * FROM insights ${where}
-          ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
-        `).all(...params, fetchLimit, offset) as Array<Record<string, unknown>>;
-
-    const total = db.prepare(`
-      SELECT COUNT(*) as count FROM insights ${filterWhere}
-    `).get(...filterParams) as { count: number };
-
-    const hasMore = insights.length > limit;
-    const items = hasMore ? insights.slice(0, limit) : insights;
-    const lastItem = items[items.length - 1];
-    const nextCursor = hasMore && lastItem
-      ? `${lastItem.created_at}|${lastItem.id}`
-      : null;
-
-    return {
-      insights: items,
-      total: total.count,
-      limit,
-      offset,
-      nextCursor,
-      hasMore,
-    };
   });
 
   fastify.get('/api/monitoring/insights/container/:containerId', {
@@ -96,73 +105,79 @@ export async function monitoringRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
     },
     preHandler: [fastify.authenticate],
-  }, async (request) => {
+  }, async (request, reply) => {
     const { containerId } = request.params as { containerId: string };
     const { timeRange = '1h', metricType } = request.query as {
       timeRange?: string;
       metricType?: string;
     };
 
-    const db = getDb();
+    try {
+      const db = getDb();
 
-    // Parse timeRange into an SQLite-compatible interval
-    let interval = '-1 hours';
-    const match = timeRange.match(/^(\d+)([mhd])$/);
-    if (match) {
-      const value = parseInt(match[1], 10);
-      const unit = match[2];
-      switch (unit) {
-        case 'm': interval = `-${value} minutes`; break;
-        case 'h': interval = `-${value} hours`; break;
-        case 'd': interval = `-${value} days`; break;
+      // Parse timeRange into an SQLite-compatible interval
+      let interval = '-1 hours';
+      const match = timeRange.match(/^(\d+)([mhd])$/);
+      if (match) {
+        const value = parseInt(match[1], 10);
+        const unit = match[2];
+        switch (unit) {
+          case 'm': interval = `-${value} minutes`; break;
+          case 'h': interval = `-${value} hours`; break;
+          case 'd': interval = `-${value} days`; break;
+        }
       }
+
+      const conditions = [
+        '(container_id = ? OR container_id LIKE ?)',
+        "category IN ('anomaly', 'predictive')",
+        "created_at >= datetime('now', ?)",
+      ];
+      const params: unknown[] = [containerId, `${containerId}%`, interval];
+
+      if (metricType) {
+        conditions.push('title LIKE ?');
+        params.push(`%${metricType}%`);
+      }
+
+      const where = conditions.join(' AND ');
+      const rows = db.prepare(`
+        SELECT id, severity, category, title, description, suggested_action, created_at
+        FROM insights
+        WHERE ${where}
+        ORDER BY created_at DESC
+        LIMIT 50
+      `).all(...params) as Array<{
+        id: string;
+        severity: string;
+        category: string;
+        title: string;
+        description: string;
+        suggested_action: string | null;
+        created_at: string;
+      }>;
+
+      // Parse out AI Analysis from description field
+      const explanations = rows.map((row) => {
+        const aiSplit = row.description.split('\n\nAI Analysis: ');
+        return {
+          id: row.id,
+          severity: row.severity,
+          category: row.category,
+          title: row.title,
+          description: aiSplit[0],
+          aiExplanation: aiSplit.length > 1 ? aiSplit[1] : null,
+          suggestedAction: row.suggested_action,
+          timestamp: row.created_at,
+        };
+      });
+
+      return { explanations };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err, containerId }, 'Failed to query container insights');
+      return reply.code(500).send({ error: 'Failed to query container insights', details: msg });
     }
-
-    const conditions = [
-      '(container_id = ? OR container_id LIKE ?)',
-      "category IN ('anomaly', 'predictive')",
-      "created_at >= datetime('now', ?)",
-    ];
-    const params: unknown[] = [containerId, `${containerId}%`, interval];
-
-    if (metricType) {
-      conditions.push('title LIKE ?');
-      params.push(`%${metricType}%`);
-    }
-
-    const where = conditions.join(' AND ');
-    const rows = db.prepare(`
-      SELECT id, severity, category, title, description, suggested_action, created_at
-      FROM insights
-      WHERE ${where}
-      ORDER BY created_at DESC
-      LIMIT 50
-    `).all(...params) as Array<{
-      id: string;
-      severity: string;
-      category: string;
-      title: string;
-      description: string;
-      suggested_action: string | null;
-      created_at: string;
-    }>;
-
-    // Parse out AI Analysis from description field
-    const explanations = rows.map((row) => {
-      const aiSplit = row.description.split('\n\nAI Analysis: ');
-      return {
-        id: row.id,
-        severity: row.severity,
-        category: row.category,
-        title: row.title,
-        description: aiSplit[0],
-        aiExplanation: aiSplit.length > 1 ? aiSplit[1] : null,
-        suggestedAction: row.suggested_action,
-        timestamp: row.created_at,
-      };
-    });
-
-    return { explanations };
   });
 
   fastify.post('/api/monitoring/insights/:id/acknowledge', {
@@ -174,11 +189,17 @@ export async function monitoringRoutes(fastify: FastifyInstance) {
       response: { 200: SuccessResponseSchema },
     },
     preHandler: [fastify.authenticate],
-  }, async (request) => {
+  }, async (request, reply) => {
     const { id } = request.params as { id: string };
-    const db = getDb();
-    db.prepare('UPDATE insights SET is_acknowledged = 1 WHERE id = ?').run(id);
-    return { success: true };
+    try {
+      const db = getDb();
+      db.prepare('UPDATE insights SET is_acknowledged = 1 WHERE id = ?').run(id);
+      return { success: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err, insightId: id }, 'Failed to acknowledge insight');
+      return (reply as any).code(500).send({ error: 'Failed to acknowledge insight', details: msg });
+    }
   });
 
   fastify.get('/api/security/audit', {
@@ -188,9 +209,15 @@ export async function monitoringRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
     },
     preHandler: [fastify.authenticate],
-  }, async () => {
-    const entries = await getSecurityAudit();
-    return { entries };
+  }, async (_request, reply) => {
+    try {
+      const entries = await getSecurityAudit();
+      return { entries };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err }, 'Failed to fetch security audit');
+      return reply.code(500).send({ error: 'Failed to fetch security audit', details: msg });
+    }
   });
 
   fastify.get('/api/security/audit/:endpointId', {
@@ -200,11 +227,17 @@ export async function monitoringRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
     },
     preHandler: [fastify.authenticate],
-  }, async (request) => {
+  }, async (request, reply) => {
     const { endpointId } = request.params as { endpointId: string };
     const parsedEndpointId = Number(endpointId);
-    const entries = await getSecurityAudit(parsedEndpointId);
-    return { entries };
+    try {
+      const entries = await getSecurityAudit(parsedEndpointId);
+      return { entries };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err, endpointId }, 'Failed to fetch security audit for endpoint');
+      return reply.code(500).send({ error: 'Failed to fetch security audit', details: msg });
+    }
   });
 
   fastify.get('/api/security/ignore-list', {
@@ -214,13 +247,19 @@ export async function monitoringRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
     },
     preHandler: [fastify.authenticate],
-  }, async () => {
-    return {
-      key: SECURITY_AUDIT_IGNORE_KEY,
-      category: 'security',
-      defaults: DEFAULT_SECURITY_AUDIT_IGNORE_PATTERNS,
-      patterns: getSecurityAuditIgnoreList(),
-    };
+  }, async (_request, reply) => {
+    try {
+      return {
+        key: SECURITY_AUDIT_IGNORE_KEY,
+        category: 'security',
+        defaults: DEFAULT_SECURITY_AUDIT_IGNORE_PATTERNS,
+        patterns: getSecurityAuditIgnoreList(),
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err }, 'Failed to fetch security ignore list');
+      return reply.code(500).send({ error: 'Failed to fetch security ignore list', details: msg });
+    }
   });
 
   fastify.put('/api/security/ignore-list', {
@@ -230,18 +269,24 @@ export async function monitoringRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
     },
     preHandler: [fastify.authenticate, fastify.requireRole('admin')],
-  }, async (request) => {
+  }, async (request, reply) => {
     const body = request.body as { patterns?: unknown };
     const patterns = Array.isArray(body?.patterns)
       ? body.patterns.filter((value): value is string => typeof value === 'string')
       : [];
 
-    const saved = setSecurityAuditIgnoreList(patterns);
-    return {
-      success: true,
-      key: SECURITY_AUDIT_IGNORE_KEY,
-      category: 'security',
-      patterns: saved,
-    };
+    try {
+      const saved = setSecurityAuditIgnoreList(patterns);
+      return {
+        success: true,
+        key: SECURITY_AUDIT_IGNORE_KEY,
+        category: 'security',
+        patterns: saved,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err }, 'Failed to update security ignore list');
+      return reply.code(500).send({ error: 'Failed to update security ignore list', details: msg });
+    }
   });
 }

--- a/backend/src/routes/stacks.test.ts
+++ b/backend/src/routes/stacks.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
+import { stacksRoutes } from './stacks.js';
+
+vi.mock('../services/portainer-client.js', () => ({
+  getStacks: vi.fn(),
+  getStack: vi.fn(),
+}));
+
+vi.mock('../services/portainer-cache.js', () => ({
+  cachedFetch: vi.fn((_key: string, _ttl: number, fn: () => Promise<any>) => fn()),
+  getCacheKey: vi.fn((...args: string[]) => args.join(':')),
+  TTL: { STACKS: 60 },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import * as portainer from '../services/portainer-client.js';
+
+const mockGetStacks = vi.mocked(portainer.getStacks);
+const mockGetStack = vi.mocked(portainer.getStack);
+
+function buildApp() {
+  const app = Fastify();
+  app.setValidatorCompiler(validatorCompiler);
+  app.decorate('authenticate', async () => undefined);
+  app.register(stacksRoutes);
+  return app;
+}
+
+const fakeStack = (id: number, name: string) => ({
+  Id: id,
+  Name: name,
+  Type: 1,
+  EndpointId: 1,
+  Status: 1,
+  Env: [],
+});
+
+describe('stacks routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return stacks list', async () => {
+    mockGetStacks.mockResolvedValue([fakeStack(1, 'web-app')] as any);
+
+    const app = buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/stacks' });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].name).toBe('web-app');
+  });
+
+  it('should return 502 when getStacks fails', async () => {
+    mockGetStacks.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const app = buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/stacks' });
+
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('Unable to fetch stacks from Portainer');
+    expect(body.details).toContain('ECONNREFUSED');
+  });
+
+  it('should return stack details', async () => {
+    mockGetStack.mockResolvedValue(fakeStack(1, 'web-app') as any);
+
+    const app = buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/stacks/1' });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.name).toBe('web-app');
+  });
+
+  it('should return 502 when getStack fails', async () => {
+    mockGetStack.mockRejectedValue(new Error('Stack not found'));
+
+    const app = buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/stacks/999' });
+
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('Unable to fetch stack details from Portainer');
+    expect(body.details).toContain('Stack not found');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "nodemailer": "^8.0.0",
         "ollama": "^0.5.12",
         "openid-client": "^6.1.0",
+        "p-limit": "^3.1.0",
         "pg": "^8.18.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
@@ -12300,7 +12301,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -16877,7 +16877,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"


### PR DESCRIPTION
## Summary

Addresses the **14% HTTP 500 error rate** under 10 concurrent users and slow dashboard summary latency (368ms p50) identified during load testing. Part of the performance hardening epic #372.

- **Concurrency limiter + connection pooling** — Added `p-limit` to cap concurrent Portainer API calls (`PORTAINER_CONCURRENCY`, default 10) and a pooled `undici.Agent` with configurable connections (`PORTAINER_MAX_CONNECTIONS`, default 20). Closes #377, Closes #378
- **Stale-while-revalidate cache** — New `cachedFetchSWR()` returns stale data instantly while kicking off background revalidation, preventing cache-miss latency spikes. Closes #373
- **Parallelized endpoint loops** — Replaced sequential `for...of` with `Promise.allSettled()` in dashboard, containers, and networks routes for concurrent per-endpoint fetches. Closes #375
- **Error handling on unprotected routes** — Added try-catch to stacks (both endpoints), containers detail, all 4 metrics handlers, and all monitoring/security-audit handlers. Closes #374
- **15+ new tests** covering concurrency limiting, SWR behavior, error responses for stacks/containers/metrics/monitoring

## Test plan

- [x] TypeCheck passes (`tsc --noEmit` — 0 errors)
- [x] Full backend test suite passes (86 files, 849 tests, 0 failures)
- [ ] Run load tests to verify error rate drops from ~14% to <1%
- [ ] Verify dashboard summary p50 improves with cache hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)