### PR TITLE
fix(#853): replace hardcoded test DB credentials with env vars (CWE-798)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -144,9 +144,15 @@ POSTGRES_APP_PASSWORD=CHANGE_ME_BEFORE_PRODUCTION
 # POSTGRES_APP_MAX_CONNECTIONS=20
 
 # PostgreSQL Test Database (for backend tests)
-# Backend tests use a real PostgreSQL database on port 5433
-# Default: postgresql://postgres:postgres@localhost:5433/portainer_dashboard_test
-# POSTGRES_TEST_URL=postgresql://postgres:postgres@localhost:5433/portainer_dashboard_test
+# Backend tests use a real PostgreSQL database on port 5433.
+# POSTGRES_TEST_URL takes full precedence when set. Otherwise individual vars below
+# are composed into a connection string (safe non-secret defaults for local dev).
+# POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test
+# POSTGRES_TEST_USER=app_user
+# POSTGRES_TEST_PASSWORD=           # Falls back to POSTGRES_APP_PASSWORD, then 'changeme-postgres-app'
+# POSTGRES_TEST_HOST=localhost
+# POSTGRES_TEST_PORT=5433
+# POSTGRES_TEST_DB=portainer_dashboard_test
 
 # TimescaleDB (metrics + KPI time-series storage)
 # TimescaleDB runs as a Docker Compose sidecar for high-performance metrics queries.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -398,13 +398,13 @@ Backend tests use a **real PostgreSQL test database** instead of mocks or in-mem
 
 - **Database**: `portainer_dashboard_test` on port **5433** (mapped from container port 5432)
 - **Initialization**: `docker/init-test-db.sh` creates the test database when the `postgres-app` container starts
-- **Test Utilities**: `backend/src/db/test-db-helper.ts` provides:
+- **Test Utilities**: `packages/core/src/db/test-db-helper.ts` provides:
   - `getTestDb()` — Returns a PostgreSQL pool connected to the test database
   - `getTestPool()` — Returns the raw `pg.Pool` for advanced usage
   - `truncateTestTables()` — Clears all tables between tests
   - `closeTestDb()` — Closes the test pool connection
-- **Migrations**: Production migrations from `backend/src/db/postgres-migrations/` are automatically applied to the test database
-- **Configuration**: Set `POSTGRES_TEST_URL` environment variable to override the default connection string (default: `postgresql://postgres:postgres@localhost:5433/portainer_dashboard_test`)
+- **Migrations**: Production migrations from `packages/core/src/db/postgres-migrations/` are automatically applied to the test database
+- **Configuration**: Set `POSTGRES_TEST_URL` to override the full connection string, or set individual vars (`POSTGRES_TEST_USER`, `POSTGRES_TEST_PASSWORD`, `POSTGRES_TEST_HOST`, `POSTGRES_TEST_PORT`, `POSTGRES_TEST_DB`). Password falls back to `POSTGRES_APP_PASSWORD`, then a safe local-dev default.
 - **CI Support**: GitHub Actions workflow includes a `postgres-test` service container for running tests in CI
 
 **Running Tests**:

--- a/packages/core/src/db/test-db-helper.test.ts
+++ b/packages/core/src/db/test-db-helper.test.ts
@@ -141,4 +141,17 @@ describe('test-db-helper env var construction', () => {
       'postgresql://custom_user:custom_pass@db.internal:5555/custom_test_db',
     );
   });
+
+  it('URL-encodes special characters in user and password', async () => {
+    const url = await getConnectionString({
+      POSTGRES_TEST_URL: undefined,
+      POSTGRES_TEST_USER: 'user@domain',
+      POSTGRES_TEST_PASSWORD: 'p@ss:word/test#1',
+    });
+
+    // @ : / # in credentials must be percent-encoded
+    expect(url).toBe(
+      'postgresql://user%40domain:p%40ss%3Aword%2Ftest%231@localhost:5433/portainer_dashboard_test',
+    );
+  });
 });

