### PR TITLE
docs: add bundle size check to architecture and build commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,9 @@ npm run test:watch         # Watch mode
 npx vitest run src/utils/crypto.test.ts --config backend/vitest.config.ts
 npx vitest run src/lib/utils.test.ts --config frontend/vitest.config.ts
 
+# Bundle size check (runs after build, enforced in CI)
+cd frontend && npx tsx scripts/check-bundle-size.ts
+
 # Docker development (preferred)
 docker compose -f docker/docker-compose.dev.yml up -d
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,9 @@ npm run test:watch         # Watch mode
 npx vitest run src/utils/crypto.test.ts --config backend/vitest.config.ts
 npx vitest run src/lib/utils.test.ts --config frontend/vitest.config.ts
 
+# Bundle size check (runs after build, enforced in CI)
+cd frontend && npx tsx scripts/check-bundle-size.ts
+
 # Docker development (preferred)
 docker compose -f docker/docker-compose.dev.yml up -d
 ```

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -62,6 +62,9 @@ npm run test:watch         # Watch mode
 npx vitest run src/utils/crypto.test.ts --config backend/vitest.config.ts
 npx vitest run src/lib/utils.test.ts --config frontend/vitest.config.ts
 
+# Bundle size check (runs after build, enforced in CI)
+cd frontend && npx tsx scripts/check-bundle-size.ts
+
 # Docker development (preferred)
 docker compose -f docker/docker-compose.dev.yml up -d
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -318,6 +318,9 @@ ai-portainer-dashboard/
 │       ├── utils/                  # Crypto (JWT/bcrypt), logging (Pino)
 │       └── plugins/                # Fastify plugins
 ├── frontend/                       # React SPA
+│   ├── scripts/
+│   │   └── check-bundle-size.ts   # Gzip budget checker (CI enforced)
+│   ├── bundle-size.config.json    # Per-chunk gzip budgets
 │   └── src/
 │       ├── pages/                  # 18 lazy-loaded page components
 │       ├── components/


### PR DESCRIPTION
## Summary

- Add `frontend/scripts/check-bundle-size.ts` and `frontend/bundle-size.config.json` to architecture project structure diagram
- Add `npx tsx scripts/check-bundle-size.ts` command to Build & Development Commands section in CLAUDE.md, AGENTS.md, and GEMINI.md

Closes #431

## Test plan

- [x] Docs-only change — no code modified
- [x] All three instruction files (CLAUDE.md, AGENTS.md, GEMINI.md) updated in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)