### PR TITLE
fix: use Type===7 for Edge Async detection instead of QueryDate

### DIFF
--- a/backend/src/services/edge-capability-guard.test.ts
+++ b/backend/src/services/edge-capability-guard.test.ts
@@ -70,11 +70,10 @@ describe('edge-capability-guard', () => {
       });
     });
 
-    it('returns no capabilities for Edge Async endpoint', async () => {
+    it('returns no capabilities for Edge Async endpoint (Type 7)', async () => {
       mockGetEndpoint.mockResolvedValue(makeRawEndpoint({
-        Type: 4,
+        Type: 7,
         EdgeID: 'edge-async-456',
-        QueryDate: Math.floor(Date.now() / 1000) - 300,
         LastCheckInDate: Math.floor(Date.now() / 1000) - 120,
         EdgeCheckinInterval: 60,
       }) as any);
@@ -96,9 +95,8 @@ describe('edge-capability-guard', () => {
 
     it('throws 422 for Edge Async endpoint missing exec capability', async () => {
       mockGetEndpoint.mockResolvedValue(makeRawEndpoint({
-        Type: 4,
+        Type: 7,
         EdgeID: 'edge-async',
-        QueryDate: Math.floor(Date.now() / 1000),
         LastCheckInDate: Math.floor(Date.now() / 1000) - 120,
         EdgeCheckinInterval: 60,
       }) as any);
@@ -115,9 +113,8 @@ describe('edge-capability-guard', () => {
 
     it('throws 422 for each capability type on Edge Async', async () => {
       const asyncEndpoint = makeRawEndpoint({
-        Type: 4,
+        Type: 7,
         EdgeID: 'edge-async',
-        QueryDate: Math.floor(Date.now() / 1000),
         LastCheckInDate: Math.floor(Date.now() / 1000) - 120,
         EdgeCheckinInterval: 60,
       });
@@ -135,11 +132,10 @@ describe('edge-capability-guard', () => {
       expect(await supportsLiveFeatures(1)).toBe(true);
     });
 
-    it('returns false for Edge Async endpoint', async () => {
+    it('returns false for Edge Async endpoint (Type 7)', async () => {
       mockGetEndpoint.mockResolvedValue(makeRawEndpoint({
-        Type: 4,
+        Type: 7,
         EdgeID: 'edge-async',
-        QueryDate: Math.floor(Date.now() / 1000),
         LastCheckInDate: Math.floor(Date.now() / 1000) - 120,
         EdgeCheckinInterval: 60,
       }) as any);

--- a/backend/src/services/portainer-normalizers-edge.test.ts
+++ b/backend/src/services/portainer-normalizers-edge.test.ts
@@ -55,20 +55,35 @@ describe('normalizeEndpoint — Edge Agent fields', () => {
     expect(result.lastCheckIn).toBeDefined();
   });
 
-  it('returns edgeMode: "async" for Edge Async endpoint (QueryDate set)', () => {
+  it('returns edgeMode: "async" for Edge Async endpoint (Type 7)', () => {
     const ep = makeEndpoint({
-      Type: 4,
+      Type: 7,
       EdgeID: 'edge-async-456',
       EdgeKey: 'key456',
       LastCheckInDate: Math.floor(Date.now() / 1000) - 120,
       EdgeCheckinInterval: 60,
-      QueryDate: Math.floor(Date.now() / 1000) - 300,
-    } as any);
+    });
     const result = normalizeEndpoint(ep);
 
     expect(result.isEdge).toBe(true);
     expect(result.edgeMode).toBe('async');
     expect(result.checkInInterval).toBe(60);
+  });
+
+  it('returns edgeMode: "standard" for Type 4 Edge endpoint even with QueryDate set', () => {
+    const ep = makeEndpoint({
+      Type: 4,
+      EdgeID: 'edge-std-with-qd',
+      EdgeKey: 'key789',
+      LastCheckInDate: Math.floor(Date.now() / 1000) - 30,
+      EdgeCheckinInterval: 5,
+      QueryDate: Math.floor(Date.now() / 1000) - 300,
+    } as any);
+    const result = normalizeEndpoint(ep);
+
+    expect(result.isEdge).toBe(true);
+    expect(result.edgeMode).toBe('standard');
+    expect(result.capabilities.realtimeLogs).toBe(true);
   });
 
   it('computes snapshotAge from snapshot Time field', () => {
@@ -140,12 +155,11 @@ describe('normalizeEndpoint — Edge Agent fields', () => {
       });
     });
 
-    it('returns all false for Edge Async endpoint', () => {
+    it('returns all false for Edge Async endpoint (Type 7)', () => {
       const ep = makeEndpoint({
-        Type: 4,
+        Type: 7,
         EdgeID: 'edge-async',
-        QueryDate: Math.floor(Date.now() / 1000),
-      } as any);
+      });
       const result = normalizeEndpoint(ep);
       expect(result.capabilities).toEqual({
         exec: false,

--- a/backend/src/services/portainer-normalizers.ts
+++ b/backend/src/services/portainer-normalizers.ts
@@ -130,8 +130,12 @@ export function normalizeEndpoint(ep: Endpoint): NormalizedEndpoint {
   }
   const snapshot = ep.Snapshots?.[0];
   const raw = snapshot?.DockerSnapshotRaw;
+  // Portainer Type 7 = Edge Agent Async (poll-based, no Docker tunnel).
+  // Type 4 = Edge Agent Standard (persistent tunnel, supports live features).
+  // Previously we used QueryDate presence as a heuristic, but that field can
+  // also be set on standard edge agents, causing false negatives.
   const edgeMode: 'standard' | 'async' | null = isEdge
-    ? ((ep as Record<string, unknown>).QueryDate ? 'async' : 'standard')
+    ? (ep.Type === 7 ? 'async' : 'standard')
     : null;
   const snapshotTime = snapshot?.Time;
   const snapshotAge = snapshotTime ? Date.now() - snapshotTime * 1000 : null;


### PR DESCRIPTION
## Summary

- **Root cause**: Edge Async detection used `QueryDate` field presence as a heuristic, but Portainer also sets `QueryDate` on **standard** Edge agents (Type 4), causing all capabilities to be falsely disabled (logs, stats, exec all blocked)
- **Fix**: Use `ep.Type === 7` (Portainer's Edge Async type) instead of `QueryDate` — matching how Portainer itself and the [Streamlit dashboard](https://github.com/kenhaesler/streamlit-portainer-dashboard) distinguish async from standard edge agents
- **Impact**: Standard Edge agents (Type 4) with `QueryDate` set will no longer be incorrectly blocked from logs, stats, exec, and other live features

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test -w backend` — 108 files, 1368 tests passing
- [x] New test: Type 4 + QueryDate set → `edgeMode: 'standard'`, `realtimeLogs: true`
- [x] Updated tests: Edge Async tests now use Type 7
- [ ] Deploy and verify logs work on standard edge endpoints that were previously blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)