### PR TITLE
fix: container logs 502 on Edge endpoints (#571)

### DIFF
--- a/backend/src/services/edge-log-fetcher.test.ts
+++ b/backend/src/services/edge-log-fetcher.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isDockerProxyUnavailable, waitForTunnel, getContainerLogsWithRetry } from './edge-log-fetcher.js';
+
+vi.mock('./portainer-client.js', () => ({
+  getContainers: vi.fn(),
+  getContainerLogs: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import * as portainer from './portainer-client.js';
+
+const mockGetContainers = vi.mocked(portainer.getContainers);
+const mockGetContainerLogs = vi.mocked(portainer.getContainerLogs);
+
+describe('isDockerProxyUnavailable', () => {
+  it('returns true for status 502', () => {
+    expect(isDockerProxyUnavailable({ status: 502 })).toBe(true);
+  });
+
+  it('returns true for status 503', () => {
+    expect(isDockerProxyUnavailable({ status: 503 })).toBe(true);
+  });
+
+  it('returns true for status 404', () => {
+    expect(isDockerProxyUnavailable({ status: 404 })).toBe(true);
+  });
+
+  it('returns false for status 401', () => {
+    expect(isDockerProxyUnavailable({ status: 401 })).toBe(false);
+  });
+
+  it('returns false for status 200', () => {
+    expect(isDockerProxyUnavailable({ status: 200 })).toBe(false);
+  });
+
+  it('returns false for non-object errors', () => {
+    expect(isDockerProxyUnavailable('error string')).toBe(false);
+    expect(isDockerProxyUnavailable(null)).toBe(false);
+    expect(isDockerProxyUnavailable(undefined)).toBe(false);
+  });
+
+  it('returns false for objects without status', () => {
+    expect(isDockerProxyUnavailable({ message: 'error' })).toBe(false);
+  });
+});
+
+describe('waitForTunnel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns immediately when tunnel is already established', async () => {
+    mockGetContainers.mockResolvedValue([]);
+
+    const promise = waitForTunnel(20, { stabilizationMs: 0 });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockGetContainers).toHaveBeenCalledWith(20, false);
+  });
+
+  it('polls until tunnel is established', async () => {
+    mockGetContainers
+      .mockRejectedValueOnce(new Error('unavailable'))
+      .mockResolvedValueOnce([]);
+
+    const promise = waitForTunnel(20, { pollIntervalMs: 500, stabilizationMs: 0 });
+    await vi.advanceTimersByTimeAsync(500);
+    await promise;
+
+    expect(mockGetContainers).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies stabilization delay after tunnel confirmation', async () => {
+    mockGetContainers.mockResolvedValue([]);
+
+    const promise = waitForTunnel(20, { stabilizationMs: 1000 });
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(mockGetContainers).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws 504 when tunnel does not establish within timeout', async () => {
+    mockGetContainers.mockRejectedValue(new Error('unavailable'));
+
+    // Attach rejection handler BEFORE advancing timers to avoid unhandled rejection
+    const promise = waitForTunnel(20, { maxWaitMs: 3000, pollIntervalMs: 1000, stabilizationMs: 0 })
+      .then(() => { throw new Error('should have thrown'); })
+      .catch((err: any) => err);
+
+    await vi.advanceTimersByTimeAsync(4000);
+
+    const err = await promise;
+    expect(err.message).toBe('Edge agent tunnel did not establish within timeout');
+    expect(err.status).toBe(504);
+  });
+});
+
+describe('getContainerLogsWithRetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns logs on first attempt when no error', async () => {
+    mockGetContainerLogs.mockResolvedValue('log output');
+
+    const result = await getContainerLogsWithRetry(1, 'abc123');
+
+    expect(result).toBe('log output');
+    expect(mockGetContainerLogs).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries with tunnel warm-up on proxy unavailable error', async () => {
+    mockGetContainerLogs
+      .mockRejectedValueOnce({ status: 502, message: 'proxy error' })
+      .mockResolvedValueOnce('log output after retry');
+
+    mockGetContainers.mockResolvedValue([]);
+
+    const promise = getContainerLogsWithRetry(20, 'abc123', {}, { maxWaitMs: 500 });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('log output after retry');
+    expect(mockGetContainerLogs).toHaveBeenCalledTimes(2);
+    expect(mockGetContainers).toHaveBeenCalled();
+  });
+
+  it('retries up to 3 times with backoff', async () => {
+    const proxyError = { status: 404, message: 'not found' };
+    mockGetContainerLogs
+      .mockRejectedValueOnce(proxyError)
+      .mockRejectedValueOnce(proxyError)
+      .mockResolvedValueOnce('log output on third attempt');
+
+    mockGetContainers.mockResolvedValue([]);
+
+    const promise = getContainerLogsWithRetry(20, 'abc123', {}, { maxWaitMs: 500 });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('log output on third attempt');
+    expect(mockGetContainerLogs).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws immediately for non-proxy errors (e.g., auth)', async () => {
+    mockGetContainerLogs.mockRejectedValue({ status: 401, message: 'Unauthorized' });
+
+    await expect(getContainerLogsWithRetry(1, 'abc123')).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(mockGetContainerLogs).toHaveBeenCalledTimes(1);
+    expect(mockGetContainers).not.toHaveBeenCalled();
+  });
+
+  it('throws after exhausting all retries', async () => {
+    const proxyError = { status: 502, message: 'proxy error' };
+    mockGetContainerLogs.mockRejectedValue(proxyError);
+    mockGetContainers.mockResolvedValue([]);
+
+    // Attach rejection handler BEFORE advancing timers to avoid unhandled rejection
+    const promise = getContainerLogsWithRetry(20, 'abc123', {}, { maxWaitMs: 500 })
+      .then(() => { throw new Error('should have thrown'); })
+      .catch((err: any) => err);
+
+    await vi.runAllTimersAsync();
+
+    const err = await promise;
+    expect(err.status).toBe(502);
+    expect(mockGetContainerLogs).toHaveBeenCalledTimes(3);
+  });
+});

