### PR TITLE
perf: reduce Portainer API load from dashboard, container detail, and security audit

### DIFF
--- a/backend/src/routes/containers.ts
+++ b/backend/src/routes/containers.ts
@@ -218,7 +218,11 @@ export async function containersRoutes(fastify: FastifyInstance) {
       containerId: string;
     };
     try {
-      const container = await portainer.getContainer(endpointId, containerId);
+      const container = await cachedFetchSWR(
+        getCacheKey('container-detail', endpointId, containerId),
+        TTL.STATS, // 60s TTL — detail changes infrequently, matches scheduler interval
+        () => portainer.getContainer(endpointId, containerId),
+      );
       return container;
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';


### PR DESCRIPTION
## Summary

- **#727**: Dashboard resources endpoint now reads metrics from TimescaleDB (batch query) instead of making live `stats?stream=false` calls to Portainer per container
- **#728**: Container detail route wrapped in `cachedFetchSWR` with 60s TTL instead of uncached Portainer API calls
- **#729**: Security audit caches full result for 5 minutes instead of N+1 container inspect recomputation on every dashboard poll

## Performance Impact

| Endpoint | Before | After |
|----------|--------|-------|
| `GET /api/dashboard/resources` | N Portainer stats calls per request (1 per running container) | 1 TimescaleDB batch query |
| `GET /api/containers/:eid/:cid` | 1 uncached Portainer call per visit | Cached with 60s SWR TTL |
| Security audit (via dashboard summary) | Full N+1 audit recomputation every 30s | Cached for 5 minutes |

**Estimated reduction: 60-170 fewer Portainer API calls/min per active user.**

## Changes

- `backend/src/services/metrics-store.ts` — Added `getLatestMetricsBatch()` using single `WHERE container_id = ANY($1)` query
- `backend/src/routes/dashboard.ts` — Replaced `collectMetrics()` loop with `getLatestMetricsBatch()` + graceful degradation
- `backend/src/routes/containers.ts` — Wrapped `getContainer()` in `cachedFetchSWR()` with 60s TTL
- `backend/src/services/security-audit.ts` — Extracted `computeSecurityAudit()`, public function wraps with `cachedFetch()` at 300s TTL
- Tests updated for all three changes (new tests for batch query, cache verification, failure handling)

## Test plan

- [x] All 1781 unit tests pass
- [x] TypeScript typecheck passes with zero errors
- [ ] Verify dashboard resources display matches previous behavior (CPU %, memory %)
- [ ] Verify container detail page loads correctly with cached data
- [ ] Verify security audit data on dashboard summary is still accurate (refreshes every 5 min)
- [ ] Load test: confirm reduced Portainer API call volume under multi-user load

Closes #727, Closes #728, Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)