### PR TITLE
Connect AI search results to table filtering

### DIFF
--- a/backend/src/db/postgres-migrations/025_command_palette_filter_action.sql
+++ b/backend/src/db/postgres-migrations/025_command_palette_filter_action.sql
@@ -1,0 +1,38 @@
+-- PostgreSQL migration: update command_palette prompt to support filter action
+-- Related to: feature/837-ai-search-filtering
+
+UPDATE settings
+SET value = 'You are a dashboard query interpreter. The user asks natural language questions about their Docker infrastructure. You MUST respond with ONLY valid JSON — no markdown, no explanation, no code fences.
+
+Available pages and their routes:
+- "/" - Home dashboard with KPIs
+- "/workloads" - Workload Explorer: all containers, filterable by state, name, image
+- "/fleet" - Fleet Overview: all endpoints/environments
+- "/health" - Container Health: health checks, unhealthy containers
+- "/images" - Image Footprint: Docker images, sizes, registries
+- "/topology" - Network Topology: container network connections
+- "/ai-monitor" - AI Monitor: AI-generated insights, anomalies
+- "/metrics" - Metrics Dashboard: CPU, memory, network metrics over time
+- "/remediation" - Remediation: suggested and pending remediation actions
+- "/traces" - Trace Explorer: distributed traces
+- "/assistant" - LLM Assistant: AI chat for infrastructure questions
+- "/edge-logs" - Edge Agent Logs
+- "/settings" - Settings
+
+Response format — choose ONE:
+
+For navigation actions (user wants to go to a page):
+{"action":"navigate","page":"/route","description":"Brief explanation of where to look"}
+
+For filter actions (user wants to find/filter specific containers by name, image, state, or other criteria):
+{"action":"filter","text":"Found N matching containers","description":"Filtered by criteria","filters":{"state":"running","image":"nginx"},"containerNames":["container-name-1","container-name-2"]}
+The "filters" object describes what criteria were used. The "containerNames" array MUST contain the exact container names from the infrastructure context that match the query. Only include containers that actually exist in the infrastructure context.
+
+For inline answers (simple factual questions that do not involve finding containers):
+{"action":"answer","text":"The answer text","description":"Based on current infrastructure data"}
+
+IMPORTANT: Use "filter" when the user asks to find, show, list, or filter containers (e.g. "show me running nginx containers", "find all stopped containers", "which containers use postgres image"). Use "answer" for general questions (e.g. "how many containers are running?", "what is the total count?"). Use "navigate" when the user wants to go to a specific page.
+
+INFRASTRUCTURE CONTEXT:',
+    updated_at = NOW()
+WHERE key = 'prompts.command_palette.system_prompt';

--- a/backend/src/routes/llm.test.ts
+++ b/backend/src/routes/llm.test.ts
@@ -411,6 +411,107 @@ describe('LLM Routes', () => {
       expect(mockChat).not.toHaveBeenCalled();
     });
 
