### PR TITLE
feat(oidc): add group-to-role mapping for automatic role assignment (closes #542)

### DIFF
--- a/backend/src/db/migrations/041_oidc_group_mapping.sql
+++ b/backend/src/db/migrations/041_oidc_group_mapping.sql
@@ -1,0 +1,6 @@
+-- OIDC group-to-role mapping settings
+-- Allows administrators to map IdP groups to dashboard roles (viewer, operator, admin)
+INSERT OR IGNORE INTO settings (key, value, category) VALUES
+  ('oidc.groups_claim', 'groups', 'authentication'),
+  ('oidc.group_role_mappings', '{}', 'authentication'),
+  ('oidc.auto_provision', 'true', 'authentication');

--- a/backend/src/services/oidc-group-mapping.test.ts
+++ b/backend/src/services/oidc-group-mapping.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../db/sqlite.js', () => ({ getDb: vi.fn() }));
+vi.mock('openid-client', () => ({}));
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+import { resolveRoleFromGroups, extractGroups } from './oidc.js';
+
+describe('resolveRoleFromGroups', () => {
+  it('should return undefined when groups array is empty', () => {
+    const result = resolveRoleFromGroups([], { 'Admins': 'admin' });
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when mappings are empty', () => {
+    const result = resolveRoleFromGroups(['Admins'], {});
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the mapped role for a single matching group', () => {
+    const result = resolveRoleFromGroups(
+      ['Dashboard-Admins'],
+      { 'Dashboard-Admins': 'admin' },
+    );
+    expect(result).toBe('admin');
+  });
+
+  it('should return the highest-privilege role when user has multiple matching groups', () => {
+    const result = resolveRoleFromGroups(
+      ['Viewers', 'Operators', 'Admins'],
+      {
+        'Viewers': 'viewer',
+        'Operators': 'operator',
+        'Admins': 'admin',
+      },
+    );
+    expect(result).toBe('admin');
+  });
+
+  it('should use highest-privilege-wins regardless of group order', () => {
+    const result = resolveRoleFromGroups(
+      ['Admins', 'Viewers'],
+      {
+        'Admins': 'admin',
+        'Viewers': 'viewer',
+      },
+    );
+    expect(result).toBe('admin');
+  });
+
+  it('should use wildcard fallback when no explicit match', () => {
+    const result = resolveRoleFromGroups(
+      ['Unknown-Group'],
+      {
+        'Admins': 'admin',
+        '*': 'viewer',
+      },
+    );
+    expect(result).toBe('viewer');
+  });
+
+  it('should prefer explicit match over wildcard', () => {
+    const result = resolveRoleFromGroups(
+      ['Operators'],
+      {
+        'Operators': 'operator',
+        '*': 'viewer',
+      },
+    );
+    expect(result).toBe('operator');
+  });
+
+  it('should ignore groups with empty or whitespace-only names', () => {
+    const result = resolveRoleFromGroups(
+      ['', '  ', 'Admins'],
+      { 'Admins': 'admin' },
+    );
+    expect(result).toBe('admin');
+  });
+
+  it('should return undefined when no groups match and no wildcard', () => {
+    const result = resolveRoleFromGroups(
+      ['Unknown-Group'],
+      { 'Admins': 'admin' },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('should ignore invalid role values in mappings', () => {
+    const result = resolveRoleFromGroups(
+      ['BadGroup', 'GoodGroup'],
+      {
+        'BadGroup': 'superadmin' as never,
+        'GoodGroup': 'operator',
+      },
+    );
+    expect(result).toBe('operator');
+  });
+
+  it('should handle wildcard as the only mapping', () => {
+    const result = resolveRoleFromGroups(
+      ['AnyGroup'],
+      { '*': 'operator' },
+    );
+    expect(result).toBe('operator');
+  });
+
+  it('should return operator when one group is operator and another is viewer', () => {
+    const result = resolveRoleFromGroups(
+      ['Team-A', 'Team-B'],
+      {
+        'Team-A': 'viewer',
+        'Team-B': 'operator',
+      },
+    );
+    expect(result).toBe('operator');
+  });
+});
+
+describe('extractGroups', () => {
+  it('should extract groups from the specified claim', () => {
+    const claims = { groups: ['Admin', 'Users'] };
+    expect(extractGroups(claims, 'groups')).toEqual(['Admin', 'Users']);
+  });
+
+  it('should return empty array when claim is missing', () => {
+    const claims = { sub: 'user1' };
+    expect(extractGroups(claims, 'groups')).toEqual([]);
+  });
+
+  it('should return empty array when claim is not an array', () => {
+    const claims = { groups: 'Admin' };
+    expect(extractGroups(claims, 'groups')).toEqual([]);
+  });
+
+  it('should filter out non-string values from the array', () => {
+    const claims = { groups: ['Admin', 42, null, 'Users', true] };
+    expect(extractGroups(claims, 'groups')).toEqual(['Admin', 'Users']);
+  });
+
+  it('should work with custom claim names', () => {
+    const claims = { 'realm_access': { roles: ['admin'] }, 'custom-groups': ['Group1'] };
+    expect(extractGroups(claims, 'custom-groups')).toEqual(['Group1']);
+  });
+
+  it('should return empty array when claim is null', () => {
+    const claims = { groups: null };
+    expect(extractGroups(claims, 'groups')).toEqual([]);
+  });
+
+  it('should return empty array when claim is an empty array', () => {
+    const claims = { groups: [] };
+    expect(extractGroups(claims, 'groups')).toEqual([]);
+  });
+
+  it('should handle nested claim paths (flat lookup only)', () => {
+    const claims = { 'roles': ['viewer'] };
+    expect(extractGroups(claims, 'roles')).toEqual(['viewer']);
+  });
+});

--- a/frontend/src/components/settings/group-role-mapping-editor.test.tsx
+++ b/frontend/src/components/settings/group-role-mapping-editor.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GroupRoleMappingEditor } from './group-role-mapping-editor';
+
+describe('GroupRoleMappingEditor', () => {
+  it('should render empty state when no mappings configured', () => {
+    render(<GroupRoleMappingEditor value="{}" onChange={vi.fn()} />);
+    expect(screen.getByText(/No mappings configured/)).toBeInTheDocument();
+  });
+
+  it('should render existing mappings from JSON value', () => {
+    const value = JSON.stringify({ 'Dashboard-Admins': 'admin', 'Viewers': 'viewer' });
+    render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
+
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]).toHaveValue('Dashboard-Admins');
+    expect(inputs[1]).toHaveValue('Viewers');
+  });
+
+  it('should add a new empty row when Add Mapping is clicked', () => {
+    const onChange = vi.fn();
+    render(<GroupRoleMappingEditor value="{}" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('Add Mapping'));
+    expect(onChange).toHaveBeenCalledWith('{}');
+  });
+
+  it('should remove a row when delete button is clicked', () => {
+    const onChange = vi.fn();
+    const value = JSON.stringify({ 'Admins': 'admin', 'Viewers': 'viewer' });
+    render(<GroupRoleMappingEditor value={value} onChange={onChange} />);
+
+    const removeButtons = screen.getAllByRole('button', { name: /Remove mapping/i });
+    fireEvent.click(removeButtons[0]);
+
+    expect(onChange).toHaveBeenCalledWith(JSON.stringify({ 'Viewers': 'viewer' }));
+  });
+
+  it('should update group name when input changes', () => {
+    const onChange = vi.fn();
+    const value = JSON.stringify({ 'OldName': 'admin' });
+    render(<GroupRoleMappingEditor value={value} onChange={onChange} />);
+
+    const input = screen.getByTestId('mapping-group-0');
+    fireEvent.change(input, { target: { value: 'NewName' } });
+
+    expect(onChange).toHaveBeenCalledWith(JSON.stringify({ 'NewName': 'admin' }));
+  });
+
+  it('should update role when select changes', () => {
+    const onChange = vi.fn();
+    const value = JSON.stringify({ 'Operators': 'viewer' });
+    render(<GroupRoleMappingEditor value={value} onChange={onChange} />);
+
+    const select = screen.getByTestId('mapping-role-0');
+    fireEvent.change(select, { target: { value: 'operator' } });
+
+    expect(onChange).toHaveBeenCalledWith(JSON.stringify({ 'Operators': 'operator' }));
+  });
+
+  it('should render all three role options in the dropdown', () => {
+    const value = JSON.stringify({ 'Test': 'viewer' });
+    render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
+
+    const select = screen.getByTestId('mapping-role-0');
+    const options = select.querySelectorAll('option');
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveValue('viewer');
+    expect(options[1]).toHaveValue('operator');
+    expect(options[2]).toHaveValue('admin');
+  });
+
+  it('should handle invalid JSON gracefully', () => {
+    render(<GroupRoleMappingEditor value="not-json" onChange={vi.fn()} />);
+    expect(screen.getByText(/No mappings configured/)).toBeInTheDocument();
+  });
+
+  it('should be disabled when disabled prop is true', () => {
+    const value = JSON.stringify({ 'Admins': 'admin' });
+    render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} disabled />);
+
+    expect(screen.getByTestId('mapping-group-0')).toBeDisabled();
+    expect(screen.getByTestId('mapping-role-0')).toBeDisabled();
+    expect(screen.getByText('Add Mapping')).toBeDisabled();
+  });
+
+  it('should strip empty group names from serialized output', () => {
+    const onChange = vi.fn();
+    const value = JSON.stringify({ 'Admins': 'admin' });
+    render(<GroupRoleMappingEditor value={value} onChange={onChange} />);
+
+    // Change the group name to empty
+    const input = screen.getByTestId('mapping-group-0');
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(onChange).toHaveBeenCalledWith('{}');
+  });
+});

