### PR TITLE
feat(#939): Kubernetes endpoint support — pods, deployments, services, namespaces

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "./routes/search.js": { "import": "./dist/routes/search.js", "types": "./dist/routes/search.d.ts" },
     "./routes/settings.js": { "import": "./dist/routes/settings.js", "types": "./dist/routes/settings.d.ts" },
     "./routes/stacks.js": { "import": "./dist/routes/stacks.js", "types": "./dist/routes/stacks.d.ts" },
-    "./routes/users.js": { "import": "./dist/routes/users.js", "types": "./dist/routes/users.d.ts" }
+    "./routes/users.js": { "import": "./dist/routes/users.js", "types": "./dist/routes/users.d.ts" },
+    "./routes/kubernetes.js": { "import": "./dist/routes/kubernetes.js", "types": "./dist/routes/kubernetes.d.ts" }
   },
   "scripts": {
     "dev": "tsx watch ../packages/server/src/index.ts",

--- a/backend/src/routes/containers.test.ts
+++ b/backend/src/routes/containers.test.ts
@@ -34,6 +34,7 @@ function buildApp() {
 const fakeEndpoint = (id: number, name: string, status = 1) => ({
   Id: id,
   Name: name,
+  Type: 1, // Docker local
   Status: status,
   Snapshots: [],
 });

--- a/backend/src/routes/containers.ts
+++ b/backend/src/routes/containers.ts
@@ -94,9 +94,11 @@ export async function containersRoutes(fastify: FastifyInstance) {
       });
     }
 
+    // Only target Docker endpoints — K8s endpoints use separate /api/kubernetes/ routes
+    const dockerEndpoints = endpoints.filter((e) => isDockerEndpoint(e.Type));
     const targetEndpoints = endpointId
-      ? endpoints.filter((e) => e.Id === endpointId)
-      : endpoints;
+      ? dockerEndpoints.filter((e) => e.Id === endpointId)
+      : dockerEndpoints;
 
     const allContainers: ReturnType<typeof normalizeContainer>[] = [];
     const errors: string[] = [];

--- a/backend/src/routes/containers.ts
+++ b/backend/src/routes/containers.ts
@@ -4,6 +4,7 @@ import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { normalizeContainer, normalizeEndpoint } from '@dashboard/core/portainer/portainer-normalizers.js';
 import { ContainerParamsSchema } from '@dashboard/core/models/api-schemas.js';
+import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 
 const log = createChildLogger('route:containers');
@@ -28,9 +29,11 @@ async function fetchAllContainers(endpointIdFilter?: number) {
     () => portainer.getEndpoints(),
   );
 
+  // Only target Docker endpoints — K8s endpoints use separate /api/kubernetes/ routes
+  const dockerEndpoints = endpoints.filter((e) => isDockerEndpoint(e.Type));
   const targetEndpoints = endpointIdFilter
-    ? endpoints.filter((e) => e.Id === endpointIdFilter)
-    : endpoints;
+    ? dockerEndpoints.filter((e) => e.Id === endpointIdFilter)
+    : dockerEndpoints;
 
   const results: ReturnType<typeof normalizeContainer>[] = [];
   const errors: string[] = [];

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -3,6 +3,7 @@ import { z } from 'zod/v4';
 import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { normalizeEndpoint, normalizeContainer } from '@dashboard/core/portainer/portainer-normalizers.js';
+import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { getKpiHistory, getLatestMetricsBatch } from '@dashboard/observability';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { buildSecurityAuditSummary, getSecurityAudit } from '@dashboard/security';
@@ -140,12 +141,14 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
 
     const normalized = endpoints.map(normalizeEndpoint);
     const upEndpoints = normalized.filter((e) => e.status === 'up');
+    // Only fetch Docker containers — K8s pods are served by /api/kubernetes/ routes
+    const upDockerEndpoints = upEndpoints.filter((e) => isDockerEndpoint(e.type));
 
-    // Get all containers from all up endpoints
+    // Get all containers from all up Docker endpoints
     const allContainers: Array<{ container: any; endpointId: number; endpointName: string }> = [];
     const resourceErrors: string[] = [];
     const settled = await Promise.allSettled(
-      upEndpoints.map((ep) =>
+      upDockerEndpoints.map((ep) =>
         cachedFetchSWR(
           getCacheKey('containers', ep.id),
           TTL.CONTAINERS,
@@ -337,13 +340,15 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
 
     const normalized = rawEndpoints.map(normalizeEndpoint);
     const upEndpoints = normalized.filter((e) => e.status === 'up');
+    // Only fetch Docker containers — K8s pods are served by /api/kubernetes/ routes
+    const upDockerEndpoints = upEndpoints.filter((e) => isDockerEndpoint(e.type));
 
     // Fetch all containers + build resources (timed as a single block)
     const resourcesTiming = await timed('resources', async () => {
       const allNormalizedContainers: Array<{ container: any; endpointId: number; endpointName: string }> = [];
       const errors: string[] = [];
       const settled = await Promise.allSettled(
-        upEndpoints.map((ep) =>
+        upDockerEndpoints.map((ep) =>
           cachedFetchSWR(
             getCacheKey('containers', ep.id),
             TTL.CONTAINERS,
@@ -362,7 +367,7 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
             endpointName: ep.name,
           })));
         } else {
-          const ep = upEndpoints[i];
+          const ep = upDockerEndpoints[i];
           const msg = result.reason instanceof Error ? result.reason.message : 'Unknown error';
           log.warn({ endpointId: ep.id, endpointName: ep.name, err: result.reason }, 'Failed to fetch containers for endpoint');
           errors.push(`${ep.name}: ${msg}`);

--- a/backend/src/routes/kubernetes.test.ts
+++ b/backend/src/routes/kubernetes.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import Fastify from 'fastify';
+import { kubernetesRoutes } from './kubernetes.js';
+vi.mock('@dashboard/core/portainer/portainer-client.js', async (importOriginal) => await importOriginal());
+import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
+import { flushTestCache, closeTestRedis } from '../test-utils/test-redis-helper.js';
+import { cache, waitForInFlight } from '@dashboard/core/portainer/portainer-cache.js';
+
+afterEach(async () => {
+  await waitForInFlight();
+});
+
+afterAll(async () => {
+  await closeTestRedis();
+});
+
+function buildApp() {
+  const app = Fastify();
+  app.decorate('authenticate', async () => undefined);
+  app.register(kubernetesRoutes);
+  return app;
+}
+
+// Endpoint type 5 = Kubernetes (local)
+const fakeK8sEndpoint = (id: number, name: string, status = 1) => ({
+  Id: id,
+  Name: name,
+  Type: 5,
+  Status: status,
+  Snapshots: [],
+});
+
+// Docker endpoints should be filtered OUT by K8s routes
+const fakeDockerEndpoint = (id: number, name: string, status = 1) => ({
+  Id: id,
+  Name: name,
+  Type: 1,
+  Status: status,
+  Snapshots: [],
+});
+
+const fakePod = (name: string, phase = 'Running') => ({
+  metadata: {
+    uid: `uid-${name}`,
+    name,
+    namespace: 'default',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    labels: {},
+  },
+  spec: {
+    nodeName: 'node-1',
+    containers: [{ name: 'app' }],
+  },
+  status: {
+    phase,
+    containerStatuses: [{
+      name: 'app',
+      ready: phase === 'Running',
+      restartCount: 0,
+      state: phase === 'Running' ? { running: {} } : { waiting: {} },
+    }],
+  },
+});
+
+const fakeDeployment = (name: string, replicas = 3) => ({
+  metadata: {
+    uid: `uid-${name}`,
+    name,
+    namespace: 'default',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    labels: {},
+  },
+  spec: { replicas },
+  status: {
+    replicas,
+    readyReplicas: replicas,
+    availableReplicas: replicas,
+    updatedReplicas: replicas,
+  },
+});
+
+const fakeService = (name: string) => ({
+  metadata: {
+    uid: `uid-${name}`,
+    name,
+    namespace: 'default',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    labels: {},
+  },
+  spec: {
+    type: 'ClusterIP',
+    clusterIP: '10.96.0.1',
+    ports: [{ port: 80, targetPort: 8080, protocol: 'TCP' }],
+  },
+});
+
+const fakeNamespace = (name: string) => ({
+  metadata: {
+    uid: `uid-${name}`,
+    name,
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    labels: {},
+  },
+  status: { phase: 'Active' },
+});
+
+describe('kubernetes routes', () => {
+  beforeEach(async () => {
+    await cache.clear();
+    await flushTestCache();
+    vi.restoreAllMocks();
+  });
+
+  describe('GET /api/kubernetes/pods', () => {
+    it('should return pods from K8s endpoints only', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeK8sEndpoint(10, 'k8s-cluster'),
+        fakeDockerEndpoint(1, 'docker-host'),
+      ] as any);
+      vi.spyOn(portainerClient, 'getPods').mockResolvedValue([
+        fakePod('nginx-abc'),
+        fakePod('redis-def'),
+      ] as any);
+
+      const app = buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/pods',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.pods).toHaveLength(2);
+      expect(body.pods[0].name).toBe('nginx-abc');
+      expect(body.pods[0].endpointId).toBe(10);
+      expect(body.pods[0].endpointName).toBe('k8s-cluster');
+      expect(body.pods[0].resourceType).toBe('pod');
+      // getPods should NOT have been called with docker endpoint ID
+      expect(portainerClient.getPods).toHaveBeenCalledTimes(1);
+      expect(portainerClient.getPods).toHaveBeenCalledWith(10, undefined);
+    });
+
+    it('should filter by namespace', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeK8sEndpoint(10, 'k8s-cluster'),
+      ] as any);
+      vi.spyOn(portainerClient, 'getPods').mockResolvedValue([
+        fakePod('app-1'),
+      ] as any);
+
+      const app = buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/pods?namespace=kube-system',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(portainerClient.getPods).toHaveBeenCalledWith(10, 'kube-system');
+    });
+
+    it('should return partial results when some endpoints fail', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeK8sEndpoint(10, 'k8s-1'),
+        fakeK8sEndpoint(20, 'k8s-2'),
+      ] as any);
+      vi.spyOn(portainerClient, 'getPods').mockImplementation(async (epId: number) => {
+        if (epId === 20) throw new Error('Connection refused');
+        return [fakePod('working-pod')] as any;
+      });
+
+      const app = buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/pods',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.pods).toHaveLength(1);
+      expect(body.errors).toHaveLength(1);
+      expect(body.partial).toBe(true);
+    });
+  });
+
+  describe('GET /api/kubernetes/deployments', () => {
+    it('should return deployments from K8s endpoints', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeK8sEndpoint(10, 'k8s-cluster'),
+      ] as any);
+      vi.spyOn(portainerClient, 'getDeployments').mockResolvedValue([
+        fakeDeployment('web-app'),
+      ] as any);
+
+      const app = buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/deployments',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.deployments).toHaveLength(1);
+      expect(body.deployments[0].name).toBe('web-app');
+      expect(body.deployments[0].replicas).toBe(3);
+      expect(body.deployments[0].resourceType).toBe('deployment');
+    });
+  });
+
+  describe('GET /api/kubernetes/services', () => {
+    it('should return services from K8s endpoints', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeK8sEndpoint(10, 'k8s-cluster'),
+      ] as any);
+      vi.spyOn(portainerClient, 'getServices').mockResolvedValue([
+        fakeService('api-svc'),
+      ] as any);
+
+      const app = buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/services',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.services).toHaveLength(1);
+      expect(body.services[0].name).toBe('api-svc');
+      expect(body.services[0].serviceType).toBe('ClusterIP');
+      expect(body.services[0].resourceType).toBe('service');
+    });
+  });
+
+  describe('GET /api/kubernetes/namespaces', () => {
+    it('should return namespaces from K8s endpoints', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeK8sEndpoint(10, 'k8s-cluster'),
+      ] as any);
+      vi.spyOn(portainerClient, 'getNamespaces').mockResolvedValue([
+        fakeNamespace('default'),
+        fakeNamespace('kube-system'),
+      ] as any);
+
+      const app = buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/namespaces',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.namespaces).toHaveLength(2);
+      expect(body.namespaces[0].name).toBe('default');
+      expect(body.namespaces[0].resourceType).toBe('namespace');
+    });
+  });
+
+  describe('GET /api/kubernetes/summary', () => {
+    it('should return pod counts by state', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeK8sEndpoint(10, 'k8s-cluster'),
+      ] as any);
+      vi.spyOn(portainerClient, 'getPods').mockResolvedValue([
+        fakePod('running-1', 'Running'),
+        fakePod('running-2', 'Running'),
+        fakePod('pending-1', 'Pending'),
+        fakePod('failed-1', 'Failed'),
+      ] as any);
+
+      const app = buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/summary',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.total).toBe(4);
+      expect(body.running).toBe(2);
+      expect(body.pending).toBe(1);
+      expect(body.failed).toBe(1);
+      expect(body.endpointCount).toBe(1);
+    });
+
+    it('should exclude Docker endpoints from summary', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeK8sEndpoint(10, 'k8s-cluster'),
+        fakeDockerEndpoint(1, 'docker-host'),
+      ] as any);
+      vi.spyOn(portainerClient, 'getPods').mockResolvedValue([
+        fakePod('pod-1'),
+      ] as any);
+
+      const app = buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/summary',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      // Only K8s endpoint should be counted
+      expect(body.endpointCount).toBe(1);
+      expect(body.total).toBe(1);
+    });
+  });
+
+  describe('GET /api/kubernetes/pods/:endpointId/:namespace/:podName/logs', () => {
+    it('should return pod logs', async () => {
+      vi.spyOn(portainerClient, 'getPodLogs').mockResolvedValue(
+        '2024-01-01T00:00:00Z Starting server...\n2024-01-01T00:00:01Z Listening on :8080\n',
+      );
+
+      const app = buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/pods/10/default/nginx-abc/logs?tail=100',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.logs).toContain('Starting server');
+      expect(portainerClient.getPodLogs).toHaveBeenCalledWith(
+        10, 'default', 'nginx-abc',
+        expect.objectContaining({ tail: 100 }),
+      );
+    });
+  });
+});

