### PR TITLE
feat(#906): add active filter chips with clear-all to Fleet Overview

### DIFF
--- a/frontend/src/shared/components/filter-chip-bar.test.tsx
+++ b/frontend/src/shared/components/filter-chip-bar.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FilterChipBar, type FilterChip } from './filter-chip-bar';
+
+// Mock framer-motion to avoid animation timing issues in tests
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual('framer-motion');
+  return {
+    ...actual,
+    useReducedMotion: () => true,
+  };
+});
+
+function makeFilter(overrides: Partial<FilterChip> = {}): FilterChip {
+  return {
+    key: 'status',
+    label: 'Status',
+    value: 'Up',
+    ...overrides,
+  };
+}
+
+describe('FilterChipBar', () => {
+  it('returns null when filters array is empty', () => {
+    const { container } = render(
+      <FilterChipBar filters={[]} onRemove={vi.fn()} onClearAll={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a chip for each filter', () => {
+    const filters = [
+      makeFilter({ key: 'status', label: 'Status', value: 'Up' }),
+      makeFilter({ key: 'type', label: 'Type', value: 'Docker' }),
+    ];
+
+    render(<FilterChipBar filters={filters} onRemove={vi.fn()} onClearAll={vi.fn()} />);
+
+    expect(screen.getByTestId('filter-chip-status')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-type')).toBeInTheDocument();
+    expect(screen.getByText('Status:')).toBeInTheDocument();
+    expect(screen.getByText('Up')).toBeInTheDocument();
+    expect(screen.getByText('Type:')).toBeInTheDocument();
+    expect(screen.getByText('Docker')).toBeInTheDocument();
+  });
+
+  it('calls onRemove with the correct key when X button is clicked', () => {
+    const onRemove = vi.fn();
+    const filters = [
+      makeFilter({ key: 'status', label: 'Status', value: 'Up' }),
+    ];
+
+    render(<FilterChipBar filters={filters} onRemove={onRemove} onClearAll={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Status filter' }));
+    expect(onRemove).toHaveBeenCalledWith('status');
+  });
+
+  it('does not show "Clear all" when only one filter is active', () => {
+    const filters = [makeFilter()];
+
+    render(<FilterChipBar filters={filters} onRemove={vi.fn()} onClearAll={vi.fn()} />);
+
+    expect(screen.queryByTestId('filter-chip-clear-all')).not.toBeInTheDocument();
+  });
+
+  it('shows "Clear all" when 2 or more filters are active', () => {
+    const filters = [
+      makeFilter({ key: 'status', label: 'Status', value: 'Up' }),
+      makeFilter({ key: 'type', label: 'Type', value: 'Docker' }),
+    ];
+
+    render(<FilterChipBar filters={filters} onRemove={vi.fn()} onClearAll={vi.fn()} />);
+
+    expect(screen.getByTestId('filter-chip-clear-all')).toBeInTheDocument();
+  });
+
+  it('calls onClearAll when "Clear all" is clicked', () => {
+    const onClearAll = vi.fn();
+    const filters = [
+      makeFilter({ key: 'status', label: 'Status', value: 'Up' }),
+      makeFilter({ key: 'type', label: 'Type', value: 'Docker' }),
+    ];
+
+    render(<FilterChipBar filters={filters} onRemove={vi.fn()} onClearAll={onClearAll} />);
+
+    fireEvent.click(screen.getByTestId('filter-chip-clear-all'));
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('has aria-live="polite" on the container', () => {
+    const filters = [makeFilter()];
+
+    render(<FilterChipBar filters={filters} onRemove={vi.fn()} onClearAll={vi.fn()} />);
+
+    expect(screen.getByTestId('filter-chip-bar')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('renders three filters and shows "Clear all"', () => {
+    const filters = [
+      makeFilter({ key: 'a', label: 'A', value: '1' }),
+      makeFilter({ key: 'b', label: 'B', value: '2' }),
+      makeFilter({ key: 'c', label: 'C', value: '3' }),
+    ];
+
+    render(<FilterChipBar filters={filters} onRemove={vi.fn()} onClearAll={vi.fn()} />);
+
+    expect(screen.getByTestId('filter-chip-a')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-b')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-c')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-clear-all')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/filter-chip-bar.tsx
+++ b/frontend/src/shared/components/filter-chip-bar.tsx
@@ -1,0 +1,61 @@
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { X } from 'lucide-react';
+import { transition } from '@/shared/lib/motion-tokens';
+
+export interface FilterChip {
+  key: string;
+  label: string;
+  value: string;
+}
+
+export interface FilterChipBarProps {
+  filters: FilterChip[];
+  onRemove: (key: string) => void;
+  onClearAll: () => void;
+}
+
+export function FilterChipBar({ filters, onRemove, onClearAll }: FilterChipBarProps) {
+  const reduceMotion = useReducedMotion();
+
+  if (filters.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap" aria-live="polite" data-testid="filter-chip-bar">
+      <AnimatePresence mode="popLayout">
+        {filters.map((filter) => (
+          <motion.span
+            key={filter.key}
+            layout
+            initial={reduceMotion ? false : { opacity: 0, scale: 0.85 }}
+            animate={reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1 }}
+            exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.85 }}
+            transition={reduceMotion ? { duration: 0 } : transition.fast}
+            className="inline-flex items-center gap-1.5 rounded-full bg-card/80 backdrop-blur-sm border border-border/50 px-3 py-1 text-sm shadow-sm"
+            data-testid={`filter-chip-${filter.key}`}
+          >
+            <span className="font-medium text-muted-foreground">{filter.label}:</span>
+            <span>{filter.value}</span>
+            <button
+              type="button"
+              onClick={() => onRemove(filter.key)}
+              className="ml-1 -mr-1 rounded-full p-0.5 transition-colors duration-150 hover:bg-destructive/10 hover:text-destructive"
+              aria-label={`Remove ${filter.label} filter`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </motion.span>
+        ))}
+      </AnimatePresence>
+      {filters.length >= 2 && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          data-testid="filter-chip-clear-all"
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create reusable `FilterChipBar` component (`frontend/src/shared/components/filter-chip-bar.tsx`) with Framer Motion animations, glassmorphic styling, and `prefers-reduced-motion` support
- Add animated filter chip bars to both Fleet Overview and Stack Overview sections in `fleet-overview.tsx`, showing active dropdown filters as visual indicator chips with individual X removal
- "Clear all" button appears when 2+ filters are active in either section; chip bar collapses to zero height when no filters active

## Details
- Follows the existing `workload-explorer.tsx` filter chip pattern exactly (AnimatePresence mode="popLayout", motion.span with layout prop, transition.fast, glassmorphic bg-card/80 backdrop-blur-sm border-border/50)
- Each chip shows filter type + value (e.g., "Status: Up", "Type: Docker", "Endpoint: ep1")
- Endpoint section chips: Status and Type filters
- Stack section chips: Status and Endpoint filters
- `aria-live="polite"` on container for screen reader announcements

## Test plan
- [x] 8 unit tests for `FilterChipBar` component (empty state, rendering, removal, clear all, aria-live)
- [x] 6 integration tests for endpoint filter chips in fleet-overview (chip appears, clear all, removal)
- [x] 6 integration tests for stack filter chips in fleet-overview (chip appears, clear all, removal via "View stacks")
- [x] All 53 fleet-overview tests pass
- [x] All 157 frontend test files pass (1455 tests)
- [x] TypeScript typecheck passes
- [x] ESLint passes with zero warnings

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)