### PR TITLE
fix: cache Portainer API calls in ES forwarder, stats collector, and monitoring cycle

### DIFF
--- a/backend/src/services/metrics-collector.test.ts
+++ b/backend/src/services/metrics-collector.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetContainerStats = vi.fn();
+const mockCachedFetch = vi.fn((_key: string, _ttl: number, fn: () => Promise<unknown>) => fn());
+
+vi.mock('./portainer-client.js', () => ({
+  getContainerStats: (...args: unknown[]) => mockGetContainerStats(...args),
+}));
+
+vi.mock('./portainer-cache.js', () => ({
+  cachedFetch: (...args: unknown[]) => mockCachedFetch(...args as [string, number, () => Promise<unknown>]),
+  getCacheKey: (...args: (string | number)[]) => args.join(':'),
+  TTL: { ENDPOINTS: 900, CONTAINERS: 300, STATS: 60 },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const { collectMetrics } = await import('./metrics-collector.js');
+
+describe('metrics-collector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetContainerStats.mockResolvedValue({
+      cpu_stats: {
+        cpu_usage: { total_usage: 200 },
+        system_cpu_usage: 1000,
+        online_cpus: 2,
+      },
+      precpu_stats: {
+        cpu_usage: { total_usage: 100 },
+        system_cpu_usage: 500,
+      },
+      memory_stats: {
+        usage: 1_048_576,
+        limit: 2_097_152,
+        stats: { cache: 0 },
+      },
+      networks: {
+        eth0: { rx_bytes: 1024, tx_bytes: 512 },
+      },
+    });
+  });
+
+  it('returns cpu, memory, and network metrics', async () => {
+    const result = await collectMetrics(1, 'abc123');
+
+    expect(result).toHaveProperty('cpu');
+    expect(result).toHaveProperty('memory');
+    expect(result).toHaveProperty('memoryBytes');
+    expect(result).toHaveProperty('networkRxBytes');
+    expect(result).toHaveProperty('networkTxBytes');
+    expect(result.cpu).toBeGreaterThanOrEqual(0);
+    expect(result.memory).toBeGreaterThanOrEqual(0);
+  });
+
+  it('wraps getContainerStats in cachedFetch with STATS TTL', async () => {
+    await collectMetrics(1, 'abc123');
+
+    expect(mockCachedFetch).toHaveBeenCalledTimes(1);
+    expect(mockCachedFetch).toHaveBeenCalledWith('stats:1:abc123', 60, expect.any(Function));
+  });
+
+  it('calls getContainerStats with correct endpoint and container IDs', async () => {
+    await collectMetrics(5, 'def456');
+
+    expect(mockGetContainerStats).toHaveBeenCalledWith(5, 'def456');
+    expect(mockCachedFetch).toHaveBeenCalledWith('stats:5:def456', 60, expect.any(Function));
+  });
+
+  it('computes network totals across multiple interfaces', async () => {
+    mockGetContainerStats.mockResolvedValue({
+      cpu_stats: {
+        cpu_usage: { total_usage: 200 },
+        system_cpu_usage: 1000,
+        online_cpus: 1,
+      },
+      precpu_stats: {
+        cpu_usage: { total_usage: 100 },
+        system_cpu_usage: 500,
+      },
+      memory_stats: {
+        usage: 1024,
+        limit: 4096,
+        stats: {},
+      },
+      networks: {
+        eth0: { rx_bytes: 100, tx_bytes: 50 },
+        eth1: { rx_bytes: 200, tx_bytes: 150 },
+      },
+    });
+
+    const result = await collectMetrics(1, 'multi-net');
+
+    expect(result.networkRxBytes).toBe(300);
+    expect(result.networkTxBytes).toBe(200);
+  });
+});

--- a/backend/src/services/metrics-collector.ts
+++ b/backend/src/services/metrics-collector.ts
@@ -1,4 +1,5 @@
 import { getContainerStats } from './portainer-client.js';
+import { cachedFetch, getCacheKey, TTL } from './portainer-cache.js';
 import { createChildLogger } from '../utils/logger.js';
 
 const log = createChildLogger('metrics-collector');
@@ -15,7 +16,11 @@ export async function collectMetrics(
   endpointId: number,
   containerId: string,
 ): Promise<CollectedMetrics> {
-  const stats = await getContainerStats(endpointId, containerId);
+  const stats = await cachedFetch(
+    getCacheKey('stats', endpointId, containerId),
+    TTL.STATS,
+    () => getContainerStats(endpointId, containerId),
+  );
 
   // CPU % calculation: (cpu_delta / system_delta) * num_cpus * 100
   const cpuDelta =


### PR DESCRIPTION
## Summary

- **#513**: ES log forwarder now caches `getEndpoints()`/`getContainers()` via `cachedFetchSWR` and increases the default poll interval from 5s to 30s (configurable via `ES_LOG_FORWARD_INTERVAL_MS` env var)
- **#514**: `getContainerStats()` is now wrapped in `cachedFetch` with the existing but previously unused `TTL.STATS` (60s) preset, eliminating redundant per-container API calls
- **#515**: Monitoring cycle and metrics scheduler now use `cachedFetchSWR` for `getEndpoints()`/`getContainers()`, sharing cache entries across services and eliminating duplicate stats collection

Collectively reduces unnecessary Portainer API calls by ~300–700/min.

Closes #513, Closes #514, Closes #515

## Test plan

- [x] All 19 tests pass across `elasticsearch-log-forwarder.test.ts`, `metrics-collector.test.ts`, `monitoring-service.test.ts`
- [x] New test: ES forwarder verifies `cachedFetchSWR` called with correct keys/TTLs
- [x] New test: metrics collector verifies `cachedFetch` called with `stats:{endpointId}:{containerId}` key and 60s TTL
- [x] New tests: monitoring service verifies `cachedFetchSWR` used for endpoints and per-endpoint containers
- [x] Full backend suite: 1319 passed, 5 pre-existing failures (unrelated)
- [x] Live verification: cache hit rate 65.4% after 2 cycles from cold start; `intervalMs: 30000` confirmed in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)