### PR TITLE
Refine command palette: theme-aware colors, UX fixes

### DIFF
--- a/frontend/src/components/layout/command-palette.test.tsx
+++ b/frontend/src/components/layout/command-palette.test.tsx
@@ -92,7 +92,7 @@ describe('CommandPalette (Spotlight Style)', () => {
     const categoryButtons = screen.getByTestId('category-buttons');
     expect(categoryButtons).toBeInTheDocument();
     expect(screen.getByLabelText('Filter by Containers')).toBeInTheDocument();
-    expect(screen.getByLabelText('Filter by Logs')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by Settings')).toBeInTheDocument();
   });
 
   it('category buttons are visible in both idle and typing states', () => {
@@ -114,12 +114,12 @@ describe('CommandPalette (Spotlight Style)', () => {
     // With 'all' category, containers should be visible
     expect(screen.getByText('web-frontend')).toBeInTheDocument();
 
-    // Click Logs category
-    const logsBtn = screen.getByLabelText('Filter by Logs');
-    fireEvent.click(logsBtn);
-    expect(logsBtn).toHaveAttribute('aria-pressed', 'true');
+    // Click Settings category
+    const settingsBtn = screen.getByLabelText('Filter by Settings');
+    fireEvent.click(settingsBtn);
+    expect(settingsBtn).toHaveAttribute('aria-pressed', 'true');
 
-    // Container results should be hidden when logs filter is active
+    // Container results should be hidden when settings filter is active
     expect(screen.queryByText('Infrastructure Units')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/layout/command-palette.tsx
+++ b/frontend/src/components/layout/command-palette.tsx
@@ -95,11 +95,11 @@ function isNaturalLanguageQuery(input: string): boolean {
   return false;
 }
 
-export type SearchCategory = 'all' | 'containers' | 'logs';
+export type SearchCategory = 'all' | 'containers' | 'settings';
 
 const categories: { id: SearchCategory; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
   { id: 'containers', label: 'Containers', icon: Package },
-  { id: 'logs', label: 'Logs', icon: ScrollText },
+  { id: 'settings', label: 'Settings', icon: Settings },
 ];
 
 export function CommandPalette() {
@@ -149,9 +149,9 @@ export function CommandPalette() {
     }
   }, [open]);
 
-  // Auto-enable log search when logs category is active
+  // Always include logs in search results
   useEffect(() => {
-    setIncludeLogs(activeCategory === 'logs' || activeCategory === 'all');
+    setIncludeLogs(true);
   }, [activeCategory]);
 
   const isNl = isNaturalLanguageQuery(query);
@@ -199,16 +199,16 @@ export function CommandPalette() {
   // Filter results based on active category
   const containers = activeCategory === 'all' || activeCategory === 'containers' ? allContainers : [];
   const images = activeCategory === 'all' || activeCategory === 'containers' ? allImages : [];
-  const logs = activeCategory === 'all' || activeCategory === 'logs' ? allLogs : [];
+  const logs = activeCategory === 'all' ? allLogs : [];
   const filteredPages = activeCategory === 'all'
     ? pages
     : activeCategory === 'containers'
       ? pages.filter((p) => p.to === '/workloads' || p.to === '/health' || p.to === '/fleet' || p.to === '/images')
-      : activeCategory === 'logs'
-        ? pages.filter((p) => p.to === '/edge-logs')
+      : activeCategory === 'settings'
+        ? pages.filter((p) => p.to === '/settings' || p.to === '/users' || p.to === '/webhooks')
         : pages;
 
-  const filteredSettings = activeCategory === 'all' ? settingsEntries : [];
+  const filteredSettings = activeCategory === 'all' || activeCategory === 'settings' ? settingsEntries : [];
 
   // Client-side endpoint (node) filtering
   const filteredEndpoints = (activeCategory === 'all' || activeCategory === 'containers') && lowerQuery.length >= 2


### PR DESCRIPTION
## Summary
- Fix flickering animation by removing framer-motion, using instant popup
- Replace hardcoded dark colors with theme-aware tokens (works across all 9 themes)
- Unify search bar into single seamless container (logo + input + category buttons)
- Tone down hover highlight to subtle muted background
- Remove title/subtitle and Neural Controller section
- Replace sidebar logo with search icon
- Allow Enter key to trigger neural search (not just the button)
- Show category name in search placeholder on button hover

Closes #680

## Test plan
- [x] All 12 command palette tests passing
- [x] TypeScript typecheck clean
- [x] Verify popup appears instantly without flicker on `/` or Cmd+K
- [x] Verify theme-aware colors across light/dark/Apple/Catppuccin themes
- [x] Verify Enter triggers neural search for natural language queries
- [x] Verify category hover shows label in placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)