### PR TITLE
Remediation table: collapsible analysis + clearer title

### DIFF
--- a/frontend/src/pages/remediation.test.tsx
+++ b/frontend/src/pages/remediation.test.tsx
@@ -86,11 +86,20 @@ describe('RemediationPage', () => {
 
   it('renders structured remediation analysis from rationale JSON', () => {
     renderPage();
+    expect(screen.getByRole('columnheader', { name: 'Analysis Summary' })).toBeInTheDocument();
     expect(screen.getByText('Critical')).toBeInTheDocument();
     expect(screen.getByText('Confidence: 82%')).toBeInTheDocument();
     expect(screen.getByText(/Root Cause:/i)).toBeInTheDocument();
     expect(screen.getByText(/Connection pool leak is exhausting memory over time\./)).toBeInTheDocument();
     expect(screen.getByText(/HIGH:/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+  });
+
+  it('toggles analysis expansion for long rationale content', () => {
+    renderPage();
+    const toggle = screen.getByRole('button', { name: 'Show more' });
+    fireEvent.click(toggle);
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument();
   });
 
   it('routes Discuss with AI with context', () => {


### PR DESCRIPTION
## Summary
- make long remediation analysis content collapsible per row (Show more / Show less)
- keep structured analysis readable in collapsed mode with expand controls
- rename table column from "AI Rationale" to "Analysis Summary"
- align Discuss with AI prefill wording to "Analysis Summary"

## Validation
- npm run test -w frontend -- src/pages/remediation.test.tsx