### PR TITLE
fix: auto-reload stale chunks after deployment (closes #785)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -83,6 +83,15 @@ http {
             proxy_read_timeout 86400;
         }
 
+        # index.html must never be cached — it contains the chunk filenames for the
+        # current build. After a deployment, browsers must fetch fresh index.html
+        # so lazy-loaded chunks resolve to the new hashed URLs.
+        location = /index.html {
+            add_header Cache-Control "no-store, no-cache, must-revalidate";
+            add_header Pragma "no-cache";
+            expires 0;
+        }
+
         # Static assets with caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             expires 1y;

--- a/frontend/src/components/shared/chunk-load-error-boundary.test.tsx
+++ b/frontend/src/components/shared/chunk-load-error-boundary.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ChunkLoadErrorBoundary } from './chunk-load-error-boundary';
+
+const RELOAD_KEY = 'chunk_load_last_reload';
+
+describe('ChunkLoadErrorBoundary', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    reloadSpy = vi.fn();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // jsdom doesn't allow reassigning window.location directly, so patch reload
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadSpy },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when no error occurs', () => {
+    render(
+      <ChunkLoadErrorBoundary>
+        <div>content</div>
+      </ChunkLoadErrorBoundary>,
+    );
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+
+  it('auto-reloads on first ChunkLoadError', () => {
+    const ThrowChunkError = () => {
+      throw Object.assign(new Error('Failed to fetch dynamically imported module'), {
+        name: 'ChunkLoadError',
+      });
+    };
+
+    render(
+      <ChunkLoadErrorBoundary>
+        <ThrowChunkError />
+      </ChunkLoadErrorBoundary>,
+    );
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(RELOAD_KEY)).not.toBeNull();
+  });
+
+  it('auto-reloads when reload key is older than cooldown', () => {
+    // Simulate a reload that happened more than 10 seconds ago
+    sessionStorage.setItem(RELOAD_KEY, String(Date.now() - 15_000));
+
+    const ThrowChunkError = () => {
+      throw new Error('Failed to fetch dynamically imported module');
+    };
+
+    render(
+      <ChunkLoadErrorBoundary>
+        <ThrowChunkError />
+      </ChunkLoadErrorBoundary>,
+    );
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows manual refresh UI when reload already happened within cooldown', () => {
+    // Simulate reload that happened 5 seconds ago (within 10s cooldown)
+    sessionStorage.setItem(RELOAD_KEY, String(Date.now() - 5_000));
+
+    const ThrowChunkError = () => {
+      throw new Error('Failed to fetch dynamically imported module');
+    };
+
+    render(
+      <ChunkLoadErrorBoundary>
+        <ThrowChunkError />
+      </ChunkLoadErrorBoundary>,
+    );
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+    expect(screen.getByText(/new version/i)).toBeInTheDocument();
+  });
+
+  it('shows generic fallback for non-chunk errors without reloading', () => {
+    const ThrowGenericError = () => {
+      throw new Error('Something else went wrong');
+    };
+
+    render(
+      <ChunkLoadErrorBoundary>
+        <ThrowGenericError />
+      </ChunkLoadErrorBoundary>,
+    );
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+    expect(screen.getByText(/unexpected error/i)).toBeInTheDocument();
+  });
+
+  it('detects ChunkLoadError by error name', () => {
+    const err = new Error('Chunk load failed');
+    err.name = 'ChunkLoadError';
+    const Throw = () => { throw err; };
+
+    render(<ChunkLoadErrorBoundary><Throw /></ChunkLoadErrorBoundary>);
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('detects ChunkLoadError by "Loading chunk" message pattern', () => {
+    const Throw = () => { throw new Error('Loading chunk 42 failed.'); };
+
+    render(<ChunkLoadErrorBoundary><Throw /></ChunkLoadErrorBoundary>);
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/shared/chunk-load-error-boundary.tsx
+++ b/frontend/src/components/shared/chunk-load-error-boundary.tsx
@@ -1,0 +1,82 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { RefreshCw } from 'lucide-react';
+
+const RELOAD_KEY = 'chunk_load_last_reload';
+/** Minimum ms between auto-reloads — prevents infinite reload loops. */
+const RELOAD_COOLDOWN_MS = 10_000;
+
+function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === 'ChunkLoadError' ||
+    /loading chunk/i.test(error.message) ||
+    /failed to fetch dynamically imported module/i.test(error.message) ||
+    /error loading dynamically imported module/i.test(error.message)
+  );
+}
+
+function shouldAutoReload(): boolean {
+  const last = sessionStorage.getItem(RELOAD_KEY);
+  if (!last) return true;
+  return Date.now() - Number(last) > RELOAD_COOLDOWN_MS;
+}
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  isChunkError: boolean;
+}
+
+/**
+ * Catches ChunkLoadError thrown by React.lazy() when a code-split chunk can
+ * no longer be fetched (e.g. after a deployment renames hashed filenames).
+ *
+ * On first occurrence: silently reloads the page so the browser fetches
+ * fresh chunk URLs from the new index.html.
+ *
+ * If a reload already happened within the last 10 s and the error persists,
+ * falls back to a manual refresh prompt instead of looping.
+ */
+export class ChunkLoadErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, isChunkError: false };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, isChunkError: isChunkLoadError(error) };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    if (isChunkLoadError(error) && shouldAutoReload()) {
+      sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+      window.location.reload();
+      return;
+    }
+    console.error('[ChunkLoadErrorBoundary] Unrecoverable error:', error, errorInfo);
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    const message = this.state.isChunkError
+      ? 'A new version of this page is available. Please refresh to continue.'
+      : 'This section encountered an unexpected error.';
+
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+        <p className="text-sm text-muted-foreground max-w-xs">{message}</p>
+        <button
+          onClick={() => window.location.reload()}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </button>
+      </div>
+    );
+  }
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import { AppLayout } from '@/components/layout/app-layout';
 import { RouteErrorBoundary } from '@/components/shared/route-error-boundary';
