### PR TITLE
fix: handle CircuitBreakerOpenError unhandled promise rejections

### DIFF
--- a/backend/src/services/portainer-cache.ts
+++ b/backend/src/services/portainer-cache.ts
@@ -736,8 +736,10 @@ export function cachedFetchSWR<T>(
           }
         })();
         inFlight.set(key, revalidate);
-        // Attach .catch() to prevent unhandled rejection if something unexpected happens
-        revalidate.catch(() => {});
+        // Safety net: catch any error that escapes the inner try/catch (e.g. from finally)
+        revalidate.catch((err) => {
+          log.warn({ key, err }, 'SWR background revalidation unhandled error');
+        });
       }
     }
     return Promise.resolve(staleInfo.data);
@@ -759,8 +761,10 @@ export function cachedFetchSWR<T>(
           }
         })();
         inFlight.set(key, revalidate);
-        // Prevent unhandled rejection warning if something unexpected escapes the try/catch
-        revalidate.catch(() => {});
+        // Safety net: catch any error that escapes the inner try/catch
+        revalidate.catch((err) => {
+          log.warn({ key, err }, 'SWR L2 background revalidation unhandled error');
+        });
       }
       return l2Data;
     }


### PR DESCRIPTION
## Summary

- **portainer-cache.ts**: The SWR background revalidation's safety-net `.catch()` now logs at warn level instead of silently swallowing errors that escape the inner try/catch block
- **security-audit.ts**: Per-endpoint container fetch wrapped in try/catch — `CircuitBreakerOpenError` skips the endpoint silently at debug level (expected behavior); other errors log at warn and also skip the endpoint — the audit continues with remaining endpoints instead of failing entirely

## Test plan

- [x] New test: circuit breaker open on endpoint 1 → endpoint 1 skipped, endpoint 2 entries returned normally
- [x] New test: non-CB network error on endpoint 1 → endpoint 1 skipped, endpoint 2 entries returned
- [x] All existing security-audit tests pass (11 tests)
- [x] All portainer-cache tests pass (45 tests)
- [x] TypeScript typecheck passes with no errors

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)