+    it('returns filter action with containerNames and filters', async () => {
+      mockChat.mockResolvedValue({
+        message: {
+          content: JSON.stringify({
+            action: 'filter',
+            text: 'Found 2 running nginx containers',
+            description: 'Filtered by state and image',
+            filters: { state: 'running', image: 'nginx' },
+            containerNames: ['nginx-proxy', 'nginx-web'],
+          }),
+        },
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/llm/query',
+        payload: { query: 'show me running nginx containers' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.action).toBe('filter');
+      expect(body.text).toBe('Found 2 running nginx containers');
+      expect(body.description).toBe('Filtered by state and image');
+      expect(body.filters).toEqual({ state: 'running', image: 'nginx' });
+      expect(body.containerNames).toEqual(['nginx-proxy', 'nginx-web']);
+    });
+
+    it('returns filter action with empty containerNames when array missing', async () => {
+      mockChat.mockResolvedValue({
+        message: {
+          content: JSON.stringify({
+            action: 'filter',
+            text: 'No matching containers found',
+            description: 'No results',
+            filters: { state: 'dead' },
+          }),
+        },
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/llm/query',
+        payload: { query: 'find dead containers' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.action).toBe('filter');
+      expect(body.containerNames).toEqual([]);
+      expect(body.filters).toEqual({ state: 'dead' });
+    });
+
+    it('returns filter action with empty filters when filters object missing', async () => {
+      mockChat.mockResolvedValue({
+        message: {
+          content: JSON.stringify({
+            action: 'filter',
+            text: 'Found 1 container',
+            containerNames: ['my-app'],
+          }),
+        },
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/llm/query',
+        payload: { query: 'find my-app container' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.action).toBe('filter');
+      expect(body.filters).toEqual({});
+      expect(body.containerNames).toEqual(['my-app']);
+    });
+
+    it('filters out non-string values from containerNames', async () => {
+      mockChat.mockResolvedValue({
+        message: {
+          content: JSON.stringify({
+            action: 'filter',
+            text: 'Found containers',
+            filters: {},
+            containerNames: ['valid-name', 123, null, 'another-valid'],
+          }),
+        },
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/llm/query',
+        payload: { query: 'show all containers' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.action).toBe('filter');
+      expect(body.containerNames).toEqual(['valid-name', 'another-valid']);
+    });
+
     it('sanitizes leaked system prompt text from model output', async () => {
       mockChat.mockResolvedValue({
         message: {

--- a/backend/src/services/prompt-store.ts
+++ b/backend/src/services/prompt-store.ts
@@ -69,11 +69,17 @@ Available pages and their routes:
 
 Response format — choose ONE:
 
-For navigation actions:
+For navigation actions (user wants to go to a page):
 {"action":"navigate","page":"/route","description":"Brief explanation of where to look"}
 
-For inline answers (simple factual questions):
+For filter actions (user wants to find/filter specific containers by name, image, state, or other criteria):
+{"action":"filter","text":"Found N matching containers","description":"Filtered by criteria","filters":{"state":"running","image":"nginx"},"containerNames":["container-name-1","container-name-2"]}
+The "filters" object describes what criteria were used. The "containerNames" array MUST contain the exact container names from the infrastructure context that match the query. Only include containers that actually exist in the infrastructure context.
+
+For inline answers (simple factual questions that do not involve finding containers):
 {"action":"answer","text":"The answer text","description":"Based on current infrastructure data"}
+
+IMPORTANT: Use "filter" when the user asks to find, show, list, or filter containers (e.g. "show me running nginx containers", "find all stopped containers", "which containers use postgres image"). Use "answer" for general questions (e.g. "how many containers are running?", "what is the total count?"). Use "navigate" when the user wants to go to a specific page.
 
 INFRASTRUCTURE CONTEXT:`,
 

--- a/frontend/src/hooks/use-nl-query.ts
+++ b/frontend/src/hooks/use-nl-query.ts
@@ -2,10 +2,12 @@ import { useMutation } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 
 export interface NlQueryResult {
-  action: 'navigate' | 'answer' | 'error';
+  action: 'navigate' | 'answer' | 'filter' | 'error';
   page?: string;
   text?: string;
   description?: string;
+  filters?: Record<string, string>;
+  containerNames?: string[];
 }
 
 export function useNlQuery() {


### PR DESCRIPTION
## Summary
- **Backend**: Adds `filter` action type to LLM response parser with `containerNames` and `filters` fields
- **Backend**: Expands `getInfrastructureSummary()` to include all containers (was limited to 10)
- **Backend**: Updates `command_palette` prompt to support `filter` action (new migration)
- **Frontend**: Extends `NlQueryResult` type with `filter` action, `filters`, and `containerNames`
- **Frontend**: `WorkloadSmartSearch` applies AI filter results to table via `onFiltered()` callback
- Shows purple "AI filter active" badge with "AI found X of Y containers" count

Closes #837

## Test plan
- [x] Backend: `filter` action parsed with containerNames and filters
- [x] Backend: Empty/missing containerNames handled gracefully
- [x] Backend: Non-string values filtered out of containerNames
- [x] Frontend: AI filter applies to table (case-insensitive name match)
- [x] Frontend: `answer` action fallback preserves current behavior (no table change)
- [x] Frontend: Clear button resets AI filter
- [x] Frontend: Typing in input clears AI filter
- [x] No regression in local filter mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>