### PR TITLE
feat(ui): apply SpotlightCard pane style to workload explorer and infrastructure

### DIFF
--- a/frontend/src/pages/infrastructure.tsx
+++ b/frontend/src/pages/infrastructure.tsx
@@ -17,6 +17,7 @@ import { SkeletonCard } from '@/components/shared/loading-skeleton';
 import { useUiStore } from '@/stores/ui-store';
 import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import { SpotlightCard } from '@/components/shared/spotlight-card';
 
 const FLEET_GRID_PAGE_SIZE = 30;
 const AUTO_TABLE_THRESHOLD = 100;
@@ -514,6 +515,7 @@ export default function InfrastructurePage() {
 
       {/* Shared summary bar */}
       {!isLoading && (
+        <SpotlightCard>
         <div
           className="flex flex-wrap items-center gap-6 rounded-lg border bg-card px-6 py-4 shadow-sm text-sm"
           data-testid="summary-bar"
@@ -554,6 +556,7 @@ export default function InfrastructurePage() {
             )}
           </div>
         </div>
+        </SpotlightCard>
       )}
 
       {/* Error state */}
@@ -658,6 +661,7 @@ export default function InfrastructurePage() {
             )}
           </>
         ) : endpoints && fleetViewMode === 'table' ? (
+          <SpotlightCard>
           <div className="rounded-lg border bg-card p-6 shadow-sm">
             <DataTable
               columns={endpointColumns}
@@ -668,6 +672,7 @@ export default function InfrastructurePage() {
               onRowClick={(row) => handleEndpointClick(row.id)}
             />
           </div>
+          </SpotlightCard>
         ) : null}
       </section>
 
@@ -768,6 +773,7 @@ export default function InfrastructurePage() {
             ))}
           </div>
         ) : (
+          <SpotlightCard>
           <div className="rounded-lg border bg-card p-6 shadow-sm">
             <DataTable
               columns={stackColumns}
@@ -778,6 +784,7 @@ export default function InfrastructurePage() {
               onRowClick={handleStackClick}
             />
           </div>
+          </SpotlightCard>
         )}
       </section>
     </div>

--- a/frontend/src/pages/workload-explorer.tsx
+++ b/frontend/src/pages/workload-explorer.tsx
@@ -23,6 +23,7 @@ import { transition } from '@/lib/motion-tokens';
 import { WorkloadSmartSearch } from '@/components/shared/workload-smart-search';
 import { SelectionActionBar } from '@/components/shared/selection-action-bar';
 import { WorkloadStatusSummary } from '@/components/workload/workload-status-summary';
+import { SpotlightCard } from '@/components/shared/spotlight-card';
 
 const MAX_COMPARE = 4;
 
@@ -424,7 +425,8 @@ export default function WorkloadExplorerPage() {
       </div>
 
       {/* Filter pane: dropdowns + status summary */}
-      <div className="rounded-xl border bg-card/50 backdrop-blur-sm p-4 shadow-sm space-y-3">
+      <SpotlightCard>
+      <div className="rounded-lg border bg-card p-4 shadow-sm space-y-3">
         <div className="flex items-center gap-4 flex-wrap">
           <div className="flex items-center gap-2">
             <label htmlFor="endpoint-select" className="text-sm font-medium">
@@ -515,12 +517,14 @@ export default function WorkloadExplorerPage() {
           />
         )}
       </div>
+      </SpotlightCard>
 
       {/* Table pane: filter chips + search + table */}
       {isLoading ? (
         <SkeletonCard className="h-[500px]" />
       ) : filteredContainers ? (
-        <div className="rounded-xl border bg-card/50 backdrop-blur-sm p-6 shadow-sm space-y-4">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card p-6 shadow-sm space-y-4">
           {/* Active filter chips */}
           {activeFilters.length > 0 && (
             <div className="flex items-center gap-2 flex-wrap" aria-live="polite">
@@ -581,6 +585,7 @@ export default function WorkloadExplorerPage() {
             onRowClick={(row) => navigate(`/containers/${row.endpointId}/${row.id}`)}
           />
         </div>
+        </SpotlightCard>
       ) : null}
 
       {/* Floating compare action bar */}


### PR DESCRIPTION
## Summary

- Wraps the **filter pane** and **table pane** on the Workload Explorer page with `SpotlightCard`
- Wraps the **summary bar**, **fleet table view**, and **stacks table view** on the Infrastructure page with `SpotlightCard`
- Matches the mouse-following radial gradient spotlight effect already used on the Home page
- Individual grid cards (`EndpointCard`, `StackCard`) are left unchanged — they're interactive buttons, not large panes

## Test plan

- [x] Visit Workload Explorer — hover over filter pane and table pane, confirm spotlight follows mouse
- [x] Visit Infrastructure — hover over summary bar, fleet table (table view mode), stacks table (table view mode), confirm spotlight effect
- [x] Confirm potato mode disables the effect (no `--x`/`--y` CSS vars updated)
- [x] Confirm reduced motion preference is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)