### PR TITLE
feat(#908): compact 3-row card layout for Fleet and Stack overview cards

### DIFF
--- a/frontend/src/features/containers/pages/__tests__/fleet-overview-cards.test.tsx
+++ b/frontend/src/features/containers/pages/__tests__/fleet-overview-cards.test.tsx
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import InfrastructurePage from '../fleet-overview';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('@/features/containers/hooks/use-endpoints', () => ({
+  useEndpoints: vi.fn(),
+}));
+
+vi.mock('@/features/containers/hooks/use-stacks', () => ({
+  useStacks: vi.fn(),
+}));
+
+vi.mock('@/shared/hooks/use-auto-refresh', () => ({
+  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn() }),
+}));
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+    request: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}));
+
+import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
+import { useStacks } from '@/features/containers/hooks/use-stacks';
+import type { Endpoint } from '@/features/containers/hooks/use-endpoints';
+import type { Stack } from '@/features/containers/hooks/use-stacks';
+import { useUiStore } from '@/stores/ui-store';
+
+const mockUseEndpoints = vi.mocked(useEndpoints);
+const mockUseStacks = vi.mocked(useStacks);
+
+function makeEndpoint(overrides: Partial<Endpoint> = {}): Endpoint {
+  return {
+    id: 1,
+    name: 'test-endpoint',
+    type: 1,
+    url: 'tcp://10.0.0.1:9001',
+    status: 'up',
+    containersRunning: 3,
+    containersStopped: 2,
+    containersHealthy: 3,
+    containersUnhealthy: 0,
+    totalContainers: 5,
+    stackCount: 2,
+    totalCpu: 4,
+    totalMemory: 8589934592, // 8.0 GB
+    isEdge: false,
+    edgeMode: null,
+    snapshotAge: null,
+    checkInInterval: null,
+    capabilities: { exec: true, realtimeLogs: true, liveStats: true, immediateActions: true },
+    ...overrides,
+  };
+}
+
+function makeStack(overrides: Partial<Stack> = {}): Stack {
+  return {
+    id: 1,
+    name: 'test-stack',
+    type: 2,
+    endpointId: 1,
+    status: 'active',
+    envCount: 3,
+    source: 'portainer',
+    createdAt: 1700000000,
+    updatedAt: 1700000000,
+    ...overrides,
+  };
+}
+
+function mockEndpoints(endpoints: Endpoint[], extra = {}) {
+  mockUseEndpoints.mockReturnValue({
+    data: endpoints,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isFetching: false,
+    ...extra,
+  } as any);
+}
+
+function mockStacks(stacks: Stack[], extra = {}) {
+  mockUseStacks.mockReturnValue({
+    data: stacks,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isFetching: false,
+    ...extra,
+  } as any);
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <InfrastructurePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('EndpointCard — compact 3-row layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+    useUiStore.setState({ pageViewModes: {} });
+    mockStacks([]);
+  });
+
+  it('renders name and ID on row 1', () => {
+    mockEndpoints([makeEndpoint({ id: 42, name: 'prod-server' })]);
+
+    renderPage();
+
+    expect(screen.getByText('prod-server')).toBeInTheDocument();
+    expect(screen.getByText('ID: 42')).toBeInTheDocument();
+  });
+
+  it('renders type tag and status badge on row 2 for non-edge endpoint', () => {
+    mockEndpoints([makeEndpoint({ type: 1, status: 'up', isEdge: false })]);
+
+    renderPage();
+
+    // Type label for Docker (type 1)
+    expect(screen.getByText('Docker')).toBeInTheDocument();
+  });
+
+  it('renders stats on row 3 (containers, stacks, CPU, memory)', () => {
+    mockEndpoints([
+      makeEndpoint({
+        totalContainers: 5,
+        containersRunning: 3,
+        stackCount: 2,
+        totalCpu: 4,
+        totalMemory: 8589934592, // 8.0 GB
+      }),
+    ]);
+
+    renderPage();
+
+    // Stats row: containers with running count
+    expect(screen.getByText(/5 containers/)).toBeInTheDocument();
+    expect(screen.getByText(/3 running/)).toBeInTheDocument();
+    // Stacks count
+    expect(screen.getByText('2 stacks')).toBeInTheDocument();
+    // CPU
+    expect(screen.getByText(/4 CPU/)).toBeInTheDocument();
+    // Memory
+    expect(screen.getByText('8.0 GB')).toBeInTheDocument();
+  });
+
+  it('renders Edge Agent badge on row 2 for edge endpoint', () => {
+    mockEndpoints([
+      makeEndpoint({
+        isEdge: true,
+        edgeMode: 'standard',
+        snapshotAge: 30000,
+        lastCheckIn: Math.floor(Date.now() / 1000) - 30,
+        checkInInterval: 5,
+        agentVersion: '2.20.0',
+      }),
+    ]);
+
+    renderPage();
+
+    expect(screen.getByText(/Edge Agent Standard/)).toBeInTheDocument();
+    expect(screen.getByText('v2.20.0')).toBeInTheDocument();
+  });
+
+  it('renders Edge Agent Async badge for async edge endpoints', () => {
+    mockEndpoints([
+      makeEndpoint({
+        isEdge: true,
+        edgeMode: 'async',
+        snapshotAge: 120000,
+        lastCheckIn: Math.floor(Date.now() / 1000) - 120,
+        checkInInterval: 60,
+      }),
+    ]);
+
+    renderPage();
+
+    expect(screen.getByText(/Edge Agent Async/)).toBeInTheDocument();
+  });
+
+  it('shows check-in and snapshot age for edge endpoints', () => {
+    mockEndpoints([
+      makeEndpoint({
+        isEdge: true,
+        edgeMode: 'standard',
+        snapshotAge: 30000,
+        lastCheckIn: Math.floor(Date.now() / 1000) - 30,
+        checkInInterval: 5,
+      }),
+    ]);
+
+    renderPage();
+
+    expect(screen.getByText(/Check-in:/)).toBeInTheDocument();
+    expect(screen.getByText(/Snapshot:/)).toBeInTheDocument();
+  });
+
+  it('"View stacks" link works and calls onViewStacks', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'ep-with-stacks', stackCount: 3 })]);
+    mockStacks([
+      makeStack({ id: 1, endpointId: 1 }),
+      makeStack({ id: 2, endpointId: 1 }),
+      makeStack({ id: 3, endpointId: 1 }),
+    ]);
+
+    renderPage();
+
+    const viewLink = screen.getByTestId('view-stacks-link');
+    expect(viewLink).toBeInTheDocument();
+    expect(viewLink).toHaveTextContent('View 3 stacks');
+
+    fireEvent.click(viewLink);
+
+    // Should filter stacks section
+    expect(screen.getByTestId('clear-stack-filter')).toBeInTheDocument();
+  });
+
+  it('uses singular "stack" when stackCount is 1', () => {
+    mockEndpoints([makeEndpoint({ stackCount: 1 })]);
+    mockStacks([makeStack({ endpointId: 1 })]);
+
+    renderPage();
+
+    // Row 3 stats (also appears in summary bar, so use getAllByText)
+    const stackTexts = screen.getAllByText('1 stack');
+    expect(stackTexts.length).toBeGreaterThanOrEqual(1);
+
+    // View stacks link
+    const viewLink = screen.getByTestId('view-stacks-link');
+    expect(viewLink).toHaveTextContent('View 1 stack');
+  });
+});
+
+describe('StackCard — compact 3-row layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+    useUiStore.setState({ pageViewModes: {} });
+  });
+
+  it('renders stack name and ID on row 1', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'local-env' })]);
+    mockStacks([makeStack({ id: 5, name: 'web-stack', endpointId: 1 })]);
+
+    renderPage();
+
+    expect(screen.getByText('web-stack')).toBeInTheDocument();
+    expect(screen.getByText('ID: 5')).toBeInTheDocument();
+  });
+
+  it('renders type tag and status badge on row 2', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'local-env' })]);
+    mockStacks([makeStack({ type: 2, status: 'active', endpointId: 1 })]);
+
+    renderPage();
+
+    // Type tag for Compose (type 2)
+    expect(screen.getByText('Compose')).toBeInTheDocument();
+  });
+
+  it('renders metadata on row 3 (endpoint name, env vars, created date)', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-env' })]);
+    mockStacks([
+      makeStack({
+        endpointId: 1,
+        envCount: 3,
+        createdAt: 1700000000,
+        source: 'portainer',
+      }),
+    ]);
+
+    renderPage();
+
+    // Endpoint name in metadata row
+    const mentions = screen.getAllByText('prod-env');
+    expect(mentions.length).toBeGreaterThanOrEqual(2); // fleet card + stack metadata
+
+    // Env vars count
+    expect(screen.getByText('3 env vars')).toBeInTheDocument();
+
+    // Created date
+    expect(screen.getByText(/Created/)).toBeInTheDocument();
+  });
+
+  it('shows Discovered badge instead of ID for inferred stacks', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'local-env' })]);
+    mockStacks([
+      makeStack({
+        id: -12345,
+        name: 'compose-app',
+        source: 'compose-label',
+        containerCount: 3,
+        envCount: 0,
+        endpointId: 1,
+      }),
+    ]);
+
+    renderPage();
+
+    expect(screen.getByText('compose-app')).toBeInTheDocument();
+    expect(screen.getByText('Discovered')).toBeInTheDocument();
+    // Should show containers instead of env vars for inferred stacks
+    expect(screen.getByText('3 containers')).toBeInTheDocument();
+  });
+
+  it('does not show Discovered badge for portainer stacks', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'local-env' })]);
+    mockStacks([
+      makeStack({ id: 5, name: 'normal-stack', source: 'portainer', endpointId: 1 }),
+    ]);
+
+    renderPage();
+
+    expect(screen.getByText('ID: 5')).toBeInTheDocument();
+    expect(screen.queryByText('Discovered')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -88,83 +88,68 @@ function EndpointCard({ endpoint, onClick, onViewStacks }: { endpoint: Endpoint;
   return (
     <button
       onClick={onClick}
-      className="w-full rounded-lg border bg-card p-6 shadow-sm text-left transition-colors hover:bg-accent/50 focus:outline-none focus:ring-2 focus:ring-ring"
+      className="w-full rounded-lg border bg-card p-4 shadow-sm text-left transition-colors hover:bg-accent/50 focus:outline-none focus:ring-2 focus:ring-ring"
     >
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-3">
-          <div className={cn(
-            'rounded-lg p-2',
-            endpoint.status === 'up'
-              ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-              : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-          )}>
-            <Server className="h-5 w-5" />
-          </div>
-          <div>
-            <h3 className="font-semibold">{endpoint.name}</h3>
-            <p className="text-xs text-muted-foreground">ID: {endpoint.id}</p>
-          </div>
+      {/* Row 1: Name + ID */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Server className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <h3 className="font-semibold truncate">{endpoint.name}</h3>
+        </div>
+        <span className="text-xs text-muted-foreground shrink-0">ID: {endpoint.id}</span>
+      </div>
+
+      {/* Row 2: Type tag + Status badge */}
+      <div className="mt-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {endpoint.isEdge ? (
+            <span className="rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+              Edge Agent {endpoint.edgeMode === 'async' ? 'Async' : 'Standard'}
+            </span>
+          ) : (
+            <span className="rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+              {getEndpointTypeLabel(endpoint.type)}
+            </span>
+          )}
+          {endpoint.isEdge && endpoint.agentVersion && (
+            <span className="text-xs text-muted-foreground">v{endpoint.agentVersion}</span>
+          )}
         </div>
         <StatusBadge status={endpoint.status} />
       </div>
 
-      <div className="mt-4 grid grid-cols-2 gap-4">
-        <div>
-          <p className="text-xs text-muted-foreground">Containers</p>
-          <div className="mt-1 flex items-center gap-2">
-            <Boxes className="h-4 w-4 text-muted-foreground" />
-            <span className="font-medium">{endpoint.totalContainers}</span>
-            <span className="text-xs text-muted-foreground">
-              ({endpoint.containersRunning} running)
-            </span>
-          </div>
-        </div>
-        <div>
-          <p className="text-xs text-muted-foreground">Stacks</p>
-          <p className="mt-1 font-medium">{endpoint.stackCount}</p>
-        </div>
+      {/* Row 3: Stats */}
+      <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Boxes className="h-3 w-3" />
+          {endpoint.totalContainers} containers ({endpoint.containersRunning} running)
+        </span>
+        <span>{endpoint.stackCount} stack{endpoint.stackCount !== 1 ? 's' : ''}</span>
+        <span className="flex items-center gap-1">
+          <Activity className="h-3 w-3" />
+          {endpoint.totalCpu} CPU
+        </span>
+        <span>{memoryGB} GB</span>
       </div>
 
-      <div className="mt-4 grid grid-cols-2 gap-4">
-        <div>
-          <p className="text-xs text-muted-foreground">CPU Cores</p>
-          <div className="mt-1 flex items-center gap-2">
-            <Activity className="h-4 w-4 text-muted-foreground" />
-            <span className="font-medium">{endpoint.totalCpu}</span>
-          </div>
-        </div>
-        <div>
-          <p className="text-xs text-muted-foreground">Memory</p>
-          <p className="mt-1 font-medium">{memoryGB} GB</p>
-        </div>
-      </div>
-
+      {/* Edge-specific: check-in + snapshot age */}
       {endpoint.isEdge && (
-        <div className="mt-4 space-y-1.5">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <span className="rounded bg-blue-100 px-2 py-0.5 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
-              Edge Agent {endpoint.edgeMode === 'async' ? 'Async' : 'Standard'}
-            </span>
-            {endpoint.agentVersion && <span>v{endpoint.agentVersion}</span>}
-          </div>
-          <div className="flex items-center gap-3 text-xs">
-            <span className="flex items-center gap-1 text-muted-foreground">
-              <Clock className="h-3 w-3" />
-              Check-in: {formatRelativeTime(endpoint.lastCheckIn ? Date.now() - endpoint.lastCheckIn * 1000 : null)}
-            </span>
-            <span className={cn('flex items-center gap-1', getSnapshotAgeColor(endpoint.snapshotAge))}>
-              Snapshot: {formatRelativeTime(endpoint.snapshotAge)}
-            </span>
-          </div>
+        <div className="mt-1.5 flex items-center gap-3 text-xs">
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <Clock className="h-3 w-3" />
+            Check-in: {formatRelativeTime(endpoint.lastCheckIn ? Date.now() - endpoint.lastCheckIn * 1000 : null)}
+          </span>
+          <span className={cn('flex items-center gap-1', getSnapshotAgeColor(endpoint.snapshotAge))}>
+            Snapshot: {formatRelativeTime(endpoint.snapshotAge)}
+          </span>
         </div>
       )}
 
-      <p className="mt-4 truncate text-xs text-muted-foreground">{endpoint.url}</p>
-
+      {/* View stacks link */}
       {onViewStacks && endpoint.stackCount > 0 && (
         <button
           onClick={(e) => { e.stopPropagation(); onViewStacks(); }}
-          className="mt-3 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+          className="mt-2 inline-flex items-center gap-1 text-xs text-primary hover:underline"
           data-testid="view-stacks-link"
         >
           View {endpoint.stackCount} stack{endpoint.stackCount !== 1 ? 's' : ''}
@@ -181,56 +166,30 @@ function StackCard({ stack, onClick }: { stack: StackWithEndpoint; onClick: () =
   return (
     <button
       onClick={onClick}
-      className="w-full rounded-lg border bg-card p-6 shadow-sm text-left transition-colors hover:bg-accent/50 focus:outline-none focus:ring-2 focus:ring-ring"
+      className="w-full rounded-lg border bg-card p-4 shadow-sm text-left transition-colors hover:bg-accent/50 focus:outline-none focus:ring-2 focus:ring-ring"
     >
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-3">
-          <div className={cn(
-            'rounded-lg p-2',
-            stack.status === 'active'
-              ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-              : 'bg-gray-100 text-gray-700 dark:bg-gray-900/30 dark:text-gray-400'
-          )}>
-            <Layers className="h-5 w-5" />
-          </div>
-          <div>
-            <h3 className="font-semibold">{stack.name}</h3>
-            {isInferred ? <DiscoveredBadge /> : <p className="text-xs text-muted-foreground">ID: {stack.id}</p>}
-          </div>
+      {/* Row 1: Name + ID/Discovered */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Layers className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <h3 className="font-semibold truncate">{stack.name}</h3>
         </div>
+        {isInferred ? <DiscoveredBadge /> : <span className="text-xs text-muted-foreground shrink-0">ID: {stack.id}</span>}
+      </div>
+
+      {/* Row 2: Type tag + Status badge */}
+      <div className="mt-2 flex items-center justify-between">
+        <span className="rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+          {getStackType(stack.type)}
+        </span>
         <StatusBadge status={stack.status} />
       </div>
 
-      <div className="mt-4 space-y-2">
-        <div>
-          <p className="text-xs text-muted-foreground">Endpoint</p>
-          <p className="mt-1 font-medium text-sm">
-            {stack.endpointName}
-            <span className="ml-2 text-xs text-muted-foreground">(ID: {stack.endpointId})</span>
-          </p>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <p className="text-xs text-muted-foreground">Type</p>
-            <p className="mt-1 text-sm font-medium">{getStackType(stack.type)}</p>
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">{isInferred ? 'Containers' : 'Env Vars'}</p>
-            <p className="mt-1 text-sm font-medium">{isInferred ? stack.containerCount ?? 0 : stack.envCount}</p>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <p className="text-xs text-muted-foreground">Created</p>
-            <p className="mt-1 text-sm">{formatDate(stack.createdAt)}</p>
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">Updated</p>
-            <p className="mt-1 text-sm">{formatDate(stack.updatedAt)}</p>
-          </div>
-        </div>
+      {/* Row 3: Metadata */}
+      <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        <span>{stack.endpointName}</span>
+        <span>{isInferred ? `${stack.containerCount ?? 0} containers` : `${stack.envCount} env vars`}</span>
+        <span>Created {formatDate(stack.createdAt)}</span>
       </div>
     </button>
   );
@@ -840,7 +799,7 @@ export default function InfrastructurePage() {
         {isLoading ? (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <SkeletonCard key={i} className="h-[220px]" />
+              <SkeletonCard key={i} className="h-[140px]" />
             ))}
           </div>
         ) : filteredEndpoints.length === 0 && endpoints && endpoints.length > 0 ? (
@@ -1019,7 +978,7 @@ export default function InfrastructurePage() {
         {isLoading ? (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <SkeletonCard key={i} className="h-[240px]" />
+              <SkeletonCard key={i} className="h-[140px]" />
             ))}
           </div>
         ) : filteredStacks.length === 0 ? (


### PR DESCRIPTION
## Summary
- Redesign EndpointCard and StackCard into compact 3-row layouts
- Row 1: Icon + Name / ID (or Discovered badge)
- Row 2: Type tag / Status badge
- Row 3: Inline stats metadata
- Reduces card height ~40% via tighter padding (p-6→p-4), inline stats, removed icon wrappers and URL line
- Updated skeleton heights to match new compact cards

## Test plan
- [x] 13 new unit tests for card data placement (`fleet-overview-cards.test.tsx`)
- [x] All 1541 existing tests pass
- [x] Frontend build succeeds
- [x] Docker compose build succeeds
- [ ] Visual: cards are noticeably shorter in grid view
- [ ] Visual: ID appears next to title on Row 1
- [ ] Visual: type tag on Row 2, status badge right-aligned
- [ ] Visual: all existing data still present
- [ ] Visual: text truncation for long names

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)