### PR TITLE
fix: ensure all pages load on SPA navigation without manual refresh

### DIFF
--- a/frontend/src/hooks/use-containers.ts
+++ b/frontend/src/hooks/use-containers.ts
@@ -70,6 +70,7 @@ export function useContainers(params?: UseContainersParams) {
       return normalizeContainersResponse(response);
     },
     staleTime: 60 * 1000,
+    refetchOnMount: 'always',
     refetchOnWindowFocus: false,
   });
 }
@@ -99,6 +100,7 @@ export function usePaginatedContainers(params: {
       return api.get<PaginatedContainers>(`/api/containers?${searchParams.toString()}`);
     },
     staleTime: 60 * 1000,
+    refetchOnMount: 'always',
     refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/hooks/use-correlated-anomalies.ts
+++ b/frontend/src/hooks/use-correlated-anomalies.ts
@@ -24,6 +24,8 @@ export function useCorrelatedAnomalies(windowSize: number = 30, minScore: number
         `/api/anomalies/correlated?windowSize=${windowSize}&minScore=${minScore}`,
       ),
     staleTime: 60 * 1000,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
     retry: 1,
   });
 }

--- a/frontend/src/hooks/use-ebpf-coverage.ts
+++ b/frontend/src/hooks/use-ebpf-coverage.ts
@@ -39,6 +39,8 @@ export function useEbpfCoverage() {
   return useQuery<{ coverage: CoverageRecord[] }>({
     queryKey: ['ebpf', 'coverage'],
     queryFn: () => api.get('/api/ebpf/coverage'),
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
     refetchInterval: isPageVisible ? 120_000 : false,
   });
 }
@@ -49,6 +51,8 @@ export function useEbpfCoverageSummary() {
   return useQuery<CoverageSummary>({
     queryKey: ['ebpf', 'coverage', 'summary'],
     queryFn: () => api.get('/api/ebpf/coverage/summary'),
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
     refetchInterval: isPageVisible ? 120_000 : false,
   });
 }

--- a/frontend/src/hooks/use-endpoints.ts
+++ b/frontend/src/hooks/use-endpoints.ts
@@ -36,6 +36,8 @@ export function useEndpoints() {
     queryKey: ['endpoints'],
     queryFn: () => api.get<Endpoint[]>('/api/endpoints'),
     staleTime: 60 * 1000,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/frontend/src/hooks/use-incidents.ts
+++ b/frontend/src/hooks/use-incidents.ts
@@ -44,6 +44,8 @@ export function useIncidents(status?: 'active' | 'resolved') {
       if (status) params.status = status;
       return api.get<IncidentsResponse>('/api/incidents', { params });
     },
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
     refetchInterval: isPageVisible ? 30_000 : false,
   });
 }

--- a/frontend/src/hooks/use-llm-observability.ts
+++ b/frontend/src/hooks/use-llm-observability.ts
@@ -95,6 +95,8 @@ export function useLlmTraces(limit: number = 50) {
     queryKey: ['llm-traces', limit],
     queryFn: async () => normalizeLlmTraces(await api.get<unknown>(`/api/llm/traces?limit=${limit}`)),
     staleTime: 30 * 1000,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
 }
 
