### PR TITLE
fix: add LLM_VERIFY_SSL for self-signed certificate support

### DIFF
--- a/backend/src/config/env.schema.ts
+++ b/backend/src/config/env.schema.ts
@@ -25,11 +25,12 @@ export const envSchema = z.object({
   PORTAINER_CB_FAILURE_THRESHOLD: z.coerce.number().int().min(1).max(50).default(5),
   PORTAINER_CB_RESET_TIMEOUT_MS: z.coerce.number().int().min(1000).max(300000).default(30000),
 
-  // Ollama
+  // Ollama / LLM
   OLLAMA_BASE_URL: z.string().url().default('http://host.docker.internal:11434'),
   OLLAMA_MODEL: z.string().default('llama3.2'),
   OLLAMA_API_ENDPOINT: z.string().url().optional(), // OpenAI-compatible endpoint (e.g., OpenWebUI)
   OLLAMA_BEARER_TOKEN: z.string().optional(), // Bearer token or username:password for Basic auth
+  LLM_VERIFY_SSL: z.string().default('true').transform((v) => v === 'true' || v === '1'),
 
   // Kibana (optional)
   KIBANA_ENDPOINT: z.string().url().optional(),

--- a/backend/src/routes/llm-feedback.ts
+++ b/backend/src/routes/llm-feedback.ts
@@ -17,7 +17,7 @@ import {
 } from '../services/feedback-store.js';
 import { getEffectivePrompt, PROMPT_FEATURES, type PromptFeature } from '../services/prompt-store.js';
 import { writeAuditLog } from '../services/audit-logger.js';
-import { getAuthHeaders } from '../services/llm-client.js';
+import { getAuthHeaders, getLlmDispatcher } from '../services/llm-client.js';
 import { createChildLogger } from '../utils/logger.js';
 
 const log = createChildLogger('llm-feedback-routes');
@@ -295,7 +295,8 @@ export async function llmFeedbackRoutes(fastify: FastifyInstance) {
             stream: false,
             temperature: 0.3,
           }),
-        });
+          dispatcher: getLlmDispatcher(),
+        } as RequestInit);
 
         if (!response.ok) {
           throw new Error(`LLM HTTP ${response.status}: ${response.statusText}`);

--- a/backend/src/services/llm-client.test.ts
+++ b/backend/src/services/llm-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { chatStream, isOllamaAvailable, ensureModel, getAuthHeaders, getFetchErrorMessage } from './llm-client.js';
+import { chatStream, isOllamaAvailable, ensureModel, getAuthHeaders, getFetchErrorMessage, getLlmDispatcher } from './llm-client.js';
 import { getEffectiveLlmConfig } from './settings-store.js';
 
 // Mock settings-store
@@ -14,6 +14,12 @@ const mockGetConfig = vi.fn().mockReturnValue({
 });
 vi.mock('./settings-store.js', () => ({
   getEffectiveLlmConfig: (...args: unknown[]) => mockGetConfig(...args),
+}));
+
+// Mock config (for getLlmDispatcher)
+const mockEnvConfig = vi.fn().mockReturnValue({ LLM_VERIFY_SSL: true });
+vi.mock('../config/index.js', () => ({
+  getConfig: (...args: unknown[]) => mockEnvConfig(...args),
 }));
 
 // Mock llm-trace-store
@@ -434,6 +440,14 @@ describe('llm-client', () => {
     it('returns generic message for non-Error values', () => {
       expect(getFetchErrorMessage('string error')).toBe('Unknown connection error');
       expect(getFetchErrorMessage(null)).toBe('Unknown connection error');
+    });
+  });
+
+  describe('getLlmDispatcher', () => {
+    it('returns undefined when LLM_VERIFY_SSL is true', () => {
+      mockEnvConfig.mockReturnValue({ LLM_VERIFY_SSL: true });
+      const dispatcher = getLlmDispatcher();
+      expect(dispatcher).toBeUndefined();
     });
   });
 });

--- a/backend/src/sockets/llm-chat.ts
+++ b/backend/src/sockets/llm-chat.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'crypto';
 import { getToolSystemPrompt, parseToolCalls, executeToolCalls, type ToolCallResult } from '../services/llm-tools.js';
 import { collectAllTools, routeToolCalls, getMcpToolPrompt, type OllamaToolCall } from '../services/mcp-tool-bridge.js';
 import { isPromptInjection, sanitizeLlmOutput } from '../services/prompt-guard.js';
-import { getAuthHeaders, getFetchErrorMessage } from '../services/llm-client.js';
+import { getAuthHeaders, getFetchErrorMessage, getLlmDispatcher } from '../services/llm-client.js';
 
 const log = createChildLogger('socket:llm');
 
@@ -216,7 +216,8 @@ async function streamLlmCall(
         max_tokens: llmConfig.maxTokens,
       }),
       signal,
-    });
+      dispatcher: getLlmDispatcher(),
+    } as RequestInit);
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -298,7 +299,8 @@ async function streamOllamaRawCall(
       options: { num_predict: llmConfig.maxTokens },
     }),
     signal,
-  });
+    dispatcher: getLlmDispatcher(),
+  } as RequestInit);
 
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -38,6 +38,8 @@ OLLAMA_MODEL=llama3.2
 # OLLAMA_API_ENDPOINT=https://your-openwebui.example.com/v1/chat/completions
 # OLLAMA_BEARER_TOKEN=your-token-or-username:password
 # Note: Use "username:password" for HTTP Basic auth, or a token for Bearer auth
+# Set to false if your LLM endpoint uses a self-signed or internal CA certificate:
+# LLM_VERIFY_SSL=false
 
 # Prompt Injection Guard (3-layer: regex + heuristic + output sanitization)
 LLM_PROMPT_GUARD_STRICT=true        # true = block on heuristic score >= 0.4; false = >= 0.7


### PR DESCRIPTION
## Summary

- Added `LLM_VERIFY_SSL` env var (default: `true`) to bypass SSL certificate verification for custom LLM endpoints
- Custom endpoints like OpenWebUI behind reverse proxies with self-signed or internal CA certificates fail with "unable to verify the first certificate"
- Uses the same undici `Agent` pattern as `PORTAINER_VERIFY_SSL` — creates a dispatcher with `rejectUnauthorized: false`
- Applied to all 9 `fetch()` calls across 4 files

## Changes

| File | Change |
|------|--------|
| `backend/src/config/env.schema.ts` | Added `LLM_VERIFY_SSL` env var |
| `backend/src/services/llm-client.ts` | Added `getLlmDispatcher()` with cached undici Agent |
| `backend/src/routes/llm.ts` | Added dispatcher to 4 fetch calls |
| `backend/src/sockets/llm-chat.ts` | Added dispatcher to 2 fetch calls |
| `backend/src/routes/llm-feedback.ts` | Added dispatcher to 1 fetch call |
| `backend/src/services/llm-client.test.ts` | Added test for getLlmDispatcher |
| `docker/.env.example` | Documented LLM_VERIFY_SSL option |

## Usage

```env
# Set to false if your LLM endpoint uses a self-signed or internal CA certificate:
LLM_VERIFY_SSL=false
```

## Test plan

- [x] `llm-client.test.ts` — 17 tests pass (includes getLlmDispatcher test)
- [x] `llm-chat.test.ts` — 23 tests pass
- [x] TypeScript typecheck clean
- [ ] Verify with self-signed cert endpoint and `LLM_VERIFY_SSL=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)