### PR TITLE
fix(#891): deduplicate metricsAdapter + add event bus emission tests

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -185,5 +185,5 @@ export async function buildApp() {
   // Static files (production only)
   await app.register(staticPlugin);
 
-  return app;
+  return { app, metricsAdapter };
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,14 +17,14 @@ process.on('unhandledRejection', (reason) => {
 
 async function main() {
   const config = getConfig();
-  const app = await buildApp();
+  const { app, metricsAdapter } = await buildApp();
 
   // Initialize databases (runs migrations)
   await getAppDb();
   await getMetricsDb();
 
-  // Build monitoring service with DI wiring
-  const monitoringService = buildMonitoringService();
+  // Build monitoring service with DI wiring (reuse the shared metricsAdapter from app.ts)
+  const monitoringService = buildMonitoringService(metricsAdapter);
 
   // Setup Socket.IO namespaces (pass infraLogsAdapter for container log tool execution)
   setupSockets(app.ioNamespaces, infraLogsAdapter);

--- a/packages/server/src/wiring.ts
+++ b/packages/server/src/wiring.ts
@@ -61,10 +61,10 @@ export function buildMetricsAdapter(): MetricsInterface {
 }
 
 /** Build the monitoring service with all cross-domain deps wired via DI. */
-export function buildMonitoringService() {
+export function buildMonitoringService(metricsAdapter?: MetricsInterface) {
   const monitoringDeps: MonitoringDeps = {
     scanner: { scanContainer },
-    metrics: buildMetricsAdapter(),
+    metrics: metricsAdapter ?? buildMetricsAdapter(),
     notifications: { notifyInsight },
     operations: { suggestAction },
   };


### PR DESCRIPTION
## Summary
- **Deduplicate `MetricsInterface` adapter**: `buildMetricsAdapter()` was called twice — once in `app.ts` for `initRemediationDeps` and again inside `buildMonitoringService()` in `wiring.ts`. Now `buildApp()` returns the shared adapter and `index.ts` passes it through, ensuring a single instance.
- **Add event bus emission tests**: 3 new tests verify the monitoring cycle correctly emits `anomaly.detected` and `insight.created` events via the typed event bus, covering the previously untested event-driven flow.

Closes review suggestions from #891.

## Test plan
- [x] All 33 monitoring-service tests pass (including 3 new event bus tests)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Pre-push hook ran full frontend test suite (156 files, 1401 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)