### PR TITLE
docs: add OTLP span export documentation (#433)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,14 @@ SQLITE_PATH=./data/dashboard.db
 # TRACES_INGESTION_ENABLED=false
 # TRACES_INGESTION_API_KEY=  # Required when TRACES_INGESTION_ENABLED=true
 
+# OpenTelemetry Span Export — forward spans to external collectors (Jaeger, Tempo, Datadog)
+# When enabled, spans stored in SQLite are also batched and sent via OTLP/HTTP JSON.
+# OTEL_EXPORTER_ENABLED=false
+# OTEL_EXPORTER_ENDPOINT=http://jaeger:4318/v1/traces
+# OTEL_EXPORTER_HEADERS={"Authorization":"Bearer your-token"}
+# OTEL_EXPORTER_BATCH_SIZE=100
+# OTEL_EXPORTER_FLUSH_INTERVAL_MS=5000
+
 # Rate Limiting
 # Global API requests per minute per IP (default: 600 in production, 1200 in development)
 # API_RATE_LIMIT=1200

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,6 +304,7 @@ ai-portainer-dashboard/
 │       │   ├── incident-summarizer.ts # LLM incident summaries
 │       │   ├── monitoring-service.ts#  Monitoring cycle orchestration
 │       │   ├── metrics-collector.ts#   CPU/memory collection
+│       │   ├── otel-exporter.ts   #   OTLP/HTTP JSON span export to external collectors
 │       │   └── ...                 #   Sessions, settings, audit, backup
 │       ├── sockets/                # Socket.IO namespaces
 │       │   ├── llm-chat.ts         #   /llm — streaming chat


### PR DESCRIPTION
## Summary

- Add comprehensive "Span Export to External Collectors" section to `docs/ebpf-trace-ingestion.md` covering configuration, architecture, collector examples (Jaeger, Tempo, Datadog), retry behavior, and zero-overhead default
- Update architecture diagram to show the optional OTLP export path
- Update file map with `otel-exporter.ts` and `trace-context.ts` entries
- Update test coverage table with 17 new otel-exporter tests
- Add 5 `OTEL_EXPORTER_*` env vars to `.env.example`
- Add `otel-exporter.ts` to `docs/architecture.md` services list

Documents the feature implemented in PR #441 (Closes #433).

## Test plan

- [x] Documentation-only change, no code modified
- [x] All env var names match `backend/src/config/env.schema.ts` exactly
- [x] File paths in file map verified to exist on dev branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)