### PR TITLE
docs: add health endpoints and Redis exponential backoff to architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@ Backend request flow is organized by route modules, with most Portainer-facing r
 | Backup | `/api/backup*` | `services/audit-logger.ts`, filesystem |
 | Cache Admin | `/api/admin/cache/*` | `services/portainer-cache.ts`, `services/audit-logger.ts` |
 | PCAP | `/api/pcap/*` | `services/pcap-service.ts`, `services/audit-logger.ts` |
+| Health | `/health`, `/health/ready`, `/health/ready/detail` | `db/sqlite.ts`, `db/timescale.ts`, `services/portainer-cache.ts` (Redis ping) |
 
 ## System Overview
 
@@ -293,7 +294,7 @@ ai-portainer-dashboard/
 │       │   └── ...                 #   Dashboard, endpoints, images, etc.
 │       ├── services/               # Business logic
 │       │   ├── portainer-client.ts #   Portainer API (retry + backoff)
-│       │   ├── portainer-cache.ts  #   Response caching (TTL)
+│       │   ├── portainer-cache.ts  #   Hybrid cache (L1 in-memory + Redis L2, exponential backoff)
 │       │   ├── llm-client.ts       #   Ollama LLM integration
 │       │   ├── adaptive-anomaly-detector.ts # Multi-method anomaly detection
 │       │   ├── isolation-forest.ts #   Isolation Forest ML algorithm


### PR DESCRIPTION
## Summary

- Add Health route row (`/health`, `/health/ready`, `/health/ready/detail`) to architecture route table — documents the public redacted vs authenticated detail split from PR #444
- Update `portainer-cache.ts` description from "Response caching (TTL)" to "Hybrid cache (L1 in-memory + Redis L2, exponential backoff)" reflecting the resilience improvements

Closes #429

## Test plan

- [x] Docs-only change — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)