### PR TITLE
fix: trust Portainer Status field for Edge endpoints (Issue #489)

### DIFF
--- a/backend/src/routes/stacks.test.ts
+++ b/backend/src/routes/stacks.test.ts
@@ -49,12 +49,12 @@ const fakeEndpoint = (id: number, name: string, status = 1) => ({
   TagIds: [],
 });
 
-const fakeEdgeEndpoint = (id: number, name: string, lastCheckIn: number) => ({
+const fakeEdgeEndpoint = (id: number, name: string, lastCheckIn: number, status = 1) => ({
   Id: id,
   Name: name,
   Type: 4,
   URL: 'tcp://10.0.0.2:9001',
-  Status: 2, // Portainer reports "down"
+  Status: status,
   Snapshots: [],
   TagIds: [],
   EdgeID: `edge-${id}`,
@@ -112,11 +112,11 @@ describe('stacks routes', () => {
     expect(body).toHaveLength(1);
   });
 
-  it('includes stacks from Edge endpoints that checked in recently', async () => {
-    const recentCheckIn = Math.floor(Date.now() / 1000) - 10; // 10s ago
+  it('includes stacks from Edge endpoints with Status=1 (up)', async () => {
+    const recentCheckIn = Math.floor(Date.now() / 1000) - 10;
     mockGetEndpoints.mockResolvedValue([
       fakeEndpoint(1, 'local'),
-      fakeEdgeEndpoint(2, 'edge-node', recentCheckIn),
+      fakeEdgeEndpoint(2, 'edge-node', recentCheckIn, 1),
     ] as any);
     mockGetStacksByEndpoint
       .mockResolvedValueOnce([fakeStack(1, 'local-stack', 1)] as any)

--- a/backend/src/services/portainer-normalizers-edge.test.ts
+++ b/backend/src/services/portainer-normalizers-edge.test.ts
@@ -169,66 +169,33 @@ describe('normalizeEndpoint — Edge Agent fields', () => {
     expect(result.agentVersion).toBe('2.19.0');
   });
 
-  describe('Edge status detection (heartbeat-based)', () => {
-    it('marks Edge endpoint as "up" when Status=1', () => {
+  describe('Status detection (trusts Portainer Status field)', () => {
+    it('marks Edge endpoint as "up" when Portainer Status=1', () => {
       const ep = makeEndpoint({
         Type: 4,
         EdgeID: 'edge-1',
         Status: 1,
-        LastCheckInDate: Math.floor(Date.now() / 1000) - 10,
       });
       expect(normalizeEndpoint(ep).status).toBe('up');
     });
 
-    it('marks Edge endpoint as "up" when Status!=1 but checked in recently', () => {
+    it('marks Edge endpoint as "down" when Portainer Status=2', () => {
       const ep = makeEndpoint({
         Type: 4,
         EdgeID: 'edge-2',
-        Status: 2, // Portainer says "down"
-        LastCheckInDate: Math.floor(Date.now() / 1000) - 10, // 10s ago
-        EdgeCheckinInterval: 5,
+        Status: 2,
       });
-      // 10s < max((5*2)+20=30, 60) = 60s threshold → should be up
+      expect(normalizeEndpoint(ep).status).toBe('down');
+    });
+
+    it('marks non-Edge endpoint as "up" when Status=1', () => {
+      const ep = makeEndpoint({ Type: 1, Status: 1 });
       expect(normalizeEndpoint(ep).status).toBe('up');
     });
 
-    it('marks Edge endpoint as "down" when Status!=1 and last check-in too old', () => {
-      const ep = makeEndpoint({
-        Type: 4,
-        EdgeID: 'edge-3',
-        Status: 2,
-        LastCheckInDate: Math.floor(Date.now() / 1000) - 300, // 5 min ago
-        EdgeCheckinInterval: 5,
-      });
-      // 300s > max((5*2)+20=30, 60) = 60s threshold → should be down
+    it('marks non-Edge endpoint as "down" when Status=2', () => {
+      const ep = makeEndpoint({ Type: 1, Status: 2 });
       expect(normalizeEndpoint(ep).status).toBe('down');
-    });
-
-    it('marks Edge endpoint as "down" when Status!=1 and no LastCheckInDate', () => {
-      const ep = makeEndpoint({
-        Type: 4,
-        EdgeID: 'edge-4',
-        Status: 2,
-      });
-      expect(normalizeEndpoint(ep).status).toBe('down');
-    });
-
-    it('marks Edge endpoint as "down" when LastCheckInDate is 0', () => {
-      const ep = makeEndpoint({
-        Type: 4,
-        EdgeID: 'edge-5',
-        Status: 2,
-        LastCheckInDate: 0,
-      });
-      expect(normalizeEndpoint(ep).status).toBe('down');
-    });
-
-    it('non-Edge endpoint trusts Status field directly', () => {
-      const down = makeEndpoint({ Type: 1, Status: 2 });
-      expect(normalizeEndpoint(down).status).toBe('down');
-
-      const up = makeEndpoint({ Type: 1, Status: 1 });
-      expect(normalizeEndpoint(up).status).toBe('up');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Removed `determineEdgeStatus()` — no longer re-derives Edge status from `LastCheckInDate`
- Trusts Portainer's `ep.Status === 1` as sole source of truth for all endpoints (Edge and non-Edge)
- Eliminates false "down" readings caused by stale cached `LastCheckInDate` drifting beyond heartbeat threshold

**Root cause**: Endpoint data is cached for 15 minutes (`TTL.ENDPOINTS=900s`), but the heartbeat threshold was ~60s. After 60 seconds, `Date.now() - cachedLastCheckInDate` would exceed the threshold, falsely marking healthy Edge endpoints as "down" for ~93% of cache lifetime.

## Test plan

- [x] 14 edge normalizer tests pass (`portainer-normalizers-edge.test.ts`)
- [x] 7 stacks route tests pass (`stacks.test.ts`) — updated `fakeEdgeEndpoint` to use `Status: 1`
- [x] Full backend suite: 1315 tests pass across 105 files
- [x] Deploy and verify Edge endpoints remain green in Fleet Overview for >5 minutes

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)