### PR TITLE
fix: use undici fetch for LLM SSL bypass (LLM_VERIFY_SSL)

### DIFF
--- a/backend/src/routes/llm-feedback.ts
+++ b/backend/src/routes/llm-feedback.ts
@@ -17,7 +17,7 @@ import {
 } from '../services/feedback-store.js';
 import { getEffectivePrompt, PROMPT_FEATURES, type PromptFeature } from '../services/prompt-store.js';
 import { writeAuditLog } from '../services/audit-logger.js';
-import { getAuthHeaders, getLlmDispatcher } from '../services/llm-client.js';
+import { getAuthHeaders, llmFetch } from '../services/llm-client.js';
 import { createChildLogger } from '../utils/logger.js';
 
 const log = createChildLogger('llm-feedback-routes');
@@ -280,7 +280,7 @@ export async function llmFeedbackRoutes(fastify: FastifyInstance) {
 
       if (llmConfig.customEnabled && llmConfig.customEndpointUrl) {
         // Custom endpoint (token is optional — some endpoints don't require auth)
-        const response = await fetch(llmConfig.customEndpointUrl, {
+        const response = await llmFetch(llmConfig.customEndpointUrl, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -295,8 +295,7 @@ export async function llmFeedbackRoutes(fastify: FastifyInstance) {
             stream: false,
             temperature: 0.3,
           }),
-          dispatcher: getLlmDispatcher(),
-        } as RequestInit);
+        });
 
         if (!response.ok) {
           throw new Error(`LLM HTTP ${response.status}: ${response.statusText}`);

--- a/backend/src/routes/llm.ts
+++ b/backend/src/routes/llm.ts
@@ -11,7 +11,7 @@ import { insertLlmTrace } from '../services/llm-trace-store.js';
 import { LlmQueryBodySchema, LlmTestConnectionBodySchema, LlmModelsQuerySchema, LlmTestPromptBodySchema } from '../models/api-schemas.js';
 import { PROMPT_TEST_FIXTURES } from '../services/prompt-test-fixtures.js';
 import { isPromptInjection, sanitizeLlmOutput } from '../services/prompt-guard.js';
-import { getAuthHeaders, getFetchErrorMessage, getLlmDispatcher } from '../services/llm-client.js';
+import { getAuthHeaders, getFetchErrorMessage, llmFetch } from '../services/llm-client.js';
 
 const log = createChildLogger('route:llm');
 
@@ -94,7 +94,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
       let fullResponse = '';
 
       if (llmConfig.customEnabled && llmConfig.customEndpointUrl) {
-        const response = await fetch(llmConfig.customEndpointUrl, {
+        const response = await llmFetch(llmConfig.customEndpointUrl, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -106,8 +106,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
             stream: false,
             format: 'json',
           }),
-          dispatcher: getLlmDispatcher(),
-        } as RequestInit);
+        });
 
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -216,11 +215,10 @@ export async function llmRoutes(fastify: FastifyInstance) {
         const baseUrl = new URL(url);
         const modelsUrl = `${baseUrl.origin}/v1/models`;
 
-        const response = await fetch(modelsUrl, {
+        const response = await llmFetch(modelsUrl, {
           headers: { 'Content-Type': 'application/json', ...getAuthHeaders(token) },
           signal: AbortSignal.timeout(10_000),
-          dispatcher: getLlmDispatcher(),
-        } as RequestInit);
+        });
 
         if (!response.ok) {
           return { ok: false, error: `HTTP ${response.status}: ${response.statusText}` };
@@ -280,7 +278,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
       let fullResponse = '';
 
       if (llmConfig.customEnabled && llmConfig.customEndpointUrl) {
-        const response = await fetch(llmConfig.customEndpointUrl, {
+        const response = await llmFetch(llmConfig.customEndpointUrl, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -293,8 +291,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
             ...(temperature !== undefined ? { temperature } : {}),
           }),
           signal: AbortSignal.timeout(60_000),
-          dispatcher: getLlmDispatcher(),
-        } as RequestInit);
+        });
 
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -411,7 +408,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
           ...getAuthHeaders(llmConfig.customEndpointToken),
         };
 
-        const response = await fetch(modelsUrl, { headers, dispatcher: getLlmDispatcher() } as RequestInit);
+        const response = await llmFetch(modelsUrl, { headers });
         if (response.ok) {
           const data = await response.json() as { data?: Array<{ id: string }> };
           return {


### PR DESCRIPTION
## Summary

- **Root cause**: Node.js global `fetch()` silently ignores the `dispatcher` option, so `LLM_VERIFY_SSL=false` had no effect — self-signed certs were still rejected
- **Fix**: Added `llmFetch()` wrapper in `llm-client.ts` that uses undici's `fetch` (which honors `dispatcher`), replaced all 9 LLM fetch calls across 4 files
- Updated tests to mock undici's fetch instead of `globalThis.fetch`

## Test plan

- [x] `backend/src/services/llm-client.test.ts` — 21 tests pass
- [x] `backend/src/sockets/llm-chat.test.ts` — 23 tests pass
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Manual: Set `LLM_VERIFY_SSL=false` and verify custom endpoint with self-signed cert connects successfully

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)