### PR TITLE
fix(security): enforce admin RBAC on mutating PCAP routes

### DIFF
--- a/backend/src/routes/pcap.ts
+++ b/backend/src/routes/pcap.ts
@@ -26,7 +26,7 @@ export async function pcapRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       body: StartCaptureRequestSchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const parsed = StartCaptureRequestSchema.safeParse(request.body);
     if (!parsed.success) {
@@ -113,7 +113,7 @@ export async function pcapRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       params: ActionIdParamsSchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
 
@@ -175,7 +175,7 @@ export async function pcapRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       params: ActionIdParamsSchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
 
@@ -213,7 +213,7 @@ export async function pcapRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       params: ActionIdParamsSchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
 


### PR DESCRIPTION
## Research
- reviewed issue #583 requirements for Security First principles #1 and #7
- confirmed mutating PCAP endpoints were only guarded by authentication

## Plan
- require admin role on mutating PCAP endpoints in backend route handlers
- add route tests for non-admin 403 and admin success paths
- add targeted security-regression coverage for PCAP admin gating

## Implementation
- add `fastify.requireRole('admin')` to:
  - POST /api/pcap/captures
  - POST /api/pcap/captures/:id/stop
  - POST /api/pcap/captures/:id/analyze
  - DELETE /api/pcap/captures/:id
- update `backend/src/routes/pcap.test.ts` with explicit non-admin 403 checks for all mutating endpoints
- add `PCAP Admin RBAC Enforcement` regression section in `backend/src/routes/security-regression.test.ts`

## Validation
- npm run test -w backend -- src/routes/pcap.test.ts src/routes/security-regression.test.ts
- npm run typecheck -w backend

Fixes #583