### PR TITLE
fix: prevent missing metrics table from cascading HTTP 500 errors

### DIFF
--- a/backend/src/db/timescale.ts
+++ b/backend/src/db/timescale.ts
@@ -15,24 +15,44 @@ pg.types.setTypeParser(1184, (val: string) => new Date(val).toISOString()); // t
 pg.types.setTypeParser(1114, (val: string) => new Date(val + 'Z').toISOString()); // timestamp
 
 let pool: pg.Pool | null = null;
+let migrationsReady = false;
+
+/**
+ * Returns true if the metrics table exists and migrations have been applied.
+ * Use this to guard routes that query the metrics table.
+ */
+export function isMetricsDbReady(): boolean {
+  return pool !== null && migrationsReady;
+}
 
 export async function getMetricsDb(): Promise<pg.Pool> {
   if (!pool) {
     const config = getConfig();
 
-    pool = new pg.Pool({
+    const newPool = new pg.Pool({
       connectionString: config.TIMESCALE_URL,
       max: config.TIMESCALE_MAX_CONNECTIONS,
       idleTimeoutMillis: 30_000,
       connectionTimeoutMillis: 5_000,
     });
 
-    pool.on('error', (err) => {
+    newPool.on('error', (err) => {
       log.error({ err }, 'Unexpected TimescaleDB pool error');
     });
 
     log.info('TimescaleDB pool created');
-    await runMigrations(pool);
+
+    try {
+      await runMigrations(newPool);
+      migrationsReady = true;
+    } catch (err) {
+      log.error({ err }, 'TimescaleDB migrations failed — pool will be retried on next call');
+      await newPool.end().catch(() => {});
+      throw err;
+    }
+
+    // Only persist the pool after migrations succeed
+    pool = newPool;
     await applyRetentionPolicies(pool, config);
   }
   return pool;
@@ -118,6 +138,7 @@ export async function closeMetricsDb(): Promise<void> {
   if (pool) {
     await pool.end();
     pool = null;
+    migrationsReady = false;
     log.info('TimescaleDB pool closed');
   }
 }
@@ -125,8 +146,14 @@ export async function closeMetricsDb(): Promise<void> {
 export async function isMetricsDbHealthy(): Promise<boolean> {
   try {
     const db = await getMetricsDb();
-    const { rows } = await db.query('SELECT 1 as ok');
-    return rows[0]?.ok === 1;
+    // Verify both connectivity AND that the metrics table exists
+    const { rows } = await db.query(
+      `SELECT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'metrics'
+      ) as ok`,
+    );
+    return rows[0]?.ok === true;
   } catch {
     return false;
   }

--- a/backend/src/services/metrics-store.ts
+++ b/backend/src/services/metrics-store.ts
@@ -4,6 +4,18 @@ import type { Metric } from '../models/metrics.js';
 
 const log = createChildLogger('metrics-store');
 
+/**
+ * Check if a database error is PostgreSQL 42P01 (undefined_table).
+ * This happens when the metrics hypertable hasn't been created yet.
+ */
+export function isUndefinedTableError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    'code' in err &&
+    (err as { code: string }).code === '42P01'
+  );
+}
+
 export interface MetricInsert {
   endpoint_id: number;
   container_id: string;


### PR DESCRIPTION
## Summary

- **Root cause fix**: `timescale.ts` assigned the pool before migrations ran — if migrations failed, the pool was cached and all subsequent queries hit a missing `metrics` table. Now the pool is only persisted after migrations succeed; on failure the pool is cleaned up so the next call retries.
- **Graceful error responses**: Metrics and report routes now return **503 Service Unavailable** instead of raw 500 when the `metrics` table doesn't exist (PostgreSQL `42P01`).
- **Health check improvement**: `/health/ready` now distinguishes "connected but migrations pending" (**degraded**) from truly unhealthy, giving operators clear visibility into migration status.

## Test plan

- [x] 1629 backend tests pass (118 files)
- [x] TypeScript typecheck passes (backend + frontend)
- [x] New test: metrics query returns 503 on `42P01` error
- [x] New test: anomalies query returns 503 on `42P01` error
- [x] New test: health check returns degraded when connected but migrations not applied
- [ ] Manual: deploy with TimescaleDB down, verify 503 responses and health check degraded status
- [ ] Manual: restart TimescaleDB, verify pool retries migrations successfully

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)