### PR TITLE
feat(reports): separate infrastructure services and default to exclusion

### DIFF
--- a/backend/src/db/migrations/033_reports_infrastructure_patterns.sql
+++ b/backend/src/db/migrations/033_reports_infrastructure_patterns.sql
@@ -1,0 +1,10 @@
+INSERT INTO settings (key, value, category, updated_at)
+SELECT
+  'reports.infrastructure_service_patterns',
+  '["traefik","portainer_agent","beyla"]',
+  'reports',
+  datetime('now')
+WHERE NOT EXISTS (
+  SELECT 1 FROM settings WHERE key = 'reports.infrastructure_service_patterns'
+);
+

--- a/backend/src/models/api-schemas.ts
+++ b/backend/src/models/api-schemas.ts
@@ -486,5 +486,6 @@ export const ReportsQuerySchema = z.object({
   timeRange: z.enum(['24h', '7d', '30d']).optional(),
   endpointId: z.coerce.number().optional(),
   containerId: z.string().optional(),
-  includeInfrastructure: QueryBooleanSchema.default(false),
+  includeInfrastructure: QueryBooleanSchema.optional(),
+  excludeInfrastructure: QueryBooleanSchema.optional(),
 });

--- a/backend/src/services/infrastructure-service-classifier.test.ts
+++ b/backend/src/services/infrastructure-service-classifier.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getInfrastructureServicePatterns,
+  isInfrastructureService,
+} from './infrastructure-service-classifier.js';
+
+const mockGetSetting = vi.hoisted(() => vi.fn());
+
+vi.mock('./settings-store.js', () => ({
+  getSetting: (...args: unknown[]) => mockGetSetting(...args),
+}));
+
+describe('infrastructure-service-classifier', () => {
+  beforeEach(() => {
+    mockGetSetting.mockReset();
+  });
+
+  it('falls back to default infrastructure patterns when setting is not present', () => {
+    mockGetSetting.mockReturnValue(undefined);
+    expect(getInfrastructureServicePatterns()).toEqual(['traefik', 'portainer_agent', 'beyla']);
+  });
+
+  it('loads patterns from JSON array setting', () => {
+    mockGetSetting.mockReturnValue({
+      value: '["Traefik","portainer_agent","beyla","Traefik"]',
+    });
+    expect(getInfrastructureServicePatterns()).toEqual(['traefik', 'portainer_agent', 'beyla']);
+  });
+
+  it('loads patterns from comma-separated setting', () => {
+    mockGetSetting.mockReturnValue({
+      value: 'traefik,portainer_agent,beyla',
+    });
+    expect(getInfrastructureServicePatterns()).toEqual(['traefik', 'portainer_agent', 'beyla']);
+  });
+
+  it('matches exact and prefixed infrastructure service names', () => {
+    const patterns = ['traefik', 'portainer_agent', 'beyla'];
+    expect(isInfrastructureService('traefik', patterns)).toBe(true);
+    expect(isInfrastructureService('traefik-prod', patterns)).toBe(true);
+    expect(isInfrastructureService('portainer_agent_1', patterns)).toBe(true);
+    expect(isInfrastructureService('customer-api', patterns)).toBe(false);
+  });
+});
+

--- a/backend/src/services/infrastructure-service-classifier.ts
+++ b/backend/src/services/infrastructure-service-classifier.ts
@@ -1,0 +1,52 @@
+import { getSetting } from './settings-store.js';
+
+const INFRASTRUCTURE_PATTERNS_KEY = 'reports.infrastructure_service_patterns';
+const DEFAULT_INFRASTRUCTURE_PATTERNS = ['traefik', 'portainer_agent', 'beyla'];
+
+function normalizePattern(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function parsePatterns(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (!Array.isArray(parsed)) return [];
+      return parsed
+        .filter((item): item is string => typeof item === 'string')
+        .map(normalizePattern)
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  return trimmed
+    .split(',')
+    .map(normalizePattern)
+    .filter(Boolean);
+}
+
+export function getInfrastructureServicePatterns(): string[] {
+  const raw = getSetting(INFRASTRUCTURE_PATTERNS_KEY)?.value ?? '';
+  const configured = parsePatterns(raw);
+  const source = configured.length > 0 ? configured : DEFAULT_INFRASTRUCTURE_PATTERNS;
+  return Array.from(new Set(source.map(normalizePattern).filter(Boolean)));
+}
+
+export function isInfrastructureService(name: string, patterns?: string[]): boolean {
+  const normalized = name.trim().toLowerCase();
+  const activePatterns = patterns && patterns.length > 0
+    ? patterns
+    : getInfrastructureServicePatterns();
+
+  return activePatterns.some((pattern) => (
+    normalized === pattern
+    || normalized.startsWith(`${pattern}-`)
+    || normalized.startsWith(`${pattern}_`)
+  ));
+}
+

--- a/frontend/src/hooks/use-reports.test.ts
+++ b/frontend/src/hooks/use-reports.test.ts
@@ -57,6 +57,27 @@ describe('useUtilizationReport', () => {
         timeRange: '7d',
         endpointId: 12,
         containerId: 'container-1',
+        excludeInfrastructure: true,
+      },
+    });
+  });
+
+  it('passes excludeInfrastructure override to utilization endpoint', async () => {
+    const getSpy = vi.mocked(api.get);
+    getSpy.mockClear();
+
+    const { result } = renderHook(
+      () => useUtilizationReport('7d', 12, 'container-1', false),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getSpy).toHaveBeenCalledWith('/api/reports/utilization', {
+      params: {
+        timeRange: '7d',
+        endpointId: 12,
+        containerId: 'container-1',
+        excludeInfrastructure: false,
       },
     });
   });
