### PR TITLE
fix: add zod v3 override and missing app.ready() in webhook test

### DIFF
--- a/backend/src/routes/webhooks.test.ts
+++ b/backend/src/routes/webhooks.test.ts
@@ -59,6 +59,7 @@ async function buildTestApp() {
     };
   });
   await app.register(webhookRoutes);
+  await app.ready();
   return {
     app,
     setRole: (role: 'viewer' | 'operator' | 'admin') => {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "concurrently": "^9.1.0",
     "husky": "^9.1.7"
   },
+  "overrides": {
+    "zod": "^3.25.0"
+  },
   "engines": {
     "node": ">=22.0.0"
   }


### PR DESCRIPTION
## Summary
- Add npm `overrides` to pin `zod` to `^3.25.0` across the dependency tree, preventing Zod v4 from being hoisted when `@modelcontextprotocol/sdk` allows `"^3.25 || ^4.0"`
- Add missing `await app.ready()` call in `webhooks.test.ts` `buildTestApp()` to match the pattern used in other test files

## Context
The Fastify Dependabot PR (#814) failed because `npm` resolved Zod v4.3.6 at the top level of `node_modules/`, breaking `fastify-type-provider-zod` v4 schema compilation (Zod v3 vs v4 API incompatibility). All routes with Zod querystring/params/body schemas returned 500 errors.

The `overrides` field is a preventive measure to ensure this doesn't recur on future dependency updates.

## Test plan
- [ ] Existing CI tests pass (no behavior change on dev, just a preventive override)
- [ ] Verify Fastify Dependabot PR (#814) passes after rebasing on this

🤖 Generated with [Claude Code](https://claude.com/claude-code)