### PR TITLE
feat(#905): add interactive status summary bar to Fleet Overview

### DIFF
--- a/frontend/src/features/containers/components/fleet/fleet-status-summary.test.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-status-summary.test.tsx
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FleetStatusSummary, type FleetStatusSummaryProps } from './fleet-status-summary';
+import type { Endpoint } from '@/features/containers/hooks/use-endpoints';
+
+// Mock framer-motion to avoid animation complexity in tests
+vi.mock('framer-motion', () => ({
+  motion: {
+    button: ({ children, ...props }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => {
+      const { initial, animate, exit, transition: _transition, ...rest } = props as any;
+      return <button {...rest}>{children}</button>;
+    },
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  useReducedMotion: () => false,
+}));
+
+function makeEndpoint(overrides: Partial<Endpoint> = {}): Endpoint {
+  return {
+    id: 1,
+    name: 'test-ep',
+    type: 1,
+    url: 'tcp://10.0.0.1:9001',
+    status: 'up',
+    containersRunning: 5,
+    containersStopped: 1,
+    containersHealthy: 4,
+    containersUnhealthy: 0,
+    totalContainers: 6,
+    stackCount: 2,
+    totalCpu: 4,
+    totalMemory: 8589934592,
+    isEdge: false,
+    edgeMode: null,
+    snapshotAge: null,
+    checkInInterval: null,
+    capabilities: { exec: true, realtimeLogs: true, liveStats: true, immediateActions: true },
+    ...overrides,
+  };
+}
+
+function renderSummary(overrides: Partial<FleetStatusSummaryProps> = {}) {
+  const defaultProps: FleetStatusSummaryProps = {
+    endpoints: [],
+    stacks: [],
+    activeEndpointStatusFilter: undefined,
+    onEndpointStatusChange: vi.fn(),
+    activeStackStatusFilter: undefined,
+    onStackStatusChange: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<FleetStatusSummary {...defaultProps} />), props: defaultProps };
+}
+
+describe('FleetStatusSummary — endpoint section', () => {
+  it('renders endpoint total count', () => {
+    renderSummary({
+      endpoints: [
+        makeEndpoint({ id: 1, status: 'up' }),
+        makeEndpoint({ id: 2, status: 'down' }),
+      ],
+    });
+
+    expect(screen.getByTestId('endpoint-total')).toHaveTextContent('2 endpoints');
+  });
+
+  it('renders singular "endpoint" for single endpoint', () => {
+    renderSummary({
+      endpoints: [makeEndpoint({ id: 1, status: 'up' })],
+    });
+
+    expect(screen.getByTestId('endpoint-total')).toHaveTextContent('1 endpoint');
+  });
+
+  it('renders up and down status pills with counts', () => {
+    renderSummary({
+      endpoints: [
+        makeEndpoint({ id: 1, status: 'up' }),
+        makeEndpoint({ id: 2, status: 'up' }),
+        makeEndpoint({ id: 3, status: 'down' }),
+      ],
+    });
+
+    const upPill = screen.getByTestId('status-pill-up');
+    expect(upPill).toHaveTextContent('Up');
+    expect(upPill).toHaveTextContent('(2)');
+
+    const downPill = screen.getByTestId('status-pill-down');
+    expect(downPill).toHaveTextContent('Down');
+    expect(downPill).toHaveTextContent('(1)');
+  });
+
+  it('shows zero count with opacity when no endpoints are down', () => {
+    renderSummary({
+      endpoints: [
+        makeEndpoint({ id: 1, status: 'up' }),
+        makeEndpoint({ id: 2, status: 'up' }),
+      ],
+    });
+
+    const downPill = screen.getByTestId('status-pill-down');
+    expect(downPill).toHaveTextContent('(0)');
+    expect(downPill.className).toContain('opacity-50');
+  });
+
+  it('calls onEndpointStatusChange with "up" when Up pill clicked', () => {
+    const onEndpointStatusChange = vi.fn();
+    renderSummary({
+      endpoints: [makeEndpoint({ id: 1, status: 'up' })],
+      onEndpointStatusChange,
+    });
+
+    fireEvent.click(screen.getByTestId('status-pill-up'));
+    expect(onEndpointStatusChange).toHaveBeenCalledWith('up');
+  });
+
+  it('calls onEndpointStatusChange with undefined when active Up pill clicked', () => {
+    const onEndpointStatusChange = vi.fn();
+    renderSummary({
+      endpoints: [makeEndpoint({ id: 1, status: 'up' })],
+      activeEndpointStatusFilter: 'up',
+      onEndpointStatusChange,
+    });
+
+    fireEvent.click(screen.getByTestId('status-pill-up'));
+    expect(onEndpointStatusChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('applies ring highlight to active endpoint pill', () => {
+    renderSummary({
+      endpoints: [makeEndpoint({ id: 1, status: 'up' })],
+      activeEndpointStatusFilter: 'up',
+    });
+
+    const upPill = screen.getByTestId('status-pill-up');
+    expect(upPill.className).toContain('ring-2');
+    expect(upPill.className).toContain('ring-primary');
+  });
+
+  it('calls onEndpointStatusChange(undefined) when total button clicked', () => {
+    const onEndpointStatusChange = vi.fn();
+    renderSummary({
+      endpoints: [makeEndpoint({ id: 1, status: 'up' })],
+      activeEndpointStatusFilter: 'up',
+      onEndpointStatusChange,
+    });
+
+    fireEvent.click(screen.getByTestId('endpoint-total'));
+    expect(onEndpointStatusChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('renders endpoint progress bar', () => {
+    renderSummary({
+      endpoints: [
+        makeEndpoint({ id: 1, status: 'up' }),
+        makeEndpoint({ id: 2, status: 'down' }),
+      ],
+    });
+
+    const bars = screen.getAllByTestId('progress-bar');
+    expect(bars.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('FleetStatusSummary — stack section', () => {
+  it('renders stack total count', () => {
+    renderSummary({
+      stacks: [
+        { status: 'active' },
+        { status: 'inactive' },
+        { status: 'active' },
+      ],
+    });
+
+    expect(screen.getByTestId('stack-total')).toHaveTextContent('3 stacks');
+  });
+
+  it('renders singular "stack" for single stack', () => {
+    renderSummary({
+      stacks: [{ status: 'active' }],
+    });
+
+    expect(screen.getByTestId('stack-total')).toHaveTextContent('1 stack');
+  });
+
+  it('renders active and inactive status pills with counts', () => {
+    renderSummary({
+      stacks: [
+        { status: 'active' },
+        { status: 'active' },
+        { status: 'inactive' },
+      ],
+    });
+
+    const activePill = screen.getByTestId('status-pill-active');
+    expect(activePill).toHaveTextContent('Active');
+    expect(activePill).toHaveTextContent('(2)');
+
+    const inactivePill = screen.getByTestId('status-pill-inactive');
+    expect(inactivePill).toHaveTextContent('Inactive');
+    expect(inactivePill).toHaveTextContent('(1)');
+  });
+
+  it('calls onStackStatusChange with "active" when Active pill clicked', () => {
+    const onStackStatusChange = vi.fn();
+    renderSummary({
+      stacks: [{ status: 'active' }],
+      onStackStatusChange,
+    });
+
+    fireEvent.click(screen.getByTestId('status-pill-active'));
+    expect(onStackStatusChange).toHaveBeenCalledWith('active');
+  });
+
+  it('calls onStackStatusChange with undefined when active pill clicked again', () => {
+    const onStackStatusChange = vi.fn();
+    renderSummary({
+      stacks: [{ status: 'active' }],
+      activeStackStatusFilter: 'active',
+      onStackStatusChange,
+    });
+
+    fireEvent.click(screen.getByTestId('status-pill-active'));
+    expect(onStackStatusChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('applies ring highlight to active stack pill', () => {
+    renderSummary({
+      stacks: [{ status: 'inactive' }],
+      activeStackStatusFilter: 'inactive',
+    });
+
+    const inactivePill = screen.getByTestId('status-pill-inactive');
+    expect(inactivePill.className).toContain('ring-2');
+    expect(inactivePill.className).toContain('ring-primary');
+  });
+
+  it('calls onStackStatusChange(undefined) when total button clicked', () => {
+    const onStackStatusChange = vi.fn();
+    renderSummary({
+      stacks: [{ status: 'active' }],
+      activeStackStatusFilter: 'active',
+      onStackStatusChange,
+    });
+
+    fireEvent.click(screen.getByTestId('stack-total'));
+    expect(onStackStatusChange).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe('FleetStatusSummary — progress bars', () => {
+  it('renders two progress bars (endpoint + stack)', () => {
+    renderSummary({
+      endpoints: [makeEndpoint({ id: 1, status: 'up' })],
+      stacks: [{ status: 'active' }],
+    });
+
+    const bars = screen.getAllByTestId('progress-bar');
+    expect(bars).toHaveLength(2);
+  });
+
+  it('does not render progress bar when totals are zero', () => {
+    renderSummary({
+      endpoints: [],
+      stacks: [],
+    });
+
+    expect(screen.queryByTestId('progress-bar')).not.toBeInTheDocument();
+  });
+});
+
+describe('FleetStatusSummary — summary bar test-id', () => {
+  it('renders with data-testid="summary-bar"', () => {
+    renderSummary({
+      endpoints: [makeEndpoint()],
+      stacks: [{ status: 'active' }],
+    });
+
+    expect(screen.getByTestId('summary-bar')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/containers/components/fleet/fleet-status-summary.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-status-summary.tsx
@@ -1,0 +1,245 @@
+import { useMemo } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { Server, Layers } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+import type { Endpoint } from '@/features/containers/hooks/use-endpoints';
+import { transition } from '@/shared/lib/motion-tokens';
+
+interface StackWithStatus {
+  status: 'active' | 'inactive';
+}
+
+const ENDPOINT_STATUS_COLORS: Record<string, { dot: string; text: string; bar: string }> = {
+  up: { dot: 'bg-emerald-500', text: 'text-emerald-700 dark:text-emerald-400', bar: 'bg-emerald-500' },
+  down: { dot: 'bg-red-500', text: 'text-red-700 dark:text-red-400', bar: 'bg-red-500' },
+};
+
+const STACK_STATUS_COLORS: Record<string, { dot: string; text: string; bar: string }> = {
+  active: { dot: 'bg-emerald-500', text: 'text-emerald-700 dark:text-emerald-400', bar: 'bg-emerald-500' },
+  inactive: { dot: 'bg-gray-500', text: 'text-gray-700 dark:text-gray-400', bar: 'bg-gray-500' },
+};
+
+export interface FleetStatusSummaryProps {
+  endpoints: Endpoint[];
+  stacks: StackWithStatus[];
+  activeEndpointStatusFilter: string | undefined;
+  onEndpointStatusChange: (status: string | undefined) => void;
+  activeStackStatusFilter: string | undefined;
+  onStackStatusChange: (status: string | undefined) => void;
+}
+
+function StatusPill({
+  label,
+  count,
+  isActive,
+  colors,
+  onClick,
+  reduceMotion,
+}: {
+  label: string;
+  count: number;
+  isActive: boolean;
+  colors: { dot: string; text: string };
+  onClick: () => void;
+  reduceMotion: boolean | null;
+}) {
+  return (
+    <motion.button
+      type="button"
+      initial={reduceMotion ? false : { opacity: 0, scale: 0.9 }}
+      animate={reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1 }}
+      exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.9 }}
+      transition={reduceMotion ? { duration: 0 } : transition.fast}
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-all duration-150',
+        count === 0 && 'opacity-50',
+        isActive
+          ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
+          : 'hover:ring-1 hover:ring-primary/30',
+      )}
+      title={isActive ? `Clear ${label} filter` : `Filter by ${label}`}
+      data-testid={`status-pill-${label.toLowerCase()}`}
+    >
+      <span className={cn('h-1.5 w-1.5 rounded-full', colors.dot)} />
+      <span className={cn(colors.text, 'capitalize')}>{label}</span>
+      <span className="text-muted-foreground">({count})</span>
+    </motion.button>
+  );
+}
+
+function ProgressBar({
+  segments,
+  total,
+}: {
+  segments: { key: string; count: number; barColor: string }[];
+  total: number;
+}) {
+  if (total === 0) return null;
+
+  return (
+    <div className="flex h-1 w-full overflow-hidden rounded-full bg-muted/50" data-testid="progress-bar">
+      {segments
+        .filter(({ count }) => count > 0)
+        .map(({ key, count, barColor }) => {
+          const percentage = (count / total) * 100;
+          return (
+            <div
+              key={key}
+              className={cn('transition-all duration-300', barColor)}
+              style={{ width: `${percentage}%` }}
+              title={`${key}: ${count} (${percentage.toFixed(1)}%)`}
+            />
+          );
+        })}
+    </div>
+  );
+}
+
+export function FleetStatusSummary({
+  endpoints,
+  stacks,
+  activeEndpointStatusFilter,
+  onEndpointStatusChange,
+  activeStackStatusFilter,
+  onStackStatusChange,
+}: FleetStatusSummaryProps) {
+  const reduceMotion = useReducedMotion();
+
+  const endpointCounts = useMemo(() => {
+    const up = endpoints.filter((ep) => ep.status === 'up').length;
+    const down = endpoints.filter((ep) => ep.status === 'down').length;
+    return { up, down, total: endpoints.length };
+  }, [endpoints]);
+
+  const stackCounts = useMemo(() => {
+    const active = stacks.filter((s) => s.status === 'active').length;
+    const inactive = stacks.filter((s) => s.status === 'inactive').length;
+    return { active, inactive, total: stacks.length };
+  }, [stacks]);
+
+  const handleEndpointPillClick = (status: string) => {
+    onEndpointStatusChange(activeEndpointStatusFilter === status ? undefined : status);
+  };
+
+  const handleStackPillClick = (status: string) => {
+    onStackStatusChange(activeStackStatusFilter === status ? undefined : status);
+  };
+
+  return (
+    <div
+      className="rounded-lg border bg-card px-6 py-4 shadow-sm text-sm space-y-4"
+      data-testid="summary-bar"
+    >
+      {/* Endpoint summary */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="flex items-center gap-2">
+            <Server className="h-4 w-4 text-muted-foreground" />
+            <button
+              type="button"
+              onClick={() => onEndpointStatusChange(undefined)}
+              className={cn(
+                'text-sm font-medium transition-colors',
+                !activeEndpointStatusFilter
+                  ? 'text-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              title="Show all endpoints"
+              data-testid="endpoint-total"
+            >
+              {endpointCounts.total} endpoint{endpointCounts.total !== 1 ? 's' : ''}
+            </button>
+          </div>
+
+          <span className="text-border">|</span>
+
+          <AnimatePresence mode="popLayout">
+            <StatusPill
+              key="up"
+              label="Up"
+              count={endpointCounts.up}
+              isActive={activeEndpointStatusFilter === 'up'}
+              colors={ENDPOINT_STATUS_COLORS.up}
+              onClick={() => handleEndpointPillClick('up')}
+              reduceMotion={reduceMotion}
+            />
+            <StatusPill
+              key="down"
+              label="Down"
+              count={endpointCounts.down}
+              isActive={activeEndpointStatusFilter === 'down'}
+              colors={ENDPOINT_STATUS_COLORS.down}
+              onClick={() => handleEndpointPillClick('down')}
+              reduceMotion={reduceMotion}
+            />
+          </AnimatePresence>
+        </div>
+
+        <ProgressBar
+          segments={[
+            { key: 'up', count: endpointCounts.up, barColor: ENDPOINT_STATUS_COLORS.up.bar },
+            { key: 'down', count: endpointCounts.down, barColor: ENDPOINT_STATUS_COLORS.down.bar },
+          ]}
+          total={endpointCounts.total}
+        />
+      </div>
+
+      <div className="h-px bg-border/50" />
+
+      {/* Stack summary */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="flex items-center gap-2">
+            <Layers className="h-4 w-4 text-muted-foreground" />
+            <button
+              type="button"
+              onClick={() => onStackStatusChange(undefined)}
+              className={cn(
+                'text-sm font-medium transition-colors',
+                !activeStackStatusFilter
+                  ? 'text-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              title="Show all stacks"
+              data-testid="stack-total"
+            >
+              {stackCounts.total} stack{stackCounts.total !== 1 ? 's' : ''}
+            </button>
+          </div>
+
+          <span className="text-border">|</span>
+
+          <AnimatePresence mode="popLayout">
+            <StatusPill
+              key="active"
+              label="Active"
+              count={stackCounts.active}
+              isActive={activeStackStatusFilter === 'active'}
+              colors={STACK_STATUS_COLORS.active}
+              onClick={() => handleStackPillClick('active')}
+              reduceMotion={reduceMotion}
+            />
+            <StatusPill
+              key="inactive"
+              label="Inactive"
+              count={stackCounts.inactive}
+              isActive={activeStackStatusFilter === 'inactive'}
+              colors={STACK_STATUS_COLORS.inactive}
+              onClick={() => handleStackPillClick('inactive')}
+              reduceMotion={reduceMotion}
+            />
+          </AnimatePresence>
+        </div>
+
+        <ProgressBar
+          segments={[
+            { key: 'active', count: stackCounts.active, barColor: STACK_STATUS_COLORS.active.bar },
+            { key: 'inactive', count: stackCounts.inactive, barColor: STACK_STATUS_COLORS.inactive.bar },
+          ]}
+          total={stackCounts.total}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace the read-only summary bar on the Fleet Overview page with interactive, clickable status pills that filter endpoints and stacks
- Create new `FleetStatusSummary` component following the `WorkloadStatusSummary` pattern (AnimatePresence, motion.button, useReducedMotion)
- Each status pill toggles a URL-persisted filter: clicking "Up (N)" shows only up endpoints; clicking again deselects
- Active pills show `ring-2 ring-primary` highlight; zero-count pills show `opacity-50`
- Horizontal progress bars visualize up/down and active/inactive distribution
- All animations respect `prefers-reduced-motion`

Closes #905

## Test plan
- [x] `FleetStatusSummary` component tests (19 tests): pill rendering, click toggle, ring highlight, progress bars, singular/plural labels
- [x] `fleet-overview` page integration tests (48 tests): pill-click filters endpoints/stacks, toggle deselect, total button clears filter
- [x] Full frontend suite passes (157 files, 1461 tests)
- [x] TypeScript strict mode (`npm run typecheck`) clean
- [x] ESLint (`npm run lint`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)