### PR TITLE
docs: add Elasticsearch log shipping to architecture and env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,17 @@ SQLITE_PATH=./data/dashboard.db
 # EMAIL_NOTIFICATIONS_ENABLED=false
 # EMAIL_RECIPIENTS=admin@example.com,ops@example.com
 
+# Log Shipping (Elasticsearch)
+# Ships Pino logs to Elasticsearch via _bulk API with batching and exponential backoff retry.
+# Disabled by default. Only works in production (NODE_ENV=production).
+# LOG_SHIPPING_ENABLED=false
+# LOG_SHIPPING_ENDPOINT=http://elasticsearch:9200
+# LOG_SHIPPING_INDEX_PREFIX=dashboard-logs
+# LOG_SHIPPING_USERNAME=
+# LOG_SHIPPING_PASSWORD=
+# LOG_SHIPPING_BATCH_SIZE=100
+# LOG_SHIPPING_FLUSH_INTERVAL_MS=5000
+
 # eBPF Trace Ingestion (Grafana Beyla)
 # Enable to accept OTLP traces from Beyla or other OpenTelemetry exporters
 # See docker/beyla/beyla.yml for the Beyla sidecar configuration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,7 +273,7 @@ sequenceDiagram
 | **Backend** | Fastify 5, TypeScript 5.7, Socket.IO 4, Zod, Jose (JWT), bcrypt |
 | **Database** | SQLite (better-sqlite3, WAL mode) |
 | **AI** | Ollama (local LLM), optional OpenWebUI support |
-| **Logging** | Pino (backend), optional Elasticsearch/Kibana integration |
+| **Logging** | Pino (backend), optional Elasticsearch log shipping via `_bulk` API (batched, retry with backoff) |
 | **DevOps** | Docker, Docker Compose, GitHub Actions CI |
 | **Testing** | Vitest, Testing Library, jsdom |
 
@@ -315,7 +315,7 @@ ai-portainer-dashboard/
 │       │   ├── sqlite.ts           #   Database init (WAL mode)
 │       │   └── migrations/         #   7 SQL migrations
 │       ├── models/                 # Zod schemas & DB queries
-│       ├── utils/                  # Crypto (JWT/bcrypt), logging (Pino)
+│       ├── utils/                  # Crypto (JWT/bcrypt), logging (Pino + ES transport)
 │       └── plugins/                # Fastify plugins
 ├── frontend/                       # React SPA
 │   └── src/


### PR DESCRIPTION
## Summary

- Update Tech Stack logging row to describe Elasticsearch `_bulk` API transport with batching and retry
- Update `utils/` directory description to mention ES transport
- Add 7 `LOG_SHIPPING_*` env vars to `.env.example` with descriptions

Documents implementation from PR #438.

Closes #434

## Test plan

- [x] Docs-only change — no code modified
- [x] Env var names match the Zod schema in `env.schema.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)