### PR TITLE
security: require Redis authentication in workloads/data-services.yml

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -1221,6 +1221,14 @@ describe('Infrastructure Exposure Defaults', () => {
     expect(content).not.toMatch(/ports:\s*\n\s*-\s*["']?9090:9090["']?/m);
   });
 
+  it('should require Redis auth in workloads/data-services.yml', () => {
+    const file = path.resolve(process.cwd(), '..', 'workloads', 'data-services.yml');
+    const content = readFileSync(file, 'utf8');
+
+    expect(content).toContain('--requirepass ${REDIS_PASSWORD:-changeme-redis}');
+    expect(content).toMatch(/redis-cli -a \\"\$\{REDIS_PASSWORD:-changeme-redis\}\\" ping/);
+  });
+
   it('should document localhost-bound Ollama startup in README', () => {
     const file = path.resolve(process.cwd(), '..', 'README.md');
     const content = readFileSync(file, 'utf8');

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -118,6 +118,7 @@ CACHE_ENABLED=true
 CACHE_TTL_SECONDS=900
 REDIS_URL=redis://redis:6379
 REDIS_PASSWORD=CHANGE_ME_BEFORE_PRODUCTION
+# Also used by workload stacks (e.g., workloads/data-services.yml, workloads/workers.yml).
 REDIS_KEY_PREFIX=aidash:cache:
 # Redis server memory limit — evicts least-recently-used keys when full (allkeys-lru)
 REDIS_MAXMEMORY=512mb

--- a/docs/test-workloads.md
+++ b/docs/test-workloads.md
@@ -16,6 +16,13 @@ Five Docker Compose stacks are provided to spin up realistic test containers acr
 ./scripts/deploy-workload.sh delete
 ```
 
+## Redis Auth Defaults
+
+- `workloads/data-services.yml` enables Redis authentication by default via `--requirepass`.
+- Set `REDIS_PASSWORD` in your project `.env` before deploying workloads.
+- If `REDIS_PASSWORD` is not set, workload stacks fall back to `changeme-redis` for local/dev convenience only.
+- Never use the fallback value outside local/dev testing.
+
 ## Stacks
 
 | Stack | Services | Purpose |

--- a/workloads/data-services.yml
+++ b/workloads/data-services.yml
@@ -28,12 +28,16 @@ services:
   db-redis:
     image: redis:7-alpine
     container_name: db-redis
-    command: redis-server --maxmemory 64mb --maxmemory-policy allkeys-lru
+    command: >
+      redis-server
+      --maxmemory 64mb
+      --maxmemory-policy allkeys-lru
+      --requirepass ${REDIS_PASSWORD:-changeme-redis}
     labels:
       app.tier: "cache"
       app.env: "production"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD-SHELL", "redis-cli -a \"${REDIS_PASSWORD:-changeme-redis}\" ping | grep -q PONG"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/workloads/workers.yml
+++ b/workloads/workers.yml
@@ -23,13 +23,16 @@ services:
 
   # API server that queries Redis and Postgres every 10s
   app-api:
-    image: alpine:latest
+    image: redis:7-alpine
     container_name: app-api
+    environment:
+      REDIS_URL: redis://:${REDIS_PASSWORD:-changeme-redis}@db-redis:6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-changeme-redis}
     command: >
       sh -c "
       while true; do
         echo \"[app-api] Pinging db-redis...\";
-        nc -z -w2 db-redis 6379 && echo '  redis: OK' || echo '  redis: FAIL';
+        redis-cli -h db-redis -a \"$$REDIS_PASSWORD\" ping 2>/dev/null | grep -q PONG && echo '  redis(auth): OK' || echo '  redis(auth): FAIL';
         echo \"[app-api] Pinging db-postgres...\";
         nc -z -w2 db-postgres 5432 && echo '  postgres: OK' || echo '  postgres: FAIL';
         sleep 10;


### PR DESCRIPTION
## Summary
- require Redis authentication in workloads/data-services.yml via --requirepass
- update Redis healthcheck to authenticate with REDIS_PASSWORD
- wire workload client usage in workloads/workers.yml with REDIS_PASSWORD and authenticated ping
- document workload Redis auth defaults in docs/test-workloads.md and clarify shared env usage in docker/.env.example
- add security regression coverage for this hardening in backend/src/routes/security-regression.test.ts

## Testing
- npx vitest run src/routes/security-regression.test.ts

Fixes #586
