### PR TITLE
feat(ui): Tier 1 visual upgrades — spotlight, sparklines, shimmer

### DIFF
--- a/frontend/src/components/shared/kpi-card.test.tsx
+++ b/frontend/src/components/shared/kpi-card.test.tsx
@@ -78,7 +78,9 @@ describe('KpiCard', () => {
       <KpiCard label="Custom" value={1} className="custom-class" />,
     );
 
-    expect(container.firstChild).toHaveClass('custom-class');
+    // The SpotlightCard wrapper is container.firstChild; the inner card div has the className
+    const innerCard = container.querySelector('.custom-class');
+    expect(innerCard).toBeInTheDocument();
   });
 
   it('should not render trend when not provided', () => {
@@ -125,8 +127,9 @@ describe('KpiCard', () => {
     const detail = screen.getByText('Last hour: +3 | Peak: 20 | Avg: 14');
     expect(detail).toBeInTheDocument();
 
-    // Simulate hover
-    fireEvent.mouseEnter(container.firstChild!);
+    // The inner card div (with the hover handler) is inside the SpotlightCard wrapper
+    const innerCard = container.querySelector('.bg-card')!;
+    fireEvent.mouseEnter(innerCard);
     // The detail container should now be visible
     expect(detail.parentElement).toHaveClass('opacity-100');
   });
@@ -140,9 +143,9 @@ describe('KpiCard', () => {
       />,
     );
 
-    const card = container.firstChild!;
-    fireEvent.mouseEnter(card);
-    fireEvent.mouseLeave(card);
+    const innerCard = container.querySelector('.bg-card')!;
+    fireEvent.mouseEnter(innerCard);
+    fireEvent.mouseLeave(innerCard);
 
     const detail = screen.getByText('Last hour: +3 | Peak: 20 | Avg: 14');
     expect(detail.parentElement).toHaveClass('opacity-0');

--- a/frontend/src/components/shared/kpi-card.tsx
+++ b/frontend/src/components/shared/kpi-card.tsx
@@ -5,6 +5,7 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { useCountUp } from '@/hooks/use-count-up';
 import { KpiSparkline } from '@/components/charts/kpi-sparkline';
 import { useUiStore } from '@/stores/ui-store';
+import { SpotlightCard } from '@/components/shared/spotlight-card';
 
 interface KpiCardProps {
   label: string;
@@ -56,67 +57,69 @@ export function KpiCard({
   const [hovered, setHovered] = useState(false);
 
   return (
-    <div
-      className={cn(
-        'rounded-lg border bg-card p-6 shadow-sm transition-all duration-200',
-        !potatoMode && 'hover:shadow-md hover:-translate-y-0.5 hover:border-primary/20',
-        className,
-      )}
-      onMouseEnter={() => !potatoMode && setHovered(true)}
-      onMouseLeave={() => !potatoMode && setHovered(false)}
-    >
-      <div className="flex items-center justify-between">
-        <p className="text-sm font-medium text-muted-foreground">{label}</p>
-        <div className="flex items-center gap-2">
-          {sparklineData && sparklineData.length >= 2 && (
-            <KpiSparkline values={sparklineData} color={sparklineColor} />
-          )}
-          {icon && <div className="text-muted-foreground">{icon}</div>}
-        </div>
-      </div>
-      <div className="mt-2 flex items-baseline gap-2">
-        <motion.p
-          className="text-3xl font-bold tracking-tight"
-          animate={
-            pulse && !reducedMotion
-              ? { scale: [1, 1.05, 1] }
-              : { scale: 1 }
-          }
-          transition={{ duration: 0.3, ease: 'easeOut' }}
-        >
-          {isNumeric ? displayValue : value}
-        </motion.p>
-        {trend && (
-          <motion.span
-            className={cn(
-              'inline-flex items-center gap-1 text-xs font-medium',
-              trend === 'up' && 'text-emerald-600 dark:text-emerald-400',
-              trend === 'down' && 'text-red-600 dark:text-red-400',
-              trend === 'neutral' && 'text-muted-foreground',
+    <SpotlightCard>
+      <div
+        className={cn(
+          'rounded-lg border bg-card p-6 shadow-sm transition-all duration-200',
+          !potatoMode && 'hover:shadow-md hover:-translate-y-0.5 hover:border-primary/20',
+          className,
+        )}
+        onMouseEnter={() => !potatoMode && setHovered(true)}
+        onMouseLeave={() => !potatoMode && setHovered(false)}
+      >
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
+          <div className="flex items-center gap-2">
+            {sparklineData && sparklineData.length >= 2 && (
+              <KpiSparkline values={sparklineData} color={sparklineColor} />
             )}
-            initial={reducedMotion ? false : { opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.8, duration: 0.2, type: 'spring', bounce: 0.4 }}
+            {icon && <div className="text-muted-foreground">{icon}</div>}
+          </div>
+        </div>
+        <div className="mt-2 flex items-baseline gap-2">
+          <motion.p
+            className="text-3xl font-bold tracking-tight"
+            animate={
+              pulse && !reducedMotion
+                ? { scale: [1, 1.05, 1] }
+                : { scale: 1 }
+            }
+            transition={{ duration: 0.3, ease: 'easeOut' }}
           >
-            {trend === 'up' && <TrendingUp className="h-3 w-3" />}
-            {trend === 'down' && <TrendingDown className="h-3 w-3" />}
-            {trend === 'neutral' && <Minus className="h-3 w-3" />}
-            {trendValue}
-          </motion.span>
+            {isNumeric ? displayValue : value}
+          </motion.p>
+          {trend && (
+            <motion.span
+              className={cn(
+                'inline-flex items-center gap-1 text-xs font-medium',
+                trend === 'up' && 'text-emerald-600 dark:text-emerald-400',
+                trend === 'down' && 'text-red-600 dark:text-red-400',
+                trend === 'neutral' && 'text-muted-foreground',
+              )}
+              initial={reducedMotion ? false : { opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.8, duration: 0.2, type: 'spring', bounce: 0.4 }}
+            >
+              {trend === 'up' && <TrendingUp className="h-3 w-3" />}
+              {trend === 'down' && <TrendingDown className="h-3 w-3" />}
+              {trend === 'neutral' && <Minus className="h-3 w-3" />}
+              {trendValue}
+            </motion.span>
+          )}
+        </div>
+
+        {/* Hover detail expansion */}
+        {hoverDetail && !potatoMode && (
+          <div
+            className={cn(
+              'overflow-hidden transition-all duration-200',
+              hovered ? 'mt-2 max-h-8 opacity-100' : 'max-h-0 opacity-0',
+            )}
+          >
+            <p className="text-xs text-muted-foreground">{hoverDetail}</p>
+          </div>
         )}
       </div>
-
-      {/* Hover detail expansion */}
-      {hoverDetail && !potatoMode && (
-        <div
-          className={cn(
-            'overflow-hidden transition-all duration-200',
-            hovered ? 'mt-2 max-h-8 opacity-100' : 'max-h-0 opacity-0',
-          )}
-        >
-          <p className="text-xs text-muted-foreground">{hoverDetail}</p>
-        </div>
-      )}
-    </div>
+    </SpotlightCard>
   );
 }

--- a/frontend/src/components/shared/shimmer-text.test.tsx
+++ b/frontend/src/components/shared/shimmer-text.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ShimmerText } from './shimmer-text';
+
+// Default: potatoMode = false
+vi.mock('@/stores/ui-store', () => ({
+  useUiStore: (selector: (s: { potatoMode: boolean }) => boolean) =>
+    selector({ potatoMode: false }),
+}));
+
+describe('ShimmerText', () => {
+  it('should render children text', () => {
+    render(<ShimmerText>Loading...</ShimmerText>);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('should have the shimmer animation class', () => {
+    render(<ShimmerText>Thinking...</ShimmerText>);
+
+    const el = screen.getByText('Thinking...');
+    expect(el).toHaveClass('shimmer-text-animate');
+  });
+
+  it('should have gradient text classes', () => {
+    render(<ShimmerText>Test</ShimmerText>);
+
+    const el = screen.getByText('Test');
+    expect(el).toHaveClass('bg-gradient-to-r');
+    expect(el).toHaveClass('bg-clip-text');
+    expect(el).toHaveClass('text-transparent');
+  });
+
+  it('should apply custom className', () => {
+    render(<ShimmerText className="text-lg">Custom</ShimmerText>);
+
+    const el = screen.getByText('Custom');
+    expect(el).toHaveClass('text-lg');
+  });
+
+  it('should set backgroundSize inline style', () => {
+    render(<ShimmerText>Styled</ShimmerText>);
+
+    const el = screen.getByText('Styled');
+    expect(el.style.backgroundSize).toBe('200% auto');
+  });
+});

--- a/frontend/src/components/shared/shimmer-text.tsx
+++ b/frontend/src/components/shared/shimmer-text.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@/lib/utils';
+import { useUiStore } from '@/stores/ui-store';
+
+interface ShimmerTextProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Animated gradient text for AI loading states.
+ * Shows a sweeping shimmer effect across the text.
+ *
+ * Respects prefers-reduced-motion (via CSS) and potato mode
+ * (falls back to static muted text).
+ */
+export function ShimmerText({ children, className }: ShimmerTextProps) {
+  const potatoMode = useUiStore((state) => state.potatoMode);
+
+  if (potatoMode) {
+    return (
+      <span className={cn('text-muted-foreground', className)}>
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-block bg-gradient-to-r from-gray-400 via-white to-gray-400 bg-clip-text text-transparent',
+        'shimmer-text-animate',
+        className,
+      )}
+      style={{ backgroundSize: '200% auto' }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/shared/sparkline.test.tsx
+++ b/frontend/src/components/shared/sparkline.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Sparkline } from './sparkline';
+
+describe('Sparkline', () => {
+  it('should render an SVG element', () => {
+    const { container } = render(
+      <Sparkline data={[10, 20, 15, 25]} />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('should render nothing for empty data', () => {
+    const { container } = render(<Sparkline data={[]} />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeNull();
+  });
+
+  it('should render nothing for single data point', () => {
+    const { container } = render(<Sparkline data={[42]} />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeNull();
+  });
+
+  it('should render 2 path elements (line + fill)', () => {
+    const { container } = render(
+      <Sparkline data={[5, 10, 8, 12, 7]} />,
+    );
+
+    const paths = container.querySelectorAll('path');
+    expect(paths).toHaveLength(2);
+  });
+
+  it('should handle flat data (all same values)', () => {
+    const { container } = render(
+      <Sparkline data={[5, 5, 5, 5]} />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+
+    const paths = container.querySelectorAll('path');
+    expect(paths).toHaveLength(2);
+  });
+
+  it('should use custom width and height', () => {
+    const { container } = render(
+      <Sparkline data={[1, 2, 3]} width={120} height={40} />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('viewBox', '0 0 120 40');
+    expect(svg).toHaveAttribute('width', '120');
+    expect(svg).toHaveAttribute('height', '40');
+  });
+
+  it('should use custom color for stroke', () => {
+    const { container } = render(
+      <Sparkline data={[1, 2, 3]} color="#ff0000" />,
+    );
+
+    const paths = container.querySelectorAll('path');
+    // Second path is the line (stroke path)
+    const linePath = paths[1];
+    expect(linePath).toHaveAttribute('stroke', '#ff0000');
+  });
+
+  it('should apply className to the SVG', () => {
+    const { container } = render(
+      <Sparkline data={[1, 2, 3]} className="my-sparkline" />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('my-sparkline');
+  });
+});

--- a/frontend/src/components/shared/sparkline.tsx
+++ b/frontend/src/components/shared/sparkline.tsx
@@ -1,0 +1,72 @@
+interface SparklineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  color?: string;
+  className?: string;
+}
+
+/**
+ * A pure SVG mini chart component for inline sparkline visualizations.
+ * Uses currentColor by default for automatic theme awareness.
+ */
+export function Sparkline({
+  data,
+  width = 96,
+  height = 32,
+  color = 'currentColor',
+  className,
+}: SparklineProps) {
+  if (data.length < 2) return null;
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1; // avoid division by zero for flat data
+
+  const points = data.map((value, index) => {
+    const x = (index / (data.length - 1)) * width;
+    // Invert Y: SVG y=0 is top, so higher values should be higher on screen
+    const y = height - ((value - min) / range) * height;
+    return { x, y };
+  });
+
+  // Build the line path
+  const linePath = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`)
+    .join(' ');
+
+  // Build the fill path (close along the bottom)
+  const fillPath = `${linePath} L ${width} ${height} L 0 ${height} Z`;
+
+  const gradientId = `sparkline-grad-${width}-${height}`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      width={width}
+      height={height}
+      className={className}
+      role="img"
+      aria-label="Sparkline chart"
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity={0.3} />
+          <stop offset="100%" stopColor={color} stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      {/* Gradient fill under the line */}
+      <path d={fillPath} fill={`url(#${gradientId})`} />
+      {/* The line itself */}
+      <path
+        d={linePath}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/shared/spotlight-card.test.tsx
+++ b/frontend/src/components/shared/spotlight-card.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SpotlightCard } from './spotlight-card';
+
+// Mock the ui-store so potatoMode defaults to false
+vi.mock('@/stores/ui-store', () => ({
+  useUiStore: (selector: (s: { potatoMode: boolean }) => boolean) =>
+    selector({ potatoMode: false }),
+}));
+
+describe('SpotlightCard', () => {
+  it('should render children', () => {
+    render(
+      <SpotlightCard>
+        <p>Card content</p>
+      </SpotlightCard>,
+    );
+
+    expect(screen.getByText('Card content')).toBeInTheDocument();
+  });
+
+  it('should have the spotlight-card class', () => {
+    const { container } = render(
+      <SpotlightCard>
+        <p>Test</p>
+      </SpotlightCard>,
+    );
+
+    expect(container.firstChild).toHaveClass('spotlight-card');
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(
+      <SpotlightCard className="my-custom-class">
+        <p>Test</p>
+      </SpotlightCard>,
+    );
+
+    expect(container.firstChild).toHaveClass('my-custom-class');
+  });
+
+  it('should have onMouseMove handler on the element', () => {
+    const { container } = render(
+      <SpotlightCard>
+        <p>Test</p>
+      </SpotlightCard>,
+    );
+
+    const el = container.firstChild as HTMLDivElement;
+    // Verify the element can receive mouse events by firing one
+    // (no error thrown = handler is attached)
+    expect(() => {
+      fireEvent.mouseMove(el, { clientX: 100, clientY: 50 });
+    }).not.toThrow();
+  });
+
+  it('should set --x and --y CSS variables on mousemove', () => {
+    const { container } = render(
+      <SpotlightCard>
+        <p>Test</p>
+      </SpotlightCard>,
+    );
+
+    const el = container.firstChild as HTMLDivElement;
+    // Mock getBoundingClientRect for predictable values
+    el.getBoundingClientRect = vi.fn(() => ({
+      left: 10,
+      top: 20,
+      right: 210,
+      bottom: 220,
+      width: 200,
+      height: 200,
+      x: 10,
+      y: 20,
+      toJSON: vi.fn(),
+    }));
+
+    fireEvent.mouseMove(el, { clientX: 60, clientY: 70 });
+
+    expect(el.style.getPropertyValue('--x')).toBe('50px');
+    expect(el.style.getPropertyValue('--y')).toBe('50px');
+  });
+});

--- a/frontend/src/components/shared/spotlight-card.tsx
+++ b/frontend/src/components/shared/spotlight-card.tsx
@@ -1,0 +1,42 @@
+import { useRef, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+import { useUiStore } from '@/stores/ui-store';
+
+interface SpotlightCardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * A wrapper component that shows a radial gradient spotlight
+ * following the mouse on hover. Uses CSS custom properties
+ * (--x, --y) instead of React state for smooth, paint-only updates.
+ *
+ * Disabled in potato mode to avoid unnecessary GPU work.
+ */
+export function SpotlightCard({ children, className }: SpotlightCardProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const potatoMode = useUiStore((state) => state.potatoMode);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (potatoMode) return;
+      const el = containerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      el.style.setProperty('--x', `${e.clientX - rect.left}px`);
+      el.style.setProperty('--y', `${e.clientY - rect.top}px`);
+    },
+    [potatoMode],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('spotlight-card', className)}
+      onMouseMove={handleMouseMove}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1896,3 +1896,122 @@ html[data-potato-mode] body {
   opacity: 1 !important;
   transform: none !important;
 }
+
+/* ============================================
+   TIER 1 VISUAL UPGRADES
+   ============================================ */
+
+/* ====== SPOTLIGHT CARD (mouse-follow radial glow) ====== */
+.spotlight-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.spotlight-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  background: radial-gradient(
+    600px circle at var(--x, 50%) var(--y, 50%),
+    rgba(255, 255, 255, 0.06),
+    transparent 40%
+  );
+}
+
+.spotlight-card:hover::before {
+  opacity: 1;
+}
+
+[data-potato-mode] .spotlight-card::before {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spotlight-card::before {
+    transition: none;
+  }
+}
+
+/* ====== NOISE / GRAIN TEXTURE OVERLAY ====== */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.03;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+}
+
+[data-potato-mode] body::after {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body::after {
+    display: none;
+  }
+}
+
+/* ====== SHIMMER TEXT ANIMATION ====== */
+@keyframes shimmer-text {
+  from {
+    background-position: 200% center;
+  }
+  to {
+    background-position: -200% center;
+  }
+}
+
+.shimmer-text-animate {
+  animation: shimmer-text 3s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shimmer-text-animate {
+    animation: none;
+    background: none;
+    color: var(--color-muted-foreground);
+    -webkit-text-fill-color: var(--color-muted-foreground);
+  }
+}
+
+/* ====== ANIMATED GRADIENT BORDERS ====== */
+@property --angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
+.animate-gradient-border {
+  --angle: 0deg;
+  border: 2px solid transparent;
+  background:
+    linear-gradient(var(--color-card, white), var(--color-card, white)) padding-box,
+    conic-gradient(from var(--angle), transparent 25%, var(--color-primary, #6366f1) 50%, transparent 75%) border-box;
+  animation: rotate-gradient-border 4s linear infinite;
+}
+
+@keyframes rotate-gradient-border {
+  to {
+    --angle: 360deg;
+  }
+}
+
+[data-potato-mode] .animate-gradient-border {
+  animation: none;
+  border-color: var(--color-border);
+  background: var(--color-card);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-gradient-border {
+    animation: none;
+    border-color: var(--color-border);
+    background: var(--color-card);
+  }
+}

--- a/frontend/src/pages/llm-assistant.tsx
+++ b/frontend/src/pages/llm-assistant.tsx
@@ -10,6 +10,7 @@ import { useLlmChat, type ToolCallEvent } from '@/hooks/use-llm-chat';
 import { useLlmModels } from '@/hooks/use-llm-models';
 import { useMcpServers } from '@/hooks/use-mcp';
 import { LlmFeedbackButtons } from '@/components/shared/llm-feedback-buttons';
+import { ShimmerText } from '@/components/shared/shimmer-text';
 
 const TOOL_DISPLAY_NAMES: Record<string, string> = {
   query_containers: 'Querying containers',
@@ -226,7 +227,7 @@ export default function LlmAssistantPage() {
                         <span className="h-2 w-2 rounded-full bg-blue-500 animate-bounce [animation-delay:-0.15s]" />
                         <span className="h-2 w-2 rounded-full bg-blue-500 animate-bounce" />
                       </div>
-                      <span className="text-[13px] text-muted-foreground">Thinking...</span>
+                      <ShimmerText className="text-[13px]">Thinking...</ShimmerText>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- **SpotlightCard**: Mouse-tracking radial gradient glow wrapper, used on KPI cards
- **Sparkline**: Pure SVG mini chart component with gradient fill for inline data viz
- **ShimmerText**: Animated gradient text for AI thinking/loading states (replaces static "Thinking...")
- **Noise texture overlay**: Subtle SVG `feTurbulence` noise pattern via CSS `::after`
- **Gradient border animation**: `@property --angle` animated conic-gradient card borders
- All animations respect `prefers-reduced-motion` and potato mode
- 18 new tests across 3 component test files

Closes #608

## Test plan
- [x] Verify spotlight glow follows cursor on KPI cards
- [x] Verify sparkline renders correctly with varying data
- [x] Verify shimmer text animation on LLM assistant thinking state
- [x] Verify all animations disabled in potato mode
- [x] Verify reduced motion preference respected
- [ ] Run `cd frontend && npx vitest run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)