### PR TITLE
Expand Recent Containers to 50 items with inline search

### DIFF
--- a/frontend/src/components/shared/data-table.tsx
+++ b/frontend/src/components/shared/data-table.tsx
@@ -37,6 +37,8 @@ interface DataTableProps<T> {
   onRowClick?: (row: T) => void;
   virtualScrolling?: boolean;
   serverPagination?: ServerPaginationProps;
+  hideSearch?: boolean;
+  externalSearchValue?: string;
 }
 
 export function DataTable<T>({
@@ -48,6 +50,8 @@ export function DataTable<T>({
   onRowClick,
   virtualScrolling,
   serverPagination,
+  hideSearch,
+  externalSearchValue,
 }: DataTableProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -69,6 +73,13 @@ export function DataTable<T>({
     state: { sorting, columnFilters },
     ...(useVirtual || isServerPaginated ? {} : { initialState: { pagination: { pageSize } } }),
   });
+
+  // Sync external search value into column filter
+  useEffect(() => {
+    if (searchKey && externalSearchValue !== undefined) {
+      table.getColumn(searchKey)?.setFilterValue(externalSearchValue);
+    }
+  }, [externalSearchValue, searchKey, table]);
 
   const { rows } = table.getRowModel();
 
@@ -206,25 +217,27 @@ export function DataTable<T>({
 
   return (
     <div data-testid="data-table" className="space-y-4">
-      <div className="flex items-center justify-between gap-4">
-        {searchKey && (
-          <input
-            data-testid="data-table-search"
-            type="text"
-            placeholder={searchPlaceholder}
-            value={searchValue}
-            onChange={(e) => table.getColumn(searchKey)?.setFilterValue(e.target.value)}
-            className="w-full max-w-sm rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          />
-        )}
-        {useVirtual && (
-          <p className="shrink-0 text-sm text-muted-foreground" data-testid="virtual-row-count">
-            {isFiltered
-              ? `${filteredCount} of ${totalCount} match${filteredCount !== 1 ? '' : 'es'}`
-              : `${totalCount} total`}
-          </p>
-        )}
-      </div>
+      {!hideSearch && (
+        <div className="flex items-center justify-between gap-4">
+          {searchKey && (
+            <input
+              data-testid="data-table-search"
+              type="text"
+              placeholder={searchPlaceholder}
+              value={searchValue}
+              onChange={(e) => table.getColumn(searchKey)?.setFilterValue(e.target.value)}
+              className="w-full max-w-sm rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          )}
+          {useVirtual && (
+            <p className="shrink-0 text-sm text-muted-foreground" data-testid="virtual-row-count">
+              {isFiltered
+                ? `${filteredCount} of ${totalCount} match${filteredCount !== 1 ? '' : 'es'}`
+                : `${totalCount} total`}
+            </p>
+          )}
+        </div>
+      )}
 
       {useVirtual ? (
         <div className="relative rounded-md border">

--- a/frontend/src/pages/home.test.tsx
+++ b/frontend/src/pages/home.test.tsx
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import HomePage from './home';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: vi.fn(({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: Math.min(count, 30) }, (_, i) => ({
+        index: i,
+        start: i * 48,
+        end: (i + 1) * 48,
+        size: 48,
+        key: i,
+      })),
+    getTotalSize: () => count * 48,
+    measureElement: vi.fn(),
+  })),
+}));
+
+vi.mock('@/hooks/use-dashboard', () => ({
+  useDashboard: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-containers', () => ({
+  useFavoriteContainers: () => ({ data: [] }),
+}));
+
+vi.mock('@/hooks/use-endpoints', () => ({
+  useEndpoints: () => ({ data: [] }),
+}));
+
+vi.mock('@/hooks/use-auto-refresh', () => ({
+  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn(), enabled: true, toggle: vi.fn() }),
+}));
+
+vi.mock('@/hooks/use-force-refresh', () => ({
+  useForceRefresh: () => ({ forceRefresh: vi.fn(), isForceRefreshing: false }),
+}));
+
+vi.mock('@/hooks/use-kpi-history', () => ({
+  useKpiHistory: () => ({ data: null }),
+}));
+
+vi.mock('@/stores/favorites-store', () => ({
+  useFavoritesStore: () => [],
+}));
+
+// Mock chart components that use canvas/SVG
+vi.mock('@/components/charts/container-state-pie', () => ({
+  ContainerStatePie: () => <div data-testid="mock-pie">Pie</div>,
+}));
+vi.mock('@/components/charts/endpoint-health-treemap', () => ({
+  EndpointHealthTreemap: () => <div data-testid="mock-treemap">Treemap</div>,
+}));
+vi.mock('@/components/charts/endpoint-health-octagons', () => ({
+  EndpointHealthOctagons: () => <div data-testid="mock-octagons">Octagons</div>,
+}));
+vi.mock('@/components/charts/workload-top-bar', () => ({
+  WorkloadTopBar: () => <div data-testid="mock-workload">Workload</div>,
+}));
+vi.mock('@/components/charts/fleet-summary-card', () => ({
+  FleetSummaryCard: () => <div data-testid="mock-fleet">Fleet</div>,
+}));
+vi.mock('@/components/charts/resource-overview-card', () => ({
+  ResourceOverviewCard: () => <div data-testid="mock-resource">Resource</div>,
+}));
+vi.mock('@/components/shared/kpi-card', () => ({
+  KpiCard: ({ label }: { label: string }) => <div data-testid="mock-kpi">{label}</div>,
+}));
+vi.mock('@/components/shared/tilt-card', () => ({
+  TiltCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/shared/spotlight-card', () => ({
+  SpotlightCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/shared/motion-page', () => ({
+  MotionPage: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  MotionReveal: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  MotionStagger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/shared/auto-refresh-toggle', () => ({
+  AutoRefreshToggle: () => <div data-testid="mock-auto-refresh" />,
+}));
+vi.mock('@/components/shared/refresh-button', () => ({
+  RefreshButton: () => <button data-testid="mock-refresh" />,
+}));
+vi.mock('@/components/shared/smart-refresh-controls', () => ({
+  SmartRefreshControls: () => <div data-testid="mock-smart-refresh" />,
+}));
+vi.mock('@/components/shared/status-badge', () => ({
+  StatusBadge: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+vi.mock('@/components/shared/favorite-button', () => ({
+  FavoriteButton: () => <button data-testid="mock-fav" />,
+}));
+
+import { useDashboard } from '@/hooks/use-dashboard';
+import type { NormalizedContainer, DashboardSummary } from '@/hooks/use-dashboard';
+
+const mockUseDashboard = vi.mocked(useDashboard);
+
+function makeContainer(i: number): NormalizedContainer {
+  return {
+    id: `c-${i}`,
+    name: `container-${i}`,
+    image: `nginx:${i}`,
+    state: i % 2 === 0 ? 'running' : 'stopped',
+    status: i % 2 === 0 ? 'Up 2 hours' : 'Exited (0)',
+    created: Math.floor(Date.now() / 1000) - i * 60,
+    endpointId: 1,
+    endpointName: 'local',
+    ports: [],
+    networks: [],
+    labels: {},
+  };
+}
+
+function makeDashboardData(containerCount: number): DashboardSummary {
+  return {
+    kpis: {
+      endpoints: 2,
+      endpointsUp: 2,
+      endpointsDown: 0,
+      running: containerCount,
+      stopped: 0,
+      healthy: containerCount,
+      unhealthy: 0,
+      total: containerCount,
+      stacks: 1,
+    },
+    security: {
+      totalAudited: 10,
+      flagged: 0,
+      ignored: 0,
+    },
+    recentContainers: Array.from({ length: containerCount }, (_, i) => makeContainer(i)),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('HomePage - Recent Containers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the Recent Containers section with title and inline search', () => {
+    mockUseDashboard.mockReturnValue({
+      data: makeDashboardData(5),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    renderPage();
+
+    expect(screen.getByText('Recent Containers')).toBeInTheDocument();
+    expect(screen.getByTestId('container-search')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Filter containers...')).toBeInTheDocument();
+  });
+
+  it('does not render the DataTable built-in search when hideSearch is used', () => {
+    mockUseDashboard.mockReturnValue({
+      data: makeDashboardData(5),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    renderPage();
+
+    // The inline search should be present
+    expect(screen.getByTestId('container-search')).toBeInTheDocument();
+    // The DataTable's built-in search should not be rendered
+    expect(screen.queryByTestId('data-table-search')).not.toBeInTheDocument();
+  });
+
+  it('renders all container rows when count is under 50', () => {
+    const containerCount = 15;
+    mockUseDashboard.mockReturnValue({
+      data: makeDashboardData(containerCount),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    renderPage();
+
+    // With pageSize=50 and 15 items, all rows should be visible (no pagination)
+    for (let i = 0; i < containerCount; i++) {
+      expect(screen.getByText(`container-${i}`)).toBeInTheDocument();
+    }
+  });
+
+  it('filters containers when typing in the inline search', async () => {
+    mockUseDashboard.mockReturnValue({
+      data: makeDashboardData(10),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    renderPage();
+
+    const searchInput = screen.getByTestId('container-search');
+    fireEvent.change(searchInput, { target: { value: 'container-3' } });
+
+    // container-3 should be visible
+    await waitFor(() => {
+      expect(screen.getByText('container-3')).toBeInTheDocument();
+      // container-0 should be filtered out
+      expect(screen.queryByText('container-0')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders all expected columns', () => {
+    mockUseDashboard.mockReturnValue({
+      data: makeDashboardData(3),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    renderPage();
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Image')).toBeInTheDocument();
+    expect(screen.getByText('State')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Endpoint')).toBeInTheDocument();
+    expect(screen.getByText('Created')).toBeInTheDocument();
+  });
+
+  it('shows skeleton when loading', () => {
+    mockUseDashboard.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    renderPage();
+
+    // Should not show the search or table when loading
+    expect(screen.queryByTestId('container-search')).not.toBeInTheDocument();
+    expect(screen.queryByText('Recent Containers')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { type ColumnDef } from '@tanstack/react-table';
-import { Server, Boxes, PackageOpen, Layers, AlertTriangle, Star, ShieldAlert } from 'lucide-react';
+import { Server, Boxes, PackageOpen, Layers, AlertTriangle, Star, ShieldAlert, Search } from 'lucide-react';
 import { useDashboard, type NormalizedContainer } from '@/hooks/use-dashboard';
 import { useFavoriteContainers } from '@/hooks/use-containers';
 import { useEndpoints } from '@/hooks/use-endpoints';
@@ -34,6 +34,7 @@ export default function HomePage() {
   const { data: favoriteContainers = [] } = useFavoriteContainers(favoriteIds);
   const { data: endpoints } = useEndpoints();
   const { data: kpiHistory } = useKpiHistory(24);
+  const [containerSearch, setContainerSearch] = useState('');
 
   const containerColumns: ColumnDef<NormalizedContainer, any>[] = useMemo(() => [
     {
@@ -382,15 +383,30 @@ export default function HomePage() {
         <MotionReveal>
           <SpotlightCard>
             <div className="rounded-lg border bg-card p-6 shadow-sm">
-              <h3 className="mb-4 text-sm font-medium text-muted-foreground">
-                Recent Containers
-              </h3>
+              <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <h3 className="text-sm font-medium text-muted-foreground">
+                  Recent Containers
+                </h3>
+                <div className="relative w-full sm:w-64">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <input
+                    data-testid="container-search"
+                    type="text"
+                    placeholder="Filter containers..."
+                    value={containerSearch}
+                    onChange={(e) => setContainerSearch(e.target.value)}
+                    className="w-full rounded-md border border-input bg-background py-2 pl-9 pr-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  />
+                </div>
+              </div>
               <DataTable
                 columns={containerColumns}
                 data={data.recentContainers}
                 searchKey="name"
                 searchPlaceholder="Filter containers..."
-                pageSize={10}
+                pageSize={50}
+                hideSearch
+                externalSearchValue={containerSearch}
               />
             </div>
           </SpotlightCard>


### PR DESCRIPTION
## Summary
- Increase Recent Containers table from 10 to 50 items
- Move search bar inline with title (flex row: title left, search right)
- Added `hideSearch` and `externalSearchValue` props to DataTable for external search control
- Responsive: search stacks below title on mobile (<640px)
- Virtual scrolling auto-activates for >50 rows (existing DataTable feature)
- 6 new home page tests passing, 29 existing DataTable tests still pass

Closes #676

## Test plan
- [ ] Verify table shows up to 50 containers
- [ ] Verify search bar is inline with title on desktop
- [ ] Verify search filtering works correctly
- [ ] Verify responsive stacking on mobile
- [ ] Verify DataTable built-in search is hidden
- [ ] Test with <50 and >50 containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)