### PR TITLE
fix: route image staleness getImages() through cache layer (closes #517)

### DIFF
--- a/backend/src/scheduler/setup.test.ts
+++ b/backend/src/scheduler/setup.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const cachedFetchSWRSpy = vi.fn((_key: string, _ttl: number, fetcher: () => Promise<unknown>) =>
+  fetcher(),
+);
+
+vi.mock('../services/portainer-cache.js', () => ({
+  cachedFetchSWR: (...args: unknown[]) =>
+    cachedFetchSWRSpy(args[0] as string, args[1] as number, args[2] as () => Promise<unknown>),
+  getCacheKey: (...args: unknown[]) => args.join(':'),
+  TTL: { ENDPOINTS: 900, CONTAINERS: 300, IMAGES: 600 },
+}));
+
+const getEndpointsMock = vi.fn().mockResolvedValue([{ Id: 1, Name: 'local' }]);
+const getImagesMock = vi.fn().mockResolvedValue([
+  { Id: 'sha256:abc123', RepoTags: ['nginx:latest'] },
+]);
+
+vi.mock('../services/portainer-client.js', () => ({
+  getEndpoints: (...args: unknown[]) => getEndpointsMock(...args),
+  getContainers: vi.fn().mockResolvedValue([]),
+  getImages: (...args: unknown[]) => getImagesMock(...args),
+}));
+
+vi.mock('../services/image-staleness.js', () => ({
+  runStalenessChecks: vi.fn().mockResolvedValue({ checked: 1, stale: 0 }),
+}));
+
+vi.mock('../config/index.js', () => ({
+  getConfig: () => ({
+    CACHE_ENABLED: true,
+    METRICS_COLLECTION_ENABLED: false,
+    MONITORING_ENABLED: false,
+    WEBHOOKS_ENABLED: false,
+    IMAGE_STALENESS_CHECK_ENABLED: false,
+    METRICS_RETENTION_DAYS: 30,
+  }),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('../services/monitoring-service.js', () => ({ runMonitoringCycle: vi.fn() }));
+vi.mock('../services/metrics-collector.js', () => ({ collectMetrics: vi.fn() }));
+vi.mock('../services/metrics-store.js', () => ({ insertMetrics: vi.fn(), cleanOldMetrics: vi.fn() }));
+vi.mock('../services/pcap-service.js', () => ({ cleanupOldCaptures: vi.fn() }));
+vi.mock('../services/portainer-backup.js', () => ({
+  createPortainerBackup: vi.fn(),
+  cleanupOldPortainerBackups: vi.fn(),
+}));
+vi.mock('../services/settings-store.js', () => ({ getSetting: vi.fn().mockReturnValue(null) }));
+vi.mock('../services/webhook-service.js', () => ({
+  startWebhookListener: vi.fn(),
+  stopWebhookListener: vi.fn(),
+  processRetries: vi.fn(),
+}));
+vi.mock('../services/kpi-store.js', () => ({
+  insertKpiSnapshot: vi.fn(),
+  cleanOldKpiSnapshots: vi.fn(),
+}));
+vi.mock('../services/portainer-normalizers.js', () => ({ normalizeEndpoint: vi.fn() }));
+vi.mock('../services/trace-context.js', () => ({ runWithTraceContext: vi.fn() }));
+vi.mock('../services/elasticsearch-log-forwarder.js', () => ({
+  startElasticsearchLogForwarder: vi.fn(),
+  stopElasticsearchLogForwarder: vi.fn(),
+}));
+
+import { runImageStalenessCheck } from './setup.js';
+
+describe('scheduler/setup – runImageStalenessCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses cachedFetchSWR for getEndpoints with TTL.ENDPOINTS', async () => {
+    await runImageStalenessCheck();
+
+    const endpointsCall = cachedFetchSWRSpy.mock.calls.find(
+      (call) => call[0] === 'endpoints',
+    );
+    expect(endpointsCall).toBeDefined();
+    expect(endpointsCall![1]).toBe(900); // TTL.ENDPOINTS
+  });
+
+  it('uses cachedFetchSWR for getImages with TTL.IMAGES', async () => {
+    await runImageStalenessCheck();
+
+    const imagesCall = cachedFetchSWRSpy.mock.calls.find(
+      (call) => (call[0] as string).startsWith('images:'),
+    );
+    expect(imagesCall).toBeDefined();
+    expect(imagesCall![0]).toBe('images:1'); // getCacheKey('images', ep.Id)
+    expect(imagesCall![1]).toBe(600); // TTL.IMAGES
+  });
+
+  it('does not call getImages directly (bypassing cache)', async () => {
+    await runImageStalenessCheck();
+
+    // getImages should only be called as a fetcher inside cachedFetchSWR
+    expect(getImagesMock).toHaveBeenCalledTimes(1);
+    expect(getImagesMock).toHaveBeenCalledWith(1);
+
+    // Verify all Portainer API calls went through cachedFetchSWR
+    // One call for endpoints + one for images per endpoint = 2 total
+    expect(cachedFetchSWRSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls cachedFetchSWR for images per endpoint', async () => {
+    getEndpointsMock.mockResolvedValueOnce([
+      { Id: 1, Name: 'local' },
+      { Id: 2, Name: 'remote' },
+    ]);
+
+    await runImageStalenessCheck();
+
+    // 1 for endpoints + 2 for images (one per endpoint)
+    expect(cachedFetchSWRSpy).toHaveBeenCalledTimes(3);
+
+    const imagesCalls = cachedFetchSWRSpy.mock.calls.filter(
+      (call) => (call[0] as string).startsWith('images:'),
+    );
+    expect(imagesCalls).toHaveLength(2);
+    expect(imagesCalls[0][0]).toBe('images:1');
+    expect(imagesCalls[1][0]).toBe('images:2');
+  });
+});

--- a/backend/src/scheduler/setup.ts
+++ b/backend/src/scheduler/setup.ts
@@ -168,7 +168,7 @@ async function runMonitoringWithErrorHandling(): Promise<void> {
   }
 }
 
-async function runImageStalenessCheck(): Promise<void> {
+export async function runImageStalenessCheck(): Promise<void> {
   log.debug('Running image staleness check');
   try {
     const endpoints = await cachedFetchSWR(
@@ -180,7 +180,11 @@ async function runImageStalenessCheck(): Promise<void> {
 
     for (const ep of endpoints) {
       try {
-        const images = await getImages(ep.Id);
+        const images = await cachedFetchSWR(
+          getCacheKey('images', ep.Id),
+          TTL.IMAGES,
+          () => getImages(ep.Id),
+        );
         for (const img of images) {
           const tags = img.RepoTags?.filter((t: string) => t !== '<none>:<none>') ?? [];
           const firstTag = tags[0] || '<none>';


### PR DESCRIPTION
## Summary
The image staleness check in the scheduler called `getImages()` directly per endpoint, bypassing the cache layer. This wraps it with `cachedFetchSWR()` using `TTL.IMAGES` (600s) so the staleness check benefits from cache hits when other services have recently fetched the same data.

Closes #517

## Root Cause
In `backend/src/scheduler/setup.ts`, `runImageStalenessCheck()` called `getImages(ep.Id)` directly instead of going through the cache layer, despite `TTL.IMAGES` already being defined.

## Fix
Wrapped the `getImages(ep.Id)` call with `cachedFetchSWR(getCacheKey('images', ep.Id), TTL.IMAGES, () => getImages(ep.Id))` — matching the pattern already used for `getEndpoints()` in the same function.

## Changes
- `backend/src/scheduler/setup.ts` — Wrapped `getImages()` with `cachedFetchSWR()` using `TTL.IMAGES`; exported `runImageStalenessCheck` for testability
- `backend/src/scheduler/setup.test.ts` — New test file (4 tests) verifying all Portainer API calls in the staleness check go through the cache layer

## Testing
- [x] Regression test added: `backend/src/scheduler/setup.test.ts`
- [x] Full backend test suite passes (4 pre-existing failures unrelated to this change)
- [x] TypeScript typecheck passes
- [x] No debug artifacts or secrets in diff

## Rollback Plan
Revert this PR: `git revert <merge-commit-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)