### PR TITLE
Add loading status indicators to LLM Assistant (closes #691)

### DIFF
--- a/frontend/src/components/metrics/inline-chat-panel.tsx
+++ b/frontend/src/components/metrics/inline-chat-panel.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useRef, useEffect, useCallback } from 'react';
-import { Bot, Send, X, User, AlertCircle, Wrench, CheckCircle2, XCircle } from 'lucide-react';
+import { Bot, Send, X, User, AlertCircle, Wrench, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
@@ -52,6 +52,7 @@ export const InlineChatPanel = memo(function InlineChatPanel({ open, onClose, co
     isStreaming,
     currentResponse,
     activeToolCalls,
+    statusMessage,
     sendMessage,
     cancelGeneration,
     clearHistory,
@@ -208,15 +209,7 @@ export const InlineChatPanel = memo(function InlineChatPanel({ open, onClose, co
 
           {/* Thinking indicator */}
           {isSending && !isStreaming && (
-            <div className="flex gap-3">
-              <BotAvatar />
-              <div className="rounded-xl bg-muted/50 p-3 border border-border/50">
-                <div className="flex items-center gap-2">
-                  <LoadingDots />
-                  <span className="text-xs text-muted-foreground">Thinking...</span>
-                </div>
-              </div>
-            </div>
+            <CompactThinkingIndicator statusMessage={statusMessage} />
           )}
 
           {/* Tool call indicator */}
@@ -292,6 +285,33 @@ function LoadingDots() {
       <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce [animation-delay:-0.3s]" />
       <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce [animation-delay:-0.15s]" />
       <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce" />
+    </div>
+  );
+}
+
+function CompactThinkingIndicator({ statusMessage }: { statusMessage: string | null }) {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => setElapsed((prev) => prev + 1), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="flex gap-3" data-testid="compact-thinking-indicator">
+      <BotAvatar />
+      <div className="rounded-xl bg-muted/50 p-3 border border-border/50">
+        <div className="flex items-center gap-2">
+          <Loader2 className="h-3.5 w-3.5 text-blue-500 animate-spin" />
+          <span className="text-xs text-muted-foreground">{statusMessage || 'Thinking...'}</span>
+          <span className="text-[10px] text-muted-foreground/60 tabular-nums">{elapsed}s</span>
+        </div>
+        {elapsed >= 15 && (
+          <p className="mt-1.5 text-[10px] text-muted-foreground/60">
+            Model may be loading...
+          </p>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Backend emits `chat:status` events during request processing (init, context building, model loading)
- Frontend shows dynamic status messages, elapsed timer, and cancel button while waiting for response
- Connection status indicator warns when WebSocket is disconnected
- Inline chat panel gets matching improvements
- Slow-model warning appears after 15 seconds

Closes #691

## Root Cause
When Ollama needs to cold-start or load a model, the gap between sending a message and receiving the first response can be very long. During this time, users only saw static "Thinking..." text with no way to tell if the system was working, disconnected, or crashed.

## Fix
Added a `chat:status` Socket.IO event that the backend emits at key processing stages:
1. **Init** — "Preparing request..."
2. **Context** — "Building infrastructure context..."
3. **Model** — "Loading model llama3.2..." / "Waiting for llama3.2..."

The frontend `useLlmChat` hook surfaces this as `statusMessage`, which the new `ThinkingIndicator` component displays alongside:
- A spinning loader icon (replacing static bouncing dots)
- An elapsed timer counting seconds
- A cancel button (available before streaming starts)
- A slow-model warning after 15s: "This is taking longer than usual. The model may be loading for the first time."
- A reconnection banner when the WebSocket disconnects

## Changes
- `backend/src/sockets/llm-chat.ts` — Emit `chat:status` at 3 stages
- `frontend/src/hooks/use-llm-chat.ts` — Handle `chat:status`, expose `statusMessage`
- `frontend/src/pages/llm-assistant.tsx` — New `ThinkingIndicator` with timer/cancel/status; connection banner
- `frontend/src/components/metrics/inline-chat-panel.tsx` — `CompactThinkingIndicator` with same features
- `backend/src/sockets/llm-chat.test.ts` — 2 new tests for status event emission
- `frontend/src/pages/llm-assistant.test.tsx` — 6 new tests for thinking indicator and connection status

## Testing
- [x] Regression tests added: `backend/src/sockets/llm-chat.test.ts` (38 passing), `frontend/src/pages/llm-assistant.test.tsx` (27 passing), `frontend/src/components/metrics/inline-chat-panel.test.tsx` (12 passing)
- [x] Full test suite passes locally
- [x] Lint checks pass
- [x] TypeScript strict mode — no errors in changed files

## Rollback Plan
Revert this PR: `git revert <merge-commit-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)