### PR TITLE
fix: container logs 404 + per-endpoint circuit breaker isolation

### DIFF
--- a/backend/src/routes/container-logs.test.ts
+++ b/backend/src/routes/container-logs.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
+import { containerLogsRoutes } from './container-logs.js';
+
+vi.mock('../services/portainer-client.js', () => ({
+  getContainerLogs: vi.fn(),
+}));
+
+vi.mock('../services/edge-capability-guard.js', () => ({
+  assertCapability: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import * as portainer from '../services/portainer-client.js';
+import { assertCapability } from '../services/edge-capability-guard.js';
+
+const mockGetContainerLogs = vi.mocked(portainer.getContainerLogs);
+const mockAssertCapability = vi.mocked(assertCapability);
+
+function buildApp() {
+  const app = Fastify();
+  app.setValidatorCompiler(validatorCompiler);
+  app.decorate('authenticate', async () => undefined);
+  app.register(containerLogsRoutes);
+  return app;
+}
+
+describe('container-logs routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns logs when endpoint supports realtimeLogs', async () => {
+    const app = buildApp();
+    mockAssertCapability.mockResolvedValue(undefined);
+    mockGetContainerLogs.mockResolvedValue('2024-01-01T00:00:00Z hello world\n');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/containers/1/abc123/logs',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.logs).toContain('hello world');
+    expect(body.endpointId).toBe(1);
+    expect(body.containerId).toBe('abc123');
+    expect(mockAssertCapability).toHaveBeenCalledWith(1, 'realtimeLogs');
+    await app.close();
+  });
+
+  it('returns 422 when endpoint lacks realtimeLogs capability', async () => {
+    const app = buildApp();
+    const err = new Error('Edge Async endpoints do not support "realtimeLogs" operations.');
+    (err as any).statusCode = 422;
+    mockAssertCapability.mockRejectedValue(err);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/containers/4/abc123/logs',
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = JSON.parse(res.body);
+    expect(body.error).toContain('realtimeLogs');
+    await app.close();
+  });
+
+  it('returns 502 when Docker proxy fails', async () => {
+    const app = buildApp();
+    mockAssertCapability.mockResolvedValue(undefined);
+    mockGetContainerLogs.mockRejectedValue(
+      new Error('Container logs unavailable — Docker daemon on this endpoint may be unreachable'),
+    );
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/containers/1/abc123/logs',
+    });
+
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body.error).toContain('Docker daemon');
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary

- **Capability guard on container-logs route**: Adds `assertCapability(endpointId, 'realtimeLogs')` before fetching logs, returning 422 for Edge Async endpoints and 502 for Docker proxy failures
- **Better Docker proxy error messages**: When Portainer returns 404 from its Docker proxy (daemon unreachable), `getContainerLogs()` and `startExec()` now throw descriptive "Docker daemon may be unreachable" errors with status 502 instead of raw 404
- **Per-endpoint circuit breaker**: Replaces the single global circuit breaker with a `Map<string, CircuitBreaker>` keyed by endpoint ID — prevents one failing endpoint (e.g. endpoint 69 returning 500) from cascading failures to all other endpoints
- **Skip Edge Async in search log calls**: Pre-checks `supportsLiveFeatures()` before fetching container logs in the search route to avoid pointless 404s

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test -w backend` — 108 files, 1367 tests passing
- [ ] New `container-logs.test.ts`: capability guard returns 422, Docker proxy failure returns 502, successful fetch works
- [ ] Extended `portainer-client.test.ts`: per-endpoint circuit breaker stats default state, reset clears breakers
- [ ] Deploy to staging, verify endpoint 4 (Edge Async) returns 422 instead of 404 on logs
- [ ] Verify endpoint 69 failures don't trip breakers for other endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)