### PR TITLE
feat(#904): add smart search to Fleet Overview page

### DIFF
--- a/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, act } from '@testing-library/react';
+import { FleetSearch } from './fleet-search';
+
+describe('FleetSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function renderSearch(props: Partial<React.ComponentProps<typeof FleetSearch>> = {}) {
+    const onSearch = vi.fn();
+    const utils = render(
+      <FleetSearch
+        onSearch={onSearch}
+        totalCount={10}
+        filteredCount={10}
+        placeholder="Search endpoints... (name:prod status:up)"
+        label="Search endpoints"
+        {...props}
+      />,
+    );
+    return { onSearch, ...utils };
+  }
+
+  it('renders with placeholder text', () => {
+    renderSearch();
+    expect(screen.getByPlaceholderText(/search endpoints/i)).toBeInTheDocument();
+  });
+
+  it('renders with aria-label', () => {
+    renderSearch();
+    expect(screen.getByRole('textbox', { name: /search endpoints/i })).toBeInTheDocument();
+  });
+
+  it('debounces search input by 300ms', () => {
+    const { onSearch } = renderSearch();
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'prod' } });
+
+    // Not called immediately
+    expect(onSearch).not.toHaveBeenCalled();
+
+    // Called after 300ms
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(onSearch).toHaveBeenCalledWith('prod');
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces multiple rapid inputs', () => {
+    const { onSearch } = renderSearch();
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'p' } });
+    act(() => { vi.advanceTimersByTime(100); });
+    fireEvent.change(input, { target: { value: 'pr' } });
+    act(() => { vi.advanceTimersByTime(100); });
+    fireEvent.change(input, { target: { value: 'pro' } });
+    act(() => { vi.advanceTimersByTime(100); });
+    fireEvent.change(input, { target: { value: 'prod' } });
+
+    // Only the debounce timer for the last input should fire
+    act(() => { vi.advanceTimersByTime(300); });
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith('prod');
+  });
+
+  it('shows clear button when input has value', () => {
+    renderSearch();
+    const input = screen.getByRole('textbox');
+
+    // No clear button initially
+    expect(screen.queryByRole('button', { name: /clear search/i })).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    expect(screen.getByRole('button', { name: /clear search/i })).toBeInTheDocument();
+  });
+
+  it('clear button resets input and calls onSearch immediately', () => {
+    const { onSearch } = renderSearch();
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'test' } });
+    fireEvent.click(screen.getByRole('button', { name: /clear search/i }));
+
+    expect((input as HTMLInputElement).value).toBe('');
+    // Clear should call onSearch immediately (not debounced)
+    expect(onSearch).toHaveBeenCalledWith('');
+  });
+
+  it('Escape key clears input', () => {
+    const { onSearch } = renderSearch();
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'test' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect((input as HTMLInputElement).value).toBe('');
+    expect(onSearch).toHaveBeenCalledWith('');
+  });
+
+  it('does not show count when not filtering', () => {
+    renderSearch({ totalCount: 10, filteredCount: 10 });
+    expect(screen.queryByTestId('fleet-search-count')).not.toBeInTheDocument();
+  });
+
+  it('shows filtered count when search reduces results', () => {
+    renderSearch({ totalCount: 10, filteredCount: 3 });
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'prod' } });
+
+    expect(screen.getByTestId('fleet-search-count')).toHaveTextContent('3 of 10');
+  });
+
+  it('does not show count when query is empty even if counts differ', () => {
+    renderSearch({ totalCount: 10, filteredCount: 10 });
+    expect(screen.queryByTestId('fleet-search-count')).not.toBeInTheDocument();
+  });
+
+  it('uses custom placeholder', () => {
+    renderSearch({ placeholder: 'Custom placeholder' });
+    expect(screen.getByPlaceholderText('Custom placeholder')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/containers/components/fleet/fleet-search.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.tsx
@@ -1,0 +1,102 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { Search, X } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+
+export interface FleetSearchProps {
+  onSearch: (query: string) => void;
+  totalCount: number;
+  filteredCount: number;
+  placeholder?: string;
+  label: string;
+}
+
+export function FleetSearch({
+  onSearch,
+  totalCount,
+  filteredCount,
+  placeholder = 'Search...',
+  label,
+}: FleetSearchProps) {
+  const [query, setQuery] = useState('');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const dispatchSearch = useCallback(
+    (value: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onSearch(value);
+      }, 300);
+    },
+    [onSearch],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setQuery(value);
+      dispatchSearch(value);
+    },
+    [dispatchSearch],
+  );
+
+  const handleClear = useCallback(() => {
+    setQuery('');
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    onSearch('');
+  }, [onSearch]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Escape') {
+        handleClear();
+      }
+    },
+    [handleClear],
+  );
+
+  const isFiltered = query.length > 0 && filteredCount !== totalCount;
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="relative flex-1">
+        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+          <Search className="h-4 w-4 text-muted-foreground" />
+        </div>
+        <input
+          type="text"
+          value={query}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className={cn(
+            'w-full rounded-lg border bg-card/80 py-2 pl-10 pr-9 text-sm',
+            'placeholder:text-muted-foreground/50',
+            'focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50',
+            'transition-all duration-200',
+          )}
+          aria-label={label}
+        />
+        {query && (
+          <button
+            onClick={handleClear}
+            className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      {isFiltered && (
+        <span className="shrink-0 text-sm text-muted-foreground" data-testid="fleet-search-count">
+          {filteredCount} of {totalCount}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/containers/lib/fleet-search-filter.test.ts
+++ b/frontend/src/features/containers/lib/fleet-search-filter.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseFleetSearchQuery,
+  filterEndpoints,
+  filterStacks,
+  type StackWithEndpoint,
+} from './fleet-search-filter';
+import type { Endpoint } from '@/features/containers/hooks/use-endpoints';
+
+function makeEndpoint(overrides: Partial<Endpoint> = {}): Endpoint {
+  return {
+    id: 1,
+    name: 'prod-server-1',
+    type: 1,
+    url: 'tcp://192.168.1.10:2376',
+    status: 'up',
+    containersRunning: 5,
+    containersStopped: 1,
+    containersHealthy: 4,
+    containersUnhealthy: 0,
+    totalContainers: 6,
+    stackCount: 3,
+    totalCpu: 4,
+    totalMemory: 8589934592,
+    isEdge: false,
+    edgeMode: null,
+    snapshotAge: null,
+    checkInInterval: null,
+    capabilities: { exec: true, realtimeLogs: true, liveStats: true, immediateActions: true },
+    ...overrides,
+  };
+}
+
+function makeStack(overrides: Partial<StackWithEndpoint> = {}): StackWithEndpoint {
+  return {
+    id: 1,
+    name: 'traefik',
+    type: 2,
+    endpointId: 1,
+    status: 'active',
+    endpointName: 'prod-server-1',
+    envCount: 3,
+    containerCount: 2,
+    ...overrides,
+  };
+}
+
+describe('parseFleetSearchQuery', () => {
+  it('returns empty array for empty string', () => {
+    expect(parseFleetSearchQuery('')).toEqual([]);
+    expect(parseFleetSearchQuery('   ')).toEqual([]);
+  });
+
+  it('returns free text token', () => {
+    expect(parseFleetSearchQuery('prod')).toEqual([{ value: 'prod' }]);
+  });
+
+  it('parses field:value token', () => {
+    expect(parseFleetSearchQuery('name:prod')).toEqual([{ field: 'name', value: 'prod' }]);
+  });
+
+  it('parses status field', () => {
+    expect(parseFleetSearchQuery('status:up')).toEqual([{ field: 'status', value: 'up' }]);
+  });
+
+  it('parses url field', () => {
+    expect(parseFleetSearchQuery('url:192.168')).toEqual([{ field: 'url', value: '192.168' }]);
+  });
+
+  it('parses type field', () => {
+    expect(parseFleetSearchQuery('type:edge')).toEqual([{ field: 'type', value: 'edge' }]);
+  });
+
+  it('parses endpoint field (for stacks)', () => {
+    expect(parseFleetSearchQuery('endpoint:prod')).toEqual([{ field: 'endpoint', value: 'prod' }]);
+  });
+
+  it('parses multiple tokens', () => {
+    expect(parseFleetSearchQuery('status:up name:prod')).toEqual([
+      { field: 'status', value: 'up' },
+      { field: 'name', value: 'prod' },
+    ]);
+  });
+
+  it('treats unknown field prefix as free text', () => {
+    expect(parseFleetSearchQuery('foo:bar')).toEqual([{ value: 'foo:bar' }]);
+  });
+
+  it('treats field: with no value as free text', () => {
+    expect(parseFleetSearchQuery('name:')).toEqual([{ value: 'name:' }]);
+  });
+
+  it('is case-insensitive for field names', () => {
+    expect(parseFleetSearchQuery('NAME:prod')).toEqual([{ field: 'name', value: 'prod' }]);
+  });
+});
+
+describe('filterEndpoints', () => {
+  const endpoints = [
+    makeEndpoint({ id: 1, name: 'prod-server-1', url: 'tcp://10.0.0.1:2376', status: 'up', type: 1 }),
+    makeEndpoint({ id: 2, name: 'staging-server', url: 'tcp://10.0.0.2:2376', status: 'up', type: 4, isEdge: true }),
+    makeEndpoint({ id: 3, name: 'dev-local', url: 'tcp://localhost:2375', status: 'down', type: 2 }),
+    makeEndpoint({ id: 4, name: 'prod-k8s', url: 'https://k8s.example.com', status: 'up', type: 5 }),
+  ];
+
+  it('returns all endpoints for empty query', () => {
+    expect(filterEndpoints(endpoints, '')).toHaveLength(4);
+  });
+
+  it('free text matches by name', () => {
+    const result = filterEndpoints(endpoints, 'prod');
+    expect(result.map(e => e.id)).toEqual([1, 4]);
+  });
+
+  it('free text matches by url', () => {
+    const result = filterEndpoints(endpoints, 'localhost');
+    expect(result.map(e => e.id)).toEqual([3]);
+  });
+
+  it('free text matches by status', () => {
+    const result = filterEndpoints(endpoints, 'down');
+    expect(result.map(e => e.id)).toEqual([3]);
+  });
+
+  it('free text matches by type name', () => {
+    const result = filterEndpoints(endpoints, 'kubernetes');
+    expect(result.map(e => e.id)).toEqual([4]);
+  });
+
+  it('name: field matches only name', () => {
+    const result = filterEndpoints(endpoints, 'name:staging');
+    expect(result.map(e => e.id)).toEqual([2]);
+  });
+
+  it('status: field matches only status', () => {
+    const result = filterEndpoints(endpoints, 'status:down');
+    expect(result.map(e => e.id)).toEqual([3]);
+  });
+
+  it('url: field matches only url', () => {
+    const result = filterEndpoints(endpoints, 'url:k8s');
+    expect(result.map(e => e.id)).toEqual([4]);
+  });
+
+  it('type: field matches endpoint type', () => {
+    const result = filterEndpoints(endpoints, 'type:edge');
+    expect(result.map(e => e.id)).toEqual([2]);
+  });
+
+  it('multiple tokens are ANDed', () => {
+    const result = filterEndpoints(endpoints, 'status:up name:prod');
+    expect(result.map(e => e.id)).toEqual([1, 4]);
+  });
+
+  it('multiple tokens AND with no match returns empty', () => {
+    const result = filterEndpoints(endpoints, 'status:down name:prod');
+    expect(result).toHaveLength(0);
+  });
+
+  it('is case-insensitive', () => {
+    const result = filterEndpoints(endpoints, 'PROD');
+    expect(result.map(e => e.id)).toEqual([1, 4]);
+  });
+
+  it('ignores non-endpoint fields gracefully', () => {
+    const result = filterEndpoints(endpoints, 'endpoint:prod');
+    // endpoint: is not an endpoint field, so no match
+    expect(result).toHaveLength(0);
+  });
+
+  it('partial match works', () => {
+    const result = filterEndpoints(endpoints, 'stag');
+    expect(result.map(e => e.id)).toEqual([2]);
+  });
+});
+
+describe('filterStacks', () => {
+  const stacks: StackWithEndpoint[] = [
+    makeStack({ id: 1, name: 'traefik', status: 'active', endpointName: 'prod-server-1', containerCount: 2 }),
+    makeStack({ id: 2, name: 'postgres-db', status: 'active', endpointName: 'prod-server-1', containerCount: 1 }),
+    makeStack({ id: 3, name: 'redis-cache', status: 'inactive', endpointName: 'staging-server', containerCount: 3 }),
+    makeStack({ id: 4, name: 'monitoring', status: 'active', endpointName: 'dev-local', containerCount: 5 }),
+  ];
+
+  it('returns all stacks for empty query', () => {
+    expect(filterStacks(stacks, '')).toHaveLength(4);
+  });
+
+  it('free text matches by stack name', () => {
+    const result = filterStacks(stacks, 'traefik');
+    expect(result.map(s => s.id)).toEqual([1]);
+  });
+
+  it('free text matches by endpoint name', () => {
+    const result = filterStacks(stacks, 'staging');
+    expect(result.map(s => s.id)).toEqual([3]);
+  });
+
+  it('free text matches by container count', () => {
+    const result = filterStacks(stacks, '5');
+    expect(result.map(s => s.id)).toEqual([4]);
+  });
+
+  it('name: field matches only stack name', () => {
+    const result = filterStacks(stacks, 'name:postgres');
+    expect(result.map(s => s.id)).toEqual([2]);
+  });
+
+  it('status: field matches only status', () => {
+    const result = filterStacks(stacks, 'status:inactive');
+    expect(result.map(s => s.id)).toEqual([3]);
+  });
+
+  it('endpoint: field matches only endpoint name', () => {
+    const result = filterStacks(stacks, 'endpoint:prod');
+    expect(result.map(s => s.id)).toEqual([1, 2]);
+  });
+
+  it('multiple tokens are ANDed', () => {
+    const result = filterStacks(stacks, 'status:active endpoint:prod');
+    expect(result.map(s => s.id)).toEqual([1, 2]);
+  });
+
+  it('multiple tokens AND with no match returns empty', () => {
+    const result = filterStacks(stacks, 'status:inactive endpoint:prod');
+    expect(result).toHaveLength(0);
+  });
+
+  it('is case-insensitive', () => {
+    // "inactive" contains "active" so all 4 match substring search
+    const result = filterStacks(stacks, 'STATUS:ACTIVE');
+    expect(result).toHaveLength(4);
+  });
+
+  it('exact status match narrows results', () => {
+    const result = filterStacks(stacks, 'status:inact');
+    expect(result.map(s => s.id)).toEqual([3]);
+  });
+
+  it('ignores non-stack fields gracefully', () => {
+    const result = filterStacks(stacks, 'url:something');
+    // url: is not a stack field, so no match
+    expect(result).toHaveLength(0);
+  });
+
+  it('partial match works', () => {
+    const result = filterStacks(stacks, 'post');
+    expect(result.map(s => s.id)).toEqual([2]);
+  });
+});

--- a/frontend/src/features/containers/lib/fleet-search-filter.ts
+++ b/frontend/src/features/containers/lib/fleet-search-filter.ts
@@ -1,0 +1,130 @@
+import type { Endpoint } from '@/features/containers/hooks/use-endpoints';
+
+export interface StackWithEndpoint {
+  id: number;
+  name: string;
+  type: number;
+  endpointId: number;
+  status: 'active' | 'inactive';
+  endpointName: string;
+  containerCount?: number;
+  envCount: number;
+  source?: 'portainer' | 'compose-label';
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+export interface FleetSearchToken {
+  field?: EndpointFieldName | StackFieldName;
+  value: string;
+}
+
+type EndpointFieldName = 'name' | 'status' | 'url' | 'type';
+type StackFieldName = 'name' | 'status' | 'endpoint';
+
+const ENDPOINT_FIELDS = new Set<EndpointFieldName>(['name', 'status', 'url', 'type']);
+const STACK_FIELDS = new Set<StackFieldName>(['name', 'status', 'endpoint']);
+
+type AllFieldNames = EndpointFieldName | StackFieldName;
+const ALL_FIELDS = new Set<AllFieldNames>(['name', 'status', 'url', 'type', 'endpoint']);
+
+function isFieldName(s: string): s is AllFieldNames {
+  return ALL_FIELDS.has(s as AllFieldNames);
+}
+
+export function parseFleetSearchQuery(query: string): FleetSearchToken[] {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  return trimmed.split(/\s+/).map((part) => {
+    const colonIndex = part.indexOf(':');
+    if (colonIndex > 0) {
+      const possibleField = part.slice(0, colonIndex).toLowerCase();
+      const value = part.slice(colonIndex + 1);
+      if (isFieldName(possibleField) && value) {
+        return { field: possibleField, value };
+      }
+    }
+    return { value: part };
+  });
+}
+
+function getEndpointTypeName(type: number): string {
+  switch (type) {
+    case 1: return 'docker';
+    case 2: return 'agent';
+    case 3: return 'azure';
+    case 4: return 'edge';
+    case 5: return 'kubernetes';
+    default: return String(type);
+  }
+}
+
+function endpointMatchesToken(endpoint: Endpoint, token: FleetSearchToken): boolean {
+  const val = token.value.toLowerCase();
+
+  if (token.field) {
+    if (!ENDPOINT_FIELDS.has(token.field as EndpointFieldName)) return false;
+    switch (token.field) {
+      case 'name':
+        return endpoint.name.toLowerCase().includes(val);
+      case 'status':
+        return endpoint.status.toLowerCase().includes(val);
+      case 'url':
+        return endpoint.url.toLowerCase().includes(val);
+      case 'type':
+        return getEndpointTypeName(endpoint.type).includes(val);
+      default:
+        return false;
+    }
+  }
+
+  // Free text — match across name, URL, status, and type
+  if (endpoint.name.toLowerCase().includes(val)) return true;
+  if (endpoint.url.toLowerCase().includes(val)) return true;
+  if (endpoint.status.toLowerCase().includes(val)) return true;
+  if (getEndpointTypeName(endpoint.type).includes(val)) return true;
+
+  return false;
+}
+
+export function filterEndpoints(endpoints: Endpoint[], query: string): Endpoint[] {
+  const tokens = parseFleetSearchQuery(query);
+  if (tokens.length === 0) return endpoints;
+  return endpoints.filter((endpoint) =>
+    tokens.every((token) => endpointMatchesToken(endpoint, token)),
+  );
+}
+
+function stackMatchesToken(stack: StackWithEndpoint, token: FleetSearchToken): boolean {
+  const val = token.value.toLowerCase();
+
+  if (token.field) {
+    if (!STACK_FIELDS.has(token.field as StackFieldName)) return false;
+    switch (token.field) {
+      case 'name':
+        return stack.name.toLowerCase().includes(val);
+      case 'status':
+        return stack.status.toLowerCase().includes(val);
+      case 'endpoint':
+        return stack.endpointName.toLowerCase().includes(val);
+      default:
+        return false;
+    }
+  }
+
+  // Free text — match across stack name, endpoint name, and container count
+  if (stack.name.toLowerCase().includes(val)) return true;
+  if (stack.endpointName.toLowerCase().includes(val)) return true;
+  if (stack.containerCount !== undefined && String(stack.containerCount).includes(val)) return true;
+
+  return false;
+}
+
+export function filterStacks(stacks: StackWithEndpoint[], query: string): StackWithEndpoint[] {
+  const tokens = parseFleetSearchQuery(query);
+  if (tokens.length === 0) return stacks;
+  return stacks.filter((stack) =>
+    tokens.every((token) => stackMatchesToken(stack, token)),
+  );
+}


### PR DESCRIPTION
## Summary
- Add search bars above both endpoint and stack sections on the Fleet Overview page
- Support `field:value` syntax for structured search (name:, status:, url:, type: for endpoints; name:, status:, endpoint: for stacks) and free-text matching across multiple fields
- Search is debounced (300ms), supports clear button (X) and Escape key, shows filtered count ("X of Y"), and resets grid pagination on new search
- Works in both grid and table view modes

## New Files
- `frontend/src/features/containers/lib/fleet-search-filter.ts` — `parseFleetSearchQuery`, `filterEndpoints`, `filterStacks` utilities with token-based AND matching
- `frontend/src/features/containers/lib/fleet-search-filter.test.ts` — 38 tests covering parser, endpoint filter, and stack filter
- `frontend/src/features/containers/components/fleet/fleet-search.tsx` — Reusable `FleetSearch` component with debounce, clear, escape, count
- `frontend/src/features/containers/components/fleet/fleet-search.test.tsx` — 11 component tests (debounce, clear, escape, count display)

## Modified Files
- `frontend/src/features/containers/pages/fleet-overview.tsx` — Integrate FleetSearch, add search state, wire filtered data to grid/table views, add search-specific empty states

## Test plan
- [x] 38 fleet-search-filter utility tests pass
- [x] 11 FleetSearch component tests pass
- [x] All 1486 frontend tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes with zero warnings

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)