### PR TITLE
fix: cache-aware heartbeat for Edge endpoint status (Issue #489)

### DIFF
--- a/backend/src/routes/stacks.test.ts
+++ b/backend/src/routes/stacks.test.ts
@@ -112,11 +112,11 @@ describe('stacks routes', () => {
     expect(body).toHaveLength(1);
   });
 
-  it('includes stacks from Edge endpoints with Status=1 (up)', async () => {
+  it('includes stacks from Edge endpoints with recent check-in (Status=2, tunnel closed)', async () => {
     const recentCheckIn = Math.floor(Date.now() / 1000) - 10;
     mockGetEndpoints.mockResolvedValue([
       fakeEndpoint(1, 'local'),
-      fakeEdgeEndpoint(2, 'edge-node', recentCheckIn, 1),
+      fakeEdgeEndpoint(2, 'edge-node', recentCheckIn, 2), // Status=2 is normal for Edge Standard
     ] as any);
     mockGetStacksByEndpoint
       .mockResolvedValueOnce([fakeStack(1, 'local-stack', 1)] as any)


### PR DESCRIPTION
## Summary

Replaces the pure `Status` field check (PR #491) with a **cache-aware heartbeat** for Edge endpoints:

- **Root cause**: Portainer's API `Status` field for Edge Standard endpoints represents the **tunnel state** (2 = closed), not agent connectivity. This is normal — Edge Standard uses on-demand tunnels. Portainer's own UI shows green because it uses `LastCheckInDate`, not `Status`.
- **Fix**: Edge endpoints use `determineEdgeStatus()` with threshold = heartbeat window (60s) + cache TTL (900s) = **960s**
- **Non-Edge**: Still trusts `Status` field directly (unchanged)

### Why this doesn't have the old cache drift problem

The old heartbeat threshold was ~60s with a 15-minute cache TTL → status drifted to "down" after 60s of cache age (93% of cache lifetime was wrong).

The new threshold is 960s (heartbeat + cache TTL) → status stays "up" for the entire cache window if the agent was checking in when the data was cached. Only truly disconnected agents (>16 min since last check-in) show as "down".

## Test plan

- [x] 17 edge normalizer tests pass — including new cache-aware threshold tests
- [x] 7 stacks route tests pass — Edge endpoint with Status=2 + recent check-in works
- [x] Full backend suite: 1324 tests pass across 105 files
- [ ] Deploy and verify Edge endpoints show green in Fleet Overview
- [ ] Verify endpoints stay green for >15 minutes (full cache cycle)

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)