### PR TITLE
fix(#858): resolve low severity security & configuration findings

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -36,6 +36,9 @@ COPY --from=tools /usr/lib/libunistring* /usr/lib/
 
 COPY --from=builder /app/frontend/dist /usr/share/nginx/html
 COPY frontend/nginx.conf /etc/nginx/nginx.conf
+COPY frontend/nginx-security-headers.conf /etc/nginx/security-headers.conf
+COPY frontend/nginx-cache-nocache.conf /etc/nginx/cache-nocache.conf
+COPY frontend/nginx-cache-immutable.conf /etc/nginx/cache-immutable.conf
 
 EXPOSE 8080
 

--- a/frontend/nginx-cache-immutable.conf
+++ b/frontend/nginx-cache-immutable.conf
@@ -1,4 +1,4 @@
 # Immutable cache headers for fingerprinted static assets (js, css, images, fonts).
 # These files contain content hashes in their filenames and never change.
 expires 1y;
-add_header Cache-Control "public, immutable";
+add_header Cache-Control "public, immutable" always;

--- a/frontend/nginx-cache-immutable.conf
+++ b/frontend/nginx-cache-immutable.conf
@@ -1,0 +1,4 @@
+# Immutable cache headers for fingerprinted static assets (js, css, images, fonts).
+# These files contain content hashes in their filenames and never change.
+expires 1y;
+add_header Cache-Control "public, immutable";

--- a/frontend/nginx-cache-nocache.conf
+++ b/frontend/nginx-cache-nocache.conf
@@ -1,0 +1,5 @@
+# No-cache headers for HTML entry point — forces browsers to always
+# revalidate so they pick up new chunk filenames after deployments.
+add_header Cache-Control "no-store, no-cache, must-revalidate";
+add_header Pragma "no-cache";
+expires 0;

--- a/frontend/nginx-cache-nocache.conf
+++ b/frontend/nginx-cache-nocache.conf
@@ -1,5 +1,5 @@
 # No-cache headers for HTML entry point — forces browsers to always
 # revalidate so they pick up new chunk filenames after deployments.
-add_header Cache-Control "no-store, no-cache, must-revalidate";
-add_header Pragma "no-cache";
+add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+add_header Pragma "no-cache" always;
 expires 0;

--- a/frontend/nginx-security-headers.conf
+++ b/frontend/nginx-security-headers.conf
@@ -1,0 +1,11 @@
+# Shared security headers — included in every location block.
+# Defined here (not at the server level) to avoid nginx's add_header
+# inheritance pitfall: any add_header in a location block silently
+# clears ALL server-level add_header directives.
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+# CSP: style-src 'unsafe-inline' required by Tailwind/Framer Motion runtime styles.
+# connect-src allows both ws: and wss: — for TLS-only deployments, remove ws: and keep wss: only.
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://media1.tenor.com; connect-src 'self' ws: wss:; font-src 'self' data:;" always;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -35,23 +35,27 @@ http {
     gzip_comp_level 6;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
 
+    # Map to restrict WebSocket Upgrade header values — mitigates H2C smuggling
+    # by only allowing the literal value "websocket" through the proxy.
+    map $http_upgrade $connection_upgrade {
+        websocket upgrade;
+        default   close;
+    }
+
     server {
         listen 8080 default_server;
         server_name _;
         root /usr/share/nginx/html;
         index index.html;
 
-        # Security headers
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        # CSP: style-src 'unsafe-inline' required by Tailwind/Framer Motion runtime styles.
-        # connect-src allows both ws: and wss: — for TLS-only deployments, remove ws: and keep wss: only.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://media1.tenor.com; connect-src 'self' ws: wss:; font-src 'self' data:;" always;
+        # Security headers are defined in an external snippet and included per
+        # location block. They are NOT set at the server level because nginx
+        # silently drops all server-level add_header directives whenever a
+        # location block defines its own add_header (CWE-16).
 
         # API proxy
         location /api/ {
+            include /etc/nginx/security-headers.conf;
             proxy_pass http://backend:3051;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -61,22 +65,26 @@ http {
 
         # Health proxy
         location /health {
+            include /etc/nginx/security-headers.conf;
             proxy_pass http://backend:3051;
             proxy_set_header Host $host;
         }
 
         # Docs proxy
         location /docs {
+            include /etc/nginx/security-headers.conf;
             proxy_pass http://backend:3051;
             proxy_set_header Host $host;
         }
 
-        # Socket.IO proxy
+        # Socket.IO proxy — Upgrade restricted to "websocket" via map to
+        # prevent H2C smuggling (CWE-444).
         location /socket.io/ {
+            include /etc/nginx/security-headers.conf;
             proxy_pass http://backend:3051;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -87,19 +95,19 @@ http {
         # current build. After a deployment, browsers must fetch fresh index.html
         # so lazy-loaded chunks resolve to the new hashed URLs.
         location = /index.html {
-            add_header Cache-Control "no-store, no-cache, must-revalidate";
-            add_header Pragma "no-cache";
-            expires 0;
+            include /etc/nginx/security-headers.conf;
+            include /etc/nginx/cache-nocache.conf;
         }
 
         # Static assets with caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-            expires 1y;
-            add_header Cache-Control "public, immutable";
+            include /etc/nginx/security-headers.conf;
+            include /etc/nginx/cache-immutable.conf;
         }
 
         # SPA fallback
         location / {
+            include /etc/nginx/security-headers.conf;
             try_files $uri $uri/ /index.html;
         }
     }

--- a/tools/grype-mcp/Dockerfile
+++ b/tools/grype-mcp/Dockerfile
@@ -26,5 +26,8 @@ ENV PATH="/opt/venv/bin:$PATH"
 WORKDIR /app
 COPY server.py .
 
+RUN useradd -r -s /bin/false -d /nonexistent appuser
+
 EXPOSE 8000
+USER appuser
 CMD ["python", "server.py"]

--- a/tools/kali-mcp/Dockerfile
+++ b/tools/kali-mcp/Dockerfile
@@ -65,6 +65,9 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY server.py /app/server.py
 
+RUN useradd -r -s /bin/false -d /nonexistent appuser
+
 EXPOSE 8000
+USER appuser
 ENTRYPOINT ["tini", "--"]
 CMD ["python", "/app/server.py"]

--- a/tools/snyk-mcp/Dockerfile
+++ b/tools/snyk-mcp/Dockerfile
@@ -30,5 +30,8 @@ ENV SNYK_TOKEN=""
 WORKDIR /app
 COPY server.py .
 
+RUN useradd -r -s /bin/false -d /nonexistent appuser
+
 EXPOSE 8000
+USER appuser
 CMD ["python3", "server.py"]


### PR DESCRIPTION
## Summary

- **Docker USER directives (CWE-250):** Added non-root `appuser` to 4 tool Dockerfiles (`kali-mcp`, `snyk-mcp`, `grype-mcp`, `nvd-mcp`) so containers no longer run as root at runtime
- **nginx header redefinition (CWE-16):** Moved security headers (`X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Content-Security-Policy`) from the `server` block into an external snippet (`nginx-security-headers.conf`) included per `location` block, preventing nginx from silently dropping headers when a location block defines its own `add_header`
- **H2C smuggling mitigation (CWE-444):** Added `map $http_upgrade $connection_upgrade` to restrict WebSocket Upgrade header to literal `"websocket"` value only, preventing HTTP/2 cleartext smuggling through the Socket.IO proxy
- **Cache header snippets:** Extracted cache directives into `nginx-cache-nocache.conf` and `nginx-cache-immutable.conf` to eliminate all direct `add_header` usage in `nginx.conf`
- **10 new security regression tests** covering USER directive presence, header snippet inclusion in all location blocks, required security headers in snippet, and H2C map configuration

## Test plan

- [x] All 71 security regression tests pass (including 10 new tests)
- [x] `npm run lint` passes with zero warnings
- [ ] CI pipeline passes
- [ ] Verify nginx starts correctly in Docker build (requires CI Docker build)

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)