### PR TITLE
fix: backend resilience — circuit breaker backoff, error handling, LLM timeouts, investigation quality (#694-#697)

### DIFF
--- a/backend/src/config/env.schema.ts
+++ b/backend/src/config/env.schema.ts
@@ -40,6 +40,7 @@ export const envSchema = z.object({
   LLM_BEARER_TOKEN: z.string().optional(), // Bearer token or username:password for Basic auth
   LLM_AUTH_TYPE: z.enum(['bearer', 'basic']).default('bearer'), // Auth header type for LLM endpoint tokens
   LLM_VERIFY_SSL: z.string().default('true').transform((v) => v === 'true' || v === '1'),
+  LLM_REQUEST_TIMEOUT: z.coerce.number().int().min(5000).max(600000).default(120000),
 
   // AI Search specific model (defaults to llama3.2:latest - change to qwen3:30b for better reasoning)
   AI_SEARCH_MODEL: z.string().default('llama3.2:latest'),
@@ -104,6 +105,7 @@ export const envSchema = z.object({
   INVESTIGATION_MAX_CONCURRENT: z.coerce.number().int().min(1).default(2),
   INVESTIGATION_LOG_TAIL_LINES: z.coerce.number().int().min(10).default(50),
   INVESTIGATION_METRICS_WINDOW_MINUTES: z.coerce.number().int().min(5).default(60),
+  INVESTIGATION_MIN_SEVERITY: z.enum(['critical', 'warning', 'info']).default('warning'),
 
   // Packet Capture (PCAP)
   PCAP_ENABLED: z.coerce.boolean().default(false),

--- a/backend/src/scheduler/setup.test.ts
+++ b/backend/src/scheduler/setup.test.ts
@@ -27,6 +27,7 @@ vi.mock('../services/portainer-client.js', () => ({
   getEndpoints: (...args: unknown[]) => getEndpointsMock(...args),
   getContainers: (...args: unknown[]) => getContainersMock(...args),
   getImages: (...args: unknown[]) => getImagesMock(...args),
+  isEndpointDegraded: () => false,
 }));
 
 vi.mock('../services/image-staleness.js', () => ({

--- a/backend/src/services/llm-client.test.ts
+++ b/backend/src/services/llm-client.test.ts
@@ -18,7 +18,7 @@ vi.mock('./settings-store.js', () => ({
 }));
 
 // Mock config (for getLlmDispatcher)
-const mockEnvConfig = vi.fn().mockReturnValue({ LLM_VERIFY_SSL: true });
+const mockEnvConfig = vi.fn().mockReturnValue({ LLM_VERIFY_SSL: true, LLM_REQUEST_TIMEOUT: 120000 });
 vi.mock('../config/index.js', () => ({
   getConfig: (...args: unknown[]) => mockEnvConfig(...args),
 }));

--- a/backend/src/services/llm-client.ts
+++ b/backend/src/services/llm-client.ts
@@ -158,7 +158,9 @@ async function chatStreamInner(
   onChunk: (chunk: string) => void,
 ): Promise<string> {
   const llmConfig = await getEffectiveLlmConfig();
+  const config = getConfig();
   const startTime = Date.now();
+  const requestTimeoutMs = config.LLM_REQUEST_TIMEOUT;
 
   const fullMessages: ChatMessage[] = [
     { role: 'system', content: systemPrompt },
@@ -185,6 +187,7 @@ async function chatStreamInner(
           messages: fullMessages,
           stream: true,
         }),
+        signal: AbortSignal.timeout(requestTimeoutMs),
       });
 
       if (!response.ok) {

--- a/backend/src/services/monitoring-service.test.ts
+++ b/backend/src/services/monitoring-service.test.ts
@@ -40,6 +40,7 @@ const mockGetContainers = vi.fn().mockResolvedValue([]);
 vi.mock('./portainer-client.js', () => ({
   getEndpoints: () => mockGetEndpoints(),
   getContainers: (...args: unknown[]) => mockGetContainers(...args),
+  isEndpointDegraded: () => false,
 }));
 
 const mockCachedFetchSWR = vi.fn((_key: string, _ttl: number, fn: () => Promise<unknown>) => fn());

--- a/backend/src/services/portainer-cache.ts
+++ b/backend/src/services/portainer-cache.ts
@@ -754,10 +754,13 @@ export function cachedFetchSWR<T>(
             await cache.set(key, data, ttlSeconds);
           } catch (err) {
             log.warn({ key, err }, 'SWR L2 background revalidation failed');
+          } finally {
+            inFlight.delete(key);
           }
         })();
         inFlight.set(key, revalidate);
-        revalidate.finally(() => { inFlight.delete(key); });
+        // Prevent unhandled rejection warning if something unexpected escapes the try/catch
+        revalidate.catch(() => {});
       }
       return l2Data;
     }

--- a/backend/src/services/portainer-client.ts
+++ b/backend/src/services/portainer-client.ts
@@ -126,6 +126,14 @@ function getBreaker(path: string): CircuitBreaker {
   return breaker;
 }
 
+/** Check whether the circuit breaker for a given endpoint is degraded (persistently failing). */
+export function isEndpointDegraded(endpointId: number): boolean {
+  const key = `endpoint-${endpointId}`;
+  const entry = breakers.get(key);
+  if (!entry) return false;
+  return entry.breaker.isDegraded();
+}
+
 /** Remove breakers for endpoints not seen in the last hour */
 export function pruneStaleBreakers(): number {
   const cutoff = Date.now() - BREAKER_MAX_IDLE_MS;

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -43,6 +43,8 @@ OLLAMA_MODEL=llama3.2
 # Use "basic" only for endpoints requiring HTTP Basic auth.
 # Set to false if your LLM endpoint uses a self-signed or internal CA certificate:
 # LLM_VERIFY_SSL=false
+# Timeout for LLM requests in milliseconds (default: 120000 = 2 minutes)
+# LLM_REQUEST_TIMEOUT=120000
 # Custom CA certificate for TLS verification with internal/self-signed certs
 # Preferred over *_VERIFY_SSL=false which disables ALL TLS verification
 # NODE_EXTRA_CA_CERTS=/certs/ca-bundle.crt


### PR DESCRIPTION
## Summary
- **#694**: Exponential backoff for circuit breaker probe intervals (30s → 60s → 120s → 240s → 300s max) with degraded endpoint detection after 5 consecutive probe failures
- **#695**: Guard unhandled `CircuitBreakerOpenError` promise rejections in SWR cache, monitoring service, and metrics scheduler; skip degraded endpoints entirely
- **#696**: Configurable `LLM_REQUEST_TIMEOUT` (default 120s) with `AbortSignal.timeout()` on custom endpoint fetch; timeout retry in anomaly explainer
- **#697**: Severity threshold gating (`INVESTIGATION_MIN_SEVERITY`) and evidence quality checks to prevent low-confidence LLM calls in investigation service

Closes #694, closes #695, closes #696, closes #697

## Root Cause
1. Circuit breaker used fixed probe intervals, causing rapid retries against a failing endpoint
2. `CircuitBreakerOpenError` was not caught in fire-and-forget SWR revalidation paths and monitoring loops
3. LLM custom endpoint fetch calls had no timeout, allowing Node's default (infinite) to hang indefinitely
4. Investigation service triggered LLM analysis regardless of insight severity or available evidence

## Changes
- `circuit-breaker.ts` — `currentResetTimeoutMs` doubles after each probe failure (capped at 300s), `isDegraded()` method, reset on success
- `portainer-client.ts` — New `isEndpointDegraded()` export
- `portainer-cache.ts` — `.catch(() => {})` guard on L2 SWR revalidation promise
- `monitoring-service.ts` — Skip degraded endpoints, distinguish `CircuitBreakerOpenError` (debug-level logging)
- `scheduler/setup.ts` — Skip degraded endpoints in metrics collection
- `llm-client.ts` — `AbortSignal.timeout(requestTimeoutMs)` on custom endpoint fetch
- `anomaly-explainer.ts` — Timeout retry logic (1 retry on timeout errors)
- `investigation-service.ts` — Severity threshold + evidence quality gate before LLM call
- `env.schema.ts` — Added `LLM_REQUEST_TIMEOUT`, `INVESTIGATION_MIN_SEVERITY`
- `docker/.env.example` — Documented new env vars

## Testing
- [x] 40 circuit breaker tests (8 new: exponential backoff + isDegraded)
- [x] 24 LLM client tests passing (mock config updated)
- [x] 33 investigation service tests (2 new: severity filtering)
- [x] 51 monitoring + scheduler tests passing (mocks updated)
- [x] Full backend suite: 1746 tests passing
- [x] TypeScript typecheck clean
- [x] ESLint zero warnings

## Rollback Plan
Revert this PR: `git revert <merge-commit-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)