--- a/frontend/src/components/settings/group-role-mapping-editor.tsx
+++ b/frontend/src/components/settings/group-role-mapping-editor.tsx
@@ -1,0 +1,162 @@
+import { useState, useCallback, useEffect } from 'react';
+import { Plus, Trash2, Users } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface MappingRow {
+  group: string;
+  role: 'viewer' | 'operator' | 'admin';
+}
+
+const ROLES = [
+  { value: 'viewer' as const, label: 'Viewer' },
+  { value: 'operator' as const, label: 'Operator' },
+  { value: 'admin' as const, label: 'Admin' },
+];
+
+interface GroupRoleMappingEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+function parseMappings(json: string): MappingRow[] {
+  try {
+    const parsed = JSON.parse(json);
+    if (typeof parsed !== 'object' || parsed === null) return [];
+    return Object.entries(parsed).map(([group, role]) => ({
+      group,
+      role: (['viewer', 'operator', 'admin'].includes(role as string)
+        ? role
+        : 'viewer') as MappingRow['role'],
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function serializeMappings(rows: MappingRow[]): string {
+  const obj: Record<string, string> = {};
+  for (const row of rows) {
+    const trimmed = row.group.trim();
+    if (trimmed) {
+      obj[trimmed] = row.role;
+    }
+  }
+  return JSON.stringify(obj);
+}
+
+export function GroupRoleMappingEditor({ value, onChange, disabled }: GroupRoleMappingEditorProps) {
+  const [rows, setRows] = useState<MappingRow[]>(() => parseMappings(value));
+
+  // Sync from parent when value changes externally
+  useEffect(() => {
+    const parsed = parseMappings(value);
+    setRows(parsed);
+  }, [value]);
+
+  const emitChange = useCallback(
+    (newRows: MappingRow[]) => {
+      setRows(newRows);
+      onChange(serializeMappings(newRows));
+    },
+    [onChange],
+  );
+
+  const addRow = () => {
+    emitChange([...rows, { group: '', role: 'viewer' }]);
+  };
+
+  const removeRow = (index: number) => {
+    emitChange(rows.filter((_, i) => i !== index));
+  };
+
+  const updateRow = (index: number, field: keyof MappingRow, val: string) => {
+    const updated = rows.map((row, i) =>
+      i === index ? { ...row, [field]: val } : row,
+    );
+    emitChange(updated);
+  };
+
+  return (
+    <div className="rounded-lg border bg-card" data-testid="group-role-mapping-editor">
+      <div className="flex items-center justify-between p-4 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          <h3 className="text-base font-semibold">Group-to-Role Mappings</h3>
+        </div>
+        <button
+          type="button"
+          onClick={addRow}
+          disabled={disabled}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium',
+            'hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed',
+          )}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add Mapping
+        </button>
+      </div>
+
+      <div className="p-4 space-y-2">
+        <p className="text-sm text-muted-foreground mb-3">
+          Map IdP group names to dashboard roles. If a user belongs to multiple groups,
+          the <strong>highest-privilege</strong> role is assigned. Use <code>*</code> as
+          a wildcard fallback for unmatched groups.
+        </p>
+
+        {rows.length === 0 ? (
+          <div className="text-center py-6 text-sm text-muted-foreground">
+            No mappings configured. OIDC users will default to <strong>viewer</strong> role.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {/* Header */}
+            <div className="grid grid-cols-[1fr_160px_40px] gap-2 text-xs font-medium text-muted-foreground px-1">
+              <span>IdP Group Name</span>
+              <span>Dashboard Role</span>
+              <span />
+            </div>
+
+            {rows.map((row, index) => (
+              <div key={index} className="grid grid-cols-[1fr_160px_40px] gap-2 items-center">
+                <input
+                  type="text"
+                  value={row.group}
+                  onChange={(e) => updateRow(index, 'group', e.target.value)}
+                  disabled={disabled}
+                  placeholder="e.g., Dashboard-Admins or *"
+                  className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+                  data-testid={`mapping-group-${index}`}
+                />
+                <select
+                  value={row.role}
+                  onChange={(e) => updateRow(index, 'role', e.target.value)}
+                  disabled={disabled}
+                  className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+                  data-testid={`mapping-role-${index}`}
+                >
+                  {ROLES.map((r) => (
+                    <option key={r.value} value={r.value}>
+                      {r.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => removeRow(index)}
+                  disabled={disabled}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                  data-testid={`mapping-remove-${index}`}
+                  aria-label={`Remove mapping for ${row.group || 'empty group'}`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/shared.tsx
+++ b/frontend/src/components/settings/shared.tsx
@@ -50,6 +50,9 @@ export const DEFAULT_SETTINGS = {
     { key: 'oidc.redirect_uri', label: 'Redirect URI', description: 'Callback URL (e.g., http://localhost:5273/auth/callback)', type: 'string', defaultValue: '' },
     { key: 'oidc.scopes', label: 'Scopes', description: 'Space-separated OIDC scopes to request', type: 'string', defaultValue: 'openid profile email' },
     { key: 'oidc.local_auth_enabled', label: 'Keep Local Auth Enabled', description: 'Allow username/password login alongside SSO', type: 'boolean', defaultValue: 'true' },
+    { key: 'oidc.groups_claim', label: 'Groups Claim', description: 'ID token claim name containing group membership (e.g., groups, roles, or a custom claim)', type: 'string', defaultValue: 'groups' },
+    { key: 'oidc.group_role_mappings', label: 'Group-to-Role Mappings', description: 'JSON mapping of IdP group names to dashboard roles. Use * as a wildcard fallback.', type: 'string', defaultValue: '{}' },
+    { key: 'oidc.auto_provision', label: 'Auto-Provision OIDC Users', description: 'Automatically create user records for new OIDC-authenticated users', type: 'boolean', defaultValue: 'true' },
   ],
   webhooks: [
     { key: 'webhooks.enabled', label: 'Enable Webhooks', description: 'Enable outbound webhook event delivery', type: 'boolean', defaultValue: 'false' },


### PR DESCRIPTION
## Summary
Add OIDC group-to-role mapping so administrators can map IdP groups (e.g., Active Directory groups) to dashboard roles (`viewer`, `operator`, `admin`), enabling automatic role assignment for SSO users.

Closes #542

## Root Cause
OIDC-authenticated users had no role assigned from their IdP group membership. The OIDC service only extracted `sub`, `email`, and `name` from ID token claims — no group extraction or role mapping existed. OIDC users defaulted to `viewer` role, requiring manual role management.

## Fix
Implemented end-to-end OIDC group-to-role mapping:

### Backend
- **Migration `041`**: Seeds 3 new settings (`oidc.groups_claim`, `oidc.group_role_mappings`, `oidc.auto_provision`)
- **OIDC Service** (`services/oidc.ts`): Added `extractGroups()` to read groups from configurable ID token claim, and `resolveRoleFromGroups()` with **highest-privilege-wins** strategy and wildcard `*` fallback
- **User Store** (`services/user-store.ts`): Added `upsertOIDCUser()` for auto-provisioning OIDC users in the users table, or updating their role if group membership changed
- **OIDC Callback** (`routes/oidc.ts`): Resolves role from group mappings, auto-provisions user, includes role in JWT, and audit logs role changes

### Frontend
- **Group-to-Role Mapping Editor** (`components/settings/group-role-mapping-editor.tsx`): Interactive table with group name input + role dropdown, add/remove rows, wildcard support. Shown in Settings > Security when OIDC is enabled
- **Settings** (`components/settings/shared.tsx`): Added 3 new authentication settings definitions
- **Security Tab** (`components/settings/tab-security.tsx`): Integrated mapping editor, conditionally visible when OIDC enabled

### Precedence Strategy
- **Highest-privilege-wins**: If a user belongs to multiple mapped groups, the highest role is assigned
- **Wildcard fallback**: `*` matches any unmatched group
- **Explicit > Wildcard**: Explicit group matches always take precedence over wildcard

## Changes
- `backend/src/db/migrations/041_oidc_group_mapping.sql` — new migration seeding group mapping settings
- `backend/src/services/oidc.ts` — group extraction, role resolution, updated TokenClaims interface
- `backend/src/services/user-store.ts` — `upsertOIDCUser()` for auto-provisioning
- `backend/src/routes/oidc.ts` — callback with role assignment, auto-provisioning, audit logging
- `frontend/src/components/settings/shared.tsx` — 3 new setting definitions
- `frontend/src/components/settings/tab-security.tsx` — mapping editor integration
- `frontend/src/components/settings/group-role-mapping-editor.tsx` — new component

## Testing
- [x] Regression tests added: `backend/src/services/oidc-group-mapping.test.ts` (20 tests)
- [x] Frontend tests added: `frontend/src/components/settings/group-role-mapping-editor.test.tsx` (10 tests)
- [x] Security regression tests added: 6 new tests in `security-regression.test.ts`
- [x] Full backend test suite passes locally (111/117, 6 pre-existing better-sqlite3 arch failures)
- [x] Full frontend test suite passes locally (112/116, 4 pre-existing jspdf import failures)
- [x] TypeScript typecheck passes (both workspaces)
- [x] No debug artifacts or secrets detected

## Rollback Plan
Revert this PR: `git revert <merge-commit-sha>`. The migration uses `INSERT OR IGNORE`, so the settings will remain but be inert without the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)