### PR TITLE
fix: strip <think> blocks from reasoning model output (closes #589)

### DIFF
--- a/frontend/src/pages/llm-assistant.test.tsx
+++ b/frontend/src/pages/llm-assistant.test.tsx
@@ -249,6 +249,50 @@ describe('normalizeMarkdown', () => {
   // We test the normalizeMarkdown function indirectly through MarkdownContent rendering.
   // The function is not exported, but its effects are visible in the rendered output.
 
+  it('strips <think> blocks from thinking models', () => {
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [
+        { id: '1', role: 'assistant', content: '<think>I need to analyze the containers...</think>All containers are healthy.', timestamp: new Date().toISOString() },
+      ],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    vi.mocked(useLlmModels).mockReturnValue({
+      data: { models: [{ name: 'llama3.2' }], default: 'llama3.2' },
+    } as any);
+
+    renderPage();
+    expect(screen.getByText('All containers are healthy.')).toBeTruthy();
+    expect(screen.queryByText(/I need to analyze/)).toBeNull();
+  });
+
+  it('strips <thinking> blocks from thinking models', () => {
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [
+        { id: '1', role: 'assistant', content: '<thinking>Reasoning about metrics</thinking>CPU usage is 45%.', timestamp: new Date().toISOString() },
+      ],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    vi.mocked(useLlmModels).mockReturnValue({
+      data: { models: [{ name: 'llama3.2' }], default: 'llama3.2' },
+    } as any);
+
+    renderPage();
+    expect(screen.getByText('CPU usage is 45%.')).toBeTruthy();
+    expect(screen.queryByText(/Reasoning about metrics/)).toBeNull();
+  });
+
   it('renders headers without space correctly', () => {
     vi.mocked(useLlmChat).mockReturnValue({
       messages: [

--- a/frontend/src/pages/llm-assistant.tsx
+++ b/frontend/src/pages/llm-assistant.tsx
@@ -453,7 +453,11 @@ function ToolCallIndicator({ events }: { events: ToolCallEvent[] }) {
  * Local models often produce malformed markdown that breaks rendering.
  */
 function normalizeMarkdown(raw: string): string {
-  let text = raw;
+  // Strip thinking blocks from reasoning models (frontend fallback — backend
+  // strips these during streaming, but this catches any that slip through)
+  let text = raw
+    .replace(/<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>/gi, '')
+    .replace(/<think(?:ing)?>[\s\S]*$/gi, '');
 
   // Fix code blocks: if language tag and code are on the same line separated by space,
   // split them. The space delimiter prevents greedy backtracking from eating into the


### PR DESCRIPTION
## Summary

Reasoning models (DeepSeek R1, QwQ, Qwen3) wrap chain-of-thought in `<think>`/`<thinking>` tags that were displayed verbatim to users, making the AI Assistant unusable with these popular models.

Closes #589

## Root Cause

Neither `sanitizeLlmOutput()` (backend), the streaming pipeline, nor `normalizeMarkdown()` (frontend) stripped `<think>...</think>` blocks from LLM output.

## Fix

Three-layer defense to ensure thinking blocks never reach the user:

1. **Backend final output** — `stripThinkingBlocks()` in `sanitizeLlmOutput()` strips complete and unclosed thinking blocks from the assembled response
2. **Backend streaming** — `ThinkingBlockFilter` class wraps all `onChunk` callbacks to suppress thinking content in real-time (handles tags split across streaming chunks, partial tags, unclosed blocks)
3. **Frontend fallback** — `normalizeMarkdown()` strips thinking blocks before rendering, catching anything that slips through

## Changes

- `backend/src/services/prompt-guard.ts` — Added `stripThinkingBlocks()`, integrated into `sanitizeLlmOutput()`
- `backend/src/sockets/llm-chat.ts` — Added `ThinkingBlockFilter` class, wrapped streaming callbacks with `emitChunk`
- `frontend/src/pages/llm-assistant.tsx` — Added thinking block stripping in `normalizeMarkdown()`
- `backend/src/services/prompt-guard.test.ts` — 14 new tests for `stripThinkingBlocks` + sanitization integration
- `backend/src/sockets/llm-chat.test.ts` — 12 new tests for `ThinkingBlockFilter` (chunk splitting, partial tags, flush)
- `frontend/src/pages/llm-assistant.test.tsx` — 2 new tests for frontend fallback stripping

## Testing

- [x] Regression tests added: 28 new tests across 3 files
- [x] Full backend test suite passes (1522 tests)
- [x] Full frontend test suite passes (944 tests)
- [x] TypeScript typecheck passes
- [x] ESLint passes (0 warnings)
- [x] Production build succeeds

## Edge Cases Handled

- Complete `<think>...</think>` and `<thinking>...</thinking>` blocks
- Unclosed thinking tags (model interrupted or malformed)
- Tags split across streaming chunks (e.g., `<thi` + `nk>`)
- Case-insensitive matching (`<THINK>`, `<Think>`, etc.)
- Multiple thinking blocks in one response
- Empty thinking blocks
- Think blocks containing system prompt fragments (stripped before leak detection)

## Rollback Plan

Revert this PR: `git revert <merge-commit-sha>`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)