### PR TITLE
Add Docker build and nightly rebuild workflows

### DIFF
--- a/.github/workflows/dev-nightly.yml
+++ b/.github/workflows/dev-nightly.yml
@@ -31,6 +31,9 @@ jobs:
             type=raw,value=dev-nightly
             type=raw,value=dev-nightly-${{ github.run_id }}
 
+      - name: Copy root lockfile into workspace
+        run: cp package-lock.json backend/
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -69,6 +72,9 @@ jobs:
           tags: |
             type=raw,value=dev-nightly
             type=raw,value=dev-nightly-${{ github.run_id }}
+
+      - name: Copy root lockfile into workspace
+        run: cp package-lock.json frontend/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,6 +33,9 @@ jobs:
             type=ref,event=pr
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' && !startsWith(github.ref, 'refs/tags/') }}
 
+      - name: Copy root lockfile into workspace
+        run: cp package-lock.json backend/
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -72,6 +75,9 @@ jobs:
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
             type=ref,event=pr
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' && !startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Copy root lockfile into workspace
+        run: cp package-lock.json frontend/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
This PR introduces two new GitHub Actions workflows to automate Docker image building and publishing for both backend and frontend services.

## Key Changes
- **docker-build.yml**: Main workflow that builds and pushes Docker images on:
  - Pushes to `main` and `dev` branches
  - Version tags (semantic versioning)
  - Pull requests (cache-only, no push)
  - Generates appropriate tags based on branch/tag context (latest, dev, semver)

- **dev-nightly.yml**: Scheduled nightly rebuild workflow that:
  - Runs daily at 04:00 UTC to pick up base image security patches
  - Builds from the `dev` branch
  - Generates `dev-nightly` and `dev-nightly-{run_id}` tags
  - Can be manually triggered via `workflow_dispatch`

## Notable Implementation Details
- Both workflows build separate backend and frontend images with independent jobs
- Uses Docker Buildx with cloud driver for efficient builds
- Includes SBOM (Software Bill of Materials) and maximum provenance for security
- Nightly builds use `no-cache: true` to ensure fresh base images with latest security patches
- PR builds use `type=cacheonly` output to validate builds without pushing
- Smart tagging logic:
  - Semantic version tags for releases
  - `latest` tag only on main branch
  - `dev` tag for dev branch (excluding tags)
  - Branch name tags for non-main branches

https://claude.ai/code/session_01RjwqYj7ZAdadDoB8DQ26R7