@@ -103,5 +105,7 @@ export function useLlmStats(hours: number = 24) {
     queryKey: ['llm-stats', hours],
     queryFn: async () => normalizeLlmStats(await api.get<unknown>(`/api/llm/stats?hours=${hours}`)),
     staleTime: 60 * 1000,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/hooks/use-metrics.ts
+++ b/frontend/src/hooks/use-metrics.ts
@@ -74,6 +74,8 @@ export function useContainerMetrics(
       );
     },
     enabled: Boolean(endpointId) && Boolean(containerId),
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
     // Poll faster while empty so first data appears sooner; back off once data is flowing.
     refetchInterval: (query) => {
       const points = query.state.data?.data?.length ?? 0;
@@ -90,6 +92,8 @@ export function useAnomalies() {
   return useQuery<Anomaly[]>({
     queryKey: ['metrics', 'anomalies'],
     queryFn: () => api.get<Anomaly[]>('/api/metrics/anomalies'),
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/frontend/src/hooks/use-monitoring.ts
+++ b/frontend/src/hooks/use-monitoring.ts
@@ -42,6 +42,8 @@ export function useMonitoring() {
     queryKey: ['monitoring', 'insights'],
     queryFn: () => api.get<{ insights: Insight[]; total: number }>('/api/monitoring/insights'),
     staleTime: 60_000,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
 
   useEffect(() => {

--- a/frontend/src/hooks/use-networks.ts
+++ b/frontend/src/hooks/use-networks.ts
@@ -23,6 +23,7 @@ export function useNetworks(endpointId?: number) {
       return api.get<Network[]>(path);
     },
     staleTime: 5 * 60 * 1000,
+    refetchOnMount: 'always',
     refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/hooks/use-remediation.ts
+++ b/frontend/src/hooks/use-remediation.ts
@@ -26,6 +26,7 @@ export function useRemediationActions(status?: string) {
     // This query is mounted in multiple places (sidebar + remediation page).
     // Prevent retry/focus bursts that can trigger transient 429 responses.
     retry: false,
+    refetchOnMount: 'always',
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     staleTime: 10_000,

--- a/frontend/src/hooks/use-security-audit.ts
+++ b/frontend/src/hooks/use-security-audit.ts
@@ -45,6 +45,7 @@ export function useSecurityAudit(endpointId?: number) {
         ? api.get<SecurityAuditResponse>(`/api/security/audit/${endpointId}`)
         : api.get<SecurityAuditResponse>('/api/security/audit'),
     staleTime: 120 * 1000,
+    refetchOnMount: 'always',
     refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/hooks/use-traces.ts
+++ b/frontend/src/hooks/use-traces.ts
@@ -114,6 +114,8 @@ export function useTraces(options?: TracesOptions) {
       '/api/traces',
       { params: options as Record<string, string | number | boolean | undefined> }
     ),
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
 }
 
@@ -132,6 +134,8 @@ export function useServiceMap(options?: TracesOptions) {
       '/api/traces/service-map',
       { params: options as Record<string, string | number | boolean | undefined> }
     ),
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
 }
 
@@ -142,5 +146,7 @@ export function useTraceSummary(options?: Omit<TracesOptions, 'limit'>) {
       '/api/traces/summary',
       { params: options as Record<string, string | number | boolean | undefined> }
     ),
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/pages/ebpf-coverage.tsx
+++ b/frontend/src/pages/ebpf-coverage.tsx
@@ -364,7 +364,10 @@ function CoverageRow({
 }
 
 export default function EbpfCoveragePage() {
-  const { data, isLoading } = useEbpfCoverage();
+  const { data, isLoading: coverageLoading, isPending: coveragePending } = useEbpfCoverage();
+  // Treat both isLoading and isPending-without-data as "loading" to avoid
+  // rendering a blank page during SPA navigation before data arrives.
+  const isLoading = coverageLoading || (coveragePending && !data);
   const syncMutation = useSyncCoverage();
 
   return (

--- a/frontend/src/pages/edge-agent-logs.tsx
+++ b/frontend/src/pages/edge-agent-logs.tsx
@@ -238,7 +238,8 @@ export default function EdgeAgentLogsPage() {
   // Fetch logs
   const {
     data: logsData,
-    isLoading,
+    isLoading: logsLoading,
+    isPending: logsPending,
     isError,
     error,
     refetch,
@@ -258,7 +259,13 @@ export default function EdgeAgentLogsPage() {
       return api.get<LogsResponse>('/api/logs/search', { params });
     },
     retry: false, // Don't retry on 503 (not configured)
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
+
+  // Treat both isLoading and isPending-without-data as "loading" to avoid
+  // rendering a blank page during SPA navigation before data arrives.
+  const isLoading = logsLoading || (logsPending && !logsData);
 
   // Check if not configured (503 error)
   const isNotConfigured = isError && (error as Error)?.message?.includes('503');

--- a/frontend/src/pages/llm-observability.tsx
+++ b/frontend/src/pages/llm-observability.tsx
@@ -115,8 +115,12 @@ export default function LlmObservabilityPage() {
   const [privacyMode, setPrivacyMode] = useState(true);
   const { interval, setInterval } = useAutoRefresh(30);
 
-  const { data: stats, isLoading: statsLoading, refetch: refetchStats } = useLlmStats(timeRange);
-  const { data: traces, isLoading: tracesLoading, refetch: refetchTraces } = useLlmTraces(50);
+  const { data: stats, isLoading: statsLoading, isPending: statsPending, refetch: refetchStats } = useLlmStats(timeRange);
+  const { data: traces, isLoading: tracesLoading, isPending: tracesPending, refetch: refetchTraces } = useLlmTraces(50);
+  // Treat both isLoading and isPending-without-data as "loading" to avoid
+  // rendering a blank page during SPA navigation before data arrives.
+  const showStatsSkeleton = statsLoading || (statsPending && !stats);
+  const showTracesSkeleton = tracesLoading || (tracesPending && !traces);
   const modelBreakdown = stats?.modelBreakdown ?? [];
   const totalModelQueries = modelBreakdown.reduce((sum, model) => sum + model.count, 0);
   const maxModelQueries = modelBreakdown.reduce((max, model) => Math.max(max, model.count), 0);
@@ -175,7 +179,7 @@ export default function LlmObservabilityPage() {
       </div>
 
       {/* KPI Cards */}
-      {statsLoading ? (
+      {showStatsSkeleton ? (
         <div className="grid gap-4 md:grid-cols-4">
           <SkeletonCard />
           <SkeletonCard />
@@ -266,7 +270,7 @@ export default function LlmObservabilityPage() {
           <Activity className="h-5 w-5 text-primary" />
           <h2 className="text-lg font-semibold">Recent Traces</h2>
         </div>
-        <TracesTable traces={traces ?? []} isLoading={tracesLoading} privacyMode={privacyMode} />
+        <TracesTable traces={traces ?? []} isLoading={showTracesSkeleton} privacyMode={privacyMode} />
       </div>
     </div>
   );

--- a/frontend/src/pages/metrics-dashboard.tsx
+++ b/frontend/src/pages/metrics-dashboard.tsx
@@ -134,10 +134,10 @@ export default function MetricsDashboardPage() {
   const llmAvailable = (llmModels?.models?.length ?? 0) > 0;
 
   // Fetch endpoints
-  const { data: endpoints, isLoading: endpointsLoading } = useEndpoints();
+  const { data: endpoints, isLoading: endpointsLoading, isPending: endpointsPending } = useEndpoints();
 
   // Fetch containers
-  const { data: allContainers, isLoading: containersLoading, refetch, isFetching } = useContainers();
+  const { data: allContainers, isLoading: containersLoading, isPending: containersPending, refetch, isFetching } = useContainers();
   const { data: networkRatesData } = useNetworkRates(selectedEndpoint ?? undefined);
   const { data: stacks } = useStacks();
 
@@ -359,7 +359,9 @@ export default function MetricsDashboardPage() {
     }
   };
 
-  const isLoading = endpointsLoading || containersLoading;
+  // Treat both isLoading and isPending-without-data as "loading" to avoid
+  // rendering a blank page during SPA navigation before data arrives.
+  const isLoading = endpointsLoading || containersLoading || (endpointsPending && !endpoints) || (containersPending && !allContainers);
   const hasSelection = selectedEndpoint && selectedContainer;
   const metricsLoading = cpuLoading || memoryLoading || memoryBytesLoading;
   const allMetricsEmpty = !metricsLoading && hasSelection

--- a/frontend/src/pages/network-topology.tsx
+++ b/frontend/src/pages/network-topology.tsx
@@ -37,8 +37,8 @@ export default function NetworkTopologyPage() {
   };
 
   const { data: endpoints } = useEndpoints();
-  const { data: containers, isLoading: containersLoading, isError: containersError, refetch: refetchContainers, isFetching: containersFetching } = useContainers(selectedEndpoint !== undefined ? { endpointId: selectedEndpoint } : undefined);
-  const { data: networks, isLoading: networksLoading, isError: networksError, refetch: refetchNetworks, isFetching: networksFetching } = useNetworks(selectedEndpoint);
+  const { data: containers, isLoading: containersLoading, isPending: containersPending, isError: containersError, refetch: refetchContainers, isFetching: containersFetching } = useContainers(selectedEndpoint !== undefined ? { endpointId: selectedEndpoint } : undefined);
+  const { data: networks, isLoading: networksLoading, isPending: networksPending, isError: networksError, refetch: refetchNetworks, isFetching: networksFetching } = useNetworks(selectedEndpoint);
   const { data: networkRatesData } = useNetworkRates(selectedEndpoint);
   const { interval, setInterval } = useAutoRefresh(30);
 
@@ -76,7 +76,9 @@ export default function NetworkTopologyPage() {
     refetchNetworks();
   };
 
-  const isLoading = containersLoading || networksLoading;
+  // Treat both isLoading and isPending-without-data as "loading" to avoid
+  // rendering a blank page during SPA navigation before data arrives.
+  const isLoading = containersLoading || networksLoading || (containersPending && !containers) || (networksPending && !networks);
   const isError = containersError || networksError;
   const isFetching = containersFetching || networksFetching;
 

--- a/frontend/src/pages/remediation.tsx
+++ b/frontend/src/pages/remediation.tsx
@@ -424,12 +424,16 @@ export default function RemediationPage() {
   // Fetch actions
   const {
     data: actionsData,
-    isLoading,
+    isLoading: actionsLoading,
+    isPending: actionsPending,
     isError,
     error,
     refetch,
     isFetching,
   } = useRemediationActions(statusFilter === 'all' ? undefined : statusFilter);
+  // Treat both isLoading and isPending-without-data as "loading" to avoid
+  // rendering a blank page during SPA navigation before data arrives.
+  const isLoading = actionsLoading || (actionsPending && !actionsData);
 
   // Mutations
   const approveAction = useApproveAction();

--- a/frontend/src/pages/security-audit.tsx
+++ b/frontend/src/pages/security-audit.tsx
@@ -59,9 +59,12 @@ export default function SecurityAuditPage() {
   const [selectedStack, setSelectedStack] = useState<string>('all');
 
   const { data: endpoints = [] } = useEndpoints();
-  const { data, isLoading, isError, error, refetch } = useSecurityAudit(
+  const { data, isLoading: auditLoading, isPending: auditPending, isError, error, refetch } = useSecurityAudit(
     selectedEndpoint === 'all' ? undefined : Number(selectedEndpoint),
   );
+  // Treat both isLoading and isPending-without-data as "loading" to avoid
+  // rendering a blank page during SPA navigation before data arrives.
+  const isLoading = auditLoading || (auditPending && !data);
 
   const entries = data?.entries ?? [];
 

--- a/frontend/src/pages/trace-explorer.tsx
+++ b/frontend/src/pages/trace-explorer.tsx
@@ -490,10 +490,14 @@ export default function TraceExplorerPage() {
     otelScopeVersionFilter,
   ]);
 
-  const { data: tracesData, isLoading, isError, error, refetch, isFetching } = useTraces(traceQuery);
+  const { data: tracesData, isLoading: tracesLoading, isPending: tracesPending, isError, error, refetch, isFetching } = useTraces(traceQuery);
   const { data: selectedTraceData } = useTrace(selectedTraceId || undefined);
   const { data: serviceMapData } = useServiceMap(traceQuery);
   const { data: summary } = useTraceSummary(traceQuery);
+
+  // Treat both isLoading and isPending-without-data as "loading" to avoid
+  // rendering a blank page during SPA navigation before data arrives.
+  const isLoading = tracesLoading || (tracesPending && !tracesData);
 
   const traces = useMemo(() => {
     if (!tracesData) return [];


### PR DESCRIPTION
## Summary

Fixes multiple pages that don't load on SPA navigation and require a manual refresh. Applies the same pattern from PR #766 (Image Footprint fix) across all affected pages.

**Root cause:** TanStack Query hooks missing `refetchOnMount: 'always'` don't refetch stale data on SPA navigation. Additionally, page components guard on `isLoading` which is only true for initial loads, causing blank pages when navigating back to a page with stale cached data.

**Pattern applied:**
- **Hooks:** Add `refetchOnMount: 'always'` and `refetchOnWindowFocus: false` to all data-fetching hooks
- **Pages:** Change skeleton guard from `isLoading` to `isLoading || (isPending && !data)` to show skeletons during the pending-but-not-yet-fetching state

### Hooks fixed (12)
- `use-containers` (useContainers, usePaginatedContainers)
- `use-networks`
- `use-endpoints`
- `use-traces` (useTraces, useServiceMap, useTraceSummary)
- `use-metrics` (useContainerMetrics, useAnomalies)
- `use-ebpf-coverage` (useEbpfCoverage, useEbpfCoverageSummary)
- `use-llm-observability` (useLlmTraces, useLlmStats)
- `use-remediation`
- `use-security-audit`
- `use-monitoring` (internal useQuery)
- `use-correlated-anomalies`
- `use-incidents`

### Pages fixed (8)
- Network Topology
- Metrics Dashboard
- Trace Explorer
- eBPF Coverage
- LLM Observability
- Remediation
- Security Audit
- Edge Agent Logs

### Pages audited but not needing page-level fix
- **AI Monitor:** Uses `useMonitoring()` which manages state internally via `useState`; hook fix is sufficient
- **LLM Assistant:** WebSocket-based, no loading state issues
- **Log Viewer:** Uses `useQueries` for per-container log fetching; hook fixes for `useContainers`/`useEndpoints` are sufficient

Closes #767

## Test plan
- [ ] All 1297 frontend tests pass (verified locally)
- [ ] TypeScript typecheck passes (verified locally)
- [ ] Navigate to each affected page via sidebar -- page should load immediately
- [ ] Navigate away and back -- page should show skeleton then data (no blank page)
- [ ] Verify Image Footprint (already fixed in #766) still works correctly

Generated with [Claude Code](https://claude.com/claude-code)