### PR TITLE
docs: add Edge Agent testing setup and docker-compose configuration

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -188,3 +188,9 @@ KALI_MCP_ALLOWED_COMMANDS=whoami,id,uname,ip,df,free,ps,ss,ls,cat
 # Get a free token at https://app.snyk.io/account
 # Free tier: 400 SCA + 100 Code + 300 IaC + 100 Container tests/month
 # SNYK_TOKEN=
+
+# Edge Agent Testing (local Edge Agent Standard for testing edge endpoints)
+# Obtained from Portainer UI when enrolling an Edge Agent.
+# Required for: docker compose -f docker/docker-compose.edge-agent.yml
+# EDGE_AGENT_ID=your-edge-agent-id
+# EDGE_AGENT_KEY=your-edge-agent-key

--- a/docker/docker-compose.edge-agent.yml
+++ b/docker/docker-compose.edge-agent.yml
@@ -1,0 +1,42 @@
+# Local Edge Agent Standard for testing
+#
+# SETUP (one-time):
+#   1. Open Portainer UI → Environments → Add environment
+#   2. Select "Docker Standalone" → "Edge Agent"
+#   3. Name: "local-edge-test"
+#   4. Portainer server URL: host.docker.internal:9000
+#   5. Click "Create" and copy EDGE_ID + EDGE_KEY from the generated command
+#   6. Paste them into docker/.env (or export them):
+#        EDGE_AGENT_ID=<paste EDGE_ID>
+#        EDGE_AGENT_KEY=<paste EDGE_KEY>
+#
+# IMPORTANT: Your Portainer must expose port 8000 for Edge tunnels.
+#   If it doesn't, recreate Portainer with:  -p 8000:8000 -p 9000:9000
+#
+# RUN:
+#   docker compose -f docker/docker-compose.edge-agent.yml up -d
+#
+# VERIFY:
+#   - Portainer UI → Environments → "local-edge-test" should show as connected
+#   - Dashboard → Fleet Overview → should show a second endpoint with Edge Agent Standard badge
+#
+# STOP:
+#   docker compose -f docker/docker-compose.edge-agent.yml down
+
+services:
+  edge-agent:
+    image: portainer/agent:2.21.0
+    container_name: portainer_edge_agent
+    restart: unless-stopped
+    environment:
+      EDGE: "1"
+      EDGE_ID: ${EDGE_AGENT_ID:?Set EDGE_AGENT_ID in .env (from Portainer UI)}
+      EDGE_KEY: ${EDGE_AGENT_KEY:?Set EDGE_AGENT_KEY in .env (from Portainer UI)}
+      EDGE_INSECURE_POLL: "1"
+      CAP_HOST_MANAGEMENT: "1"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/volumes:/var/lib/docker/volumes
+      - /:/host
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -347,6 +347,24 @@ sequenceDiagram
 | **DevOps** | Docker, Docker Compose, GitHub Actions CI |
 | **Testing** | Vitest, Testing Library, jsdom, Playwright (E2E) |
 
+## Docker Development
+
+### Standard Development Stack
+```bash
+docker compose -f docker/docker-compose.dev.yml up -d
+```
+
+Runs backend (Fastify) and frontend (Vite) in hot-reload containers with auto-refresh on code changes.
+
+### Edge Agent Testing
+```bash
+docker compose -f docker/docker-compose.edge-agent.yml up -d
+```
+
+Runs a **Portainer Edge Agent Standard** container locally for testing Edge features (e.g., endpoints registered as edge agents). Requires `EDGE_AGENT_ID` and `EDGE_AGENT_KEY` environment variables in `docker/.env` (obtained from Portainer UI when enrolling an edge agent). Port 8000 must be exposed on the Portainer instance for Edge tunnels.
+
+---
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary

Added documentation and Docker Compose configuration for local Edge Agent testing, enabling developers to test Edge endpoint functionality without production infrastructure.

**Changes:**
- `docker/docker-compose.edge-agent.yml` — Runs Portainer Edge Agent Standard container locally with setup/verification instructions
- `docs/architecture.md` — Added "Docker Development" section documenting both standard dev stack and Edge Agent testing
- `docker/.env.example` — Added `EDGE_AGENT_ID` and `EDGE_AGENT_KEY` configuration variables

## Why This Matters

Developers testing Edge endpoint features (heartbeat status, edge-specific routes, fleet overview) previously had no local way to enroll and test Edge agents. This docker-compose file provides a one-step local setup that mirrors production enrollment workflow.

## Test Plan

- [x] docker-compose.edge-agent.yml starts cleanly with valid EDGE_AGENT_ID and EDGE_AGENT_KEY
- [x] Edge Agent connects to Portainer and appears in Environments list
- [x] Dashboard Fleet Overview displays the edge endpoint with "Edge Agent Standard" badge
- [x] Documentation is clear with setup steps and verification instructions

## Related

Supports ongoing Edge Agent integration work (#452)

🤖 Generated with [Claude Code](https://claude.com/claude-code)