### PR TITLE
fix: pass max_tokens to all LLM call paths and fix code block regex

### DIFF
--- a/backend/src/sockets/llm-chat.ts
+++ b/backend/src/sockets/llm-chat.ts
@@ -208,6 +208,7 @@ async function streamLlmCall(
         model: selectedModel,
         messages,
         stream: true,
+        max_tokens: llmConfig.maxTokens,
       }),
       signal,
     });
@@ -249,6 +250,7 @@ async function streamLlmCall(
       model: selectedModel,
       messages,
       stream: true,
+      options: { num_predict: llmConfig.maxTokens },
     });
 
     for await (const chunk of response) {
@@ -280,6 +282,7 @@ async function streamOllamaRawCall(
       model: selectedModel,
       messages,
       stream: true,
+      options: { num_predict: llmConfig.maxTokens },
     }),
     signal,
   });
@@ -447,6 +450,7 @@ async function callOllamaWithNativeTools(
       function: t.function,
     })),
     stream: false,
+    options: { num_predict: llmConfig.maxTokens },
   });
 
   const content = response.message?.content || '';

--- a/frontend/src/pages/llm-assistant.tsx
+++ b/frontend/src/pages/llm-assistant.tsx
@@ -432,8 +432,10 @@ function ToolCallIndicator({ events }: { events: ToolCallEvent[] }) {
 function normalizeMarkdown(raw: string): string {
   let text = raw;
 
-  // Fix code blocks: normalize ```language to have a newline after the opening fence
-  text = text.replace(/```(\w+)([^\n])/g, '```$1\n$2');
+  // Fix code blocks: if language tag and code are on the same line separated by space,
+  // split them. The space delimiter prevents greedy backtracking from eating into the
+  // language name (e.g., "```bash\n" was incorrectly split into "```bas\nh" by the old regex).
+  text = text.replace(/^(```\w+) +(.+)$/gm, '$1\n$2');
 
   // Fix unclosed code fences — count triple backticks, if odd close the last one
   const fenceCount = (text.match(/```/g) || []).length;

--- a/frontend/src/pages/settings.test.tsx
+++ b/frontend/src/pages/settings.test.tsx
@@ -37,7 +37,7 @@ describe('LlmSettingsSection', () => {
     'llm.model': 'llama3.2',
     'llm.temperature': '0.7',
     'llm.ollama_url': 'http://host.docker.internal:11434',
-    'llm.max_tokens': '2048',
+    'llm.max_tokens': '20000',
     'llm.custom_endpoint_enabled': 'false',
     'llm.custom_endpoint_url': '',
     'llm.custom_endpoint_token': '',


### PR DESCRIPTION
## Summary
- Ensures `max_tokens` is passed through all LLM call paths (was missing in some socket handlers)
- Fixes code block regex parsing in the chat UI

Follow-up to PR #396 (MCP tool calling). This commit was made after #396 merged.

Closes #390

## Test plan
- [ ] Verify LLM chat responses respect configured max_tokens
- [ ] Verify code blocks render correctly in chat responses
- [ ] Existing settings tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)