### PR TITLE
fix: prevent raw tool_calls JSON from reaching LLM assistant chat UI

### DIFF
--- a/backend/src/sockets/llm-chat.test.ts
+++ b/backend/src/sockets/llm-chat.test.ts
@@ -184,6 +184,31 @@ describe('looksLikeToolCallAttempt', () => {
     const json = '{"containers":[{"name":"nginx","state":"running"}]}';
     expect(looksLikeToolCallAttempt(json)).toBe(false);
   });
+
+  it('returns true for inline tool_calls embedded in a sentence', () => {
+    const inline = 'I will now call: {"tool_calls":[{"tool":"get_containers","arguments":{}}]}';
+    expect(looksLikeToolCallAttempt(inline)).toBe(true);
+  });
+
+  it('returns true for OpenAI streaming delta format with "tool_call"', () => {
+    const delta = '{"tool_call":{"id":"call_1","function":{"name":"get_containers","arguments":"{}"}}}';
+    expect(looksLikeToolCallAttempt(delta)).toBe(true);
+  });
+
+  it('returns true for JSON array of function-call objects at root', () => {
+    const arr = '[{"function":{"name":"get_logs","arguments":{"container":"nginx"}}}]';
+    expect(looksLikeToolCallAttempt(arr)).toBe(true);
+  });
+
+  it('returns true for code fence with function-call array', () => {
+    const fenced = '```json\n[{"function":{"name":"list_containers","arguments":{}}}]\n```';
+    expect(looksLikeToolCallAttempt(fenced)).toBe(true);
+  });
+
+  it('returns false for a JSON array of container objects (not tool calls)', () => {
+    const arr = '[{"name":"nginx","state":"running"},{"name":"redis","state":"stopped"}]';
+    expect(looksLikeToolCallAttempt(arr)).toBe(false);
+  });
 });
 
 describe('formatChatContext', () => {


### PR DESCRIPTION
## Summary
- Expanded `looksLikeToolCallAttempt()` to detect 5 additional tool-call JSON patterns: inline JSON embedded in natural language, OpenAI streaming delta format, root-level function-call arrays, code fences with function arrays, and case-insensitive `tool_call` detection
- Added `stripToolCallsJson()` in `prompt-guard.ts` — strips code fences, inline `tool_calls` objects, OpenAI delta format, and function-call arrays from LLM output (supports 3-level brace nesting)
- `sanitizeLlmOutput()` now applies `stripToolCallsJson()` as a post-stream sanitization pass
- Added 6 new `looksLikeToolCallAttempt` tests and 11 new `stripToolCallsJson` / `sanitizeLlmOutput` tests

## Test plan
- [x] Raw JSON `{"tool_calls":[...]}` detected and stripped
- [x] OpenAI delta format `{"tool_call":{"function":{...}}}` detected and stripped
- [x] Code fence with tool calls stripped, surrounding text preserved
- [x] Natural language mentioning "tool_calls" is NOT flagged
- [x] All 128 tests passing (85 prompt-guard + 43 llm-chat)

Closes #702