### PR TITLE
fix: SSE streaming + LLM settings clarity

### DIFF
--- a/backend/src/routes/llm-feedback.ts
+++ b/backend/src/routes/llm-feedback.ts
@@ -17,6 +17,7 @@ import {
 } from '../services/feedback-store.js';
 import { getEffectivePrompt, PROMPT_FEATURES, type PromptFeature } from '../services/prompt-store.js';
 import { writeAuditLog } from '../services/audit-logger.js';
+import { getAuthHeaders } from '../services/llm-client.js';
 import { createChildLogger } from '../utils/logger.js';
 
 const log = createChildLogger('llm-feedback-routes');
@@ -277,13 +278,13 @@ export async function llmFeedbackRoutes(fastify: FastifyInstance) {
 
       let responseText = '';
 
-      if (llmConfig.customEnabled && llmConfig.customEndpointUrl && llmConfig.customEndpointToken) {
-        // Custom endpoint
+      if (llmConfig.customEnabled && llmConfig.customEndpointUrl) {
+        // Custom endpoint (token is optional — some endpoints don't require auth)
         const response = await fetch(llmConfig.customEndpointUrl, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${llmConfig.customEndpointToken}`,
+            ...getAuthHeaders(llmConfig.customEndpointToken),
           },
           body: JSON.stringify({
             model: llmConfig.model,

--- a/docker/docker-compose.edge-agent.yml
+++ b/docker/docker-compose.edge-agent.yml
@@ -4,7 +4,9 @@
 #   1. Open Portainer UI → Environments → Add environment
 #   2. Select "Docker Standalone" → "Edge Agent"
 #   3. Name: "local-edge-test"
-#   4. Portainer server URL: host.docker.internal:9000
+#   4. Portainer server URL: http://portainer.local:9000
+#      (This works because extra_hosts below maps portainer.local to the host.
+#       You can also use host.docker.internal:9000 if you prefer.)
 #   5. Click "Create" and copy EDGE_ID + EDGE_KEY from the generated command
 #   6. Paste them into docker/.env (or export them):
 #        EDGE_AGENT_ID=<paste EDGE_ID>
@@ -25,7 +27,7 @@
 
 services:
   edge-agent:
-    image: portainer/agent:2.21.0
+    image: portainer/agent:2.38.0
     container_name: portainer_edge_agent
     restart: unless-stopped
     environment:
@@ -38,5 +40,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes:/var/lib/docker/volumes
       - /:/host
+      - portainer_agent_data:/data
     extra_hosts:
       - "host.docker.internal:host-gateway"
+      - "portainer.local:host-gateway"
+
+volumes:
+  portainer_agent_data:

--- a/frontend/src/pages/settings.test.tsx
+++ b/frontend/src/pages/settings.test.tsx
@@ -64,7 +64,7 @@ describe('LlmSettingsSection', () => {
       { wrapper: createWrapper() },
     );
 
-    expect(screen.getByText('LLM / Ollama')).toBeInTheDocument();
+    expect(screen.getByText('LLM Configuration')).toBeInTheDocument();
   });
 
   it('renders model dropdown populated from API', async () => {
@@ -137,13 +137,13 @@ describe('LlmSettingsSection', () => {
     expect(screen.getByLabelText(/api key/i)).toBeInTheDocument();
   });
 
-  it('calls onChange when custom endpoint toggle is clicked', async () => {
+  it('calls onChange when Custom API card is clicked', async () => {
     render(
       <LlmSettingsSection values={defaultValues} originalValues={defaultValues} onChange={onChange} />,
       { wrapper: createWrapper() },
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /toggle custom api endpoint/i }));
+    fireEvent.click(screen.getByText('Custom API'));
     expect(onChange).toHaveBeenCalledWith('llm.custom_endpoint_enabled', 'true');
   });
 
@@ -194,7 +194,7 @@ describe('LlmSettingsSection', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
 
-    expect(mockError).toHaveBeenCalledWith('Set a custom endpoint URL before testing connection');
+    expect(mockError).toHaveBeenCalledWith('Set an API endpoint URL before testing connection');
     expect(mockPost).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **Fix SSE streaming parsing**: OpenAI-compatible APIs send `data: {json}` (Server-Sent Events) format, but the streaming parsers in `llm-client.ts` and `llm-chat.ts` did raw `JSON.parse(line)` without stripping the `data: ` prefix — causing **all streaming content to be silently dropped**. Now properly strips the prefix and handles `[DONE]` sentinel.
- **Fix last triple-AND guard**: `llm-feedback.ts` still required a non-empty token (`customEnabled && url && token`). Changed to `customEnabled && url` with `getAuthHeaders()` for proper auth handling.
- **Refactor LLM Settings UI**: Replace confusing toggle with two clear selectable cards ("Ollama (Local)" vs "Custom API") so users understand they choose one backend, not both. Only shows relevant fields for the selected mode.

## Test plan

- [x] Backend tests: 1329 passed (14 LLM client tests including new SSE parsing tests)
- [x] Frontend tests: 880 passed (17 settings tests updated for new UI)
- [x] TypeScript: clean typecheck
- [ ] Manual: configure Custom API endpoint in settings, verify streaming works
- [ ] Manual: configure Ollama, verify streaming still works
- [ ] Manual: test connection with empty token (should work)

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)