### PR TITLE
fix: cache Portainer API calls in security audit (closes #516)

### DIFF
--- a/backend/src/services/portainer-cache.ts
+++ b/backend/src/services/portainer-cache.ts
@@ -610,6 +610,7 @@ export const cache = new HybridCache();
 export const TTL = {
   ENDPOINTS: 900,    // 15 minutes
   CONTAINERS: 300,   // 5 minutes
+  CONTAINER_INSPECT: 300, // 5 minutes — host config changes very infrequently
   STACKS: 600,       // 10 minutes
   IMAGES: 600,       // 10 minutes
   NETWORKS: 600,     // 10 minutes


### PR DESCRIPTION
## Summary
Wraps the three uncached Portainer API calls in `getSecurityAudit()` with `cachedFetch()`, eliminating the N+1 call pattern that generated 1+E+C direct API calls per audit request.

Closes #516

## Root Cause
`getSecurityAudit()` called `getEndpoints()`, `getContainers()`, and `getContainerHostConfig()` directly without using the cache layer. With 3 endpoints and 20 containers, every dashboard page load triggered 24+ uncached Portainer API calls.

## Fix
- Wrap `getEndpoints()` with `cachedFetch()` using `TTL.ENDPOINTS` (15min)
- Wrap `getContainers()` with `cachedFetch()` using `TTL.CONTAINERS` (5min)
- Wrap `getContainerHostConfig()` with `cachedFetch()` using new `TTL.CONTAINER_INSPECT` (5min)
- Cache keys (`endpoints`, `containers:{id}`, `inspect:{epId}:{cId}`) are shared with dashboard and other consumers, so most calls become cache hits

## Changes
- `backend/src/services/portainer-cache.ts` — Add `CONTAINER_INSPECT: 300` TTL preset
- `backend/src/services/security-audit.ts` — Use `cachedFetch()` for all three Portainer API calls
- `backend/src/services/security-audit.test.ts` — Mock cache module, add test verifying correct cache keys and TTLs

## Testing
- [x] Regression test added: verifies `cachedFetch` called with correct keys/TTLs
- [x] All 8 security-audit service tests pass
- [x] All 4 security-audit route tests pass
- [x] Full backend suite passes (108 files, 1369 tests)
- [x] TypeScript typecheck passes

## Rollback Plan
Revert this PR: `git revert <merge-commit-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)