### PR TITLE
fix: reduce monitoring cycle log noise (closes #698)

### DIFF
--- a/backend/src/services/circuit-breaker.ts
+++ b/backend/src/services/circuit-breaker.ts
@@ -27,12 +27,16 @@ export class CircuitBreakerOpenError extends Error {
   }
 }
 
+/** Number of consecutive probe failures before switching to DEBUG-level logging. */
+const PROBE_FAILURE_LOG_THRESHOLD = 3;
+
 export class CircuitBreaker {
   private state: CircuitState = 'CLOSED';
   private failures = 0;
   private successes = 0;
   private lastFailure?: Date;
   private openedAt?: number;
+  private consecutiveProbeFailures = 0;
 
   private readonly cbName: string;
   private readonly failureThreshold: number;
@@ -50,7 +54,7 @@ export class CircuitBreaker {
     if (this.state === 'OPEN') {
       if (this.shouldTransitionToHalfOpen()) {
         this.state = 'HALF_OPEN';
-        log.info({ name: this.cbName }, 'Circuit breaker transitioning to HALF_OPEN');
+        this.logTransition('Circuit breaker transitioning to HALF_OPEN');
       } else {
         throw new CircuitBreakerOpenError(this.cbName, this.resetTimeoutMs);
       }
@@ -71,7 +75,7 @@ export class CircuitBreaker {
   getState(): CircuitState {
     if (this.state === 'OPEN' && this.shouldTransitionToHalfOpen()) {
       this.state = 'HALF_OPEN';
-      log.info({ name: this.cbName }, 'Circuit breaker transitioning to HALF_OPEN');
+      this.logTransition('Circuit breaker transitioning to HALF_OPEN');
     }
     return this.state;
   }
@@ -89,6 +93,7 @@ export class CircuitBreaker {
     this.state = 'CLOSED';
     this.failures = 0;
     this.successes = 0;
+    this.consecutiveProbeFailures = 0;
     this.lastFailure = undefined;
     this.openedAt = undefined;
     log.info({ name: this.cbName }, 'Circuit breaker reset to CLOSED');
@@ -101,9 +106,17 @@ export class CircuitBreaker {
 
   private onSuccess(): void {
     if (this.state === 'HALF_OPEN') {
-      log.info({ name: this.cbName }, 'Circuit breaker probe succeeded \u2014 closing circuit');
+      if (this.consecutiveProbeFailures > 0) {
+        log.info(
+          { name: this.cbName, previousConsecutiveFailures: this.consecutiveProbeFailures },
+          'Circuit breaker probe succeeded after consecutive failures \u2014 closing circuit',
+        );
+      } else {
+        log.info({ name: this.cbName }, 'Circuit breaker probe succeeded \u2014 closing circuit');
+      }
       this.state = 'CLOSED';
       this.failures = 0;
+      this.consecutiveProbeFailures = 0;
     }
     this.successes++;
   }
@@ -112,7 +125,20 @@ export class CircuitBreaker {
     this.failures++;
     this.lastFailure = new Date();
     if (this.state === 'HALF_OPEN') {
-      log.warn({ name: this.cbName }, 'Circuit breaker probe failed \u2014 re-opening circuit');
+      this.consecutiveProbeFailures++;
+      if (this.consecutiveProbeFailures <= PROBE_FAILURE_LOG_THRESHOLD) {
+        log.warn({ name: this.cbName }, 'Circuit breaker probe failed \u2014 re-opening circuit');
+      } else if (this.consecutiveProbeFailures === PROBE_FAILURE_LOG_THRESHOLD + 1) {
+        log.warn(
+          { name: this.cbName, consecutiveFailures: this.consecutiveProbeFailures },
+          'Circuit breaker probe continues to fail \u2014 suppressing further warnings to debug level',
+        );
+      } else {
+        log.debug(
+          { name: this.cbName, consecutiveFailures: this.consecutiveProbeFailures },
+          'Circuit breaker probe failed \u2014 re-opening circuit (suppressed)',
+        );
+      }
       this.state = 'OPEN';
       this.openedAt = Date.now();
       return;
@@ -124,6 +150,18 @@ export class CircuitBreaker {
       );
       this.state = 'OPEN';
       this.openedAt = Date.now();
+    }
+  }
+
+  /** Log transition message at INFO for the first few transitions, then at DEBUG to reduce noise. */
+  private logTransition(message: string): void {
+    if (this.consecutiveProbeFailures < PROBE_FAILURE_LOG_THRESHOLD) {
+      log.info({ name: this.cbName }, message);
+    } else {
+      log.debug(
+        { name: this.cbName, consecutiveFailures: this.consecutiveProbeFailures },
+        message,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

Reduces monitoring log noise from ~51% errors/warnings to primarily actionable log lines by addressing the three main noise sources identified in #698.

Closes #698

## Root Cause

Three compounding factors caused excessive log volume:
1. **Circuit breaker probe loops**: OPEN→HALF_OPEN→OPEN cycle generated 2 WARN-level lines every 30 seconds per failing endpoint
2. **Per-item error logging**: Container fetch failures and metrics read failures logged individually (e.g., 46 separate "Failed to collect metrics" warnings per cycle)
3. **Static cycle summaries**: Full monitoring cycle stats logged at INFO every cycle even when nothing changed

## Fix

### 1. Circuit breaker log rate-limiting (`circuit-breaker.ts`)
- Track `consecutiveProbeFailures` counter on each circuit breaker instance
- First 3 probe failures log at WARN (existing behavior)
- 4th failure logs a "suppressing further warnings" notice at WARN
- Subsequent failures log at DEBUG level
- HALF_OPEN transition messages also demoted to DEBUG after threshold
- Counter resets on successful probe or `reset()`

### 2. Error aggregation (`monitoring-service.ts`, `scheduler/setup.ts`)
- Container fetch failures: single warning with count instead of per-endpoint warnings
- Metrics read failures: single warning with count instead of per-container warnings
- Scheduler endpoint/container metrics failures: same aggregation pattern

### 3. Delta-based cycle summaries (`monitoring-service.ts`)
- Track previous cycle stats (endpoints, containers, totalInsights, anomalies, securityFindings)
- Log at INFO only when any key metric changes by >10%
- Otherwise log at DEBUG with "(no significant changes)" suffix
- First cycle always logs at INFO (no previous stats to compare)

## Changes
- `backend/src/services/circuit-breaker.ts` — Add probe failure counter, rate-limit transition/failure logs
- `backend/src/services/circuit-breaker.test.ts` — 4 new tests for log suppression behavior
- `backend/src/services/monitoring-service.ts` — Error aggregation, delta-based summaries, `resetPreviousCycleStats()` export
- `backend/src/services/monitoring-service.test.ts` — 3 new tests for error aggregation, mock cleanup fix
- `backend/src/scheduler/setup.ts` — Aggregate per-container/endpoint failure warnings

## Testing
- [x] 4 new circuit breaker tests for probe failure suppression
- [x] 3 new monitoring service tests for error aggregation
- [x] All 32 circuit breaker tests pass
- [x] All 28 monitoring service tests pass
- [x] Full backend test suite passes (1736 passed, 44 skipped — DB-dependent)
- [x] Backend lint passes (zero warnings)
- [x] Backend TypeScript type check passes

## Rollback Plan
Revert this PR: `git revert <merge-commit-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)