### PR TITLE
Fix Edge heartbeat threshold and add diagnostic logging

### DIFF
--- a/backend/src/services/portainer-normalizers-edge.test.ts
+++ b/backend/src/services/portainer-normalizers-edge.test.ts
@@ -188,7 +188,7 @@ describe('normalizeEndpoint — Edge Agent fields', () => {
         LastCheckInDate: Math.floor(Date.now() / 1000) - 10, // 10s ago
         EdgeCheckinInterval: 5,
       });
-      // 10s < max(5*3=15, 60) = 60s threshold → should be up
+      // 10s < max((5*2)+20=30, 60) = 60s threshold → should be up
       expect(normalizeEndpoint(ep).status).toBe('up');
     });
 
@@ -200,7 +200,7 @@ describe('normalizeEndpoint — Edge Agent fields', () => {
         LastCheckInDate: Math.floor(Date.now() / 1000) - 300, // 5 min ago
         EdgeCheckinInterval: 5,
       });
-      // 300s > max(5*3=15, 60) = 60s threshold → should be down
+      // 300s > max((5*2)+20=30, 60) = 60s threshold → should be down
       expect(normalizeEndpoint(ep).status).toBe('down');
     });
 
@@ -209,6 +209,16 @@ describe('normalizeEndpoint — Edge Agent fields', () => {
         Type: 4,
         EdgeID: 'edge-4',
         Status: 2,
+      });
+      expect(normalizeEndpoint(ep).status).toBe('down');
+    });
+
+    it('marks Edge endpoint as "down" when LastCheckInDate is 0', () => {
+      const ep = makeEndpoint({
+        Type: 4,
+        EdgeID: 'edge-5',
+        Status: 2,
+        LastCheckInDate: 0,
       });
       expect(normalizeEndpoint(ep).status).toBe('down');
     });


### PR DESCRIPTION
## Summary

- **Aligned heartbeat formula with Portainer**: Changed from `max(interval * 3, 60)` to `max((interval * 2) + 20, 60)` — matches Portainer's own edge agent heartbeat check
- **Fixed `LastCheckInDate === 0` bug**: `0` is falsy in JS, so `!lastCheckIn` incorrectly treated it as "no check-in". Now uses `== null || <= 0`
- **Added diagnostic logging**: Info-level log for every Edge endpoint normalization (shows raw Portainer fields: Status, EdgeID, LastCheckInDate, EdgeCheckinInterval). Debug-level log for heartbeat decision (elapsed time, threshold, result)
- **Added `/api/endpoints/debug/edge-status`**: Auth-required endpoint that returns raw Portainer data alongside normalized status for each endpoint — use this in production to diagnose Edge status issues without SSH

## Diagnosis steps after deploy

1. Deploy this to production
2. Hit `GET /api/endpoints/debug/edge-status` (with auth token) to see raw Portainer data for all endpoints
3. Check backend logs for `Normalizing Edge endpoint` entries — these show exactly what Portainer returns
4. Share the output so we can identify why Edge endpoints are showing as red

Closes #452

## Test plan

- [x] 16 edge normalizer tests pass (including new `LastCheckInDate === 0` test)
- [x] 7 stacks route tests pass
- [ ] Deploy to production and check `/api/endpoints/debug/edge-status` output
- [ ] Verify Edge Agent endpoints show as green after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)