### PR TITLE
security: gate operational trigger endpoints behind admin role

### DIFF
--- a/backend/src/routes/images.test.ts
+++ b/backend/src/routes/images.test.ts
@@ -23,6 +23,7 @@ function buildApp() {
   const app = Fastify();
   app.setValidatorCompiler(validatorCompiler);
   app.decorate('authenticate', async () => undefined);
+  app.decorate('requireRole', () => async () => undefined);
   app.register(imagesRoutes);
   return app;
 }

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -96,7 +96,7 @@ export async function imagesRoutes(fastify: FastifyInstance) {
       summary: 'Trigger image staleness check for all images',
       security: [{ bearerAuth: [] }],
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async () => {
     try {
       const endpoints = await cachedFetch(

--- a/backend/src/routes/notifications.test.ts
+++ b/backend/src/routes/notifications.test.ts
@@ -29,6 +29,7 @@ describe('Notification Routes', () => {
     app = Fastify({ logger: false });
     app.setValidatorCompiler(validatorCompiler);
     app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', () => async () => undefined);
     await app.register(notificationRoutes);
     await app.ready();
   });

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -56,7 +56,7 @@ export async function notificationRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       body: NotificationTestBodySchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request) => {
     const { channel } = request.body as { channel: 'teams' | 'email' };
     const result = await sendTestNotification(channel);


### PR DESCRIPTION
## Summary
- Added `requireRole('admin')` to `POST /api/images/staleness/check` and `POST /api/notifications/test`
- These operational trigger endpoints were previously accessible to any authenticated user
- Added `requireRole` decorator mock to existing unit tests to prevent breakage
- Added 4 new security regression tests (viewer/operator denied, admin allowed)

Closes #585

## Test plan
- [x] 4 new security regression tests in `security-regression.test.ts`
- [x] Updated `images.test.ts` and `notifications.test.ts` with `requireRole` mock
- [x] All 1620 backend tests passing
- [ ] Manual: verify non-admin users get 403 on these endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)