### PR TITLE
fix(#855): prevent shell injection in branch policy workflow (CWE-78)

### DIFF
--- a/.github/workflows/enforce-branch-policy.yml
+++ b/.github/workflows/enforce-branch-policy.yml
@@ -11,8 +11,10 @@ jobs:
     steps:
       - name: Verify PR source is dev
         if: github.head_ref != 'dev'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "::error::PRs to main must come from the dev branch. Got: ${{ github.head_ref }}"
+          echo "::error::PRs to main must come from the dev branch. Got: $HEAD_REF"
           exit 1
       - name: Source branch OK
         if: github.head_ref == 'dev'


### PR DESCRIPTION
## Summary
- Fixes shell injection vulnerability (CWE-78) in `.github/workflows/enforce-branch-policy.yml` where `${{ github.head_ref }}` was interpolated directly into a `run:` block
- An attacker could craft a PR branch name containing shell metacharacters to execute arbitrary commands in the CI runner
- Fix uses an `env:` variable binding (`HEAD_REF`) so the value is passed safely as an environment variable instead of being interpolated into the shell script

## Changes
- Added `env: HEAD_REF: ${{ github.head_ref }}` to the "Verify PR source is dev" step
- Changed `${{ github.head_ref }}` in the `run:` block to `$HEAD_REF`
- The `if:` expression contexts remain unchanged (they use GitHub's expression evaluator, not shell, so they are safe)

## Test plan
- [x] Workflow YAML syntax is valid
- [ ] Open a PR to `main` from a non-`dev` branch to verify the error message still displays correctly
- [ ] Verify that a PR from `dev` to `main` still passes the check

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)