### PR TITLE
Add Stack column to Workload Explorer table

### DIFF
--- a/frontend/src/pages/workload-explorer.test.tsx
+++ b/frontend/src/pages/workload-explorer.test.tsx
@@ -204,6 +204,19 @@ describe('WorkloadExplorerPage', () => {
     expect(screen.getByTestId('workloads-table')).not.toHaveTextContent('billing-api-1');
   });
 
+  it('includes stack field in CSV export rows', () => {
+    mockQueryString = 'endpoint=1';
+    render(<WorkloadExplorerPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+
+    const [rows] = mockExportToCsv.mock.calls[0] as [Array<Record<string, unknown>>];
+    const workersRow = rows.find((r) => r.name === 'workers-api-1');
+    const beylaRow = rows.find((r) => r.name === 'beyla');
+    expect(workersRow?.stack).toBe('workers');
+    expect(beylaRow?.stack).toBe('No Stack');
+  });
+
   it('exports visible rows to CSV', () => {
     mockQueryString = 'endpoint=1';
     render(<WorkloadExplorerPage />);

--- a/frontend/src/pages/workload-explorer.tsx
+++ b/frontend/src/pages/workload-explorer.tsx
@@ -193,6 +193,29 @@ export default function WorkloadExplorerPage() {
       },
     },
     {
+      id: 'stack',
+      header: 'Stack',
+      size: 160,
+      cell: ({ row }) => {
+        const stackName = resolveContainerStackName(row.original, knownStackNames);
+        if (!stackName) {
+          return <span className="text-muted-foreground/50 text-xs">—</span>;
+        }
+        return (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setSelectedStack(stackName);
+            }}
+            className="inline-flex items-center rounded-md bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-800 transition-colors hover:bg-purple-200 hover:ring-1 hover:ring-purple-300 dark:bg-purple-900/30 dark:text-purple-300 dark:hover:bg-purple-900/50"
+            title={`Filter by stack: ${stackName}`}
+          >
+            {truncate(stackName, 25)}
+          </button>
+        );
+      },
+    },
+    {
       accessorKey: 'endpointName',
       header: 'Endpoint',
       cell: ({ row }) => {
@@ -209,7 +232,7 @@ export default function WorkloadExplorerPage() {
       header: 'Created',
       cell: ({ getValue }) => formatDate(new Date(getValue<number>() * 1000)),
     },
-  ], [navigate]);
+  ], [navigate, knownStackNames]);
 
   if (isError) {
     return (


### PR DESCRIPTION
## Summary
- Adds a Stack column between Group and Endpoint in the Workload Explorer table
- Stack names resolve via `resolveContainerStackName()` and display as purple badges
- Clicking a stack badge filters the table by that stack

Closes #831

## Test plan
- [x] Stack column renders with correct resolved names
- [x] Clicking stack badge applies stack filter via URL params
- [x] Containers without a stack show em-dash
- [x] CSV export includes stack field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>