--- a/backend/src/routes/kubernetes.ts
+++ b/backend/src/routes/kubernetes.ts
@@ -1,0 +1,318 @@
+import { FastifyInstance } from 'fastify';
+import * as portainer from '@dashboard/core/portainer/portainer-client.js';
+import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
+import {
+  normalizePod,
+  normalizeDeployment,
+  normalizeService,
+  normalizeNamespace,
+  normalizeEndpoint,
+} from '@dashboard/core/portainer/portainer-normalizers.js';
+import { isKubernetesEndpoint } from '@dashboard/core/models/portainer.js';
+import { createChildLogger } from '@dashboard/core/utils/logger.js';
+
+const log = createChildLogger('kubernetes-routes');
+
+/** Get all "up" Kubernetes endpoints, normalized. */
+async function getK8sEndpoints() {
+  const endpoints = await cachedFetch(
+    getCacheKey('endpoints'),
+    TTL.ENDPOINTS,
+    () => portainer.getEndpoints(),
+  );
+  return endpoints
+    .filter((ep) => isKubernetesEndpoint(ep.Type))
+    .map(normalizeEndpoint)
+    .filter((ep) => ep.status === 'up');
+}
+
+export async function kubernetesRoutes(fastify: FastifyInstance) {
+  // ── Pods ───────────────────────────────────────────────────────────────────
+  fastify.get('/api/kubernetes/pods', {
+    schema: {
+      tags: ['Kubernetes'],
+      summary: 'List pods across all Kubernetes endpoints',
+      security: [{ bearerAuth: [] }],
+      querystring: {
+        type: 'object',
+        properties: {
+          namespace: { type: 'string' },
+          endpointId: { type: 'number' },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request) => {
+    const { namespace, endpointId } = request.query as { namespace?: string; endpointId?: number };
+    const endpoints = await getK8sEndpoints();
+    const filtered = endpointId ? endpoints.filter((ep) => ep.id === endpointId) : endpoints;
+
+    const results = await Promise.allSettled(
+      filtered.map(async (ep) => {
+        const pods = await cachedFetch(
+          getCacheKey('k8s-pods', ep.id, namespace ?? 'all'),
+          TTL.K8S_PODS,
+          () => portainer.getPods(ep.id, namespace),
+        );
+        return pods.map((pod) => normalizePod(pod, ep.id, ep.name));
+      }),
+    );
+
+    const pods = [];
+    const errors = [];
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        pods.push(...result.value);
+      } else {
+        const ep = filtered[i];
+        log.warn({ endpointId: ep.id, err: result.reason }, 'Failed to fetch pods');
+        errors.push({ endpointId: ep.id, endpointName: ep.name, error: String(result.reason) });
+      }
+    }
+
+    return { pods, errors, partial: errors.length > 0 };
+  });
+
+  // ── Deployments ────────────────────────────────────────────────────────────
+  fastify.get('/api/kubernetes/deployments', {
+    schema: {
+      tags: ['Kubernetes'],
+      summary: 'List deployments across all Kubernetes endpoints',
+      security: [{ bearerAuth: [] }],
+      querystring: {
+        type: 'object',
+        properties: {
+          namespace: { type: 'string' },
+          endpointId: { type: 'number' },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request) => {
+    const { namespace, endpointId } = request.query as { namespace?: string; endpointId?: number };
+    const endpoints = await getK8sEndpoints();
+    const filtered = endpointId ? endpoints.filter((ep) => ep.id === endpointId) : endpoints;
+
+    const results = await Promise.allSettled(
+      filtered.map(async (ep) => {
+        const deployments = await cachedFetch(
+          getCacheKey('k8s-deployments', ep.id, namespace ?? 'all'),
+          TTL.K8S_DEPLOYMENTS,
+          () => portainer.getDeployments(ep.id, namespace),
+        );
+        return deployments.map((dep) => normalizeDeployment(dep, ep.id, ep.name));
+      }),
+    );
+
+    const deployments = [];
+    const errors = [];
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        deployments.push(...result.value);
+      } else {
+        const ep = filtered[i];
+        log.warn({ endpointId: ep.id, err: result.reason }, 'Failed to fetch deployments');
+        errors.push({ endpointId: ep.id, endpointName: ep.name, error: String(result.reason) });
+      }
+    }
+
+    return { deployments, errors, partial: errors.length > 0 };
+  });
+
+  // ── Services ───────────────────────────────────────────────────────────────
+  fastify.get('/api/kubernetes/services', {
+    schema: {
+      tags: ['Kubernetes'],
+      summary: 'List services across all Kubernetes endpoints',
+      security: [{ bearerAuth: [] }],
+      querystring: {
+        type: 'object',
+        properties: {
+          namespace: { type: 'string' },
+          endpointId: { type: 'number' },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request) => {
+    const { namespace, endpointId } = request.query as { namespace?: string; endpointId?: number };
+    const endpoints = await getK8sEndpoints();
+    const filtered = endpointId ? endpoints.filter((ep) => ep.id === endpointId) : endpoints;
+
+    const results = await Promise.allSettled(
+      filtered.map(async (ep) => {
+        const services = await cachedFetch(
+          getCacheKey('k8s-services', ep.id, namespace ?? 'all'),
+          TTL.K8S_SERVICES,
+          () => portainer.getServices(ep.id, namespace),
+        );
+        return services.map((svc) => normalizeService(svc, ep.id, ep.name));
+      }),
+    );
+
+    const services = [];
+    const errors = [];
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        services.push(...result.value);
+      } else {
+        const ep = filtered[i];
+        log.warn({ endpointId: ep.id, err: result.reason }, 'Failed to fetch services');
+        errors.push({ endpointId: ep.id, endpointName: ep.name, error: String(result.reason) });
+      }
+    }
+
+    return { services, errors, partial: errors.length > 0 };
+  });
+
+  // ── Namespaces ─────────────────────────────────────────────────────────────
+  fastify.get('/api/kubernetes/namespaces', {
+    schema: {
+      tags: ['Kubernetes'],
+      summary: 'List namespaces across all Kubernetes endpoints',
+      security: [{ bearerAuth: [] }],
+      querystring: {
+        type: 'object',
+        properties: {
+          endpointId: { type: 'number' },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request) => {
+    const { endpointId } = request.query as { endpointId?: number };
+    const endpoints = await getK8sEndpoints();
+    const filtered = endpointId ? endpoints.filter((ep) => ep.id === endpointId) : endpoints;
+
+    const results = await Promise.allSettled(
+      filtered.map(async (ep) => {
+        const namespaces = await cachedFetch(
+          getCacheKey('k8s-namespaces', ep.id),
+          TTL.K8S_NAMESPACES,
+          () => portainer.getNamespaces(ep.id),
+        );
+        return namespaces.map((ns) => normalizeNamespace(ns, ep.id, ep.name));
+      }),
+    );
+
+    const namespaces = [];
+    const errors = [];
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        namespaces.push(...result.value);
+      } else {
+        const ep = filtered[i];
+        log.warn({ endpointId: ep.id, err: result.reason }, 'Failed to fetch namespaces');
+        errors.push({ endpointId: ep.id, endpointName: ep.name, error: String(result.reason) });
+      }
+    }
+
+    return { namespaces, errors, partial: errors.length > 0 };
+  });
+
+  // ── Pod Logs (read-only) ──────────────────────────────────────────────────
+  fastify.get('/api/kubernetes/pods/:endpointId/:namespace/:podName/logs', {
+    schema: {
+      tags: ['Kubernetes'],
+      summary: 'Get pod logs (read-only)',
+      security: [{ bearerAuth: [] }],
+      params: {
+        type: 'object',
+        required: ['endpointId', 'namespace', 'podName'],
+        properties: {
+          endpointId: { type: 'number' },
+          namespace: { type: 'string' },
+          podName: { type: 'string' },
+        },
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          tail: { type: 'number', default: 100 },
+          sinceSeconds: { type: 'number' },
+          timestamps: { type: 'boolean', default: true },
+          container: { type: 'string' },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request) => {
+    const { endpointId, namespace, podName } = request.params as {
+      endpointId: number;
+      namespace: string;
+      podName: string;
+    };
+    const { tail, sinceSeconds, timestamps, container } = request.query as {
+      tail?: number;
+      sinceSeconds?: number;
+      timestamps?: boolean;
+      container?: string;
+    };
+
+    const logs = await portainer.getPodLogs(endpointId, namespace, podName, {
+      tail,
+      sinceSeconds,
+      timestamps,
+      container,
+    });
+    return { logs };
+  });
+
+  // ── Summary (for dashboard KPIs) ──────────────────────────────────────────
+  fastify.get('/api/kubernetes/summary', {
+    schema: {
+      tags: ['Kubernetes'],
+      summary: 'Kubernetes cluster summary (pod counts by state)',
+      security: [{ bearerAuth: [] }],
+    },
+    preHandler: [fastify.authenticate],
+  }, async () => {
+    const endpoints = await getK8sEndpoints();
+
+    const results = await Promise.allSettled(
+      endpoints.map(async (ep) => {
+        const pods = await cachedFetch(
+          getCacheKey('k8s-pods', ep.id, 'all'),
+          TTL.K8S_PODS,
+          () => portainer.getPods(ep.id),
+        );
+        return pods.map((pod) => normalizePod(pod, ep.id, ep.name));
+      }),
+    );
+
+    let running = 0;
+    let pending = 0;
+    let failed = 0;
+    let succeeded = 0;
+    let unknown = 0;
+    const allPods = [];
+
+    for (const result of results) {
+      if (result.status !== 'fulfilled') continue;
+      for (const pod of result.value) {
+        allPods.push(pod);
+        switch (pod.state) {
+          case 'running': running++; break;
+          case 'pending': pending++; break;
+          case 'failed': failed++; break;
+          case 'succeeded': succeeded++; break;
+          default: unknown++; break;
+        }
+      }
+    }
+
+    return {
+      total: allPods.length,
+      running,
+      pending,
+      failed,
+      succeeded,
+      unknown,
+      endpointCount: endpoints.length,
+    };
+  });
+}

--- a/backend/src/routes/kubernetes.ts
+++ b/backend/src/routes/kubernetes.ts
@@ -240,7 +240,7 @@ export async function kubernetesRoutes(fastify: FastifyInstance) {
       },
     },
     preHandler: [fastify.authenticate],
-  }, async (request) => {
+  }, async (request, reply) => {
     const { endpointId, namespace, podName } = request.params as {
       endpointId: number;
       namespace: string;
@@ -253,13 +253,19 @@ export async function kubernetesRoutes(fastify: FastifyInstance) {
       container?: string;
     };
 
-    const logs = await portainer.getPodLogs(endpointId, namespace, podName, {
-      tail,
-      sinceSeconds,
-      timestamps,
-      container,
-    });
-    return { logs };
+    try {
+      const logs = await portainer.getPodLogs(endpointId, namespace, podName, {
+        tail,
+        sinceSeconds,
+        timestamps,
+        container,
+      });
+      return { logs };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err, endpointId, namespace, podName }, 'Failed to fetch pod logs');
+      return reply.code(502).send({ error: 'Unable to fetch pod logs from Portainer', details: msg });
+    }
   });
 
   // ── Summary (for dashboard KPIs) ──────────────────────────────────────────

--- a/backend/src/routes/search.test.ts
+++ b/backend/src/routes/search.test.ts
@@ -23,7 +23,7 @@ let mockGetContainerLogs: any;
 
 function seedPortainerMocks() {
   mockGetEndpoints.mockResolvedValue([
-    { Id: 1, Name: 'prod', Status: 1 },
+    { Id: 1, Name: 'prod', Type: 1, Status: 1 },
   ] as any);
 
   mockGetContainers.mockResolvedValue([
@@ -149,8 +149,8 @@ describe('Search Routes', () => {
   it('fetches containers and images in parallel across multiple endpoints', async () => {
     // Two endpoints — verify containers and images are fetched for both
     mockGetEndpoints.mockResolvedValue([
-      { Id: 1, Name: 'prod', Status: 1 },
-      { Id: 2, Name: 'staging', Status: 1 },
+      { Id: 1, Name: 'prod', Type: 1, Status: 1 },
+      { Id: 2, Name: 'staging', Type: 1, Status: 1 },
     ] as any);
 
     mockGetContainers.mockResolvedValue([
@@ -187,8 +187,8 @@ describe('Search Routes', () => {
 
   it('returns partial results when one endpoint fails', async () => {
     mockGetEndpoints.mockResolvedValue([
-      { Id: 1, Name: 'prod', Status: 1 },
-      { Id: 2, Name: 'broken', Status: 1 },
+      { Id: 1, Name: 'prod', Type: 1, Status: 1 },
+      { Id: 2, Name: 'broken', Type: 1, Status: 1 },
     ] as any);
 
     mockGetContainers

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -4,6 +4,7 @@ import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { normalizeContainer, normalizeEndpoint, normalizeStack } from '@dashboard/core/portainer/portainer-normalizers.js';
 import { supportsLiveFeatures } from '@dashboard/infrastructure';
+import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { SearchQuerySchema } from '@dashboard/core/models/api-schemas.js';
 
@@ -89,10 +90,10 @@ async function searchContainerLogs(
     () => portainer.getEndpoints(),
   );
 
-  // Fetch containers from all endpoints in parallel
+  // Fetch containers from Docker endpoints only — K8s pods are searched separately
   const upEndpoints = endpoints
     .map(normalizeEndpoint)
-    .filter((ep) => ep.status === 'up');
+    .filter((ep) => ep.status === 'up' && isDockerEndpoint(ep.type));
 
   const containerResults = await Promise.allSettled(
     upEndpoints.map(async (ep) => {
@@ -216,9 +217,9 @@ export async function searchRoutes(fastify: FastifyInstance) {
       () => portainer.getEndpoints(),
     );
 
-    const upEndpoints = endpoints.map(normalizeEndpoint).filter((ep) => ep.status === 'up');
+    const upEndpoints = endpoints.map(normalizeEndpoint).filter((ep) => ep.status === 'up' && isDockerEndpoint(ep.type));
 
-    // Fetch containers, images, and stacks in parallel across all endpoints
+    // Fetch containers, images, and stacks in parallel across all Docker endpoints
     const [endpointResults, stacksRaw] = await Promise.all([
       Promise.allSettled(
         upEndpoints.map(async (ep) => {

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -9,6 +9,7 @@ import {
   type NormalizedStack,
 } from '@dashboard/core/portainer/portainer-normalizers.js';
 import { StackIdParamsSchema } from '@dashboard/core/models/api-schemas.js';
+import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 
 const log = createChildLogger('route:stacks');
@@ -35,7 +36,8 @@ export async function stacksRoutes(fastify: FastifyInstance) {
       return reply.code(502).send({ error: 'Unable to connect to Portainer', details: msg });
     }
 
-    const upEndpoints = endpoints.filter((ep) => normalizeEndpoint(ep).status === 'up');
+    // Only Docker endpoints have stacks/compose — K8s uses Helm charts (not yet supported)
+    const upEndpoints = endpoints.filter((ep) => isDockerEndpoint(ep.Type) && normalizeEndpoint(ep).status === 'up');
     const seen = new Set<number>();
     const results: NormalizedStack[] = [];
     const errors: string[] = [];

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -5,6 +5,7 @@ import * as Tabs from '@radix-ui/react-tabs';
 import {
   Server, Layers, LayoutGrid, List, AlertTriangle,
   ChevronLeft, ChevronRight, Search, ArrowRight, X,
+  Box,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useEndpoints, type Endpoint } from '@/features/containers/hooks/use-endpoints';
@@ -24,13 +25,14 @@ import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { FleetStatusSummary } from '@/features/containers/components/fleet/fleet-status-summary';
 import { FleetSearch } from '@/features/containers/components/fleet/fleet-search';
 import { filterEndpoints, filterStacks, type StackWithEndpoint } from '@/features/containers/lib/fleet-search-filter';
+import { useK8sPods, useK8sDeployments, useK8sServices, useK8sNamespaces, type K8sPod, type K8sDeployment, type K8sService } from '@/features/kubernetes/hooks/use-kubernetes';
 
 const FLEET_GRID_PAGE_SIZE = 30;
 const AUTO_TABLE_THRESHOLD = 100;
 const ALL_FILTER = '__all__';
 
-type InfraTab = 'fleet' | 'stacks';
-const VALID_TABS: InfraTab[] = ['fleet', 'stacks'];
+type InfraTab = 'fleet' | 'stacks' | 'kubernetes';
+const VALID_TABS: InfraTab[] = ['fleet', 'stacks', 'kubernetes'];
 const TAB_TRIGGER_CLASS =
   'flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors hover:text-primary data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary';
 
@@ -304,6 +306,25 @@ export default function InfrastructurePage() {
     refetch: refetchStacks,
     isFetching: stacksFetching,
   } = useStacks();
+
+  // Kubernetes data
+  const {
+    data: k8sPods,
+    isLoading: k8sPodsLoading,
+    refetch: refetchK8sPods,
+    isFetching: k8sPodsFetching,
+  } = useK8sPods();
+  const {
+    data: k8sDeployments,
+    isLoading: k8sDeploymentsLoading,
+  } = useK8sDeployments();
+  const {
+    data: k8sServices,
+    isLoading: k8sServicesLoading,
+  } = useK8sServices();
+  const {
+    data: k8sNamespaces,
+  } = useK8sNamespaces();
 
   const isLoading = endpointsLoading || stacksLoading;
   const isFetching = endpointsFetching || stacksFetching;
@@ -677,6 +698,118 @@ export default function InfrastructurePage() {
     },
   ], []);
 
+  // ── Kubernetes column definitions ───────────────────────────────────────────
+  const k8sPodColumns: ColumnDef<K8sPod, unknown>[] = useMemo(() => [
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      cell: ({ row }) => (
+        <div>
+          <span className="font-medium">{row.original.name}</span>
+          <span className="ml-2 text-xs text-muted-foreground">{row.original.namespace}</span>
+        </div>
+      ),
+    },
+    {
+      accessorKey: 'state',
+      header: 'State',
+      cell: ({ row }) => <StatusBadge status={row.original.state === 'running' ? 'healthy' : row.original.state === 'pending' ? 'warning' : row.original.state === 'failed' ? 'error' : row.original.state} />,
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ getValue }) => <span className="text-xs text-muted-foreground">{getValue<string>()}</span>,
+    },
+    {
+      id: 'ready',
+      header: 'Ready',
+      cell: ({ row }) => `${row.original.containers.filter((c) => c.ready).length}/${row.original.containers.length}`,
+    },
+    {
+      accessorKey: 'restarts',
+      header: 'Restarts',
+    },
+    {
+      accessorKey: 'nodeName',
+      header: 'Node',
+      cell: ({ getValue }) => <span className="text-xs">{getValue<string>()}</span>,
+    },
+    {
+      accessorKey: 'endpointName',
+      header: 'Cluster',
+      cell: ({ getValue }) => <span className="text-xs text-muted-foreground">{getValue<string>()}</span>,
+    },
+  ], []);
+
+  const k8sDeploymentColumns: ColumnDef<K8sDeployment, unknown>[] = useMemo(() => [
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      cell: ({ row }) => (
+        <div>
+          <span className="font-medium">{row.original.name}</span>
+          <span className="ml-2 text-xs text-muted-foreground">{row.original.namespace}</span>
+        </div>
+      ),
+    },
+    {
+      id: 'ready',
+      header: 'Ready',
+      cell: ({ row }) => `${row.original.readyReplicas ?? 0}/${row.original.replicas}`,
+    },
+    {
+      id: 'upToDate',
+      header: 'Up-to-date',
+      cell: ({ row }) => row.original.updatedReplicas ?? 0,
+    },
+    {
+      id: 'available',
+      header: 'Available',
+      cell: ({ row }) => row.original.availableReplicas ?? 0,
+    },
+    {
+      accessorKey: 'endpointName',
+      header: 'Cluster',
+      cell: ({ getValue }) => <span className="text-xs text-muted-foreground">{getValue<string>()}</span>,
+    },
+  ], []);
+
+  const k8sServiceColumns: ColumnDef<K8sService, unknown>[] = useMemo(() => [
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      cell: ({ row }) => (
+        <div>
+          <span className="font-medium">{row.original.name}</span>
+          <span className="ml-2 text-xs text-muted-foreground">{row.original.namespace}</span>
+        </div>
+      ),
+    },
+    {
+      accessorKey: 'serviceType',
+      header: 'Type',
+    },
+    {
+      accessorKey: 'clusterIP',
+      header: 'Cluster IP',
+      cell: ({ getValue }) => <span className="text-xs font-mono">{getValue<string>()}</span>,
+    },
+    {
+      id: 'ports',
+      header: 'Ports',
+      cell: ({ row }) => (
+        <span className="text-xs font-mono">
+          {row.original.ports.map((p) => `${p.port}/${p.protocol}`).join(', ')}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'endpointName',
+      header: 'Cluster',
+      cell: ({ getValue }) => <span className="text-xs text-muted-foreground">{getValue<string>()}</span>,
+    },
+  ], []);
+
   const hasError = endpointsError || stacksError;
   const errorMessage = endpointsError
     ? (endpointErrorObj instanceof Error ? endpointErrorObj.message : 'Failed to load endpoints')
@@ -741,6 +874,15 @@ export default function InfrastructurePage() {
           <Tabs.Trigger value="stacks" className={TAB_TRIGGER_CLASS} data-testid="tab-stacks">
             <Layers className="h-4 w-4" />
             Stack Overview
+          </Tabs.Trigger>
+          <Tabs.Trigger value="kubernetes" className={TAB_TRIGGER_CLASS} data-testid="tab-kubernetes">
+            <Box className="h-4 w-4" />
+            Kubernetes
+            {k8sPods && k8sPods.length > 0 && (
+              <span className="ml-1 rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-semibold text-primary">
+                {k8sPods.length}
+              </span>
+            )}
           </Tabs.Trigger>
         </Tabs.List>
 
@@ -1070,6 +1212,89 @@ export default function InfrastructurePage() {
               searchPlaceholder="Search stacks..."
               pageSize={15}
               onRowClick={handleStackClick}
+            />
+          </div>
+          </SpotlightCard>
+        )}
+      </section>
+        </Tabs.Content>
+
+        <Tabs.Content value="kubernetes" className="mt-4">
+      <section aria-labelledby="k8s-heading" className="space-y-4">
+        <h2 id="k8s-heading" className="sr-only">Kubernetes Resources</h2>
+
+        {/* K8s summary bar */}
+        <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-card p-3 shadow-sm text-sm">
+          <span className="font-medium">Kubernetes</span>
+          <span className="text-muted-foreground">
+            {k8sPods?.length ?? 0} pods
+          </span>
+          <span className="text-muted-foreground">
+            {k8sDeployments?.length ?? 0} deployments
+          </span>
+          <span className="text-muted-foreground">
+            {k8sServices?.length ?? 0} services
+          </span>
+          <span className="text-muted-foreground">
+            {k8sNamespaces?.length ?? 0} namespaces
+          </span>
+          <div className="ml-auto">
+            <RefreshButton
+              onClick={() => refetchK8sPods()}
+              isLoading={k8sPodsFetching}
+            />
+          </div>
+        </div>
+
+        {/* Pods table */}
+        {k8sPodsLoading ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
+          </div>
+        ) : (
+          <SpotlightCard>
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <h3 className="mb-4 text-sm font-semibold">Pods</h3>
+            <DataTable
+              columns={k8sPodColumns}
+              data={k8sPods ?? []}
+              searchKey="name"
+              searchPlaceholder="Search pods..."
+              pageSize={15}
+            />
+          </div>
+          </SpotlightCard>
+        )}
+
+        {/* Deployments table */}
+        {!k8sDeploymentsLoading && k8sDeployments && k8sDeployments.length > 0 && (
+          <SpotlightCard>
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <h3 className="mb-4 text-sm font-semibold">Deployments</h3>
+            <DataTable
+              columns={k8sDeploymentColumns}
+              data={k8sDeployments}
+              searchKey="name"
+              searchPlaceholder="Search deployments..."
+              pageSize={15}
+            />
+          </div>
+          </SpotlightCard>
+        )}
+
+        {/* Services table */}
+        {!k8sServicesLoading && k8sServices && k8sServices.length > 0 && (
+          <SpotlightCard>
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <h3 className="mb-4 text-sm font-semibold">Services</h3>
+            <DataTable
+              columns={k8sServiceColumns}
+              data={k8sServices}
+              searchKey="name"
+              searchPlaceholder="Search services..."
+              pageSize={15}
             />
           </div>
           </SpotlightCard>

--- a/frontend/src/features/kubernetes/hooks/use-kubernetes.ts
+++ b/frontend/src/features/kubernetes/hooks/use-kubernetes.ts
@@ -1,0 +1,200 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/shared/lib/api';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface K8sPod {
+  id: string;
+  name: string;
+  namespace: string;
+  images: string[];
+  state: 'running' | 'pending' | 'succeeded' | 'failed' | 'unknown';
+  status: string;
+  restarts: number;
+  created: number;
+  nodeName?: string;
+  podIP?: string;
+  endpointId: number;
+  endpointName: string;
+  labels: Record<string, string>;
+  containers: Array<{ name: string; image?: string; ready: boolean; restartCount: number }>;
+  resourceType: 'pod';
+}
+
+export interface K8sDeployment {
+  id: string;
+  name: string;
+  namespace: string;
+  images: string[];
+  replicas: number;
+  readyReplicas: number;
+  availableReplicas: number;
+  updatedReplicas: number;
+  created: number;
+  labels: Record<string, string>;
+  endpointId: number;
+  endpointName: string;
+  resourceType: 'deployment';
+}
+
+export interface K8sService {
+  id: string;
+  name: string;
+  namespace: string;
+  serviceType: string;
+  clusterIP: string;
+  ports: Array<{
+    name?: string;
+    port: number;
+    targetPort: number | string;
+    protocol: string;
+    nodePort?: number;
+  }>;
+  created: number;
+  labels: Record<string, string>;
+  endpointId: number;
+  endpointName: string;
+  resourceType: 'service';
+}
+
+export interface K8sNamespace {
+  id: string;
+  name: string;
+  status: string;
+  created: number;
+  labels: Record<string, string>;
+  endpointId: number;
+  endpointName: string;
+  resourceType: 'namespace';
+}
+
+export interface K8sSummary {
+  total: number;
+  running: number;
+  pending: number;
+  failed: number;
+  succeeded: number;
+  unknown: number;
+  endpointCount: number;
+}
+
+interface K8sListResponse<T> {
+  pods?: T[];
+  deployments?: T[];
+  services?: T[];
+  namespaces?: T[];
+  errors: Array<{ endpointId: number; endpointName: string; error: string }>;
+  partial: boolean;
+}
+
+// ── Hooks ─────────────────────────────────────────────────────────────────────
+
+export function useK8sPods(params?: { namespace?: string; endpointId?: number }) {
+  const { namespace, endpointId } = params ?? {};
+
+  return useQuery<K8sPod[]>({
+    queryKey: ['kubernetes', 'pods', { namespace, endpointId }],
+    queryFn: async () => {
+      const searchParams = new URLSearchParams();
+      if (namespace) searchParams.set('namespace', namespace);
+      if (endpointId !== undefined) searchParams.set('endpointId', String(endpointId));
+      const qs = searchParams.toString();
+      const path = qs ? `/api/kubernetes/pods?${qs}` : '/api/kubernetes/pods';
+      const res = await api.get<K8sListResponse<K8sPod>>(path);
+      return res.pods ?? [];
+    },
+    staleTime: STALE_TIMES.LONG,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useK8sDeployments(params?: { namespace?: string; endpointId?: number }) {
+  const { namespace, endpointId } = params ?? {};
+
+  return useQuery<K8sDeployment[]>({
+    queryKey: ['kubernetes', 'deployments', { namespace, endpointId }],
+    queryFn: async () => {
+      const searchParams = new URLSearchParams();
+      if (namespace) searchParams.set('namespace', namespace);
+      if (endpointId !== undefined) searchParams.set('endpointId', String(endpointId));
+      const qs = searchParams.toString();
+      const path = qs ? `/api/kubernetes/deployments?${qs}` : '/api/kubernetes/deployments';
+      const res = await api.get<K8sListResponse<K8sDeployment>>(path);
+      return res.deployments ?? [];
+    },
+    staleTime: STALE_TIMES.LONG,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useK8sServices(params?: { namespace?: string; endpointId?: number }) {
+  const { namespace, endpointId } = params ?? {};
+
+  return useQuery<K8sService[]>({
+    queryKey: ['kubernetes', 'services', { namespace, endpointId }],
+    queryFn: async () => {
+      const searchParams = new URLSearchParams();
+      if (namespace) searchParams.set('namespace', namespace);
+      if (endpointId !== undefined) searchParams.set('endpointId', String(endpointId));
+      const qs = searchParams.toString();
+      const path = qs ? `/api/kubernetes/services?${qs}` : '/api/kubernetes/services';
+      const res = await api.get<K8sListResponse<K8sService>>(path);
+      return res.services ?? [];
+    },
+    staleTime: STALE_TIMES.LONG,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useK8sNamespaces(params?: { endpointId?: number }) {
+  const { endpointId } = params ?? {};
+
+  return useQuery<K8sNamespace[]>({
+    queryKey: ['kubernetes', 'namespaces', { endpointId }],
+    queryFn: async () => {
+      const searchParams = new URLSearchParams();
+      if (endpointId !== undefined) searchParams.set('endpointId', String(endpointId));
+      const qs = searchParams.toString();
+      const path = qs ? `/api/kubernetes/namespaces?${qs}` : '/api/kubernetes/namespaces';
+      const res = await api.get<K8sListResponse<K8sNamespace>>(path);
+      return res.namespaces ?? [];
+    },
+    staleTime: STALE_TIMES.LONG,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useK8sSummary() {
+  return useQuery<K8sSummary>({
+    queryKey: ['kubernetes', 'summary'],
+    queryFn: () => api.get<K8sSummary>('/api/kubernetes/summary'),
+    staleTime: STALE_TIMES.LONG,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useK8sPodLogs(
+  endpointId: number,
+  namespace: string,
+  podName: string,
+  options?: { tail?: number; sinceSeconds?: number; container?: string },
+) {
+  return useQuery<{ logs: string }>({
+    queryKey: ['kubernetes', 'pod-logs', endpointId, namespace, podName, options],
+    queryFn: async () => {
+      const searchParams = new URLSearchParams();
+      if (options?.tail !== undefined) searchParams.set('tail', String(options.tail));
+      if (options?.sinceSeconds !== undefined) searchParams.set('sinceSeconds', String(options.sinceSeconds));
+      if (options?.container) searchParams.set('container', options.container);
+      searchParams.set('timestamps', 'true');
+      const qs = searchParams.toString();
+      return api.get<{ logs: string }>(
+        `/api/kubernetes/pods/${endpointId}/${encodeURIComponent(namespace)}/${encodeURIComponent(podName)}/logs?${qs}`,
+      );
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+    enabled: !!endpointId && !!namespace && !!podName,
+  });
+}

--- a/frontend/src/features/kubernetes/hooks/use-kubernetes.ts
+++ b/frontend/src/features/kubernetes/hooks/use-kubernetes.ts
@@ -43,7 +43,7 @@ export interface K8sService {
   name: string;
   namespace: string;
   serviceType: string;
-  clusterIP: string;
+  clusterIP?: string;
   ports: Array<{
     name?: string;
     port: number;

--- a/packages/ai-intelligence/src/routes/llm.ts
+++ b/packages/ai-intelligence/src/routes/llm.ts
@@ -7,6 +7,7 @@ import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { getConfig } from '@dashboard/core/config/index.js';
 import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { normalizeEndpoint, normalizeContainer } from '@dashboard/core/portainer/portainer-normalizers.js';
+import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { getEffectiveLlmConfig } from '@dashboard/core/services/settings-store.js';
 import { getEffectivePrompt, PROMPT_FEATURES, type PromptFeature } from '../services/prompt-store.js';
@@ -33,7 +34,7 @@ async function getInfrastructureSummary(): Promise<string> {
     const normalized = endpoints.map(normalizeEndpoint);
 
     const allContainers = [];
-    for (const ep of normalized.filter(e => e.status === 'up').slice(0, 10)) {
+    for (const ep of normalized.filter(e => e.status === 'up' && isDockerEndpoint(e.type)).slice(0, 10)) {
       try {
         const containers = await cachedFetch(
           getCacheKey('containers', ep.id),

--- a/packages/ai-intelligence/src/services/llm-tools.ts
+++ b/packages/ai-intelligence/src/services/llm-tools.ts
@@ -1,6 +1,7 @@
 import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { normalizeContainer, normalizeEndpoint } from '@dashboard/core/portainer/portainer-normalizers.js';
+import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { getMetricsDb } from '@dashboard/core/db/timescale.js';
 import { getTraces, getTrace, getTraceSummary } from '@dashboard/core/tracing/trace-store.js';
@@ -263,6 +264,7 @@ async function findContainerByName(
 
   const nameLower = name.toLowerCase();
   for (const ep of endpoints) {
+    if (!isDockerEndpoint(ep.Type)) continue;
     const norm = normalizeEndpoint(ep);
     if (norm.status !== 'up') continue;
     try {
@@ -296,6 +298,7 @@ async function executeQueryContainers(
 
     const allContainers = [];
     for (const ep of endpoints) {
+      if (!isDockerEndpoint(ep.Type)) continue;
       const norm = normalizeEndpoint(ep);
       if (norm.status !== 'up') continue;
       try {

--- a/packages/ai-intelligence/src/services/monitoring-service.ts
+++ b/packages/ai-intelligence/src/services/monitoring-service.ts
@@ -6,6 +6,7 @@ import { getEndpoints, getContainers, isEndpointDegraded, isCircuitOpen } from '
 import { CircuitBreakerOpenError } from '@dashboard/core/portainer/circuit-breaker.js';
 import { cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { normalizeEndpoint, normalizeContainer } from '@dashboard/core/portainer/portainer-normalizers.js';
+import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { detectAnomaliesBatch } from './adaptive-anomaly-detector.js';
 import type { BatchDetectionItem } from './adaptive-anomaly-detector.js';
 import { detectAnomalyIsolationForest } from './isolation-forest-detector.js';
@@ -148,6 +149,8 @@ export function createMonitoringService(deps: MonitoringDeps) {
       // Skip endpoints with open or degraded circuit breakers — #694/#695/#759
       let skippedCb = 0;
       const activeEndpoints = rawEndpoints.filter((ep) => {
+        // Skip K8s endpoints — monitoring only applies to Docker containers
+        if (!isDockerEndpoint(ep.Type)) return false;
         if (isCircuitOpen(ep.Id) || isEndpointDegraded(ep.Id)) {
           skippedCb++;
           return false;

--- a/packages/core/src/models/portainer.ts
+++ b/packages/core/src/models/portainer.ts
@@ -178,3 +178,150 @@ export type Network = z.infer<typeof NetworkSchema>;
 export type DockerImage = z.infer<typeof ImageSchema>;
 export type EdgeJob = z.infer<typeof EdgeJobSchema>;
 export type EdgeJobTask = z.infer<typeof EdgeJobTaskSchema>;
+
+// ── Kubernetes Resource Schemas ──────────────────────────────────────────────
+
+/** Portainer endpoint type constants */
+export const DOCKER_ENDPOINT_TYPES = new Set([1, 2, 4]); // Docker, Agent, Edge Docker
+export const KUBERNETES_ENDPOINT_TYPES = new Set([5, 6, 7]); // K8s Local, Agent, Edge
+
+/** Check whether a Portainer endpoint type is Kubernetes. */
+export function isKubernetesEndpoint(type: number): boolean {
+  return KUBERNETES_ENDPOINT_TYPES.has(type);
+}
+
+/** Check whether a Portainer endpoint type is Docker. */
+export function isDockerEndpoint(type: number): boolean {
+  return DOCKER_ENDPOINT_TYPES.has(type);
+}
+
+// Kubernetes Pod (raw K8s API response shape)
+export const K8sObjectMetaSchema = z.object({
+  name: z.string(),
+  namespace: z.string().optional(),
+  uid: z.string().optional(),
+  creationTimestamp: z.string().optional(),
+  labels: z.record(z.string(), z.string()).optional().default({}),
+  annotations: z.record(z.string(), z.string()).optional().default({}),
+  ownerReferences: z.array(z.object({
+    kind: z.string(),
+    name: z.string(),
+    uid: z.string().optional(),
+  })).optional().default([]),
+}).passthrough();
+
+export const K8sContainerStatusSchema = z.object({
+  name: z.string(),
+  ready: z.boolean().optional(),
+  restartCount: z.number().optional().default(0),
+  state: z.record(z.string(), z.unknown()).optional().default({}),
+  image: z.string().optional(),
+  imageID: z.string().optional(),
+}).passthrough();
+
+export const K8sPodSchema = z.object({
+  metadata: K8sObjectMetaSchema,
+  spec: z.object({
+    nodeName: z.string().optional(),
+    containers: z.array(z.object({
+      name: z.string(),
+      image: z.string().optional(),
+      ports: z.array(z.object({
+        containerPort: z.number().optional(),
+        protocol: z.string().optional(),
+        name: z.string().optional(),
+      })).optional().default([]),
+      resources: z.object({
+        requests: z.record(z.string(), z.string()).optional(),
+        limits: z.record(z.string(), z.string()).optional(),
+      }).optional(),
+    })).optional().default([]),
+    restartPolicy: z.string().optional(),
+  }).passthrough(),
+  status: z.object({
+    phase: z.string().optional(),
+    conditions: z.array(z.object({
+      type: z.string(),
+      status: z.string(),
+    })).optional().default([]),
+    containerStatuses: z.array(K8sContainerStatusSchema).optional().default([]),
+    startTime: z.string().optional(),
+    hostIP: z.string().optional(),
+    podIP: z.string().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+export const K8sDeploymentSchema = z.object({
+  metadata: K8sObjectMetaSchema,
+  spec: z.object({
+    replicas: z.number().optional().default(1),
+    selector: z.object({
+      matchLabels: z.record(z.string(), z.string()).optional(),
+    }).optional(),
+    template: z.object({
+      spec: z.object({
+        containers: z.array(z.object({
+          name: z.string(),
+          image: z.string().optional(),
+        })).optional().default([]),
+      }).passthrough().optional(),
+    }).passthrough().optional(),
+  }).passthrough(),
+  status: z.object({
+    replicas: z.number().optional().default(0),
+    readyReplicas: z.number().optional().default(0),
+    availableReplicas: z.number().optional().default(0),
+    unavailableReplicas: z.number().optional().default(0),
+    updatedReplicas: z.number().optional().default(0),
+  }).passthrough().optional(),
+}).passthrough();
+
+export const K8sServiceSchema = z.object({
+  metadata: K8sObjectMetaSchema,
+  spec: z.object({
+    type: z.string().optional().default('ClusterIP'),
+    clusterIP: z.string().optional(),
+    ports: z.array(z.object({
+      name: z.string().optional(),
+      port: z.number(),
+      targetPort: z.union([z.number(), z.string()]).optional(),
+      protocol: z.string().optional().default('TCP'),
+      nodePort: z.number().optional(),
+    })).optional().default([]),
+    selector: z.record(z.string(), z.string()).optional(),
+    externalIPs: z.array(z.string()).optional().default([]),
+    loadBalancerIP: z.string().optional(),
+  }).passthrough(),
+  status: z.object({
+    loadBalancer: z.object({
+      ingress: z.array(z.object({
+        ip: z.string().optional(),
+        hostname: z.string().optional(),
+      })).optional().default([]),
+    }).optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+export const K8sNamespaceSchema = z.object({
+  metadata: K8sObjectMetaSchema,
+  status: z.object({
+    phase: z.string().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+// K8s list response wrapper
+export const K8sListSchema = <T extends z.ZodTypeAny>(itemSchema: T) => z.object({
+  kind: z.string().optional(),
+  apiVersion: z.string().optional(),
+  items: z.array(itemSchema),
+}).passthrough();
+
+export const K8sPodListSchema = K8sListSchema(K8sPodSchema);
+export const K8sDeploymentListSchema = K8sListSchema(K8sDeploymentSchema);
+export const K8sServiceListSchema = K8sListSchema(K8sServiceSchema);
+export const K8sNamespaceListSchema = K8sListSchema(K8sNamespaceSchema);
+
+export type K8sPod = z.infer<typeof K8sPodSchema>;
+export type K8sDeployment = z.infer<typeof K8sDeploymentSchema>;
+export type K8sService = z.infer<typeof K8sServiceSchema>;
+export type K8sNamespace = z.infer<typeof K8sNamespaceSchema>;

--- a/packages/core/src/portainer/__tests__/kubernetes-normalizers.test.ts
+++ b/packages/core/src/portainer/__tests__/kubernetes-normalizers.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizePod,
+  normalizeDeployment,
+  normalizeService,
+  normalizeNamespace,
+} from '../portainer-normalizers.js';
+import { isDockerEndpoint, isKubernetesEndpoint } from '../../models/portainer.js';
+
+describe('endpoint type helpers', () => {
+  it('isDockerEndpoint returns true for Docker types (1,2,4)', () => {
+    expect(isDockerEndpoint(1)).toBe(true);
+    expect(isDockerEndpoint(2)).toBe(true);
+    expect(isDockerEndpoint(4)).toBe(true);
+  });
+
+  it('isDockerEndpoint returns false for non-Docker types', () => {
+    expect(isDockerEndpoint(3)).toBe(false); // Azure
+    expect(isDockerEndpoint(5)).toBe(false); // K8s
+    expect(isDockerEndpoint(6)).toBe(false); // Edge K8s
+    expect(isDockerEndpoint(7)).toBe(false); // Edge Async
+  });
+
+  it('isKubernetesEndpoint returns true for K8s types (5,6,7)', () => {
+    expect(isKubernetesEndpoint(5)).toBe(true);
+    expect(isKubernetesEndpoint(6)).toBe(true);
+    expect(isKubernetesEndpoint(7)).toBe(true);
+  });
+
+  it('isKubernetesEndpoint returns false for non-K8s types', () => {
+    expect(isKubernetesEndpoint(1)).toBe(false);
+    expect(isKubernetesEndpoint(2)).toBe(false);
+    expect(isKubernetesEndpoint(3)).toBe(false);
+    expect(isKubernetesEndpoint(4)).toBe(false);
+  });
+});
+
+describe('normalizePod', () => {
+  const basePod = {
+    metadata: {
+      uid: 'uid-1',
+      name: 'nginx-abc',
+      namespace: 'default',
+      creationTimestamp: '2024-06-15T10:30:00Z',
+      labels: { app: 'nginx' },
+    },
+    spec: {
+      nodeName: 'node-1',
+      containers: [{ name: 'nginx' }, { name: 'sidecar' }],
+    },
+    status: {
+      phase: 'Running',
+      containerStatuses: [
+        { name: 'nginx', ready: true, restartCount: 2, state: { running: {} } },
+        { name: 'sidecar', ready: true, restartCount: 0, state: { running: {} } },
+      ],
+    },
+  };
+
+  it('normalizes a running pod correctly', () => {
+    const result = normalizePod(basePod as any, 10, 'k8s-cluster');
+
+    expect(result.id).toBe('uid-1');
+    expect(result.name).toBe('nginx-abc');
+    expect(result.namespace).toBe('default');
+    expect(result.state).toBe('running');
+    expect(result.containers).toHaveLength(2);
+    expect(result.containers.filter((c) => c.ready)).toHaveLength(2);
+    expect(result.restarts).toBe(2); // sum of all containers
+    expect(result.nodeName).toBe('node-1');
+    expect(result.endpointId).toBe(10);
+    expect(result.endpointName).toBe('k8s-cluster');
+    expect(result.resourceType).toBe('pod');
+    expect(result.labels).toEqual({ app: 'nginx' });
+  });
+
+  it('maps Failed phase to failed state', () => {
+    const failedPod = {
+      ...basePod,
+      status: { ...basePod.status, phase: 'Failed' },
+    };
+    const result = normalizePod(failedPod as any, 10, 'cluster');
+    expect(result.state).toBe('failed');
+  });
+
+  it('detects CrashLoopBackOff from container statuses', () => {
+    const crashPod = {
+      ...basePod,
+      status: {
+        phase: 'Running',
+        containerStatuses: [{
+          name: 'app',
+          ready: false,
+          restartCount: 10,
+          state: { waiting: { reason: 'CrashLoopBackOff' } },
+        }],
+      },
+    };
+    const result = normalizePod(crashPod as any, 10, 'cluster');
+    expect(result.status).toBe('CrashLoopBackOff');
+  });
+});
+
+describe('normalizeDeployment', () => {
+  it('normalizes a deployment correctly', () => {
+    const dep = {
+      metadata: {
+        uid: 'dep-uid',
+        name: 'web-app',
+        namespace: 'production',
+        creationTimestamp: '2024-06-15T10:30:00Z',
+        labels: { tier: 'frontend' },
+      },
+      spec: { replicas: 3 },
+      status: {
+        replicas: 3,
+        readyReplicas: 3,
+        availableReplicas: 3,
+        updatedReplicas: 3,
+      },
+    };
+
+    const result = normalizeDeployment(dep as any, 10, 'cluster');
+    expect(result.name).toBe('web-app');
+    expect(result.namespace).toBe('production');
+    expect(result.replicas).toBe(3);
+    expect(result.readyReplicas).toBe(3);
+    expect(result.resourceType).toBe('deployment');
+  });
+});
+
+describe('normalizeService', () => {
+  it('normalizes a service correctly', () => {
+    const svc = {
+      metadata: {
+        uid: 'svc-uid',
+        name: 'api-svc',
+        namespace: 'default',
+        creationTimestamp: '2024-06-15T10:30:00Z',
+        labels: {},
+      },
+      spec: {
+        type: 'NodePort',
+        clusterIP: '10.96.0.50',
+        ports: [
+          { name: 'http', port: 80, targetPort: 8080, protocol: 'TCP', nodePort: 30080 },
+        ],
+      },
+    };
+
+    const result = normalizeService(svc as any, 10, 'cluster');
+    expect(result.name).toBe('api-svc');
+    expect(result.serviceType).toBe('NodePort');
+    expect(result.clusterIP).toBe('10.96.0.50');
+    expect(result.ports).toHaveLength(1);
+    expect(result.ports[0].nodePort).toBe(30080);
+    expect(result.resourceType).toBe('service');
+  });
+});
+
+describe('normalizeNamespace', () => {
+  it('normalizes a namespace correctly', () => {
+    const ns = {
+      metadata: {
+        uid: 'ns-uid',
+        name: 'kube-system',
+        creationTimestamp: '2024-01-01T00:00:00Z',
+        labels: { 'kubernetes.io/metadata.name': 'kube-system' },
+      },
+      status: { phase: 'Active' },
+    };
+
+    const result = normalizeNamespace(ns as any, 10, 'cluster');
+    expect(result.name).toBe('kube-system');
+    expect(result.status).toBe('Active');
+    expect(result.resourceType).toBe('namespace');
+    expect(result.endpointId).toBe(10);
+  });
+});

--- a/packages/core/src/portainer/portainer-cache.ts
+++ b/packages/core/src/portainer/portainer-cache.ts
@@ -650,6 +650,11 @@ export const TTL = {
   IMAGES: 600,       // 10 minutes
   NETWORKS: 600,     // 10 minutes
   STATS: 60,         // 1 minute
+  // Kubernetes resources
+  K8S_PODS: 300,         // 5 minutes — pods change frequently
+  K8S_DEPLOYMENTS: 300,  // 5 minutes
+  K8S_SERVICES: 600,     // 10 minutes — services are relatively stable
+  K8S_NAMESPACES: 900,   // 15 minutes — namespaces rarely change
 } as const;
 
 export function getCacheKey(resource: string, ...args: (string | number)[]): string {

--- a/packages/core/src/portainer/portainer-client.ts
+++ b/packages/core/src/portainer/portainer-client.ts
@@ -11,8 +11,11 @@ import {
   EndpointArraySchema, ContainerArraySchema, StackArraySchema,
   NetworkArraySchema, ImageArraySchema,
   EdgeJobSchema, EdgeJobArraySchema, EdgeJobTaskArraySchema,
+  K8sPodListSchema, K8sDeploymentListSchema, K8sServiceListSchema, K8sNamespaceListSchema,
+  isKubernetesEndpoint, isDockerEndpoint,
   type Endpoint, type Container, type Stack,
   type ContainerStats, type Network, type DockerImage, type EdgeJob, type EdgeJobTask,
+  type K8sPod, type K8sDeployment, type K8sService, type K8sNamespace,
 } from '../models/portainer.js';
 
 const log = createChildLogger('portainer-client');
@@ -101,13 +104,13 @@ interface BreakerEntry {
   lastUsed: number;
 }
 const breakers = new Map<string, BreakerEntry>();
-const ENDPOINT_PATH_RE = /\/api\/endpoints\/(\d+)\//;
+const ENDPOINT_PATH_RE = /(?:\/api\/endpoints\/(\d+)\/|\/kubernetes\/(\d+)\/)/;
 const BREAKER_PRUNE_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 const BREAKER_MAX_IDLE_MS = 60 * 60 * 1000; // 1 hour
 
 function extractBreakerKey(path: string): string {
   const match = path.match(ENDPOINT_PATH_RE);
-  return match ? `endpoint-${match[1]}` : 'global';
+  return match ? `endpoint-${match[1] || match[2]}` : 'global';
 }
 
 function getBreaker(path: string): CircuitBreaker {
@@ -834,4 +837,90 @@ export async function getEdgeJobTaskLogs(jobId: number, taskId: string): Promise
     throw new PortainerError(errorBody || `Edge job task logs fetch failed: ${res.status}`, classifyError(res.status), res.status);
   }
   return await res.text();
+}
+
+// Re-export endpoint type helpers for convenience
+export { isKubernetesEndpoint, isDockerEndpoint } from '../models/portainer.js';
+
+// ── Kubernetes API ─────────────────────────────────────────────────────────
+
+/** Fetch all pods from a Kubernetes endpoint via Portainer's K8s API proxy. */
+export async function getPods(endpointId: number, namespace?: string): Promise<K8sPod[]> {
+  const path = namespace
+    ? `/api/endpoints/${endpointId}/kubernetes/api/v1/namespaces/${encodeURIComponent(namespace)}/pods`
+    : `/api/endpoints/${endpointId}/kubernetes/api/v1/pods`;
+  const raw = await portainerFetch<unknown>(path, { timeout: 30000 });
+  return K8sPodListSchema.parse(raw).items;
+}
+
+/** Fetch all deployments from a Kubernetes endpoint. */
+export async function getDeployments(endpointId: number, namespace?: string): Promise<K8sDeployment[]> {
+  const path = namespace
+    ? `/api/endpoints/${endpointId}/kubernetes/apis/apps/v1/namespaces/${encodeURIComponent(namespace)}/deployments`
+    : `/api/endpoints/${endpointId}/kubernetes/apis/apps/v1/deployments`;
+  const raw = await portainerFetch<unknown>(path, { timeout: 30000 });
+  return K8sDeploymentListSchema.parse(raw).items;
+}
+
+/** Fetch all services from a Kubernetes endpoint. */
+export async function getServices(endpointId: number, namespace?: string): Promise<K8sService[]> {
+  const path = namespace
+    ? `/api/endpoints/${endpointId}/kubernetes/api/v1/namespaces/${encodeURIComponent(namespace)}/services`
+    : `/api/endpoints/${endpointId}/kubernetes/api/v1/services`;
+  const raw = await portainerFetch<unknown>(path, { timeout: 30000 });
+  return K8sServiceListSchema.parse(raw).items;
+}
+
+/** Fetch all namespaces from a Kubernetes endpoint. */
+export async function getNamespaces(endpointId: number): Promise<K8sNamespace[]> {
+  const raw = await portainerFetch<unknown>(
+    `/api/endpoints/${endpointId}/kubernetes/api/v1/namespaces`,
+    { timeout: 30000 },
+  );
+  return K8sNamespaceListSchema.parse(raw).items;
+}
+
+/** Fetch logs for a specific pod from a Kubernetes endpoint (read-only). */
+export async function getPodLogs(
+  endpointId: number,
+  namespace: string,
+  podName: string,
+  options: { tail?: number; sinceSeconds?: number; timestamps?: boolean; container?: string } = {},
+): Promise<string> {
+  const params = new URLSearchParams({
+    tailLines: String(options.tail || 100),
+    timestamps: String(options.timestamps ?? true),
+  });
+  if (options.sinceSeconds) params.set('sinceSeconds', String(options.sinceSeconds));
+  if (options.container) params.set('container', options.container);
+
+  const path = `/api/endpoints/${endpointId}/kubernetes/api/v1/namespaces/${encodeURIComponent(namespace)}/pods/${encodeURIComponent(podName)}/log?${params}`;
+  const url = buildApiUrl(path);
+  const headers = buildApiHeaders();
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  try {
+    const res = await undiciFetch(url, {
+      headers,
+      dispatcher: getDispatcher(),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    if (!res.ok) {
+      const errorBody = await readErrorBody(res);
+      throw new PortainerError(
+        errorBody || `Pod log fetch failed: ${res.status}`,
+        classifyError(res.status),
+        res.status,
+      );
+    }
+    return await res.text();
+  } catch (err) {
+    clearTimeout(timer);
+    if (err instanceof PortainerError) throw err;
+    const msg = err instanceof Error ? err.message : 'Network error';
+    throw new PortainerError(msg, 'network');
+  }
 }

--- a/packages/core/src/portainer/portainer-normalizers.ts
+++ b/packages/core/src/portainer/portainer-normalizers.ts
@@ -289,6 +289,7 @@ export interface NormalizedDeployment {
   replicas: number;
   readyReplicas: number;
   availableReplicas: number;
+  updatedReplicas: number;
   created: number;
   endpointId: number;
   endpointName: string;
@@ -401,6 +402,7 @@ export function normalizeDeployment(
     replicas: dep.spec.replicas ?? 1,
     readyReplicas: dep.status?.readyReplicas ?? 0,
     availableReplicas: dep.status?.availableReplicas ?? 0,
+    updatedReplicas: dep.status?.updatedReplicas ?? 0,
     created: parseK8sTimestamp(dep.metadata.creationTimestamp),
     endpointId,
     endpointName,

--- a/packages/core/src/portainer/portainer-normalizers.ts
+++ b/packages/core/src/portainer/portainer-normalizers.ts
@@ -1,4 +1,5 @@
-import type { Endpoint, Container, Stack, Network } from '../models/portainer.js';
+import type { Endpoint, Container, Stack, Network, K8sPod, K8sDeployment, K8sService, K8sNamespace } from '../models/portainer.js';
+import { isKubernetesEndpoint } from '../models/portainer.js';
 import { createChildLogger } from '../utils/logger.js';
 
 const log = createChildLogger('normalizers');
@@ -257,3 +258,199 @@ export function normalizeNetwork(
     containers: Object.keys(n.Containers || {}),
   };
 }
+
+// ── Kubernetes Normalizers ─────────────────────────────────────────────────
+
+export type K8sPodState = 'running' | 'pending' | 'succeeded' | 'failed' | 'unknown';
+
+export interface NormalizedPod {
+  id: string;
+  name: string;
+  namespace: string;
+  images: string[];
+  state: K8sPodState;
+  status: string;
+  restarts: number;
+  created: number;
+  nodeName?: string;
+  podIP?: string;
+  endpointId: number;
+  endpointName: string;
+  labels: Record<string, string>;
+  containers: Array<{ name: string; image?: string; ready: boolean; restartCount: number }>;
+  resourceType: 'pod';
+}
+
+export interface NormalizedDeployment {
+  id: string;
+  name: string;
+  namespace: string;
+  images: string[];
+  replicas: number;
+  readyReplicas: number;
+  availableReplicas: number;
+  created: number;
+  endpointId: number;
+  endpointName: string;
+  labels: Record<string, string>;
+  resourceType: 'deployment';
+}
+
+export interface NormalizedService {
+  id: string;
+  name: string;
+  namespace: string;
+  serviceType: string;
+  clusterIP?: string;
+  ports: Array<{ name?: string; port: number; targetPort?: string | number; protocol: string; nodePort?: number }>;
+  created: number;
+  endpointId: number;
+  endpointName: string;
+  labels: Record<string, string>;
+  resourceType: 'service';
+}
+
+export interface NormalizedNamespace {
+  id: string;
+  name: string;
+  status: string;
+  created: number;
+  labels: Record<string, string>;
+  endpointId: number;
+  endpointName: string;
+  resourceType: 'namespace';
+}
+
+function parseK8sTimestamp(ts?: string): number {
+  if (!ts) return 0;
+  const ms = Date.parse(ts);
+  return isNaN(ms) ? 0 : Math.floor(ms / 1000);
+}
+
+function mapPodPhase(phase?: string): K8sPodState {
+  switch (phase?.toLowerCase()) {
+    case 'running': return 'running';
+    case 'pending': return 'pending';
+    case 'succeeded': return 'succeeded';
+    case 'failed': return 'failed';
+    default: return 'unknown';
+  }
+}
+
+/** Build a human-readable status string for a pod (e.g. "Running", "CrashLoopBackOff"). */
+function buildPodStatusString(pod: K8sPod): string {
+  const phase = pod.status?.phase ?? 'Unknown';
+  // Check container statuses for more specific reasons
+  for (const cs of pod.status?.containerStatuses ?? []) {
+    const waiting = cs.state?.['waiting'] as { reason?: string } | undefined;
+    if (waiting?.reason) return waiting.reason;
+    const terminated = cs.state?.['terminated'] as { reason?: string } | undefined;
+    if (terminated?.reason) return terminated.reason;
+  }
+  return phase;
+}
+
+export function normalizePod(
+  pod: K8sPod,
+  endpointId: number,
+  endpointName: string,
+): NormalizedPod {
+  const restarts = (pod.status?.containerStatuses ?? [])
+    .reduce((sum, cs) => sum + (cs.restartCount ?? 0), 0);
+
+  return {
+    id: pod.metadata.uid ?? `${pod.metadata.namespace}/${pod.metadata.name}`,
+    name: pod.metadata.name,
+    namespace: pod.metadata.namespace ?? 'default',
+    images: pod.spec.containers.map((c) => c.image ?? '').filter(Boolean),
+    state: mapPodPhase(pod.status?.phase),
+    status: buildPodStatusString(pod),
+    restarts,
+    created: parseK8sTimestamp(pod.metadata.creationTimestamp),
+    nodeName: pod.spec.nodeName,
+    podIP: pod.status?.podIP,
+    endpointId,
+    endpointName,
+    labels: pod.metadata.labels ?? {},
+    containers: pod.spec.containers.map((specC) => {
+      const statusC = (pod.status?.containerStatuses ?? []).find((s) => s.name === specC.name);
+      return {
+        name: specC.name,
+        image: specC.image,
+        ready: statusC?.ready ?? false,
+        restartCount: statusC?.restartCount ?? 0,
+      };
+    }),
+    resourceType: 'pod',
+  };
+}
+
+export function normalizeDeployment(
+  dep: K8sDeployment,
+  endpointId: number,
+  endpointName: string,
+): NormalizedDeployment {
+  const images = (dep.spec.template?.spec?.containers ?? [])
+    .map((c) => c.image ?? '').filter(Boolean);
+
+  return {
+    id: dep.metadata.uid ?? `${dep.metadata.namespace}/${dep.metadata.name}`,
+    name: dep.metadata.name,
+    namespace: dep.metadata.namespace ?? 'default',
+    images,
+    replicas: dep.spec.replicas ?? 1,
+    readyReplicas: dep.status?.readyReplicas ?? 0,
+    availableReplicas: dep.status?.availableReplicas ?? 0,
+    created: parseK8sTimestamp(dep.metadata.creationTimestamp),
+    endpointId,
+    endpointName,
+    labels: dep.metadata.labels ?? {},
+    resourceType: 'deployment',
+  };
+}
+
+export function normalizeService(
+  svc: K8sService,
+  endpointId: number,
+  endpointName: string,
+): NormalizedService {
+  return {
+    id: svc.metadata.uid ?? `${svc.metadata.namespace}/${svc.metadata.name}`,
+    name: svc.metadata.name,
+    namespace: svc.metadata.namespace ?? 'default',
+    serviceType: svc.spec.type ?? 'ClusterIP',
+    clusterIP: svc.spec.clusterIP,
+    ports: (svc.spec.ports ?? []).map((p) => ({
+      name: p.name,
+      port: p.port,
+      targetPort: p.targetPort,
+      protocol: p.protocol ?? 'TCP',
+      nodePort: p.nodePort,
+    })),
+    created: parseK8sTimestamp(svc.metadata.creationTimestamp),
+    endpointId,
+    endpointName,
+    labels: svc.metadata.labels ?? {},
+    resourceType: 'service',
+  };
+}
+
+export function normalizeNamespace(
+  ns: K8sNamespace,
+  endpointId: number,
+  endpointName: string,
+): NormalizedNamespace {
+  return {
+    id: ns.metadata.uid ?? ns.metadata.name,
+    name: ns.metadata.name,
+    status: ns.status?.phase ?? 'Active',
+    created: parseK8sTimestamp(ns.metadata.creationTimestamp),
+    labels: ns.metadata.labels ?? {},
+    endpointId,
+    endpointName,
+    resourceType: 'namespace',
+  };
+}
+
+/** Re-export for convenience */
+export { isKubernetesEndpoint } from '../models/portainer.js';

--- a/packages/security/src/__tests__/security-audit.test.ts
+++ b/packages/security/src/__tests__/security-audit.test.ts
@@ -47,7 +47,7 @@ describe('security-audit service', () => {
       (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => fetcher(),
     );
 
-    mockGetEndpoints = vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([{ Id: 1, Name: 'prod' }] as any);
+    mockGetEndpoints = vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([{ Id: 1, Name: 'prod', Type: 1 }] as any);
     // List endpoint returns sparse HostConfig (only NetworkMode in practice)
     mockGetContainers = vi.spyOn(portainerClient, 'getContainers').mockResolvedValue([
       {
@@ -177,8 +177,8 @@ describe('security-audit service', () => {
   it('skips endpoint and continues when circuit breaker is open', async () => {
     // Two endpoints: endpoint 1 has open circuit breaker, endpoint 2 works fine
     mockGetEndpoints.mockResolvedValue([
-      { Id: 1, Name: 'prod' },
-      { Id: 2, Name: 'staging' },
+      { Id: 1, Name: 'prod', Type: 1 },
+      { Id: 2, Name: 'staging', Type: 1 },
     ]);
 
     // mockCachedFetch: endpoint 1 containers fetch throws CircuitBreakerOpenError,
@@ -212,8 +212,8 @@ describe('security-audit service', () => {
 
   it('skips endpoint and continues when containers fetch fails with non-CB error', async () => {
     mockGetEndpoints.mockResolvedValue([
-      { Id: 1, Name: 'prod' },
-      { Id: 2, Name: 'staging' },
+      { Id: 1, Name: 'prod', Type: 1 },
+      { Id: 2, Name: 'staging', Type: 1 },
     ]);
 
     mockCachedFetch.mockImplementation((key: string, _ttl: number, fetcher: () => Promise<unknown>) => {

--- a/packages/security/src/services/harbor-sync.ts
+++ b/packages/security/src/services/harbor-sync.ts
@@ -3,6 +3,7 @@ import { withSpan } from '@dashboard/core/tracing/trace-context.js';
 import * as harbor from './harbor-client.js';
 import * as store from './harbor-vulnerability-store.js';
 import { getEndpoints, getContainers } from '@dashboard/core/portainer/portainer-client.js';
+import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { parseImageRef } from './image-staleness.js';
 import type { VulnerabilityInsert } from './harbor-vulnerability-store.js';
@@ -32,7 +33,7 @@ async function collectRunningImages(): Promise<RunningImage[]> {
 
   const images: RunningImage[] = [];
 
-  for (const ep of endpoints) {
+  for (const ep of endpoints.filter((e) => isDockerEndpoint(e.Type))) {
     try {
       const containers = await cachedFetchSWR(
         getCacheKey('containers', ep.Id),

--- a/packages/security/src/services/security-audit.ts
+++ b/packages/security/src/services/security-audit.ts
@@ -1,6 +1,6 @@
 import { getEndpoints, getContainers, getContainerHostConfig } from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
-import type { Container } from '@dashboard/core/models/portainer.js';
+import { type Container, isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { getSetting, setSetting } from '@dashboard/core/services/settings-store.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { CircuitBreakerOpenError } from '@dashboard/core/portainer/circuit-breaker.js';
@@ -127,7 +127,7 @@ async function computeSecurityAudit(endpointId?: number): Promise<SecurityAuditE
 
   const entries: SecurityAuditEntry[] = [];
 
-  for (const endpoint of scopedEndpoints) {
+  for (const endpoint of scopedEndpoints.filter((ep) => isDockerEndpoint(ep.Type))) {
     let containers: Awaited<ReturnType<typeof getContainers>>;
     try {
       containers = await cachedFetch(

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -26,6 +26,7 @@ import { networksRoutes } from 'backend/routes/networks.js';
 import { searchRoutes } from 'backend/routes/search.js';
 import { cacheAdminRoutes } from 'backend/routes/cache-admin.js';
 import { userRoutes } from 'backend/routes/users.js';
+import { kubernetesRoutes } from 'backend/routes/kubernetes.js';
 
 // Routes from domain packages
 import {
@@ -151,6 +152,7 @@ export async function buildApp() {
   await app.register(searchRoutes);
   await app.register(cacheAdminRoutes);
   await app.register(userRoutes);
+  await app.register(kubernetesRoutes);
 
   // Routes — domain packages
   await app.register(monitoringRoutes, {

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -2,6 +2,7 @@ import pLimit from 'p-limit';
 import { getConfig } from '@dashboard/core/config/index.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { getEndpoints, getContainers, isEndpointDegraded, getImages } from '@dashboard/core/portainer/index.js';
+import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { cachedFetch, cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/index.js';
 import { normalizeEndpoint, type NormalizedEndpoint } from '@dashboard/core/portainer/index.js';
 import { getSetting, getEffectiveHarborConfig, cleanExpiredSessions } from '@dashboard/core/services/index.js';
@@ -137,12 +138,13 @@ export async function runMetricsCollection(): Promise<void> {
       () => getEndpoints(),
     );
 
-    // Skip Edge Async endpoints — they lack persistent tunnels for live stats
-    // Also skip endpoints whose circuit breaker is degraded (#694/#695)
+    // Skip Kubernetes endpoints (types 5/6/7) — metrics collection uses Docker API.
+    // Skip Edge Async endpoints — they lack persistent tunnels for live stats.
+    // Also skip endpoints whose circuit breaker is degraded (#694/#695).
     const normalized = endpoints.map(normalizeEndpoint);
     const liveCapableEndpoints = endpoints.filter((_ep, i) => {
       const n = normalized[i];
-      return n.capabilities.liveStats && !isEndpointDegraded(_ep.Id);
+      return isDockerEndpoint(_ep.Type) && n.capabilities.liveStats && !isEndpointDegraded(_ep.Id);
     });
 
     if (liveCapableEndpoints.length < endpoints.length) {
@@ -410,9 +412,10 @@ async function warmCache(): Promise<void> {
       TTL.ENDPOINTS,
       () => getEndpoints(),
     );
-    // Pre-fetch containers for all endpoints in parallel
+    // Pre-fetch containers for Docker endpoints only (K8s endpoints use different API)
+    const dockerEndpoints = endpoints.filter((ep) => isDockerEndpoint(ep.Type));
     await Promise.allSettled(
-      endpoints.map((ep) =>
+      dockerEndpoints.map((ep) =>
         cachedFetch(
           getCacheKey('containers', ep.Id),
           TTL.CONTAINERS,
@@ -420,7 +423,7 @@ async function warmCache(): Promise<void> {
         ),
       ),
     );
-    log.info({ endpoints: endpoints.length }, 'Cache warmed successfully');
+    log.info({ endpoints: endpoints.length, dockerEndpoints: dockerEndpoints.length }, 'Cache warmed successfully');
   } catch (err) {
     log.warn({ err }, 'Cache warming failed — first requests will be slower');
   }


### PR DESCRIPTION
## Summary

Implements full read-only Kubernetes resource support across the stack, as specified in #939.

- **Backend**: 6 new API routes (`/api/kubernetes/pods`, `/deployments`, `/services`, `/namespaces`, `/summary`, `/pods/:id/:ns/:name/logs`) with per-endpoint circuit breakers, L1/L2 caching, and partial-failure handling via `Promise.allSettled`
- **Core**: K8s Zod schemas, Portainer API client methods (`getPods`, `getDeployments`, `getServices`, `getNamespaces`, `getPodLogs`), normalizers with `resourceType` discriminator, and `isDockerEndpoint`/`isKubernetesEndpoint` type guards
- **Docker-only guards**: 11 existing files updated to filter endpoints with `isDockerEndpoint()` before calling Docker-specific APIs (containers, stacks, search, dashboard, AI intelligence, security audit, harbor sync, monitoring, scheduler)
- **Frontend**: New Kubernetes tab in Fleet Overview with pods/deployments/services DataTables, pod count badge, K8s summary bar, and React Query hooks (`useK8sPods`, `useK8sDeployments`, `useK8sServices`, `useK8sNamespaces`, `useK8sSummary`, `useK8sPodLogs`)
- **Tests**: 9 backend route tests + 10 normalizer unit tests; fixed existing container/search test fixtures to include endpoint `Type` field

## Test plan

- [x] All 1549 existing tests pass (no regressions)
- [x] 9 new K8s route tests pass (endpoint filtering, namespace filtering, partial failure, pod logs, summary)
- [x] 10 new normalizer tests pass (type guards, pod/deployment/service/namespace normalization, CrashLoopBackOff detection)
- [ ] Manual: verify K8s tab appears in Fleet Overview when K8s endpoints exist
- [ ] Manual: verify Docker-only views still work correctly with mixed endpoint environments

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)