### PR TITLE
perf: reduce excessive Portainer API calls with smarter caching (closes #594)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,7 @@ import authPlugin from './plugins/auth.js';
 import socketIoPlugin from './plugins/socket-io.js';
 import compressPlugin from './plugins/compress.js';
 import securityHeadersPlugin from './plugins/security-headers.js';
+import cacheControlPlugin from './plugins/cache-control.js';
 import staticPlugin from './plugins/static.js';
 import { healthRoutes } from './routes/health.js';
 import { authRoutes } from './routes/auth.js';
@@ -92,6 +93,7 @@ export async function buildApp() {
   await app.register(requestTracing);
   await app.register(compressPlugin);
   await app.register(securityHeadersPlugin);
+  await app.register(cacheControlPlugin);
   await app.register(corsPlugin);
   await app.register(rateLimitPlugin);
   await app.register(swaggerPlugin);

--- a/backend/src/plugins/cache-control.test.ts
+++ b/backend/src/plugins/cache-control.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import Fastify from 'fastify';
+import cacheControlPlugin from './cache-control.js';
+
+async function buildTestApp() {
+  const app = Fastify();
+  await app.register(cacheControlPlugin);
+
+  // Register test routes
+  app.get('/api/endpoints', async () => ({ ok: true }));
+  app.get('/api/containers', async () => ({ ok: true }));
+  app.get('/api/images', async () => ({ ok: true }));
+  app.get('/api/networks', async () => ({ ok: true }));
+  app.get('/api/stacks', async () => ({ ok: true }));
+  app.get('/api/dashboard/summary', async () => ({ ok: true }));
+  app.get('/api/auth/session', async () => ({ ok: true }));
+  app.get('/api/admin/cache/stats', async () => ({ ok: true }));
+  app.get('/api/llm/models', async () => ({ ok: true }));
+  app.get('/api/health', async () => ({ ok: true }));
+  app.post('/api/containers/restart', async () => ({ ok: true }));
+
+  await app.ready();
+  return app;
+}
+
+describe('cache-control plugin', () => {
+  it('sets private max-age for cacheable GET routes', async () => {
+    const app = await buildTestApp();
+
+    const cases = [
+      { url: '/api/endpoints', expected: 'private, max-age=60' },
+      { url: '/api/containers', expected: 'private, max-age=30' },
+      { url: '/api/images', expected: 'private, max-age=120' },
+      { url: '/api/networks', expected: 'private, max-age=120' },
+      { url: '/api/stacks', expected: 'private, max-age=60' },
+      { url: '/api/dashboard/summary', expected: 'private, max-age=30' },
+    ];
+
+    for (const { url, expected } of cases) {
+      const res = await app.inject({ method: 'GET', url });
+      expect(res.headers['cache-control']).toBe(expected);
+    }
+
+    await app.close();
+  });
+
+  it('sets no-store for sensitive routes', async () => {
+    const app = await buildTestApp();
+
+    const sensitiveRoutes = [
+      '/api/auth/session',
+      '/api/admin/cache/stats',
+      '/api/llm/models',
+    ];
+
+    for (const url of sensitiveRoutes) {
+      const res = await app.inject({ method: 'GET', url });
+      expect(res.headers['cache-control']).toBe('no-store');
+    }
+
+    await app.close();
+  });
+
+  it('does not set Cache-Control for non-GET requests', async () => {
+    const app = await buildTestApp();
+
+    const res = await app.inject({ method: 'POST', url: '/api/containers/restart' });
+    expect(res.headers['cache-control']).toBeUndefined();
+
+    await app.close();
+  });
+
+  it('does not set Cache-Control for unmatched routes', async () => {
+    const app = await buildTestApp();
+
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.headers['cache-control']).toBeUndefined();
+
+    await app.close();
+  });
+});

--- a/backend/src/plugins/cache-control.ts
+++ b/backend/src/plugins/cache-control.ts
@@ -1,0 +1,67 @@
+import { FastifyInstance } from 'fastify';
+import fp from 'fastify-plugin';
+
+/**
+ * Cache-Control header plugin.
+ *
+ * Adds Cache-Control headers to API responses based on route patterns,
+ * allowing browsers and proxies to cache stable data and reduce
+ * redundant requests to the backend.
+ */
+
+interface CacheRule {
+  /** Route prefix to match (e.g. '/api/endpoints') */
+  prefix: string;
+  /** max-age in seconds */
+  maxAge: number;
+}
+
+const CACHE_RULES: CacheRule[] = [
+  { prefix: '/api/endpoints', maxAge: 60 },
+  { prefix: '/api/containers', maxAge: 30 },
+  { prefix: '/api/images', maxAge: 120 },
+  { prefix: '/api/networks', maxAge: 120 },
+  { prefix: '/api/stacks', maxAge: 60 },
+  { prefix: '/api/dashboard/summary', maxAge: 30 },
+];
+
+/** Routes that must never be cached */
+const NO_CACHE_PREFIXES = [
+  '/api/auth',
+  '/api/admin',
+  '/api/llm',
+  '/api/remediation',
+  '/api/settings',
+];
+
+async function cacheControlPlugin(fastify: FastifyInstance) {
+  fastify.addHook('onSend', async (request, reply, payload) => {
+    const url = request.url;
+
+    // Skip if header already set (e.g. SSE streams)
+    if (reply.getHeader('Cache-Control')) return payload;
+
+    // Skip non-GET requests — mutations should never be cached
+    if (request.method !== 'GET') return payload;
+
+    // Explicitly no-cache for sensitive routes
+    for (const prefix of NO_CACHE_PREFIXES) {
+      if (url.startsWith(prefix)) {
+        reply.header('Cache-Control', 'no-store');
+        return payload;
+      }
+    }
+
+    // Apply cache rules
+    for (const rule of CACHE_RULES) {
+      if (url.startsWith(rule.prefix)) {
+        reply.header('Cache-Control', `private, max-age=${rule.maxAge}`);
+        return payload;
+      }
+    }
+
+    return payload;
+  });
+}
+
+export default fp(cacheControlPlugin, { name: 'cache-control' });

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -22,7 +22,7 @@ export async function imagesRoutes(fastify: FastifyInstance) {
     if (endpointId) {
       const images = await cachedFetch(
         getCacheKey('images', endpointId),
-        TTL.CONTAINERS,
+        TTL.IMAGES,
         () => portainer.getImages(endpointId),
       );
       return images.map((img) => normalizeImage(img, endpointId));
@@ -40,7 +40,7 @@ export async function imagesRoutes(fastify: FastifyInstance) {
         try {
           const images = await cachedFetch(
             getCacheKey('images', ep.Id),
-            TTL.CONTAINERS,
+            TTL.IMAGES,
             () => portainer.getImages(ep.Id),
           );
           return images.map((img) => normalizeImage(img, ep.Id, ep.Name));
@@ -110,7 +110,7 @@ export async function imagesRoutes(fastify: FastifyInstance) {
         try {
           const images = await cachedFetch(
             getCacheKey('images', ep.Id),
-            TTL.CONTAINERS,
+            TTL.IMAGES,
             () => portainer.getImages(ep.Id),
           );
           for (const img of images) {

--- a/backend/src/services/log-analyzer.test.ts
+++ b/backend/src/services/log-analyzer.test.ts
@@ -23,6 +23,12 @@ vi.mock('./portainer-client.js', () => ({
   getContainerLogs: (...args: unknown[]) => mockGetContainerLogs(...args),
 }));
 
+// cachedFetch passthrough — invokes the fetcher function directly
+vi.mock('./portainer-cache.js', () => ({
+  cachedFetch: (_key: string, _ttl: number, fn: () => Promise<unknown>) => fn(),
+  getCacheKey: (...args: (string | number)[]) => args.join(':'),
+}));
+
 import { analyzeContainerLogs, analyzeLogsForContainers } from './log-analyzer.js';
 
 describe('log-analyzer', () => {

--- a/backend/src/services/portainer-cache.ts
+++ b/backend/src/services/portainer-cache.ts
@@ -102,7 +102,7 @@ class TtlCache {
 
 class HybridCache {
   private memory = new TtlCache();
-  private readonly l1TtlSeconds = 5; // Short L1 TTL for instant access
+  private readonly l1TtlSeconds = 30; // L1 TTL for instant access without Redis round-trip
   private hits = 0;
   private misses = 0;
   private compressedCount = 0;

--- a/frontend/src/hooks/use-cache-admin.ts
+++ b/frontend/src/hooks/use-cache-admin.ts
@@ -21,7 +21,7 @@ export function useCacheStats() {
   return useQuery<CacheStats>({
     queryKey: ['admin', 'cache', 'stats'],
     queryFn: () => api.get<CacheStats>('/api/admin/cache/stats'),
-    refetchInterval: 10_000,
+    refetchInterval: 30_000,
   });
 }
 

--- a/frontend/src/hooks/use-containers.ts
+++ b/frontend/src/hooks/use-containers.ts
@@ -30,5 +30,7 @@ export function useContainers(endpointId?: number) {
         : '/api/containers';
       return api.get<Container[]>(path);
     },
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/hooks/use-dashboard.ts
+++ b/frontend/src/hooks/use-dashboard.ts
@@ -66,7 +66,8 @@ export function useDashboard() {
   return useQuery<DashboardSummary>({
     queryKey: ['dashboard', 'summary'],
     queryFn: () => api.get<DashboardSummary>('/api/dashboard/summary'),
-    staleTime: 30 * 1000,
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: false,
     refetchInterval: enabled ? interval * 1000 : false,
   });
 }

--- a/frontend/src/hooks/use-networks.ts
+++ b/frontend/src/hooks/use-networks.ts
@@ -23,5 +23,6 @@ export function useNetworks(endpointId?: number) {
       return api.get<Network[]>(path);
     },
     staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/hooks/use-security-audit.ts
+++ b/frontend/src/hooks/use-security-audit.ts
@@ -44,6 +44,8 @@ export function useSecurityAudit(endpointId?: number) {
       endpointId
         ? api.get<SecurityAuditResponse>(`/api/security/audit/${endpointId}`)
         : api.get<SecurityAuditResponse>('/api/security/audit'),
+    staleTime: 120 * 1000,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/frontend/src/providers/query-provider.test.tsx
+++ b/frontend/src/providers/query-provider.test.tsx
@@ -22,7 +22,7 @@ describe('QueryProvider', () => {
     expect(defaults.queries.staleTime).toBe(30_000);
     expect(defaults.queries.gcTime).toBe(600_000);
     expect(defaults.queries.retry).toBe(2);
-    expect(defaults.queries.refetchOnWindowFocus).toBe(true);
+    expect(defaults.queries.refetchOnWindowFocus).toBe(false);
     expect(defaults.queries.refetchOnReconnect).toBe('always');
   });
 

--- a/frontend/src/providers/query-provider.tsx
+++ b/frontend/src/providers/query-provider.tsx
@@ -11,7 +11,7 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             gcTime: 10 * 60 * 1000,
             retry: 2,
             retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
-            refetchOnWindowFocus: true,
+            refetchOnWindowFocus: false,
             refetchOnReconnect: 'always',
             placeholderData: keepPreviousData,
           },


### PR DESCRIPTION
## Summary

Implements 10 of the 13 recommendations from #594 to dramatically reduce Portainer API call volume. Changes span backend caching, frontend query tuning, and new browser-level Cache-Control headers.

Closes #594

## Root Cause

Multiple layers of inefficiency: L1 cache expired every 5s, ES log forwarder made ~40 uncached API calls/min, monitoring cycle duplicated stats collection, frontend re-fetched 10x more often than backend cache lifetime, and every tab switch triggered cascading API calls.

## Changes

### Tier 1 — High Impact, Low Effort
| File | Change |
|------|--------|
| `backend/src/services/portainer-cache.ts` | L1 TTL 5s → 30s |
| `backend/src/routes/images.ts` | `TTL.CONTAINERS` → `TTL.IMAGES` |
| `frontend/src/hooks/use-containers.ts` | staleTime 60s, refetchOnWindowFocus off |
| `frontend/src/hooks/use-security-audit.ts` | staleTime 120s, refetchOnWindowFocus off |
| `frontend/src/hooks/use-dashboard.ts` | staleTime 60s, refetchOnWindowFocus off |
| `frontend/src/hooks/use-networks.ts` | refetchOnWindowFocus off |
| `frontend/src/providers/query-provider.tsx` | Global refetchOnWindowFocus: false |

### Tier 2 — High Impact, Medium Effort
| File | Change |
|------|--------|
| `backend/src/services/elasticsearch-log-forwarder.ts` | Cache logs with 25s TTL (~38 calls/min saved) |
| `backend/src/services/log-analyzer.ts` | Cache logs with 60s TTL |
| `backend/src/sockets/llm-chat.ts` | Cache infrastructure context for 30s |

### Tier 3 — Medium Impact, Higher Effort
| File | Change |
|------|--------|
| `backend/src/services/monitoring-service.ts` | Read stats from DB instead of Portainer API |
| `backend/src/scheduler/setup.ts` | Warm cache on startup |
| `backend/src/plugins/cache-control.ts` | **New** — Cache-Control headers plugin |
| `backend/src/app.ts` | Register cache-control plugin |
| `frontend/src/hooks/use-cache-admin.ts` | Polling 10s → 30s |

### Deferred (require larger architectural changes)
- R7: Socket.IO broadcast for container state changes
- R10: Socket.IO push for metrics data
- R13: Batch security audit HostConfig calls (N+1)

## Estimated Impact

| Source | Savings |
|--------|---------|
| ES log forwarder caching (R5) | ~38 API calls/min |
| Monitoring cycle dedup (R9) | ~20 calls/5min |
| L1 TTL increase (R1) | ~50% fewer Redis lookups |
| Frontend staleTime + focus (R3+R4) | ~6-10 calls/30s |
| LLM context caching (R8) | ~10 lookups/message |
| Cache warming (R11) | Eliminates first-request thundering herd |
| Cache-Control headers (R12) | Browser/proxy caching layer |

## Testing

- [x] Backend: 115 test files, 1528 tests — all pass
- [x] Frontend: 111 test files, 949 tests — all pass
- [x] TypeScript typecheck clean
- [x] Lint passes (0 warnings)
- [x] New tests: `cache-control.test.ts` (4 tests)
- [x] Updated tests: ES log forwarder, log analyzer, monitoring service, query provider

## Rollback Plan

Revert this PR: `git revert <merge-commit-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)