### PR TITLE
fix: copy OpenSSL shared libraries for tcpdump in production image (closes #588)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,6 +43,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Build backend image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./backend/Dockerfile
+          tags: backend-smoke-test:latest
+          load: true
+
+      - name: Smoke test — validate tcpdump shared libraries
+        run: docker run --rm backend-smoke-test:latest tcpdump --version
+
       - name: Build and push backend
         uses: docker/build-push-action@v6
         with:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -39,8 +39,10 @@ FROM dhi.io/node:24-alpine3.23 AS runtime
 COPY --from=tools /usr/bin/dumb-init /usr/bin/dumb-init
 COPY --from=tools /usr/bin/wget /usr/bin/wget
 COPY --from=tools /usr/bin/tcpdump /usr/bin/tcpdump
-# Copy shared libraries needed by tcpdump
+# Copy shared libraries needed by tcpdump (libpcap + OpenSSL)
 COPY --from=tools /usr/lib/libpcap* /usr/lib/
+COPY --from=tools /usr/lib/libcrypto* /usr/lib/
+COPY --from=tools /usr/lib/libssl* /usr/lib/
 # Copy pre-created data directory with correct ownership
 COPY --from=tools --chown=node:node /opt/app/data /app/data
 


### PR DESCRIPTION
## Summary
Fixes PCAP AI Analysis failing in the production Docker image because `tcpdump` could not find OpenSSL shared libraries (`libcrypto.so.3`, `libssl.so.3`).

Closes #588

## Root Cause
The multi-stage Dockerfile copied `tcpdump` and `libpcap*` from the tools stage to the runtime stage, but **did not copy the OpenSSL libraries** that Alpine's tcpdump links against for TLS/SSL packet inspection. This caused `extractPcapSummary()` to fail with "Error loading shared library libcrypto.so.3: No such file or directory".

## Fix
- Added `COPY --from=tools /usr/lib/libcrypto* /usr/lib/` and `COPY --from=tools /usr/lib/libssl* /usr/lib/` to the runtime stage in `backend/Dockerfile`
- Added a CI smoke test step in `docker-build.yml` that runs `tcpdump --version` inside the built image to catch missing shared libraries

## Changes
- `backend/Dockerfile` — Copy OpenSSL shared libraries alongside libpcap
- `.github/workflows/docker-build.yml` — Add smoke test step that validates tcpdump can execute

## Testing
- [x] Dockerfile fix verified by inspecting COPY directives
- [x] CI smoke test added: `docker run --rm <image> tcpdump --version`
- [x] No changes to application code — existing tests unaffected
- [x] Dev image (`Dockerfile.dev`) unaffected (installs all deps in single stage)

## Rollback Plan
Revert this PR: `git revert <merge-commit-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)