### PR TITLE
perf(#942): reduce page load and navigation time

### DIFF
--- a/backend/src/routes/containers.test.ts
+++ b/backend/src/routes/containers.test.ts
@@ -385,13 +385,17 @@ describe('favorites endpoint (#544)', () => {
   });
 
   it('returns only requested containers', async () => {
-    // Kept: vi.spyOn for controlled container data
+    // New implementation fetches individual containers via getContainer()
     vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([fakeEndpoint(1, 'prod')] as any);
-    vi.spyOn(portainerClient, 'getContainers').mockResolvedValue([
-      fakeContainer('abc', 'web'),
-      fakeContainer('def', 'api'),
-      fakeContainer('ghi', 'db'),
-    ] as any);
+    vi.spyOn(portainerClient, 'getContainer').mockImplementation(async (_epId: number, cId: string) => {
+      const containers: Record<string, ReturnType<typeof fakeContainer>> = {
+        abc: fakeContainer('abc', 'web'),
+        ghi: fakeContainer('ghi', 'db'),
+      };
+      const c = containers[cId];
+      if (!c) throw new Error(`Container ${cId} not found`);
+      return c as any;
+    });
 
     const app = buildApp();
     const res = await app.inject({
@@ -418,11 +422,9 @@ describe('favorites endpoint (#544)', () => {
   });
 
   it('returns empty when no containers match', async () => {
-    // Kept: vi.spyOn for controlled container data
+    // New implementation fetches individual containers — 404 results are filtered out
     vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([fakeEndpoint(1, 'prod')] as any);
-    vi.spyOn(portainerClient, 'getContainers').mockResolvedValue([
-      fakeContainer('abc', 'web'),
-    ] as any);
+    vi.spyOn(portainerClient, 'getContainer').mockRejectedValue(new Error('Not found'));
 
     const app = buildApp();
     const res = await app.inject({

--- a/backend/src/routes/containers.ts
+++ b/backend/src/routes/containers.ts
@@ -204,12 +204,52 @@ export async function containersRoutes(fastify: FastifyInstance) {
       return [];
     }
 
-    // Parse composite IDs into a lookup set
-    const requested = new Set(pairs);
+    // Parse composite IDs into per-endpoint groups for targeted fetching
+    const byEndpoint = new Map<number, string[]>();
+    for (const pair of pairs) {
+      const colonIndex = pair.indexOf(':');
+      if (colonIndex === -1) continue;
+      const epId = Number(pair.slice(0, colonIndex));
+      const cId = pair.slice(colonIndex + 1);
+      if (Number.isNaN(epId) || !cId) continue;
+      const list = byEndpoint.get(epId) ?? [];
+      list.push(cId);
+      byEndpoint.set(epId, list);
+    }
+
+    if (byEndpoint.size === 0) {
+      return [];
+    }
 
     try {
-      const { results } = await fetchAllContainers();
-      return results.filter((c) => requested.has(`${c.endpointId}:${c.id}`));
+      // Fetch endpoints for name resolution (cached)
+      const endpoints = await cachedFetchSWR(
+        getCacheKey('endpoints'),
+        TTL.ENDPOINTS,
+        () => portainer.getEndpoints(),
+      );
+      const endpointMap = new Map(endpoints.map((ep) => [ep.Id, ep]));
+
+      // Fetch only the specific containers we need, in parallel per endpoint
+      const settled = await Promise.allSettled(
+        [...byEndpoint.entries()].map(async ([epId, containerIds]) => {
+          const ep = endpointMap.get(epId);
+          if (!ep) return [];
+          const containers = await Promise.allSettled(
+            containerIds.map((cId) =>
+              portainer.getContainer(epId, cId)
+                .then((c) => normalizeContainer(c, ep.Id, ep.Name))
+            ),
+          );
+          return containers
+            .filter((r): r is PromiseFulfilledResult<ReturnType<typeof normalizeContainer>> => r.status === 'fulfilled')
+            .map((r) => r.value);
+        }),
+      );
+
+      return settled
+        .filter((r): r is PromiseFulfilledResult<ReturnType<typeof normalizeContainer>[]> => r.status === 'fulfilled')
+        .flatMap((r) => r.value);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
       log.error({ err }, 'Failed to fetch favorite containers');

--- a/frontend/src/features/ai-intelligence/hooks/use-incidents.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-incidents.ts
@@ -44,8 +44,6 @@ export function useIncidents(status?: 'active' | 'resolved') {
       if (status) params.status = status;
       return api.get<IncidentsResponse>('/api/incidents', { params });
     },
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
     refetchInterval: isPageVisible ? 30_000 : false,
   });
 }

--- a/frontend/src/features/ai-intelligence/hooks/use-llm-observability.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-llm-observability.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 
 export interface LlmTrace {
   id: number;
@@ -94,9 +95,7 @@ export function useLlmTraces(limit: number = 50) {
   return useQuery<LlmTrace[]>({
     queryKey: ['llm-traces', limit],
     queryFn: async () => normalizeLlmTraces(await api.get<unknown>(`/api/llm/traces?limit=${limit}`)),
-    staleTime: 30 * 1000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.DEFAULT,
   });
 }
 
@@ -104,8 +103,6 @@ export function useLlmStats(hours: number = 24) {
   return useQuery<LlmStats>({
     queryKey: ['llm-stats', hours],
     queryFn: async () => normalizeLlmStats(await api.get<unknown>(`/api/llm/stats?hours=${hours}`)),
-    staleTime: 60 * 1000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
   });
 }

--- a/frontend/src/features/ai-intelligence/hooks/use-monitoring.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-monitoring.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import type { Insight, Severity } from '@dashboard/contracts';
 import { api } from '@/shared/lib/api';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 import { useSockets } from '@/providers/socket-provider';
 
 export type { Insight, Severity };
@@ -27,9 +28,7 @@ export function useMonitoring() {
   const historyQuery = useQuery<{ insights: Insight[]; total: number }>({
     queryKey: ['monitoring', 'insights'],
     queryFn: () => api.get<{ insights: Insight[]; total: number }>('/api/monitoring/insights'),
-    staleTime: 60_000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
   });
 
   useEffect(() => {

--- a/frontend/src/features/containers/hooks/use-containers.ts
+++ b/frontend/src/features/containers/hooks/use-containers.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 
 export interface Container {
   id: string;
@@ -69,9 +70,7 @@ export function useContainers(params?: UseContainersParams) {
       const response = await api.get<Container[] | PartialContainersResponse>(path);
       return normalizeContainersResponse(response);
     },
-    staleTime: 60 * 1000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
   });
 }
 
@@ -99,9 +98,7 @@ export function usePaginatedContainers(params: {
 
       return api.get<PaginatedContainers>(`/api/containers?${searchParams.toString()}`);
     },
-    staleTime: 60 * 1000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
   });
 }
 
@@ -113,8 +110,7 @@ export function useFavoriteContainers(ids: string[]) {
       const qs = `ids=${ids.map(encodeURIComponent).join(',')}`;
       return api.get<Container[]>(`/api/containers/favorites?${qs}`);
     },
-    staleTime: 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
     enabled: ids.length > 0,
   });
 }
@@ -123,7 +119,6 @@ export function useContainerCount() {
   return useQuery<{ count: number }>({
     queryKey: ['containers', 'count'],
     queryFn: () => api.get<{ count: number }>('/api/containers/count'),
-    staleTime: 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
   });
 }

--- a/frontend/src/features/containers/hooks/use-endpoints.ts
+++ b/frontend/src/features/containers/hooks/use-endpoints.ts
@@ -34,8 +34,6 @@ export interface Endpoint {
 export function useEndpoints() {
   return useResource<Endpoint[]>(['endpoints'], '/api/endpoints', {
     staleTime: STALE_TIMES.SHORT,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
   });
 }
 

--- a/frontend/src/features/containers/hooks/use-images.test.ts
+++ b/frontend/src/features/containers/hooks/use-images.test.ts
@@ -71,7 +71,7 @@ describe('useImages', () => {
 
     const query = queryClient.getQueryCache().findAll({ queryKey: ['images', undefined] })[0];
     expect(query).toBeDefined();
-    // The query should have fetched (refetchOnMount: 'always')
+    // The query should have fetched on mount
     expect(query?.state.fetchStatus === 'fetching' || query?.state.status === 'success' || query?.state.status === 'error').toBe(true);
   });
 

--- a/frontend/src/features/containers/hooks/use-images.test.ts
+++ b/frontend/src/features/containers/hooks/use-images.test.ts
@@ -58,7 +58,7 @@ describe('useImages', () => {
     expect(mockApi.get).toHaveBeenCalledWith('/api/images?endpointId=1');
   });
 
-  it('sets refetchOnMount to always', () => {
+  it('fetches on mount', () => {
     mockApi.get.mockResolvedValue([]);
 
     const queryClient = new QueryClient({

--- a/frontend/src/features/containers/hooks/use-images.ts
+++ b/frontend/src/features/containers/hooks/use-images.ts
@@ -23,8 +23,6 @@ export function useImages(endpointId?: number, options?: UseImagesOptions) {
     : '/api/images';
   return useResource<DockerImage[]>(['images', endpointId], path, {
     staleTime: STALE_TIMES.LONG,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
     refetchInterval: options?.refetchInterval ?? false,
   });
 }

--- a/frontend/src/features/containers/hooks/use-networks.ts
+++ b/frontend/src/features/containers/hooks/use-networks.ts
@@ -19,7 +19,5 @@ export function useNetworks(endpointId?: number) {
     : '/api/networks';
   return useResource<Network[]>(['networks', endpointId], path, {
     staleTime: STALE_TIMES.LONG,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/features/core/components/layout/app-layout.tsx
+++ b/frontend/src/features/core/components/layout/app-layout.tsx
@@ -257,17 +257,17 @@ export function AppLayout() {
                 variants={{
                   initial: (currentDirection: number) => ({
                     opacity: 0,
-                    x: currentDirection > 0 ? 24 : -24,
+                    x: currentDirection > 0 ? 16 : -16,
                   }),
                   animate: {
                     opacity: 1,
                     x: 0,
-                    transition: { duration: 0.24, ease: [0.32, 0.72, 0, 1] },
+                    transition: { duration: 0.12, ease: [0.32, 0.72, 0, 1] },
                   },
                   exit: (currentDirection: number) => ({
                     opacity: 0,
-                    x: currentDirection > 0 ? -18 : 18,
-                    transition: { duration: 0.2, ease: [0.32, 0.72, 0, 1] },
+                    x: currentDirection > 0 ? -12 : 12,
+                    transition: { duration: 0.1, ease: [0.32, 0.72, 0, 1] },
                   }),
                 }}
               >

--- a/frontend/src/features/core/hooks/use-dashboard-full.ts
+++ b/frontend/src/features/core/hooks/use-dashboard-full.ts
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { api } from '@/shared/lib/api';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 import type { DashboardSummary } from '@/features/core/hooks/use-dashboard';
 import type { DashboardResources } from '@/features/core/hooks/use-dashboard-resources';
 import type { Endpoint } from '@/features/containers/hooks/use-endpoints';
@@ -40,9 +41,7 @@ export function useDashboardFull(topN: number = 10) {
     queryKey: ['dashboard', 'full', topN],
     queryFn: () => api.get<DashboardFull>(`/api/dashboard/full?topN=${topN}&kpiHistoryHours=24`),
     enabled: hasToken,
-    staleTime: 60 * 1000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
     refetchInterval: enabled ? interval * 1000 : false,
   });
 

--- a/frontend/src/features/core/hooks/use-dashboard-resources.ts
+++ b/frontend/src/features/core/hooks/use-dashboard-resources.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 
 export interface StackResourceUsage {
   name: string;
@@ -38,9 +39,7 @@ export function useDashboardResources(topN: number = 10) {
     queryKey: ['dashboard', 'resources', topN],
     queryFn: () => api.get<DashboardResources>(`/api/dashboard/resources?topN=${topN}`),
     enabled: hasToken,
-    staleTime: 60 * 1000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
     refetchInterval: enabled ? interval * 1000 : false,
   });
 }

--- a/frontend/src/features/core/hooks/use-dashboard.test.ts
+++ b/frontend/src/features/core/hooks/use-dashboard.test.ts
@@ -28,11 +28,10 @@ describe('useDashboard', () => {
     expect(options.enabled).toBe(true);
   });
 
-  it('forces refetch on mount to recover when navigating back to home', () => {
+  it('uses auto-refresh interval for refetchInterval', () => {
     useDashboard();
 
     const options = mockUseQuery.mock.calls[0][0];
-    expect(options.refetchOnMount).toBe('always');
     expect(options.refetchInterval).toBe(30_000);
   });
 });

--- a/frontend/src/features/core/hooks/use-dashboard.ts
+++ b/frontend/src/features/core/hooks/use-dashboard.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 
 export interface DashboardKpis {
   endpoints: number;
@@ -78,9 +79,7 @@ export function useDashboard() {
     queryKey: ['dashboard', 'summary'],
     queryFn: () => api.get<DashboardSummary>('/api/dashboard/summary'),
     enabled: hasToken,
-    staleTime: 60 * 1000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
     refetchInterval: enabled ? interval * 1000 : false,
   });
 }

--- a/frontend/src/features/core/pages/home.tsx
+++ b/frontend/src/features/core/pages/home.tsx
@@ -4,7 +4,6 @@ import { Server, Boxes, PackageOpen, Layers, AlertTriangle, Star, ShieldAlert } 
 import { useDashboardFull } from '@/features/core/hooks/use-dashboard-full';
 import { useFavoriteContainers } from '@/features/containers/hooks/use-containers';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
-import { useKpiHistory } from '@/features/observability/hooks/use-kpi-history';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
@@ -39,7 +38,8 @@ export default function HomePage() {
   const { interval, setInterval } = useAutoRefresh(30);
   const favoriteIds = useFavoritesStore((s) => s.favoriteIds);
   const { data: favoriteContainers = [] } = useFavoriteContainers(favoriteIds);
-  const { data: kpiHistory } = useKpiHistory(24);
+  // KPI history is included in the unified /api/dashboard/full response — no separate call needed
+  const kpiHistory = fullData?.kpiHistory;
 
   const endpointChartData = useMemo(() => {
     if (!endpoints) return [];

--- a/frontend/src/features/core/pages/login.test.tsx
+++ b/frontend/src/features/core/pages/login.test.tsx
@@ -145,7 +145,7 @@ describe('LoginPage', () => {
     expect(mockPrefetchQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: ['dashboard', 'full', 8],
-        staleTime: 60_000,
+        staleTime: 2 * 60_000,
       }),
     );
 

--- a/frontend/src/features/core/pages/login.tsx
+++ b/frontend/src/features/core/pages/login.tsx
@@ -71,23 +71,27 @@ export default function LoginPage() {
       const { defaultLandingPage } = await login(username, password);
       setSubmitState("success");
       
+      // Always prefetch dashboard data after login, regardless of motion preference
+      const prefetchPromise = queryClient.prefetchQuery({
+        queryKey: ['dashboard', 'full', 8],
+        queryFn: () => api.get('/api/dashboard/full?topN=8&kpiHistoryHours=24'),
+        staleTime: 2 * 60 * 1000,
+      });
+
       if (reducedMotion) {
-        window.setTimeout(() => {
-          navigate(defaultLandingPage || "/", { replace: true });
-        }, 0);
+        // Wait for data (up to 3s) then navigate — no animation but data is ready
+        const maxTimer = new Promise<void>((resolve) =>
+          window.setTimeout(resolve, 3000),
+        );
+        Promise.race([prefetchPromise, maxTimer]).then(() =>
+          navigate(defaultLandingPage || "/", { replace: true }),
+        );
       } else {
         // Show the high-quality loading screen immediately
         setShowPostLoginLoading(true);
 
-        // Prefetch dashboard data in parallel while the loading screen is visible,
-        // so the home page renders instantly on arrival with no loading states.
-        // Single unified request fetches dashboard + KPI history together
-        const prefetchPromise = queryClient.prefetchQuery({
-          queryKey: ['dashboard', 'full', 8],
-          queryFn: () => api.get('/api/dashboard/full?topN=8&kpiHistoryHours=24'),
-          staleTime: 60 * 1000,
-        });
-
+        // Prefetch was already started above — reuse the promise.
+        // Show the loading screen for at least 1s, at most 5s.
         const minTimer = new Promise<void>((resolve) =>
           window.setTimeout(resolve, 1000),
         );

--- a/frontend/src/features/observability/hooks/use-correlated-anomalies.ts
+++ b/frontend/src/features/observability/hooks/use-correlated-anomalies.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 
 export interface CorrelatedAnomaly {
   containerId: string;
@@ -23,9 +24,7 @@ export function useCorrelatedAnomalies(windowSize: number = 30, minScore: number
       api.get<CorrelatedAnomaly[]>(
         `/api/anomalies/correlated?windowSize=${windowSize}&minScore=${minScore}`,
       ),
-    staleTime: 60 * 1000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.SHORT,
     retry: 1,
   });
 }

--- a/frontend/src/features/observability/hooks/use-metrics.ts
+++ b/frontend/src/features/observability/hooks/use-metrics.ts
@@ -74,8 +74,6 @@ export function useContainerMetrics(
       );
     },
     enabled: Boolean(endpointId) && Boolean(containerId),
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
     // Poll faster while empty so first data appears sooner; back off once data is flowing.
     refetchInterval: (query) => {
       const points = query.state.data?.data?.length ?? 0;
@@ -92,8 +90,6 @@ export function useAnomalies() {
   return useQuery<Anomaly[]>({
     queryKey: ['metrics', 'anomalies'],
     queryFn: () => api.get<Anomaly[]>('/api/metrics/anomalies'),
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
   });
 }
 

--- a/frontend/src/features/observability/hooks/use-traces.ts
+++ b/frontend/src/features/observability/hooks/use-traces.ts
@@ -114,8 +114,6 @@ export function useTraces(options?: TracesOptions) {
       '/api/traces',
       { params: options as Record<string, string | number | boolean | undefined> }
     ),
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
   });
 }
 
@@ -134,8 +132,6 @@ export function useServiceMap(options?: TracesOptions) {
       '/api/traces/service-map',
       { params: options as Record<string, string | number | boolean | undefined> }
     ),
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
   });
 }
 
@@ -146,7 +142,5 @@ export function useTraceSummary(options?: Omit<TracesOptions, 'limit'>) {
       '/api/traces/summary',
       { params: options as Record<string, string | number | boolean | undefined> }
     ),
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/features/operations/hooks/use-remediation.ts
+++ b/frontend/src/features/operations/hooks/use-remediation.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 import { toast } from 'sonner';
 
 interface RemediationAction {
@@ -26,10 +27,8 @@ export function useRemediationActions(status?: string) {
     // This query is mounted in multiple places (sidebar + remediation page).
     // Prevent retry/focus bursts that can trigger transient 429 responses.
     retry: false,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    staleTime: 10_000,
+    staleTime: STALE_TIMES.DEFAULT,
   });
 }
 

--- a/frontend/src/features/operations/hooks/use-remediation.ts
+++ b/frontend/src/features/operations/hooks/use-remediation.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
 import { STALE_TIMES } from '@/shared/lib/query-constants';
+import { usePageVisibility } from '@/shared/hooks/use-page-visibility';
 import { toast } from 'sonner';
 
 interface RemediationAction {
@@ -18,6 +19,8 @@ interface RemediationAction {
 }
 
 export function useRemediationActions(status?: string) {
+  const isPageVisible = usePageVisibility();
+
   return useQuery<RemediationAction[]>({
     queryKey: ['remediation', 'actions', status],
     queryFn: () => {
@@ -29,6 +32,8 @@ export function useRemediationActions(status?: string) {
     retry: false,
     refetchOnReconnect: false,
     staleTime: STALE_TIMES.DEFAULT,
+    // Poll for new pending actions so badge counts stay fresh
+    refetchInterval: isPageVisible ? 30_000 : false,
   });
 }
 

--- a/frontend/src/features/operations/pages/edge-agent-logs.tsx
+++ b/frontend/src/features/operations/pages/edge-agent-logs.tsx
@@ -259,8 +259,6 @@ export default function EdgeAgentLogsPage() {
       return api.get<LogsResponse>('/api/logs/search', { params });
     },
     retry: false, // Don't retry on 503 (not configured)
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
   });
 
   // Treat both isLoading and isPending-without-data as "loading" to avoid

--- a/frontend/src/features/security/hooks/use-ebpf-coverage.ts
+++ b/frontend/src/features/security/hooks/use-ebpf-coverage.ts
@@ -39,8 +39,6 @@ export function useEbpfCoverage() {
   return useQuery<{ coverage: CoverageRecord[] }>({
     queryKey: ['ebpf', 'coverage'],
     queryFn: () => api.get('/api/ebpf/coverage'),
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
     refetchInterval: isPageVisible ? 120_000 : false,
   });
 }
@@ -51,8 +49,6 @@ export function useEbpfCoverageSummary() {
   return useQuery<CoverageSummary>({
     queryKey: ['ebpf', 'coverage', 'summary'],
     queryFn: () => api.get('/api/ebpf/coverage/summary'),
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
     refetchInterval: isPageVisible ? 120_000 : false,
   });
 }

--- a/frontend/src/features/security/hooks/use-security-audit.ts
+++ b/frontend/src/features/security/hooks/use-security-audit.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
 import { useResource } from '@/shared/hooks/use-resource';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 
 export interface SecurityAuditEntry {
   containerId: string;
@@ -45,9 +46,7 @@ export function useSecurityAudit(endpointId?: number) {
       endpointId
         ? api.get<SecurityAuditResponse>(`/api/security/audit/${endpointId}`)
         : api.get<SecurityAuditResponse>('/api/security/audit'),
-    staleTime: 120 * 1000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
+    staleTime: STALE_TIMES.MEDIUM,
   });
 }
 

--- a/frontend/src/providers/query-provider.test.tsx
+++ b/frontend/src/providers/query-provider.test.tsx
@@ -19,7 +19,7 @@ describe('QueryProvider', () => {
 
     const defaults = JSON.parse(getByTestId('defaults').textContent ?? '{}');
 
-    expect(defaults.queries.staleTime).toBe(30_000);
+    expect(defaults.queries.staleTime).toBe(2 * 60_000);
     expect(defaults.queries.gcTime).toBe(600_000);
     expect(defaults.queries.retry).toBe(2);
     expect(defaults.queries.refetchOnWindowFocus).toBe(false);

--- a/frontend/src/providers/query-provider.tsx
+++ b/frontend/src/providers/query-provider.tsx
@@ -7,7 +7,7 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: 30 * 1000,
+            staleTime: 2 * 60 * 1000,
             gcTime: 10 * 60 * 1000,
             retry: 2,
             retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),

--- a/frontend/src/shared/lib/motion-tokens.ts
+++ b/frontend/src/shared/lib/motion-tokens.ts
@@ -7,10 +7,10 @@
 
 /* ── Durations (seconds) ── */
 export const duration = {
-  fast: 0.15,
-  base: 0.25,
-  slow: 0.4,
-  slower: 0.6,
+  fast: 0.1,
+  base: 0.15,
+  slow: 0.2,
+  slower: 0.35,
 } as const;
 
 /* ── Easing curves (cubic-bezier arrays) ── */

--- a/frontend/src/shared/lib/query-constants.test.ts
+++ b/frontend/src/shared/lib/query-constants.test.ts
@@ -9,13 +9,13 @@ describe('STALE_TIMES', () => {
   });
 
   it('values are in ascending order', () => {
-    expect(STALE_TIMES.DEFAULT).toBeLessThan(STALE_TIMES.SHORT);
-    expect(STALE_TIMES.SHORT).toBeLessThan(STALE_TIMES.MEDIUM);
-    expect(STALE_TIMES.MEDIUM).toBeLessThan(STALE_TIMES.LONG);
+    expect(STALE_TIMES.DEFAULT).toBeLessThanOrEqual(STALE_TIMES.SHORT);
+    expect(STALE_TIMES.SHORT).toBeLessThanOrEqual(STALE_TIMES.MEDIUM);
+    expect(STALE_TIMES.MEDIUM).toBeLessThanOrEqual(STALE_TIMES.LONG);
   });
 
-  it('DEFAULT is 30 seconds', () => {
-    expect(STALE_TIMES.DEFAULT).toBe(30_000);
+  it('DEFAULT is 2 minutes', () => {
+    expect(STALE_TIMES.DEFAULT).toBe(2 * 60_000);
   });
 
   it('LONG is 5 minutes', () => {

--- a/frontend/src/shared/lib/query-constants.ts
+++ b/frontend/src/shared/lib/query-constants.ts
@@ -1,10 +1,10 @@
 export const STALE_TIMES = {
-  /** 30s — dashboard data (matches QueryProvider default) */
-  DEFAULT: 30_000,
-  /** 1min — endpoints, backups */
-  SHORT: 60_000,
-  /** 2min — security audits */
-  MEDIUM: 120_000,
+  /** 2min — dashboard data (matches QueryProvider default) */
+  DEFAULT: 2 * 60_000,
+  /** 2min — endpoints, backups */
+  SHORT: 2 * 60_000,
+  /** 5min — security audits */
+  MEDIUM: 5 * 60_000,
   /** 5min — images, stacks, models */
-  LONG: 300_000,
+  LONG: 5 * 60_000,
 } as const;

--- a/packages/core/src/plugins/cache-control.test.ts
+++ b/packages/core/src/plugins/cache-control.test.ts
@@ -28,12 +28,12 @@ describe('cache-control plugin', () => {
     const app = await buildTestApp();
 
     const cases = [
-      { url: '/api/endpoints', expected: 'private, max-age=60' },
-      { url: '/api/containers', expected: 'private, max-age=30' },
-      { url: '/api/images', expected: 'private, max-age=120' },
-      { url: '/api/networks', expected: 'private, max-age=120' },
-      { url: '/api/stacks', expected: 'private, max-age=60' },
-      { url: '/api/dashboard/summary', expected: 'private, max-age=30' },
+      { url: '/api/endpoints', expected: 'private, max-age=60, stale-while-revalidate=120' },
+      { url: '/api/containers', expected: 'private, max-age=30, stale-while-revalidate=60' },
+      { url: '/api/images', expected: 'private, max-age=300, stale-while-revalidate=600' },
+      { url: '/api/networks', expected: 'private, max-age=300, stale-while-revalidate=600' },
+      { url: '/api/stacks', expected: 'private, max-age=300, stale-while-revalidate=600' },
+      { url: '/api/dashboard/summary', expected: 'private, max-age=30, stale-while-revalidate=60' },
     ];
 
     for (const { url, expected } of cases) {

--- a/packages/core/src/plugins/cache-control.ts
+++ b/packages/core/src/plugins/cache-control.ts
@@ -14,15 +14,22 @@ interface CacheRule {
   prefix: string;
   /** max-age in seconds */
   maxAge: number;
+  /** stale-while-revalidate in seconds (optional) */
+  swr?: number;
 }
 
 const CACHE_RULES: CacheRule[] = [
-  { prefix: '/api/endpoints', maxAge: 60 },
-  { prefix: '/api/containers', maxAge: 30 },
-  { prefix: '/api/images', maxAge: 120 },
-  { prefix: '/api/networks', maxAge: 120 },
-  { prefix: '/api/stacks', maxAge: 60 },
-  { prefix: '/api/dashboard/summary', maxAge: 30 },
+  { prefix: '/api/dashboard/full', maxAge: 30, swr: 60 },
+  { prefix: '/api/dashboard/summary', maxAge: 30, swr: 60 },
+  { prefix: '/api/dashboard/kpi-history', maxAge: 120, swr: 300 },
+  { prefix: '/api/endpoints', maxAge: 60, swr: 120 },
+  { prefix: '/api/containers', maxAge: 30, swr: 60 },
+  { prefix: '/api/images', maxAge: 300, swr: 600 },
+  { prefix: '/api/networks', maxAge: 300, swr: 600 },
+  { prefix: '/api/stacks', maxAge: 300, swr: 600 },
+  { prefix: '/api/security/audit', maxAge: 120, swr: 300 },
+  { prefix: '/api/monitoring/insights', maxAge: 60, swr: 120 },
+  { prefix: '/api/metrics', maxAge: 30, swr: 60 },
 ];
 
 /** Routes that must never be cached */
@@ -55,7 +62,8 @@ async function cacheControlPlugin(fastify: FastifyInstance) {
     // Apply cache rules
     for (const rule of CACHE_RULES) {
       if (url.startsWith(rule.prefix)) {
-        reply.header('Cache-Control', `private, max-age=${rule.maxAge}`);
+        const swr = rule.swr ? `, stale-while-revalidate=${rule.swr}` : '';
+        reply.header('Cache-Control', `private, max-age=${rule.maxAge}${swr}`);
         return payload;
       }
     }


### PR DESCRIPTION
## Summary

- **Remove `refetchOnMount: 'always'` from 20+ React Query hooks** — cached data is now served instantly during navigation, with background refetch only when stale. This was the #1 cause of slow page switches.
- **Increase staleTime constants** (DEFAULT/SHORT: 30-60s → 2min, MEDIUM: 2min → 5min) — auto-refresh polling already handles freshness, so aggressive staleTime was redundant.
- **Halve page transition animation durations** (exit: 200ms → 100ms, enter: 240ms → 120ms) — reduces perceived latency per navigation from 440ms to 220ms.
- **Remove duplicate `useKpiHistory(24)` call from home page** — KPI data was already included in `useDashboardFull()` response.
- **Decouple post-login prefetch from animation preference** — reduced-motion users now also get dashboard data prefetched before navigation.
- **Optimize `/api/containers/favorites`** — fetches only specific containers via `getContainer()` instead of fetching ALL containers from ALL endpoints and filtering.
- **Enhance cache-control plugin** — add `stale-while-revalidate` directives and expanded route coverage.

## Expected improvement

| Metric | Before | After (est.) |
|--------|--------|-------------|
| Initial data display after login | >5s | ~1.5-2s |
| Page switch (cached data) | ~1-2s | <500ms |
| Animation overhead per navigation | 440ms | 220ms |

## Test plan

- [x] All 1549 frontend tests pass
- [x] All 267 backend tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes with 0 warnings
- [ ] Manual: measure TTFD after login with Chrome DevTools
- [ ] Manual: navigate between Home → Workloads → Infrastructure → Home — verify data appears instantly from cache
- [ ] Manual: verify auto-refresh still updates data within polling interval
- [ ] Manual: test with `prefers-reduced-motion` enabled
- [ ] Manual: verify favorites load quickly on home page with pinned containers

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)