--- a/packages/core/src/db/test-db-helper.test.ts
+++ b/packages/core/src/db/test-db-helper.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for test-db-helper env var construction.
+ *
+ * These tests verify that the connection URL is built from individual
+ * environment variables, and that POSTGRES_TEST_URL takes full precedence.
+ *
+ * Because the env vars are evaluated at module scope, each test uses
+ * vi.resetModules() + a fresh dynamic import so the module re-evaluates
+ * process.env on each load.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import pg from 'pg';
+
+// Snapshot of original env so we can restore after each test
+const originalEnv = { ...process.env };
+
+// We spy on pg.Pool to capture the connectionString passed to it
+// without actually connecting to a database.
+let poolSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.resetModules();
+  // Spy on pg.Pool constructor to capture the options
+  poolSpy = vi.spyOn(pg, 'Pool').mockImplementation(
+    () =>
+      ({
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+        connect: vi.fn(),
+        end: vi.fn().mockResolvedValue(undefined),
+      }) as unknown as pg.Pool,
+  );
+});
+
+afterEach(() => {
+  // Restore environment
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+/**
+ * Helper: sets env vars, dynamically imports test-db-helper, calls getTestPool()
+ * (which triggers ensurePool → new pg.Pool), and returns the connectionString
+ * that was passed to the Pool constructor.
+ */
+async function getConnectionString(envOverrides: Record<string, string | undefined>): Promise<string> {
+  // Apply overrides (undefined = delete)
+  for (const [key, value] of Object.entries(envOverrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  // Dynamic import after env is set — module-scope vars re-evaluate
+  const mod = await import('./test-db-helper.js');
+  await mod.getTestPool();
+
+  // Extract connectionString from the Pool constructor call
+  expect(poolSpy).toHaveBeenCalledTimes(1);
+  const opts = poolSpy.mock.calls[0][0] as pg.PoolConfig;
+  return opts.connectionString!;
+}
+
+describe('test-db-helper env var construction', () => {
+  it('uses safe defaults when no env vars are set', async () => {
+    // Remove all overrides so defaults kick in
+    const url = await getConnectionString({
+      POSTGRES_TEST_URL: undefined,
+      POSTGRES_TEST_USER: undefined,
+      POSTGRES_TEST_PASSWORD: undefined,
+      POSTGRES_TEST_HOST: undefined,
+      POSTGRES_TEST_PORT: undefined,
+      POSTGRES_TEST_DB: undefined,
+      POSTGRES_APP_PASSWORD: undefined,
+    });
+
+    expect(url).toBe(
+      'postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test',
+    );
+  });
+
+  it('POSTGRES_TEST_URL takes full precedence over individual vars', async () => {
+    const fullUrl = 'postgresql://custom:secret@remote:9999/mydb';
+    const url = await getConnectionString({
+      POSTGRES_TEST_URL: fullUrl,
+      POSTGRES_TEST_USER: 'ignored',
+      POSTGRES_TEST_PASSWORD: 'ignored',
+    });
+
+    expect(url).toBe(fullUrl);
+  });
+
+  it('POSTGRES_TEST_PASSWORD overrides the default password', async () => {
+    const url = await getConnectionString({
+      POSTGRES_TEST_URL: undefined,
+      POSTGRES_TEST_PASSWORD: 'ci-injected-password',
+      POSTGRES_APP_PASSWORD: undefined,
+    });
+
+    expect(url).toBe(
+      'postgresql://app_user:ci-injected-password@localhost:5433/portainer_dashboard_test',
+    );
+  });
+
+  it('POSTGRES_APP_PASSWORD is used as fallback when POSTGRES_TEST_PASSWORD is not set', async () => {
+    const url = await getConnectionString({
+      POSTGRES_TEST_URL: undefined,
+      POSTGRES_TEST_PASSWORD: undefined,
+      POSTGRES_APP_PASSWORD: 'compose-password',
+    });
+
+    expect(url).toBe(
+      'postgresql://app_user:compose-password@localhost:5433/portainer_dashboard_test',
+    );
+  });
+
+  it('POSTGRES_TEST_PASSWORD takes priority over POSTGRES_APP_PASSWORD', async () => {
+    const url = await getConnectionString({
+      POSTGRES_TEST_URL: undefined,
+      POSTGRES_TEST_PASSWORD: 'explicit-test-pw',
+      POSTGRES_APP_PASSWORD: 'compose-password',
+    });
+
+    expect(url).toBe(
+      'postgresql://app_user:explicit-test-pw@localhost:5433/portainer_dashboard_test',
+    );
+  });
+
+  it('individual host/port/user/db vars are respected', async () => {
+    const url = await getConnectionString({
+      POSTGRES_TEST_URL: undefined,
+      POSTGRES_TEST_USER: 'custom_user',
+      POSTGRES_TEST_PASSWORD: 'custom_pass',
+      POSTGRES_TEST_HOST: 'db.internal',
+      POSTGRES_TEST_PORT: '5555',
+      POSTGRES_TEST_DB: 'custom_test_db',
+    });
+
+    expect(url).toBe(
+      'postgresql://custom_user:custom_pass@db.internal:5555/custom_test_db',
+    );
+  });
+});

--- a/packages/core/src/db/test-db-helper.ts
+++ b/packages/core/src/db/test-db-helper.ts
@@ -24,7 +24,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 pg.types.setTypeParser(1184, (val: string) => new Date(val).toISOString()); // timestamptz
 pg.types.setTypeParser(1114, (val: string) => new Date(val + 'Z').toISOString()); // timestamp
 
-const DEFAULT_URL = 'postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test';
+// Build connection URL from individual env vars (safe defaults for local dev).
+// POSTGRES_TEST_URL still takes full precedence (see ensurePool below).
+const PGUSER = process.env.POSTGRES_TEST_USER ?? 'app_user';
+const PGPASSWORD = process.env.POSTGRES_TEST_PASSWORD ?? process.env.POSTGRES_APP_PASSWORD ?? 'changeme-postgres-app';
+const PGHOST = process.env.POSTGRES_TEST_HOST ?? 'localhost';
+const PGPORT = process.env.POSTGRES_TEST_PORT ?? '5433';
+const PGDATABASE = process.env.POSTGRES_TEST_DB ?? 'portainer_dashboard_test';
+
+const DEFAULT_URL = `postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}`;
 
 let pool: pg.Pool | null = null;
 let adapter: PostgresAdapter | null = null;

--- a/packages/core/src/db/test-db-helper.ts
+++ b/packages/core/src/db/test-db-helper.ts
@@ -32,7 +32,8 @@ const PGHOST = process.env.POSTGRES_TEST_HOST ?? 'localhost';
 const PGPORT = process.env.POSTGRES_TEST_PORT ?? '5433';
 const PGDATABASE = process.env.POSTGRES_TEST_DB ?? 'portainer_dashboard_test';
 
-const DEFAULT_URL = `postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}`;
+// URL-encode user and password so special characters (@, :, /, %, #) don't break the URI.
+const DEFAULT_URL = `postgresql://${encodeURIComponent(PGUSER)}:${encodeURIComponent(PGPASSWORD)}@${PGHOST}:${PGPORT}/${PGDATABASE}`;
 
 let pool: pg.Pool | null = null;
 let adapter: PostgresAdapter | null = null;


### PR DESCRIPTION
## Summary

- Replace hardcoded PostgreSQL connection string in `test-db-helper.ts` with individual env var construction (`POSTGRES_TEST_USER`, `POSTGRES_TEST_PASSWORD`, `POSTGRES_TEST_HOST`, `POSTGRES_TEST_PORT`, `POSTGRES_TEST_DB`)
- `POSTGRES_TEST_URL` still takes full precedence when set (existing behavior preserved)
- Password fallback chain: `POSTGRES_TEST_PASSWORD` > `POSTGRES_APP_PASSWORD` > local dev default — CI can inject just the password without building a full URL
- Update `docker/.env.example` with the new env vars and usage comments
- Add 6 unit tests verifying env var override logic (defaults, full URL precedence, password fallback, individual var composition)

Closes #853

## Test plan

- [x] New unit tests pass: `cd packages/core && npx vitest run src/db/test-db-helper.test.ts` (6 tests)
- [x] Frontend tests pass (1401 tests, pre-push hook)
- [x] TypeScript typecheck passes
- [ ] CI runs full backend integration suite with real PostgreSQL
- [ ] Verify zero-config local dev still works (no env vars set → default connection string unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)