### PR TITLE
fix: login typewriter shows full 'POWERED BY AI' text (closes #465)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1325,12 +1325,12 @@ input.input-solid-bg:focus {
 
 .login-typewriter {
   margin-inline: auto;
-  width: 18ch;
+  width: 22ch;
   overflow: hidden;
   white-space: nowrap;
   border-right: 2px solid color-mix(in oklab, var(--color-foreground) 60%, transparent);
   animation:
-    login-typewriter 1s steps(18, end) 260ms both,
+    login-typewriter 1s steps(13, end) 260ms both,
     login-cursor 900ms step-end infinite;
 }
 
@@ -1484,7 +1484,7 @@ input.input-solid-bg:focus {
     width: 0;
   }
   to {
-    width: 18ch;
+    width: 22ch;
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes the login page typewriter animation clipping the final "I" in "POWERED BY AI".

Closes #465

## Root Cause
The `.login-typewriter` CSS class used `width: 18ch` which didn't account for the `0.24em` letter-spacing applied via `tracking-[0.24em]` on the subtitle. The extra spacing caused the rendered text to exceed the container width, and `overflow: hidden` clipped the last character.

## Fix
- Increased container/animation width from `18ch` → `22ch` to accommodate letter-spacing
- Corrected `steps(18, end)` → `steps(13, end)` to match the actual 13-character string ("POWERED BY AI"), giving a cleaner one-character-per-step typewriter effect

## Changes
- `frontend/src/index.css` — `.login-typewriter` width + steps count, `@keyframes login-typewriter` target width

## Testing
- [x] Full text "POWERED BY AI" visible after animation completes
- [x] Login page tests pass (3/3)
- [x] Full frontend test suite passes (915/916 — 1 pre-existing unrelated failure in `use-container-logs.test.ts`)
- [x] No debug artifacts or secrets in diff

## Rollback Plan
Revert this PR: `git revert <merge-commit-sha>`