### PR TITLE
feat: redesign Ask AI from sidebar to centered top popup

### DIFF
--- a/frontend/src/components/metrics/inline-chat-panel.test.tsx
+++ b/frontend/src/components/metrics/inline-chat-panel.test.tsx
@@ -113,6 +113,34 @@ describe('InlineChatPanel', () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
+  it('calls onClose when Escape key is pressed', () => {
+    const onClose = vi.fn();
+    render(
+      <InlineChatPanel open={true} onClose={onClose} context={defaultContext} />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('inline-chat-panel'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when backdrop is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <InlineChatPanel open={true} onClose={onClose} context={defaultContext} />,
+    );
+
+    fireEvent.click(screen.getByTestId('chat-backdrop'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('renders as a dialog with accessible label', () => {
+    render(
+      <InlineChatPanel open={true} onClose={vi.fn()} context={defaultContext} />,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Ask AI' })).toBeInTheDocument();
+  });
+
   it('does not send empty messages', () => {
     render(
       <InlineChatPanel open={true} onClose={vi.fn()} context={defaultContext} />,


### PR DESCRIPTION
## Summary

- Converts the Ask AI chat panel from a full-height right sidebar (`fixed inset-y-0 right-0`, 420-480px wide) into a centered floating dialog anchored at the top of the viewport
- Adds backdrop blur overlay (`bg-black/50 backdrop-blur-sm`) with click-to-close
- Adds Escape key dismissal via `onKeyDown` handler
- Uses `role="dialog" aria-label="Ask AI"` for proper accessibility
- Animation changed from `slide-in-from-right` to `fade-in-0 zoom-in-95` matching the command palette pattern
- Messages area bounded to `max-h-[50vh]` instead of `flex-1` for popup sizing

## Test plan

- [x] 12/12 tests pass including 3 new tests (Escape key, backdrop click, dialog ARIA role)
- [x] ESLint clean (0 warnings)
- [x] TypeScript typecheck passes (both workspaces)
- [x] Production build succeeds
- [ ] Visual verification: popup appears centered with blurred backdrop
- [ ] Visual verification: Escape key and backdrop click both close the panel
- [ ] Visual verification: chat messages scroll within the bounded area

🤖 Generated with [Claude Code](https://claude.com/claude-code)