### PR TITLE
Home: expand endpoint health, restore timer toggle

### DIFF
--- a/frontend/src/components/charts/endpoint-health-octagons.tsx
+++ b/frontend/src/components/charts/endpoint-health-octagons.tsx
@@ -296,9 +296,9 @@ export const EndpointHealthOctagons = memo(function EndpointHealthOctagons({
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex flex-col">
       {/* Hexagon honeycomb grid */}
-      <div ref={containerRef} className="flex-1 overflow-y-auto py-2">
+      <div ref={containerRef} className="py-2">
         <motion.div
           className="relative w-full"
           style={{ height: layout.totalHeight || 'auto' }}


### PR DESCRIPTION
## Summary
- Removed Container State Pie chart from Home page (per issue comment)
- Expanded Endpoint Health hexagons to full width with dynamic height — no internal scrollbar, pane grows to fit all endpoints
- Replaced SmartRefreshControls dropdown with AutoRefreshToggle pill buttons + RefreshButton (refresh & bypass cache), matching fleet overview pattern

## Test plan
- [x] Home page loads without errors
- [x] Endpoint Health hexagons span full width and grow dynamically (no scroll)
- [x] Container State Pie chart no longer appears
- [x] Timer interval toggle works (Off, 15s, 30s, 1m, 2m, 5m)
- [x] Refresh and bypass cache buttons work
- [x] Responsive on smaller screens
- [x] All existing tests pass

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)