### PR TITLE
fix: stop Socket.IO reconnect thrashing on effect re-runs

### DIFF
--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -10,7 +10,7 @@ function cacheKey(namespace: string, token: string): string {
 }
 
 export function getSocket(token: string): Socket {
-  if (mainSocket?.connected) return mainSocket;
+  if (mainSocket) return mainSocket;
 
   mainSocket = io(SOCKET_URL, {
     auth: { token },
@@ -18,7 +18,9 @@ export function getSocket(token: string): Socket {
     transports: ['websocket', 'polling'],
     reconnection: true,
     reconnectionAttempts: 10,
-    reconnectionDelay: 1000,
+    reconnectionDelay: 1_000,
+    reconnectionDelayMax: 30_000,
+    randomizationFactor: 0.5,
   });
 
   return mainSocket;
@@ -30,12 +32,11 @@ export function getNamespaceSocket(
 ): Socket {
   const key = cacheKey(namespace, token);
   const existing = namespaceCache.get(key);
-  if (existing?.connected) return existing;
 
-  // Clean up stale entry if it exists but is disconnected
-  if (existing) {
-    namespaceCache.delete(key);
-  }
+  // Return the existing socket regardless of connection state.
+  // Socket.io manages reconnection automatically — creating a new socket
+  // while the old one's reconnect timer is running causes thrashing.
+  if (existing) return existing;
 
   const socket = io(`${SOCKET_URL}/${namespace}`, {
     auth: { token },
@@ -43,13 +44,20 @@ export function getNamespaceSocket(
     transports: ['websocket', 'polling'],
     reconnection: true,
     reconnectionAttempts: 10,
-    reconnectionDelay: 1000,
+    reconnectionDelay: 1_000,
+    reconnectionDelayMax: 30_000,
+    randomizationFactor: 0.5,
   });
 
   namespaceCache.set(key, socket);
 
-  socket.on('disconnect', () => {
-    namespaceCache.delete(key);
+  // Only evict from cache on explicit client-initiated disconnect.
+  // Network errors and server restarts use reason codes like 'transport close'
+  // or 'io server disconnect' — for those, socket.io reconnects automatically.
+  socket.on('disconnect', (reason) => {
+    if (reason === 'io client disconnect') {
+      namespaceCache.delete(key);
+    }
   });
 
   return socket;

--- a/frontend/src/providers/socket-provider.test.tsx
+++ b/frontend/src/providers/socket-provider.test.tsx
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
 import { SocketProvider } from './socket-provider';
 
 const mockUseAuth = vi.fn(() => ({ token: 'token-1', isAuthenticated: true }));
@@ -33,6 +33,16 @@ vi.mock('@/lib/socket', () => ({
 }));
 
 describe('SocketProvider', () => {
+  beforeEach(() => {
+    // Reset to default implementations before each test so that
+    // a mockImplementation in one test doesn't leak into the next.
+    mockUseAuth.mockReturnValue({ token: 'token-1', isAuthenticated: true });
+    mockUseUiStore.mockImplementation((selector: (state: { potatoMode: boolean }) => boolean) =>
+      selector({ potatoMode: false }),
+    );
+    mockGetNamespaceSocket.mockImplementation((namespace: string) => createMockSocket(namespace));
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -71,5 +81,60 @@ describe('SocketProvider', () => {
     expect(mockGetNamespaceSocket).toHaveBeenCalledWith('monitoring', 'token-1');
     expect(mockGetNamespaceSocket).not.toHaveBeenCalledWith('llm', 'token-1');
     expect(mockGetNamespaceSocket).not.toHaveBeenCalledWith('remediation', 'token-1');
+  });
+
+  it('does not disconnect sockets when effect re-runs (no thrashing)', async () => {
+    // Simulate the provider re-rendering (e.g., potato mode toggle).
+    // Sockets should NOT be disconnected — only event listeners should change.
+    const { rerender } = render(
+      <SocketProvider>
+        <div>child</div>
+      </SocketProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockGetNamespaceSocket).toHaveBeenCalledTimes(3);
+    });
+
+    const createdSockets = mockGetNamespaceSocket.mock.results.map((r) => r.value);
+
+    // Re-render with same props (simulates token refresh or minor state change)
+    await act(async () => {
+      rerender(
+        <SocketProvider>
+          <div>child</div>
+        </SocketProvider>,
+      );
+    });
+
+    // No socket should have been explicitly disconnected
+    for (const socket of createdSockets) {
+      expect(socket.disconnect).not.toHaveBeenCalled();
+    }
+  });
+
+  it('calls disconnectAll on logout', async () => {
+    const { rerender } = render(
+      <SocketProvider>
+        <div>child</div>
+      </SocketProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockGetNamespaceSocket).toHaveBeenCalled();
+    });
+
+    // Simulate logout
+    mockUseAuth.mockReturnValue({ token: null as unknown as string, isAuthenticated: false });
+
+    await act(async () => {
+      rerender(
+        <SocketProvider>
+          <div>child</div>
+        </SocketProvider>,
+      );
+    });
+
+    expect(mockDisconnectAll).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes #756

Two root causes fixed:

**1. socket-provider.tsx: cleanup disconnecting all sockets on every effect re-run**

The cleanup function called `socket.disconnect()` on every effect cleanup — which runs any time `isAuthenticated`, `token`, or `potatoMode` changes. This tore down all three WebSocket connections simultaneously, then the new effect run created fresh ones, racing with socket.io's own reconnection timers.

Fix: cleanup only removes event listeners (`s.off(...)`). Sockets are only explicitly disconnected on logout (`isAuthenticated` becomes false via `disconnectAll()`). Socket.io handles reconnection automatically.

**2. socket.ts: getNamespaceSocket() replacing in-flight reconnecting sockets**

`getNamespaceSocket()` checked `existing?.connected` and deleted disconnected sockets from cache, immediately creating new ones. When a socket was in the middle of its reconnection backoff, this created a second socket racing with the first, and reset the backoff timer on every cycle.

Fix: return the existing socket regardless of connection state — it will reconnect on its own. Only evict from cache on `'io client disconnect'` (explicit client-initiated), not on `'transport close'` or `'io server disconnect'` (transient errors). Added `reconnectionDelayMax: 30_000` and `randomizationFactor: 0.5` for proper exponential backoff with jitter.

## Test plan

- [x] `cd frontend && npx vitest run src/lib/socket.test.ts src/providers/socket-provider.test.tsx` — 16 tests pass
- [x] `npm run typecheck -w frontend` — no type errors
- New test: "reuses disconnected socket for same namespace+token (avoids thrashing)"
- New test: "does not disconnect sockets when effect re-runs (no thrashing)"
- New test: "calls disconnectAll on logout"

🤖 Generated with [Claude Code](https://claude.com/claude-code)