### PR TITLE
docs: require documentation updates in every feature PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ Purple (purple-500):  AI-generated insight, recommendation
 ## Code Quality Standards
 
 - **Readability first** — Clear naming, logical grouping, consistent formatting. Prefer explicit over clever.
-- **Document all changes** — Update relevant documentation when behavior changes.
+- **Document all changes** — Every feature implementation must include documentation updates in the same PR. Update `docs/architecture.md` (route table, project structure, Mermaid diagrams), `.env.example` (new env vars), and `CLAUDE.md`/`AGENTS.md`/`GEMINI.md` (new build commands or workflow rules). Do not merge code without corresponding docs.
 - **Test coverage required** — See "Mandatory Rules" section above. This is non-negotiable.
 - ESLint config is in each workspace's `eslint.config.js`. TypeScript strict mode is on in both.
 - Do not add unnecessary abstractions, over-engineer, or add features beyond what is requested.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ Purple (purple-500):  AI-generated insight, recommendation
 ## Code Quality Standards
 
 - **Readability first** — Clear naming, logical grouping, consistent formatting. Prefer explicit over clever.
-- **Document all changes** — Update relevant documentation when behavior changes.
+- **Document all changes** — Every feature implementation must include documentation updates in the same PR. Update `docs/architecture.md` (route table, project structure, Mermaid diagrams), `.env.example` (new env vars), and `CLAUDE.md`/`AGENTS.md`/`GEMINI.md` (new build commands or workflow rules). Do not merge code without corresponding docs.
 - **Test coverage required** — See "Mandatory Rules" section above. This is non-negotiable.
 - ESLint config is in each workspace's `eslint.config.js`. TypeScript strict mode is on in both.
 - Do not add unnecessary abstractions, over-engineer, or add features beyond what is requested.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -208,7 +208,7 @@ Purple (purple-500):  AI-generated insight, recommendation
 ## Code Quality Standards
 
 - **Readability first** — Clear naming, logical grouping, consistent formatting. Prefer explicit over clever.
-- **Document all changes** — Update relevant documentation when behavior changes.
+- **Document all changes** — Every feature implementation must include documentation updates in the same PR. Update `docs/architecture.md` (route table, project structure, Mermaid diagrams), `.env.example` (new env vars), and `CLAUDE.md`/`AGENTS.md`/`GEMINI.md` (new build commands or workflow rules). Do not merge code without corresponding docs.
 - **Test coverage required** — See "Mandatory Rules" section above. This is non-negotiable.
 - ESLint config is in each workspace's `eslint.config.js`. TypeScript strict mode is on in both.
 - Do not add unnecessary abstractions, over-engineer, or add features beyond what is requested.


### PR DESCRIPTION
## Summary

- Strengthened the "Document all changes" rule in Code Quality Standards to be explicit and enforceable
- Old: "Update relevant documentation when behavior changes" (vague)
- New: Lists exactly which files must be updated with every feature PR:
  - `docs/architecture.md` — route table, project structure, Mermaid diagrams
  - `.env.example` — new environment variables
  - `CLAUDE.md`/`AGENTS.md`/`GEMINI.md` — new build commands or workflow rules
- All three instruction files updated in sync

## Test plan

- [x] Docs-only change — no code modified
- [x] CLAUDE.md, AGENTS.md, GEMINI.md all contain identical updated rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)