@@ -84,6 +105,7 @@ describe('useTrendsReport', () => {
         timeRange: '30d',
         endpointId: 9,
         containerId: 'container-77',
+        excludeInfrastructure: true,
       },
     });
   });

--- a/frontend/src/hooks/use-reports.ts
+++ b/frontend/src/hooks/use-reports.ts
@@ -15,6 +15,7 @@ export interface ContainerReport {
   container_id: string;
   container_name: string;
   endpoint_id: number;
+  service_type: 'application' | 'infrastructure';
   cpu: MetricStats | null;
   memory: MetricStats | null;
   memory_bytes: MetricStats | null;
@@ -23,11 +24,14 @@ export interface ContainerReport {
 export interface Recommendation {
   container_id: string;
   container_name: string;
+  service_type: 'application' | 'infrastructure';
   issues: string[];
 }
 
 export interface UtilizationReport {
   timeRange: string;
+  includeInfrastructure: boolean;
+  excludeInfrastructure: boolean;
   containers: ContainerReport[];
   fleetSummary: {
     totalContainers: number;
@@ -49,6 +53,8 @@ interface TrendPoint {
 
 export interface TrendsReport {
   timeRange: string;
+  includeInfrastructure: boolean;
+  excludeInfrastructure: boolean;
   trends: {
     cpu: TrendPoint[];
     memory: TrendPoint[];
@@ -60,14 +66,16 @@ export function useUtilizationReport(
   timeRange: string,
   endpointId?: number,
   containerId?: string,
+  excludeInfrastructure = true,
 ) {
   return useQuery<UtilizationReport>({
-    queryKey: ['reports', 'utilization', timeRange, endpointId, containerId],
+    queryKey: ['reports', 'utilization', timeRange, endpointId, containerId, excludeInfrastructure],
     queryFn: () => {
-      const params: Record<string, string | number | undefined> = {
+      const params: Record<string, string | number | boolean | undefined> = {
         timeRange,
         endpointId,
         containerId,
+        excludeInfrastructure,
       };
       return api.get<UtilizationReport>('/api/reports/utilization', { params });
     },
@@ -78,14 +86,16 @@ export function useTrendsReport(
   timeRange: string,
   endpointId?: number,
   containerId?: string,
+  excludeInfrastructure = true,
 ) {
   return useQuery<TrendsReport>({
-    queryKey: ['reports', 'trends', timeRange, endpointId, containerId],
+    queryKey: ['reports', 'trends', timeRange, endpointId, containerId, excludeInfrastructure],
     queryFn: () => {
-      const params: Record<string, string | number | undefined> = {
+      const params: Record<string, string | number | boolean | undefined> = {
         timeRange,
         endpointId,
         containerId,
+        excludeInfrastructure,
       };
       return api.get<TrendsReport>('/api/reports/trends', { params });
     },


### PR DESCRIPTION
## Summary
- default reports to exclude infrastructure services (excludeInfrastructure=true behavior)
- add DB-backed infrastructure classification source via reports.infrastructure_service_patterns
- add service_type metadata and apply consistent filtering across utilization/trends/management/CSV
- split reports UI into Application Services and Infrastructure Services
- update backend/frontend tests for new query and behavior

## Validation
- npm run test -w backend -- src/routes/reports.test.ts src/services/infrastructure-service-classifier.test.ts
- npm run test -w frontend -- src/hooks/use-reports.test.ts src/pages/reports.test.tsx
- npm run typecheck

Closes #601