### PR TITLE
fix(ci): run E2E tests on all PRs to main and nightly on dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, dev]
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  schedule:
+    # Nightly E2E on dev branch at 02:00 UTC
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 jobs:
@@ -116,11 +119,17 @@ jobs:
   e2e:
     name: E2E Smoke Tests
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'e2e') || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+      contains(github.event.pull_request.labels.*.name, 'e2e')
     needs: [build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- E2E tests now **auto-run on all PRs targeting `main`** (no `e2e` label needed)
- Label-gate **preserved for PRs targeting `dev`** (saves CI time on feature branches)
- Added **nightly cron schedule at 02:00 UTC** running E2E on the `dev` branch
- Schedule checkout uses explicit `ref` to ensure `dev` is tested (not default branch)

Closes #563

## Changes
| What | Where |
|------|-------|
| Add `schedule` trigger | `.github/workflows/ci.yml` line 9-11 |
| Update E2E `if` condition | `.github/workflows/ci.yml` line 122-126 |
| Add `ref` for schedule checkout | `.github/workflows/ci.yml` line 132 |

## E2E trigger matrix

| Event | Target | Label | E2E runs? |
|-------|--------|-------|-----------|
| PR | `main` | any | Yes (auto) |
| PR | `dev` | `e2e` | Yes |
| PR | `dev` | none | No |
| Schedule | `dev` | — | Yes (nightly 02:00 UTC) |
| Manual | any | — | Yes |

## Test plan
- [ ] Open a PR targeting `main` → E2E should trigger automatically
- [ ] Open a PR targeting `dev` without `e2e` label → E2E should NOT trigger
- [ ] Open a PR targeting `dev` with `e2e` label → E2E should trigger
- [ ] Verify nightly cron runs against `dev` branch (check Actions tab after 02:00 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)