--- a/backend/src/services/edge-log-fetcher.ts
+++ b/backend/src/services/edge-log-fetcher.ts
@@ -6,11 +6,12 @@ const log = createChildLogger('edge-log-fetcher');
 /**
  * Check if an error indicates the Docker proxy is unavailable
  * (tunnel not yet established for Edge Standard endpoints).
+ * Checks for 404, 502, and 503 — all indicate the proxy cannot reach Docker.
  */
 export function isDockerProxyUnavailable(err: unknown): boolean {
   if (err && typeof err === 'object' && 'status' in err) {
     const status = (err as { status: number }).status;
-    return status === 502 || status === 404;
+    return status === 502 || status === 503 || status === 404;
   }
   return false;
 }
@@ -20,12 +21,15 @@ export function isDockerProxyUnavailable(err: unknown): boolean {
  * Docker API calls. The first proxy request triggers Portainer's
  * `SetTunnelStatusToRequired()`, and subsequent polls wait for the
  * Chisel reverse tunnel to come up.
+ *
+ * After confirming the tunnel is up, waits an additional stabilization
+ * delay to allow the proxy to fully initialize for all Docker API operations.
  */
 export async function waitForTunnel(
   endpointId: number,
-  options: { maxWaitMs?: number; pollIntervalMs?: number } = {},
+  options: { maxWaitMs?: number; pollIntervalMs?: number; stabilizationMs?: number } = {},
 ): Promise<void> {
-  const { maxWaitMs = 15000, pollIntervalMs = 2000 } = options;
+  const { maxWaitMs = 15000, pollIntervalMs = 2000, stabilizationMs = 1000 } = options;
   const deadline = Date.now() + maxWaitMs;
 
   log.info({ endpointId, maxWaitMs, pollIntervalMs }, 'Waiting for Edge tunnel to establish');
@@ -34,6 +38,14 @@ export async function waitForTunnel(
     try {
       await portainer.getContainers(endpointId, false);
       log.info({ endpointId }, 'Edge tunnel established');
+
+      // Wait for the proxy to fully stabilize before returning.
+      // The tunnel may accept list operations before individual container
+      // operations (logs, inspect) are fully routable.
+      if (stabilizationMs > 0) {
+        log.debug({ endpointId, stabilizationMs }, 'Waiting for proxy stabilization');
+        await new Promise((resolve) => setTimeout(resolve, stabilizationMs));
+      }
       return;
     } catch {
       const remaining = deadline - Date.now();
@@ -49,8 +61,9 @@ export async function waitForTunnel(
 
 /**
  * Fetch container logs with automatic tunnel warm-up retry.
- * On 502/404 (tunnel not established), triggers a lightweight Docker API call
- * to open the tunnel, polls until ready, then retries the log fetch.
+ * On 502/503/404 (tunnel not established or proxy unavailable), triggers a
+ * lightweight Docker API call to open the tunnel, polls until ready, then
+ * retries the log fetch with exponential backoff (up to 3 attempts).
  */
 export async function getContainerLogsWithRetry(
   endpointId: number,
@@ -58,14 +71,33 @@ export async function getContainerLogsWithRetry(
   options: { tail?: number; since?: number; until?: number; timestamps?: boolean } = {},
   retryOptions: { maxWaitMs?: number; pollIntervalMs?: number } = {},
 ): Promise<string> {
-  try {
-    return await portainer.getContainerLogs(endpointId, containerId, options);
-  } catch (err) {
-    if (isDockerProxyUnavailable(err)) {
-      log.info({ endpointId, containerId }, 'Docker proxy unavailable, attempting tunnel warm-up');
-      await waitForTunnel(endpointId, retryOptions);
+  const MAX_RETRIES = 3;
+  let lastErr: unknown;
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
       return await portainer.getContainerLogs(endpointId, containerId, options);
+    } catch (err) {
+      lastErr = err;
+
+      if (!isDockerProxyUnavailable(err)) {
+        throw err;
+      }
+
+      if (attempt === 0) {
+        log.info({ endpointId, containerId }, 'Docker proxy unavailable, attempting tunnel warm-up');
+        await waitForTunnel(endpointId, retryOptions);
+      } else {
+        // Subsequent retries use exponential backoff
+        const delay = Math.pow(2, attempt) * 500;
+        log.info(
+          { endpointId, containerId, attempt, delay },
+          'Log fetch still failing after tunnel warm-up, retrying with backoff',
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
-    throw err;
   }
+
+  throw lastErr;
 }


### PR DESCRIPTION
## Summary
- Fix container logs always returning 502 on Edge endpoints by making URL construction, headers, and retry logic consistent across all Portainer API calls
- Add stabilization delay after tunnel warm-up and 3-attempt retry with exponential backoff

Closes #571

## Root Cause
`getContainerLogs` and other raw `undiciFetch` calls had multiple inconsistencies compared to `portainerFetch`:
1. **URL construction**: Did not strip trailing slashes from `PORTAINER_API_URL`, potentially causing `//api/` double-slash routing failures
2. **Missing headers**: Did not include `Content-Type: application/json` header that `portainerFetch` includes
3. **No stabilization delay**: After tunnel warm-up, the log fetch fired < 2ms later — the proxy may accept list operations before individual container operations (logs, inspect) are fully routable
4. **Single retry**: Only 1 retry attempt after warm-up, now 3 attempts with exponential backoff
5. **Lost diagnostics**: Error response bodies from Portainer were discarded, losing actual error messages

## Fix
- Extract shared `buildApiUrl()` and `buildApiHeaders()` helpers used by both `portainerFetch` and all raw fetch calls
- Add `readErrorBody()` to capture and log Portainer's actual error response
- Add 1s stabilization delay in `waitForTunnel` after tunnel confirmation
- Improve `getContainerLogsWithRetry` to 3 attempts with exponential backoff
- Add 503 to `isDockerProxyUnavailable` detection
- Add 15s timeout to `getContainerLogs` via `AbortController`
- Preserve actual HTTP status codes instead of remapping (e.g., 404→502)

## Changes
- `backend/src/services/portainer-client.ts` - Shared helpers, consistent request construction, error body reading
- `backend/src/services/edge-log-fetcher.ts` - Stabilization delay, 3-retry backoff, 503 detection
- `backend/src/services/edge-tunnel-retry.test.ts` - Updated for new behavior
- `backend/src/services/portainer-client.test.ts` - Tests for `buildApiUrl` and `buildApiHeaders`
- `backend/src/services/edge-log-fetcher.test.ts` - New: comprehensive tests for retry logic

## Testing
- [x] Regression tests added: `backend/src/services/edge-log-fetcher.test.ts` (16 tests)
- [x] Updated existing tests: `edge-tunnel-retry.test.ts` (16 tests), `portainer-client.test.ts` (12 tests)
- [x] Full test suite passes locally (58 affected tests)
- [x] TypeScript type check passes
- [x] ESLint passes on all changed files

## Rollback Plan
Revert this PR: `git revert <merge-commit-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)