### PR TITLE
fix: support ParisNeo Ollama Proxy Bearer auth (closes #507)

### DIFF
--- a/backend/src/config/env.schema.ts
+++ b/backend/src/config/env.schema.ts
@@ -30,6 +30,7 @@ export const envSchema = z.object({
   OLLAMA_MODEL: z.string().default('llama3.2'),
   LLM_OPENAI_ENDPOINT: z.string().url().optional(), // OpenAI-compatible endpoint (e.g., OpenWebUI)
   LLM_BEARER_TOKEN: z.string().optional(), // Bearer token or username:password for Basic auth
+  LLM_AUTH_TYPE: z.enum(['bearer', 'basic']).default('bearer'), // Auth header type for LLM endpoint tokens
   LLM_VERIFY_SSL: z.string().default('true').transform((v) => v === 'true' || v === '1'),
 
   // Kibana (optional)

--- a/backend/src/routes/llm-feedback.ts
+++ b/backend/src/routes/llm-feedback.ts
@@ -17,7 +17,7 @@ import {
 } from '../services/feedback-store.js';
 import { getEffectivePrompt, PROMPT_FEATURES, type PromptFeature } from '../services/prompt-store.js';
 import { writeAuditLog } from '../services/audit-logger.js';
-import { getAuthHeaders, llmFetch, createOllamaClient } from '../services/llm-client.js';
+import { getAuthHeaders, llmFetch, createConfiguredOllamaClient } from '../services/llm-client.js';
 import { createChildLogger } from '../utils/logger.js';
 
 const log = createChildLogger('llm-feedback-routes');
@@ -283,7 +283,7 @@ export async function llmFeedbackRoutes(fastify: FastifyInstance) {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            ...getAuthHeaders(llmConfig.customEndpointToken),
+            ...getAuthHeaders(llmConfig.customEndpointToken, llmConfig.authType),
           },
           body: JSON.stringify({
             model: llmConfig.model,
@@ -304,7 +304,7 @@ export async function llmFeedbackRoutes(fastify: FastifyInstance) {
         responseText = data.choices?.[0]?.message?.content ?? '';
       } else {
         // Ollama
-        const ollama = createOllamaClient(llmConfig.ollamaUrl);
+        const ollama = createConfiguredOllamaClient(llmConfig);
         const response = await ollama.chat({
           model: llmConfig.model,
           messages: [

--- a/backend/src/services/settings-store.ts
+++ b/backend/src/services/settings-store.ts
@@ -53,9 +53,10 @@ export function getEffectiveLlmConfig() {
   // When disabled, the Ollama SDK is used for native Ollama access.
   const customEnabled = getSetting('llm.custom_endpoint_enabled')?.value === 'true' || !!config.LLM_OPENAI_ENDPOINT;
   const customEndpointToken = getSetting('llm.custom_endpoint_token')?.value || config.LLM_BEARER_TOKEN;
+  const authType = (getSetting('llm.auth_type')?.value as 'bearer' | 'basic') || config.LLM_AUTH_TYPE;
   const maxTokens = parseInt(getSetting('llm.max_tokens')?.value || '20000', 10) || 20000;
   const maxToolIterations = parseInt(getSetting('llm.max_tool_iterations')?.value || '', 10) || config.LLM_MAX_TOOL_ITERATIONS;
-  return { ollamaUrl, model, customEnabled, customEndpointUrl, customEndpointToken, maxTokens, maxToolIterations };
+  return { ollamaUrl, model, customEnabled, customEndpointUrl, customEndpointToken, authType, maxTokens, maxToolIterations };
 }
 
 /**

--- a/backend/src/sockets/llm-chat.test.ts
+++ b/backend/src/sockets/llm-chat.test.ts
@@ -109,8 +109,15 @@ describe('getAuthHeaders', () => {
     });
   });
 
-  it('returns Basic header for username:password format', () => {
-    const result = getAuthHeaders('admin:secret123');
+  it('returns Bearer header for colon-containing token with default authType', () => {
+    // ParisNeo Ollama Proxy format: Bearer user:token
+    expect(getAuthHeaders('admin:secret123')).toEqual({
+      Authorization: 'Bearer admin:secret123',
+    });
+  });
+
+  it('returns Basic header when authType is explicitly basic', () => {
+    const result = getAuthHeaders('admin:secret123', 'basic');
     const expected = Buffer.from('admin:secret123').toString('base64');
     expect(result).toEqual({
       Authorization: `Basic ${expected}`,

--- a/backend/src/sockets/llm-chat.ts
+++ b/backend/src/sockets/llm-chat.ts
@@ -11,7 +11,7 @@ import { randomUUID } from 'crypto';
 import { getToolSystemPrompt, parseToolCalls, executeToolCalls, type ToolCallResult } from '../services/llm-tools.js';
 import { collectAllTools, routeToolCalls, getMcpToolPrompt, type OllamaToolCall } from '../services/mcp-tool-bridge.js';
 import { isPromptInjection, sanitizeLlmOutput } from '../services/prompt-guard.js';
-import { getAuthHeaders, getFetchErrorMessage, llmFetch, createOllamaClient } from '../services/llm-client.js';
+import { getAuthHeaders, getFetchErrorMessage, llmFetch, createOllamaClient, createConfiguredOllamaClient } from '../services/llm-client.js';
 
 const log = createChildLogger('socket:llm');
 
@@ -206,7 +206,7 @@ async function streamLlmCall(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        ...getAuthHeaders(llmConfig.customEndpointToken),
+        ...getAuthHeaders(llmConfig.customEndpointToken, llmConfig.authType),
       },
       body: JSON.stringify({
         model: selectedModel,
@@ -257,7 +257,7 @@ async function streamLlmCall(
       }
     }
   } else {
-    const ollama = createOllamaClient(llmConfig.ollamaUrl);
+    const ollama = createConfiguredOllamaClient(llmConfig);
     const response = await ollama.chat({
       model: selectedModel,
       messages,
@@ -288,7 +288,7 @@ async function streamOllamaRawCall(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...getAuthHeaders(llmConfig.customEndpointToken),
+      ...getAuthHeaders(llmConfig.customEndpointToken, llmConfig.authType),
     },
     body: JSON.stringify({
       model: selectedModel,
@@ -453,7 +453,7 @@ async function callOllamaWithNativeTools(
     return { content: '', toolCalls: [] };
   }
 
-  const ollama = createOllamaClient(llmConfig.ollamaUrl);
+  const ollama = createConfiguredOllamaClient(llmConfig);
   const response = await ollama.chat({
     model: selectedModel,
     messages,

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -37,7 +37,9 @@ OLLAMA_MODEL=llama3.2
 # For OpenWebUI or authenticated Ollama endpoints (optional):
 # LLM_OPENAI_ENDPOINT=https://your-openwebui.example.com/v1/chat/completions
 # LLM_BEARER_TOKEN=your-token-or-username:password
-# Note: Use "username:password" for HTTP Basic auth, or a token for Bearer auth
+# LLM_AUTH_TYPE=bearer  # Auth header type: "bearer" (default) or "basic"
+# Note: Bearer works with ParisNeo Ollama Proxy (user:token format) and most API keys.
+# Use "basic" only for endpoints requiring HTTP Basic auth.
 # Set to false if your LLM endpoint uses a self-signed or internal CA certificate:
 # LLM_VERIFY_SSL=false
 

--- a/frontend/src/pages/settings.test.tsx
+++ b/frontend/src/pages/settings.test.tsx
@@ -41,6 +41,7 @@ describe('LlmSettingsSection', () => {
     'llm.custom_endpoint_enabled': 'false',
     'llm.custom_endpoint_url': '',
     'llm.custom_endpoint_token': '',
+    'llm.auth_type': 'bearer',
   };
 
   let onChange: ReturnType<typeof vi.fn>;

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -152,6 +152,7 @@ const DEFAULT_SETTINGS = {
     { key: 'llm.custom_endpoint_enabled', label: 'Custom Endpoint Enabled', description: 'Use a custom OpenAI-compatible API endpoint', type: 'boolean', defaultValue: 'false' },
     { key: 'llm.custom_endpoint_url', label: 'Custom Endpoint URL', description: 'OpenAI-compatible chat completions URL', type: 'string', defaultValue: '' },
     { key: 'llm.custom_endpoint_token', label: 'Custom Endpoint Token', description: 'Bearer token for custom endpoint', type: 'password', defaultValue: '' },
+    { key: 'llm.auth_type', label: 'Auth Type', description: 'Authentication header type (Bearer for most LLM proxies including ParisNeo Ollama Proxy)', type: 'string', defaultValue: 'bearer' },
   ],
   authentication: [
     { key: 'oidc.enabled', label: 'Enable OIDC/SSO', description: 'Enable OpenID Connect single sign-on authentication', type: 'boolean', defaultValue: 'false' },
@@ -653,6 +654,7 @@ export function LlmSettingsSection({ values, originalValues, onChange, disabled 
   const customEnabled = values['llm.custom_endpoint_enabled'] === 'true';
   const customUrl = values['llm.custom_endpoint_url'] || '';
   const customToken = values['llm.custom_endpoint_token'] || '';
+  const authType = values['llm.auth_type'] || 'bearer';
 
   // Only pass host to useLlmModels when using Ollama — when custom is enabled,
   // pass undefined so the backend uses the configured custom endpoint
@@ -668,7 +670,7 @@ export function LlmSettingsSection({ values, originalValues, onChange, disabled 
 
   const hasChanges = [
     'llm.model', 'llm.temperature', 'llm.ollama_url', 'llm.max_tokens',
-    'llm.custom_endpoint_enabled', 'llm.custom_endpoint_url', 'llm.custom_endpoint_token',
+    'llm.custom_endpoint_enabled', 'llm.custom_endpoint_url', 'llm.custom_endpoint_token', 'llm.auth_type',
   ].some((key) => values[key] !== originalValues[key]);
   const llmConfigured = Boolean(selectedModel.trim()) && (customEnabled ? Boolean(customUrl.trim()) : Boolean(ollamaUrl.trim()));
 
@@ -846,6 +848,22 @@ export function LlmSettingsSection({ values, originalValues, onChange, disabled 
                     {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                   </button>
                 </div>
+              </div>
+              <div>
+                <label htmlFor="auth-type-select" className="text-sm font-medium">Auth Header Type</label>
+                <p className="text-xs text-muted-foreground mb-1.5">
+                  Bearer works with most proxies including ParisNeo Ollama Proxy (user:token format). Use Basic only for endpoints that require HTTP Basic auth.
+                </p>
+                <select
+                  id="auth-type-select"
+                  value={authType}
+                  onChange={(e) => onChange('llm.auth_type', e.target.value)}
+                  disabled={disabled}
+                  className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+                >
+                  <option value="bearer">Bearer (default)</option>
+                  <option value="basic">Basic</option>
+                </select>
               </div>
             </>
           )}
@@ -2919,6 +2937,7 @@ export default function SettingsPage() {
     'llm.custom_endpoint_enabled',
     'llm.custom_endpoint_url',
     'llm.custom_endpoint_token',
+    'llm.auth_type',
     'oidc.enabled',
     'oidc.issuer_url',
     'oidc.client_id',


### PR DESCRIPTION
## Summary
Fix Ollama integration incompatibility with ParisNeo Ollama Proxy Server by replacing colon-based auth type auto-detection with explicit user-configurable auth type.

Closes #507

## Root Cause
`getAuthHeaders()` used a heuristic: if token contains `:`, convert to Basic auth. ParisNeo Ollama Proxy uses `Bearer user:token` format, so our code incorrectly sent `Basic base64(user:token)` instead of `Bearer user:token`, causing 403 Forbidden responses. Additionally, the Ollama SDK path passed no auth headers at all.

## Fix
- **Explicit auth type**: Added `LLM_AUTH_TYPE` env var and `llm.auth_type` setting with values `bearer` (default) or `basic`, replacing the error-prone auto-detection
- **Auth-injected SDK client**: New `createConfiguredOllamaClient()` wraps the Ollama SDK with an authenticated fetch that injects auth headers on every request — enabling proxy auth on ALL Ollama SDK call sites
- **Graceful proxy handling**: `ensureModel()` now catches 403/405 from proxy-blocked endpoints (`/api/pull`) and logs a warning instead of failing
- **Settings UI**: Added auth type dropdown to LLM settings when using Custom API mode

## Changes
- `backend/src/config/env.schema.ts` — Add `LLM_AUTH_TYPE` env var (bearer/basic)
- `backend/src/services/settings-store.ts` — Add `authType` to `getEffectiveLlmConfig()`
- `backend/src/services/llm-client.ts` — Fix `getAuthHeaders()`, add `createConfiguredOllamaClient()`, harden `ensureModel()`
- `backend/src/sockets/llm-chat.ts` — Use configured client and pass authType
- `backend/src/routes/llm.ts` — Update all 5 Ollama call sites
- `backend/src/routes/llm-feedback.ts` — Update Ollama call site
- `docker/.env.example` — Document `LLM_AUTH_TYPE`
- `frontend/src/pages/settings.tsx` — Add auth type dropdown in Custom API section

## Testing
- [x] Regression tests updated: `llm-client.test.ts` (24 tests), `llm-chat.test.ts` (24 tests)
- [x] New tests: Bearer with colon tokens, explicit basic auth, explicit bearer auth
- [x] Full backend suite passes (123 LLM-related tests green)
- [x] Frontend settings tests pass (17 tests)
- [x] TypeScript strict typecheck passes (both workspaces)
- [x] ESLint clean on all modified files

## Rollback Plan
Revert this PR. The `LLM_AUTH_TYPE` env var defaults to `bearer`, so existing setups without the variable continue working as before (Bearer tokens without colons are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)