+import { ChunkLoadErrorBoundary } from '@/components/shared/chunk-load-error-boundary';
 
 // Lazy-loaded pages
 const Login = lazy(() => import('@/pages/login'));
@@ -42,7 +43,11 @@ function PageLoader() {
 }
 
 function LazyPage({ children }: { children: React.ReactNode }) {
-  return <Suspense fallback={<PageLoader />}>{children}</Suspense>;
+  return (
+    <ChunkLoadErrorBoundary>
+      <Suspense fallback={<PageLoader />}>{children}</Suspense>
+    </ChunkLoadErrorBoundary>
+  );
 }
 
 export const router = createBrowserRouter([


### PR DESCRIPTION
## Summary

After a new deployment, browsers can serve a cached `index.html` referencing old chunk filenames. When a user logs in, `navigate("/")` triggers `React.lazy()` to fetch the renamed chunk — which no longer exists — causing a `TypeError: Failed to fetch dynamically imported module`.

Closes #785
Refs #753

## Root Cause

`nginx.conf` has no `Cache-Control` header for `index.html`, so browsers cache it with default heuristics. After deployment, the stale `index.html` references old content-hashed chunk URLs that no longer exist on the server.

## Fix

Two-pronged approach:

1. **`nginx.conf`**: Add `location = /index.html` with `Cache-Control: no-store, no-cache, must-revalidate` — prevents browsers from caching `index.html`, ensuring fresh chunk URLs after deployment

2. **`ChunkLoadErrorBoundary`**: New React class error boundary wrapping every `LazyPage` in the router:
   - Detects chunk load errors by error name (`ChunkLoadError`) and message patterns (`Failed to fetch dynamically imported module`, `Loading chunk`)
   - On first occurrence: silently reloads the page so the browser fetches fresh `index.html` with correct chunk URLs
   - 10-second `sessionStorage` cooldown prevents infinite reload loops
   - If error persists after auto-reload: shows a manual "Refresh" prompt instead of looping

## Changes

- `frontend/nginx.conf` — Added `location = /index.html` with no-cache headers
- `frontend/src/components/shared/chunk-load-error-boundary.tsx` — New error boundary component (82 lines)
- `frontend/src/components/shared/chunk-load-error-boundary.test.tsx` — 7 test cases
- `frontend/src/router.tsx` — Wrapped `LazyPage` with `ChunkLoadErrorBoundary`

## Testing

- [x] Regression tests added: `frontend/src/components/shared/chunk-load-error-boundary.test.tsx` (7 cases)
  - Renders children when no error
  - Auto-reloads on first ChunkLoadError
  - Auto-reloads when cooldown expired
  - Shows manual refresh when within cooldown
  - Shows generic fallback for non-chunk errors
  - Detects by error name
  - Detects by "Loading chunk" message pattern
- [ ] Full test suite passes (CI)
- [ ] Lint checks pass (CI)
- [ ] Build succeeds (CI)

## Rollback Plan

Revert this PR: `git revert <merge-commit-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)