### PR TITLE
fix: custom LLM endpoint falls through to Ollama when token is empty

### DIFF
--- a/backend/src/routes/llm.ts
+++ b/backend/src/routes/llm.ts
@@ -100,7 +100,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
 
       let fullResponse = '';
 
-      if (llmConfig.customEnabled && llmConfig.customEndpointUrl && llmConfig.customEndpointToken) {
+      if (llmConfig.customEnabled && llmConfig.customEndpointUrl) {
         const response = await fetch(llmConfig.customEndpointUrl, {
           method: 'POST',
           headers: {
@@ -217,20 +217,13 @@ export async function llmRoutes(fastify: FastifyInstance) {
     const { url, token, ollamaUrl } = request.body;
 
     try {
-      if (url && token) {
-        // Test custom OpenAI-compatible endpoint
+      if (url) {
+        // Test custom OpenAI-compatible endpoint (token is optional)
         const baseUrl = new URL(url);
         const modelsUrl = `${baseUrl.origin}/v1/models`;
 
-        const authHeaders: Record<string, string> = {};
-        if (token.includes(':')) {
-          authHeaders['Authorization'] = `Basic ${Buffer.from(token).toString('base64')}`;
-        } else {
-          authHeaders['Authorization'] = `Bearer ${token}`;
-        }
-
         const response = await fetch(modelsUrl, {
-          headers: { 'Content-Type': 'application/json', ...authHeaders },
+          headers: { 'Content-Type': 'application/json', ...getAuthHeaders(token) },
           signal: AbortSignal.timeout(10_000),
         });
 
@@ -292,7 +285,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
     try {
       let fullResponse = '';
 
-      if (llmConfig.customEnabled && llmConfig.customEndpointUrl && llmConfig.customEndpointToken) {
+      if (llmConfig.customEnabled && llmConfig.customEndpointUrl) {
         const response = await fetch(llmConfig.customEndpointUrl, {
           method: 'POST',
           headers: {
@@ -414,7 +407,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
 
     try {
       // If using custom API endpoint, try OpenAI-compatible /v1/models
-      if (!customHost && llmConfig.customEnabled && llmConfig.customEndpointUrl && llmConfig.customEndpointToken) {
+      if (!customHost && llmConfig.customEnabled && llmConfig.customEndpointUrl) {
         const baseUrl = new URL(llmConfig.customEndpointUrl);
         const modelsUrl = `${baseUrl.origin}/v1/models`;
 

--- a/backend/src/sockets/llm-chat.ts
+++ b/backend/src/sockets/llm-chat.ts
@@ -214,7 +214,7 @@ async function streamLlmCall(
 ): Promise<string> {
   let fullResponse = '';
 
-  if (llmConfig.customEnabled && llmConfig.customEndpointUrl && llmConfig.customEndpointToken) {
+  if (llmConfig.customEnabled && llmConfig.customEndpointUrl) {
     const response = await fetch(llmConfig.customEndpointUrl, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary

- Fixed triple-AND guard (`customEnabled && url && token`) that required a non-empty token to use custom endpoints — token is now optional
- `isOllamaAvailable()` now tests the custom endpoint when configured instead of always testing Ollama
- `ensureModel()` skips Ollama model pull when custom endpoint is enabled
- ByteString errors (from Ollama SDK receiving HTML) translated to actionable message
- `test-connection` endpoint no longer requires token parameter
- Applied consistently across all 3 LLM files: `llm-client.ts`, `llm.ts` routes, `llm-chat.ts` socket

**Root cause**: When using Open WebUI (or any OpenAI-compatible API) without an auth token, the guard `customEnabled && url && token` evaluated to `false`, falling through to the Ollama SDK. The SDK then hit Open WebUI's HTML pages, producing `Cannot convert argument to a ByteString` (character 8226 = Unicode bullet from HTML).

## Test plan

- [x] 9 LLM client tests pass (`llm-client.test.ts`) — includes new tests for:
  - Custom endpoint used with empty token
  - Bearer token included when set
  - ByteString error translation
  - `isOllamaAvailable()` respects custom endpoint
  - `ensureModel()` skips Ollama when custom endpoint enabled
- [x] Full backend suite: 1323 tests pass across 105 files
- [ ] Manual: Enable custom endpoint in Settings with Open WebUI URL, leave token empty, send chat message

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)