### PR TITLE
feat: Edge Async log collection via Edge Jobs (Phase 2)

### DIFF
--- a/backend/src/models/portainer.ts
+++ b/backend/src/models/portainer.ts
@@ -153,6 +153,15 @@ export const EdgeJobSchema = z.object({
   })).optional(),
 }).passthrough();
 
+export const EdgeJobTaskSchema = z.object({
+  Id: z.string(),
+  EndpointId: z.number(),
+  LogsStatus: z.number().optional(),
+  CollectLogs: z.boolean().optional(),
+}).passthrough();
+
+export const EdgeJobTaskArraySchema = z.array(EdgeJobTaskSchema);
+
 // Pre-compiled array schemas (parsed once at module level for Zod internal caching)
 export const EndpointArraySchema = z.array(EndpointSchema);
 export const ContainerArraySchema = z.array(ContainerSchema);
@@ -168,3 +177,4 @@ export type ContainerStats = z.infer<typeof ContainerStatsSchema>;
 export type Network = z.infer<typeof NetworkSchema>;
 export type DockerImage = z.infer<typeof ImageSchema>;
 export type EdgeJob = z.infer<typeof EdgeJobSchema>;
+export type EdgeJobTask = z.infer<typeof EdgeJobTaskSchema>;

--- a/backend/src/routes/container-logs.test.ts
+++ b/backend/src/routes/container-logs.test.ts
@@ -14,6 +14,14 @@ vi.mock('../services/edge-log-fetcher.js', () => ({
 vi.mock('../services/edge-capability-guard.js', () => ({
   assertCapability: vi.fn(),
   isEdgeStandard: vi.fn(),
+  isEdgeAsync: vi.fn(),
+}));
+
+vi.mock('../services/edge-async-log-fetcher.js', () => ({
+  initiateEdgeAsyncLogCollection: vi.fn(),
+  checkEdgeJobStatus: vi.fn(),
+  retrieveEdgeJobLogs: vi.fn(),
+  cleanupEdgeJob: vi.fn(),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -27,12 +35,23 @@ vi.mock('../utils/logger.js', () => ({
 
 import * as portainer from '../services/portainer-client.js';
 import { getContainerLogsWithRetry } from '../services/edge-log-fetcher.js';
-import { assertCapability, isEdgeStandard } from '../services/edge-capability-guard.js';
+import { assertCapability, isEdgeStandard, isEdgeAsync } from '../services/edge-capability-guard.js';
+import {
+  initiateEdgeAsyncLogCollection,
+  checkEdgeJobStatus,
+  retrieveEdgeJobLogs,
+  cleanupEdgeJob,
+} from '../services/edge-async-log-fetcher.js';
 
 const mockGetContainerLogs = vi.mocked(portainer.getContainerLogs);
 const mockGetContainerLogsWithRetry = vi.mocked(getContainerLogsWithRetry);
 const mockAssertCapability = vi.mocked(assertCapability);
 const mockIsEdgeStandard = vi.mocked(isEdgeStandard);
+const mockIsEdgeAsync = vi.mocked(isEdgeAsync);
+const mockInitiateCollection = vi.mocked(initiateEdgeAsyncLogCollection);
+const mockCheckStatus = vi.mocked(checkEdgeJobStatus);
+const mockRetrieveLogs = vi.mocked(retrieveEdgeJobLogs);
+const mockCleanup = vi.mocked(cleanupEdgeJob);
 
 function buildApp() {
   const app = Fastify();
@@ -46,6 +65,8 @@ describe('container-logs routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  // ─── Existing GET /logs tests ────────────────────────────────────
 
   it('returns logs when endpoint supports realtimeLogs (non-edge)', async () => {
     const app = buildApp();
@@ -159,6 +180,83 @@ describe('container-logs routes', () => {
     expect(res.statusCode).toBe(200);
     expect(mockGetContainerLogs).toHaveBeenCalled();
     expect(mockGetContainerLogsWithRetry).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  // ─── POST /logs/collect tests ────────────────────────────────────
+
+  it('POST /logs/collect returns 202 with jobId for Edge Async endpoint', async () => {
+    const app = buildApp();
+    mockIsEdgeAsync.mockResolvedValue(true);
+    mockInitiateCollection.mockResolvedValue({ jobId: 42, endpointId: 7, containerId: 'abc123' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/containers/7/abc123/logs/collect',
+    });
+
+    expect(res.statusCode).toBe(202);
+    const body = JSON.parse(res.body);
+    expect(body.jobId).toBe(42);
+    expect(body.status).toBe('collecting');
+    expect(mockInitiateCollection).toHaveBeenCalledWith(7, 'abc123', { tail: undefined });
+    await app.close();
+  });
+
+  it('POST /logs/collect returns 400 for non-Edge-Async endpoint', async () => {
+    const app = buildApp();
+    mockIsEdgeAsync.mockResolvedValue(false);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/containers/1/abc123/logs/collect',
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error).toContain('not Edge Async');
+    expect(mockInitiateCollection).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  // ─── GET /logs/collect/:jobId tests ──────────────────────────────
+
+  it('GET /logs/collect/:jobId returns 200 with logs when ready', async () => {
+    const app = buildApp();
+    mockCheckStatus.mockResolvedValue({ ready: true, taskId: 'task-1' });
+    mockRetrieveLogs.mockResolvedValue('collected log output\n');
+    mockCleanup.mockResolvedValue(undefined);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/containers/7/abc123/logs/collect/42',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.logs).toBe('collected log output\n');
+    expect(body.containerId).toBe('abc123');
+    expect(body.endpointId).toBe(7);
+    expect(body.source).toBe('edge-job');
+    expect(typeof body.durationMs).toBe('number');
+    expect(mockCleanup).toHaveBeenCalledWith(42);
+    await app.close();
+  });
+
+  it('GET /logs/collect/:jobId returns 202 when still collecting', async () => {
+    const app = buildApp();
+    mockCheckStatus.mockResolvedValue({ ready: false });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/containers/7/abc123/logs/collect/42',
+    });
+
+    expect(res.statusCode).toBe(202);
+    const body = JSON.parse(res.body);
+    expect(body.jobId).toBe(42);
+    expect(body.status).toBe('collecting');
+    expect(mockRetrieveLogs).not.toHaveBeenCalled();
     await app.close();
   });
 });

--- a/backend/src/routes/container-logs.ts
+++ b/backend/src/routes/container-logs.ts
@@ -1,13 +1,27 @@
 import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
 import * as portainer from '../services/portainer-client.js';
 import { getContainerLogsWithRetry } from '../services/edge-log-fetcher.js';
 import { ContainerParamsSchema, ContainerLogsQuerySchema } from '../models/api-schemas.js';
-import { assertCapability, isEdgeStandard } from '../services/edge-capability-guard.js';
+import { assertCapability, isEdgeStandard, isEdgeAsync } from '../services/edge-capability-guard.js';
+import {
+  initiateEdgeAsyncLogCollection,
+  checkEdgeJobStatus,
+  retrieveEdgeJobLogs,
+  cleanupEdgeJob,
+} from '../services/edge-async-log-fetcher.js';
 import { createChildLogger } from '../utils/logger.js';
 
 const log = createChildLogger('container-logs-route');
 
+const CollectJobIdParamsSchema = z.object({
+  endpointId: z.coerce.number(),
+  containerId: z.string(),
+  jobId: z.coerce.number(),
+});
+
 export async function containerLogsRoutes(fastify: FastifyInstance) {
+  // Existing: GET live container logs (rejects Edge Async with 422)
   fastify.get('/api/containers/:endpointId/:containerId/logs', {
     schema: {
       tags: ['Containers'],
@@ -58,6 +72,91 @@ export async function containerLogsRoutes(fastify: FastifyInstance) {
       }
       const message = err instanceof Error ? err.message : 'Failed to fetch container logs';
       log.error({ err, endpointId, containerId }, 'Failed to fetch container logs');
+      return reply.status(502).send({ error: message });
+    }
+  });
+
+  // POST: Initiate Edge Async log collection via Edge Job
+  fastify.post('/api/containers/:endpointId/:containerId/logs/collect', {
+    schema: {
+      tags: ['Containers'],
+      summary: 'Initiate async log collection for Edge Async endpoints',
+      security: [{ bearerAuth: [] }],
+      params: ContainerParamsSchema,
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const { endpointId, containerId } = request.params as {
+      endpointId: number;
+      containerId: string;
+    };
+    const body = request.body as { tail?: number } | undefined;
+
+    try {
+      const edgeAsync = await isEdgeAsync(endpointId);
+      if (!edgeAsync) {
+        return reply.status(400).send({
+          error: 'This endpoint is not Edge Async. Use the standard logs endpoint.',
+        });
+      }
+
+      const handle = await initiateEdgeAsyncLogCollection(endpointId, containerId, {
+        tail: body?.tail,
+      });
+
+      return reply.status(202).send({
+        jobId: handle.jobId,
+        status: 'collecting',
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to initiate log collection';
+      log.error({ err, endpointId, containerId }, 'Failed to initiate async log collection');
+      return reply.status(502).send({ error: message });
+    }
+  });
+
+  // GET: Poll for Edge Job log collection status / retrieve results
+  fastify.get('/api/containers/:endpointId/:containerId/logs/collect/:jobId', {
+    schema: {
+      tags: ['Containers'],
+      summary: 'Check async log collection status or retrieve results',
+      security: [{ bearerAuth: [] }],
+      params: CollectJobIdParamsSchema,
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const { endpointId, containerId, jobId } = request.params as {
+      endpointId: number;
+      containerId: string;
+      jobId: number;
+    };
+
+    const startTime = Date.now();
+
+    try {
+      const handle = { jobId, endpointId, containerId };
+      const status = await checkEdgeJobStatus(handle);
+
+      if (!status.ready || !status.taskId) {
+        return reply.status(202).send({
+          jobId,
+          status: 'collecting',
+        });
+      }
+
+      const logs = await retrieveEdgeJobLogs(jobId, status.taskId);
+      await cleanupEdgeJob(jobId);
+
+      return reply.status(200).send({
+        logs,
+        containerId,
+        endpointId,
+        durationMs: Date.now() - startTime,
+        source: 'edge-job',
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to retrieve logs';
+      log.error({ err, endpointId, containerId, jobId }, 'Failed to check/retrieve async logs');
       return reply.status(502).send({ error: message });
     }
   });

--- a/backend/src/services/edge-async-log-fetcher.test.ts
+++ b/backend/src/services/edge-async-log-fetcher.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./portainer-client.js', () => ({
+  createEdgeJob: vi.fn(),
+  getEdgeJobTasks: vi.fn(),
+  collectEdgeJobTaskLogs: vi.fn(),
+  getEdgeJobTaskLogs: vi.fn(),
+  deleteEdgeJob: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import * as portainer from './portainer-client.js';
+import {
+  initiateEdgeAsyncLogCollection,
+  checkEdgeJobStatus,
+  retrieveEdgeJobLogs,
+  cleanupEdgeJob,
+  getEdgeAsyncContainerLogs,
+} from './edge-async-log-fetcher.js';
+
+const mockCreateEdgeJob = vi.mocked(portainer.createEdgeJob);
+const mockGetEdgeJobTasks = vi.mocked(portainer.getEdgeJobTasks);
+const mockCollectEdgeJobTaskLogs = vi.mocked(portainer.collectEdgeJobTaskLogs);
+const mockGetEdgeJobTaskLogs = vi.mocked(portainer.getEdgeJobTaskLogs);
+const mockDeleteEdgeJob = vi.mocked(portainer.deleteEdgeJob);
+
+describe('edge-async-log-fetcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('initiateEdgeAsyncLogCollection', () => {
+    it('creates an Edge Job with correct script and config', async () => {
+      mockCreateEdgeJob.mockResolvedValue({
+        Id: 42,
+        Created: Date.now(),
+        CronExpression: '0 0 1 1 *',
+        Name: 'ci-logs-test',
+        Recurring: false,
+      });
+
+      const handle = await initiateEdgeAsyncLogCollection(5, 'abc123def456', { tail: 200 });
+
+      expect(handle).toEqual({ jobId: 42, endpointId: 5, containerId: 'abc123def456' });
+      expect(mockCreateEdgeJob).toHaveBeenCalledWith({
+        name: expect.stringMatching(/^ci-logs-abc123def456-\d+$/),
+        cronExpression: '0 0 1 1 *',
+        recurring: false,
+        endpoints: [5],
+        fileContent: '#!/bin/sh\ndocker logs --tail 200 --timestamps abc123def456 2>&1',
+      });
+    });
+
+    it('defaults to tail 100 when not specified', async () => {
+      mockCreateEdgeJob.mockResolvedValue({
+        Id: 1,
+        Created: Date.now(),
+        CronExpression: '0 0 1 1 *',
+        Name: 'ci-logs-test',
+        Recurring: false,
+      });
+
+      await initiateEdgeAsyncLogCollection(1, 'container1');
+
+      expect(mockCreateEdgeJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileContent: expect.stringContaining('--tail 100'),
+        }),
+      );
+    });
+  });
+
+  describe('checkEdgeJobStatus', () => {
+    it('returns ready=true with taskId when LogsStatus is 2', async () => {
+      mockGetEdgeJobTasks.mockResolvedValue([
+        { Id: 'task-1', EndpointId: 5, LogsStatus: 2 },
+      ]);
+
+      const result = await checkEdgeJobStatus({ jobId: 42, endpointId: 5, containerId: 'abc' });
+
+      expect(result).toEqual({ ready: true, taskId: 'task-1' });
+    });
+
+    it('returns ready=false when LogsStatus is not 2', async () => {
+      mockGetEdgeJobTasks.mockResolvedValue([
+        { Id: 'task-1', EndpointId: 5, LogsStatus: 1 },
+      ]);
+
+      const result = await checkEdgeJobStatus({ jobId: 42, endpointId: 5, containerId: 'abc' });
+
+      expect(result).toEqual({ ready: false });
+    });
+
+    it('returns ready=false when no task matches endpointId', async () => {
+      mockGetEdgeJobTasks.mockResolvedValue([
+        { Id: 'task-1', EndpointId: 99, LogsStatus: 2 },
+      ]);
+
+      const result = await checkEdgeJobStatus({ jobId: 42, endpointId: 5, containerId: 'abc' });
+
+      expect(result).toEqual({ ready: false });
+    });
+
+    it('returns ready=false when task list is empty', async () => {
+      mockGetEdgeJobTasks.mockResolvedValue([]);
+
+      const result = await checkEdgeJobStatus({ jobId: 42, endpointId: 5, containerId: 'abc' });
+
+      expect(result).toEqual({ ready: false });
+    });
+  });
+
+  describe('retrieveEdgeJobLogs', () => {
+    it('triggers collection then retrieves text', async () => {
+      mockCollectEdgeJobTaskLogs.mockResolvedValue(undefined);
+      mockGetEdgeJobTaskLogs.mockResolvedValue('2024-01-01T00:00:00Z log line 1\n');
+
+      const logs = await retrieveEdgeJobLogs(42, 'task-1');
+
+      expect(mockCollectEdgeJobTaskLogs).toHaveBeenCalledWith(42, 'task-1');
+      expect(mockGetEdgeJobTaskLogs).toHaveBeenCalledWith(42, 'task-1');
+      expect(logs).toContain('log line 1');
+    });
+  });
+
+  describe('cleanupEdgeJob', () => {
+    it('calls deleteEdgeJob', async () => {
+      mockDeleteEdgeJob.mockResolvedValue(undefined);
+
+      await cleanupEdgeJob(42);
+
+      expect(mockDeleteEdgeJob).toHaveBeenCalledWith(42);
+    });
+
+    it('warns but does not throw on failure', async () => {
+      mockDeleteEdgeJob.mockRejectedValue(new Error('Not found'));
+
+      await expect(cleanupEdgeJob(42)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getEdgeAsyncContainerLogs', () => {
+    it('completes full lifecycle: initiate, poll, retrieve, cleanup', async () => {
+      mockCreateEdgeJob.mockResolvedValue({
+        Id: 42,
+        Created: Date.now(),
+        CronExpression: '0 0 1 1 *',
+        Name: 'test',
+        Recurring: false,
+      });
+
+      // First poll: not ready; second poll: ready
+      mockGetEdgeJobTasks
+        .mockResolvedValueOnce([{ Id: 'task-1', EndpointId: 5, LogsStatus: 1 }])
+        .mockResolvedValueOnce([{ Id: 'task-1', EndpointId: 5, LogsStatus: 2 }]);
+
+      mockCollectEdgeJobTaskLogs.mockResolvedValue(undefined);
+      mockGetEdgeJobTaskLogs.mockResolvedValue('collected logs\n');
+      mockDeleteEdgeJob.mockResolvedValue(undefined);
+
+      const logs = await getEdgeAsyncContainerLogs(5, 'abc123', {
+        tail: 50,
+        maxWaitMs: 15000,
+        pollIntervalMs: 10,
+      });
+
+      expect(logs).toBe('collected logs\n');
+      expect(mockCreateEdgeJob).toHaveBeenCalledTimes(1);
+      expect(mockGetEdgeJobTasks).toHaveBeenCalledTimes(2);
+      expect(mockCollectEdgeJobTaskLogs).toHaveBeenCalledTimes(1);
+      expect(mockDeleteEdgeJob).toHaveBeenCalledWith(42);
+    });
+
+    it('throws on timeout and still cleans up', async () => {
+      mockCreateEdgeJob.mockResolvedValue({
+        Id: 99,
+        Created: Date.now(),
+        CronExpression: '0 0 1 1 *',
+        Name: 'test',
+        Recurring: false,
+      });
+
+      mockGetEdgeJobTasks.mockResolvedValue([
+        { Id: 'task-1', EndpointId: 5, LogsStatus: 1 },
+      ]);
+      mockDeleteEdgeJob.mockResolvedValue(undefined);
+
+      await expect(
+        getEdgeAsyncContainerLogs(5, 'abc123', { maxWaitMs: 50, pollIntervalMs: 10 }),
+      ).rejects.toThrow(/timed out/);
+
+      expect(mockDeleteEdgeJob).toHaveBeenCalledWith(99);
+    });
+
+    it('cleans up even when retrieval fails', async () => {
+      mockCreateEdgeJob.mockResolvedValue({
+        Id: 77,
+        Created: Date.now(),
+        CronExpression: '0 0 1 1 *',
+        Name: 'test',
+        Recurring: false,
+      });
+
+      mockGetEdgeJobTasks.mockResolvedValue([
+        { Id: 'task-1', EndpointId: 5, LogsStatus: 2 },
+      ]);
+      mockCollectEdgeJobTaskLogs.mockRejectedValue(new Error('Collection failed'));
+      mockDeleteEdgeJob.mockResolvedValue(undefined);
+
+      await expect(
+        getEdgeAsyncContainerLogs(5, 'abc123', { maxWaitMs: 5000, pollIntervalMs: 10 }),
+      ).rejects.toThrow('Collection failed');
+
+      expect(mockDeleteEdgeJob).toHaveBeenCalledWith(77);
+    });
+  });
+});

--- a/backend/src/services/edge-async-log-fetcher.ts
+++ b/backend/src/services/edge-async-log-fetcher.ts
@@ -1,0 +1,118 @@
+import * as portainer from './portainer-client.js';
+import { createChildLogger } from '../utils/logger.js';
+
+const log = createChildLogger('edge-async-log-fetcher');
+
+export interface EdgeAsyncLogHandle {
+  jobId: number;
+  endpointId: number;
+  containerId: string;
+}
+
+export interface EdgeAsyncLogOptions {
+  tail?: number;
+}
+
+export interface EdgeJobStatusResult {
+  ready: boolean;
+  taskId?: string;
+}
+
+/**
+ * Create an Edge Job that runs `docker logs` on the agent.
+ * Returns a handle for subsequent status checks and log retrieval.
+ */
+export async function initiateEdgeAsyncLogCollection(
+  endpointId: number,
+  containerId: string,
+  opts: EdgeAsyncLogOptions = {},
+): Promise<EdgeAsyncLogHandle> {
+  const tail = opts.tail ?? 100;
+  const script = `#!/bin/sh\ndocker logs --tail ${tail} --timestamps ${containerId} 2>&1`;
+  const name = `ci-logs-${containerId.slice(0, 12)}-${Date.now()}`;
+
+  log.info({ endpointId, containerId, tail, name }, 'Creating Edge Job for async log collection');
+
+  const job = await portainer.createEdgeJob({
+    name,
+    cronExpression: '0 0 1 1 *',
+    recurring: false,
+    endpoints: [endpointId],
+    fileContent: script,
+  });
+
+  return { jobId: job.Id, endpointId, containerId };
+}
+
+/**
+ * Check whether the Edge Job task has completed and logs are available.
+ * LogsStatus === 2 means logs are collected and ready for retrieval.
+ */
+export async function checkEdgeJobStatus(handle: EdgeAsyncLogHandle): Promise<EdgeJobStatusResult> {
+  const tasks = await portainer.getEdgeJobTasks(handle.jobId);
+  const task = tasks.find((t) => t.EndpointId === handle.endpointId);
+
+  if (!task) {
+    return { ready: false };
+  }
+
+  if (task.LogsStatus === 2) {
+    return { ready: true, taskId: task.Id };
+  }
+
+  return { ready: false };
+}
+
+/**
+ * Trigger log collection on a completed task and retrieve the log text.
+ */
+export async function retrieveEdgeJobLogs(jobId: number, taskId: string): Promise<string> {
+  await portainer.collectEdgeJobTaskLogs(jobId, taskId);
+  return await portainer.getEdgeJobTaskLogs(jobId, taskId);
+}
+
+/**
+ * Delete the Edge Job. Logs a warning on failure but does not throw.
+ */
+export async function cleanupEdgeJob(jobId: number): Promise<void> {
+  try {
+    await portainer.deleteEdgeJob(jobId);
+    log.info({ jobId }, 'Cleaned up Edge Job');
+  } catch (err) {
+    log.warn({ jobId, err }, 'Failed to clean up Edge Job');
+  }
+}
+
+/**
+ * Blocking convenience function: initiate log collection, poll until ready,
+ * retrieve logs, and clean up. Suitable for LLM tool calls where blocking is acceptable.
+ * Max wait: 120s (configurable via maxWaitMs).
+ */
+export async function getEdgeAsyncContainerLogs(
+  endpointId: number,
+  containerId: string,
+  opts: EdgeAsyncLogOptions & { maxWaitMs?: number; pollIntervalMs?: number } = {},
+): Promise<string> {
+  const { maxWaitMs = 120000, pollIntervalMs = 5000, ...logOpts } = opts;
+  const handle = await initiateEdgeAsyncLogCollection(endpointId, containerId, logOpts);
+
+  try {
+    const deadline = Date.now() + maxWaitMs;
+
+    while (Date.now() < deadline) {
+      const status = await checkEdgeJobStatus(handle);
+      if (status.ready && status.taskId) {
+        const logs = await retrieveEdgeJobLogs(handle.jobId, status.taskId);
+        return logs;
+      }
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await new Promise((resolve) => setTimeout(resolve, Math.min(pollIntervalMs, remaining)));
+    }
+
+    throw new Error(`Edge Job log collection timed out after ${maxWaitMs}ms`);
+  } finally {
+    await cleanupEdgeJob(handle.jobId);
+  }
+}

--- a/backend/src/services/edge-capability-guard.ts
+++ b/backend/src/services/edge-capability-guard.ts
@@ -76,3 +76,21 @@ export async function isEdgeStandard(endpointId: number): Promise<boolean> {
     return false;
   }
 }
+
+/**
+ * Check if an endpoint is Edge Async (Type 7 — no Docker tunnel).
+ * These endpoints require Edge Jobs for log retrieval.
+ */
+export async function isEdgeAsync(endpointId: number): Promise<boolean> {
+  try {
+    const raw = await cachedFetchSWR(
+      getCacheKey('endpoint', endpointId),
+      TTL.ENDPOINTS,
+      () => getEndpoint(endpointId),
+    );
+    const norm = normalizeEndpoint(raw);
+    return norm.edgeMode === 'async';
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/hooks/use-edge-async-logs.test.ts
+++ b/frontend/src/hooks/use-edge-async-logs.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useEdgeAsyncLogs } from './use-edge-async-logs';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+import { api } from '@/lib/api';
+
+const mockApi = vi.mocked(api);
+
+describe('useEdgeAsyncLogs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts in idle state', () => {
+    const { result } = renderHook(() => useEdgeAsyncLogs(7, 'abc123'));
+    expect(result.current.status).toBe('idle');
+    expect(result.current.logs).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('transitions idle → initiating → collecting → complete', async () => {
+    mockApi.post.mockResolvedValue({ jobId: 42, status: 'collecting' });
+    mockApi.get.mockResolvedValue({
+      logs: 'collected output\n',
+      containerId: 'abc123',
+      endpointId: 7,
+      durationMs: 15000,
+      source: 'edge-job',
+    });
+
+    const { result } = renderHook(() => useEdgeAsyncLogs(7, 'abc123'));
+
+    // Trigger collection
+    await act(async () => {
+      result.current.collect({ tail: 100 });
+    });
+
+    // After POST resolves, should be 'collecting'
+    expect(result.current.status).toBe('collecting');
+
+    // Advance timer to trigger first poll (async-aware)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(result.current.status).toBe('complete');
+    expect(result.current.logs).toBe('collected output\n');
+    expect(result.current.durationMs).toBe(15000);
+  });
+
+  it('sets error state on initiation failure', async () => {
+    mockApi.post.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useEdgeAsyncLogs(7, 'abc123'));
+
+    await act(async () => {
+      result.current.collect();
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('Network error');
+  });
+
+  it('sets error on poll failure', async () => {
+    mockApi.post.mockResolvedValue({ jobId: 42, status: 'collecting' });
+    mockApi.get.mockRejectedValue(new Error('Server error'));
+
+    const { result } = renderHook(() => useEdgeAsyncLogs(7, 'abc123'));
+
+    await act(async () => {
+      result.current.collect();
+    });
+
+    expect(result.current.status).toBe('collecting');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('Server error');
+  });
+
+  it('reset returns to idle', async () => {
+    mockApi.post.mockResolvedValue({ jobId: 42, status: 'collecting' });
+
+    const { result } = renderHook(() => useEdgeAsyncLogs(7, 'abc123'));
+
+    await act(async () => {
+      result.current.collect();
+    });
+
+    expect(result.current.status).toBe('collecting');
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.logs).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/frontend/src/hooks/use-edge-async-logs.ts
+++ b/frontend/src/hooks/use-edge-async-logs.ts
@@ -1,0 +1,107 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { api } from '@/lib/api';
+
+export type EdgeAsyncLogStatus = 'idle' | 'initiating' | 'collecting' | 'complete' | 'error';
+
+interface CollectResponse {
+  jobId: number;
+  status: string;
+}
+
+interface LogsReadyResponse {
+  logs: string;
+  containerId: string;
+  endpointId: number;
+  durationMs: number;
+  source: string;
+}
+
+const MAX_POLLS = 24; // 24 * 5s = 120s max
+const POLL_INTERVAL_MS = 5000;
+
+export function useEdgeAsyncLogs(endpointId: number | undefined, containerId: string | undefined) {
+  const [status, setStatus] = useState<EdgeAsyncLogStatus>('idle');
+  const [logs, setLogs] = useState<string | null>(null);
+  const [durationMs, setDurationMs] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollCountRef = useRef(0);
+
+  const clearPoll = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+    pollCountRef.current = 0;
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => clearPoll, [clearPoll]);
+
+  const collect = useCallback(async (opts?: { tail?: number }) => {
+    if (!endpointId || !containerId) return;
+
+    setStatus('initiating');
+    setLogs(null);
+    setDurationMs(null);
+    setError(null);
+    clearPoll();
+
+    let jobId: number;
+
+    try {
+      const res = await api.post<CollectResponse>(
+        `/api/containers/${endpointId}/${containerId}/logs/collect`,
+        opts?.tail ? { tail: opts.tail } : undefined,
+      );
+      jobId = res.jobId;
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err.message : 'Failed to initiate log collection');
+      return;
+    }
+
+    setStatus('collecting');
+    pollCountRef.current = 0;
+
+    pollIntervalRef.current = setInterval(async () => {
+      pollCountRef.current += 1;
+
+      if (pollCountRef.current > MAX_POLLS) {
+        clearPoll();
+        setStatus('error');
+        setError('Log collection timed out. The Edge agent may be offline or slow to respond.');
+        return;
+      }
+
+      try {
+        const res = await api.get<CollectResponse | LogsReadyResponse>(
+          `/api/containers/${endpointId}/${containerId}/logs/collect/${jobId}`,
+        );
+
+        if ('logs' in res) {
+          clearPoll();
+          setLogs(res.logs);
+          setDurationMs(res.durationMs);
+          setStatus('complete');
+        }
+        // else still 'collecting' — keep polling
+      } catch (err) {
+        clearPoll();
+        setStatus('error');
+        setError(err instanceof Error ? err.message : 'Failed to retrieve logs');
+      }
+    }, POLL_INTERVAL_MS);
+  }, [endpointId, containerId, clearPoll]);
+
+  const reset = useCallback(() => {
+    clearPoll();
+    setStatus('idle');
+    setLogs(null);
+    setDurationMs(null);
+    setError(null);
+  }, [clearPoll]);
+
+  return { status, logs, durationMs, error, collect, reset };
+}

--- a/frontend/src/pages/container-detail.tsx
+++ b/frontend/src/pages/container-detail.tsx
@@ -230,20 +230,11 @@ export default function ContainerDetailPage() {
         </Tabs.Content>
 
         <Tabs.Content value="logs" className="focus:outline-none">
-          {capabilities.realtimeLogs ? (
-            <ContainerLogsViewer
-              endpointId={container.endpointId}
-              containerId={container.id}
-            />
-          ) : (
-            <div className="rounded-lg border bg-card p-8 text-center">
-              <Wifi className="mx-auto h-10 w-10 text-muted-foreground" />
-              <p className="mt-4 font-medium">Real-time logs unavailable</p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                This Edge Async endpoint does not support real-time log streaming
-              </p>
-            </div>
-          )}
+          <ContainerLogsViewer
+            endpointId={container.endpointId}
+            containerId={container.id}
+            isEdgeAsync={isEdgeAsync}
+          />
         </Tabs.Content>
 
         <Tabs.Content value="metrics" className="focus:outline-none">


### PR DESCRIPTION
## Summary

- Adds Edge Jobs-based log retrieval for Edge Async endpoints (Type 7) that lack Docker tunnels
- Two-step HTTP pattern: POST `/logs/collect` initiates collection, GET `/logs/collect/:jobId` polls for results — stays within the frontend's 30s API timeout
- LLM tool transparently uses blocking `getEdgeAsyncContainerLogs()` for Edge Async containers
- Frontend `EdgeAsyncLogCollector` component with idle/collecting/complete/error state machine and 5s polling

Closes #531

### Backend
- `edge-async-log-fetcher.ts`: 5 exported functions (initiate, check, retrieve, cleanup, blocking convenience)
- `portainer-client.ts`: 3 new methods for Edge Job task APIs (get tasks, collect logs, get logs)
- `edge-capability-guard.ts`: `isEdgeAsync()` detection
- `container-logs.ts`: POST + GET `/logs/collect` routes
- `llm-tools.ts`: Edge Async branch in `executeGetContainerLogs`

### Frontend
- `use-edge-async-logs.ts`: State machine hook with polling and cleanup on unmount
- `container-logs-viewer.tsx`: `isEdgeAsync` prop, `EdgeAsyncLogCollector` with styled state cards
- `container-detail.tsx`: Always renders `ContainerLogsViewer` (handles both modes internally)

## Test plan

- [ ] Backend: 12 new tests in `edge-async-log-fetcher.test.ts` (all lifecycle + error paths)
- [ ] Backend: 4 new tests in `container-logs.test.ts` (POST 202/400, GET 200/202)
- [ ] Frontend: 5 new tests in `use-edge-async-logs.test.ts` (state transitions, errors, reset)
- [ ] All 110 backend test files pass (1400 tests)
- [ ] All 107 frontend test files pass (922 tests)
- [ ] TypeScript compiles cleanly in both workspaces
- [ ] ESLint passes in both workspaces
- [ ] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)