### PR TITLE
fix(docker): pin TimescaleDB image to 2.25.0-pg17

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -147,7 +147,8 @@ services:
       - dashboard-net
 
   timescaledb:
-    image: timescale/timescaledb:latest-pg17
+    # Pinned version — avoid :latest for reproducible builds (see #554)
+    image: timescale/timescaledb:2.25.0-pg17
     restart: unless-stopped
     environment:
       POSTGRES_DB: metrics

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -127,7 +127,8 @@ services:
       - dashboard-net
 
   timescaledb:
-    image: timescale/timescaledb:latest-pg17
+    # Pinned version — avoid :latest for reproducible builds (see #554)
+    image: timescale/timescaledb:2.25.0-pg17
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## Summary
- Pin `timescale/timescaledb:latest-pg17` → `timescale/timescaledb:2.25.0-pg17` in both compose files
- Ensures reproducible builds — the `:latest` tag meant any `docker pull` could introduce breaking changes

Closes #554

## Changes
| File | Change |
|------|--------|
| `docker/docker-compose.yml` | Pin image + add comment |
| `docker/docker-compose.dev.yml` | Pin image + add comment |

## Test plan
- [ ] `docker compose -f docker/docker-compose.yml config` parses without errors
- [ ] `docker compose -f docker/docker-compose.dev.yml config` parses without errors
- [ ] `docker compose -f docker/docker-compose.dev.yml pull timescaledb` pulls the pinned image

🤖 Generated with [Claude Code](https://claude.com/claude-code)