### PR TITLE
feat(#916): add frontend route guards for auth-protected pages

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, Navigate } from 'react-router-dom';
 import { AppLayout } from '@/features/core/components/layout/app-layout';
 import { RouteErrorBoundary } from '@/shared/components/feedback/route-error-boundary';
 import { ChunkLoadErrorBoundary } from '@/shared/components/feedback/chunk-load-error-boundary';
+import { ProtectedRoute } from '@/shared/components/feedback/protected-route';
 
 // Lazy-loaded pages
 const Login = lazy(() => import('@/features/core/pages/login'));
@@ -97,8 +98,8 @@ export const router = createBrowserRouter([
       { path: 'users', element: <Navigate to="/settings?tab=users" replace /> },
       { path: 'investigations/:id', element: <LazyPage><InvestigationDetail /></LazyPage> },
       { path: 'investigations/insight/:insightId', element: <LazyPage><InvestigationDetail /></LazyPage> },
-      { path: 'backups', element: <LazyPage><Backups /></LazyPage> },
-      { path: 'settings', element: <LazyPage><Settings /></LazyPage> },
+      { path: 'backups', element: <ProtectedRoute requiredRole="admin"><LazyPage><Backups /></LazyPage></ProtectedRoute> },
+      { path: 'settings', element: <ProtectedRoute requiredRole="admin"><LazyPage><Settings /></LazyPage></ProtectedRoute> },
     ],
   },
   { path: '*', element: <Navigate to="/" replace />, errorElement: <RouteErrorBoundary /> },

--- a/frontend/src/shared/components/feedback/protected-route.test.tsx
+++ b/frontend/src/shared/components/feedback/protected-route.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ProtectedRoute } from './protected-route';
+
+const mockUseAuth = vi.fn();
+vi.mock('@/providers/auth-provider', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+function renderWithRouter(element: React.ReactNode, initialPath = '/protected') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/login" element={<div>Login Page</div>} />
+        <Route path="/" element={<div>Home Page</div>} />
+        <Route path="/protected" element={element} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ProtectedRoute', () => {
+  it('renders children when authenticated', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, role: 'viewer' });
+    renderWithRouter(
+      <ProtectedRoute><div>Protected Content</div></ProtectedRoute>
+    );
+    expect(screen.getByText('Protected Content')).toBeInTheDocument();
+  });
+
+  it('redirects to /login when not authenticated', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, role: 'viewer' });
+    renderWithRouter(
+      <ProtectedRoute><div>Protected Content</div></ProtectedRoute>
+    );
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+  });
+
+  it('renders children when requiredRole matches', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, role: 'admin' });
+    renderWithRouter(
+      <ProtectedRoute requiredRole="admin"><div>Admin Content</div></ProtectedRoute>
+    );
+    expect(screen.getByText('Admin Content')).toBeInTheDocument();
+  });
+
+  it('redirects to / when role does not match and no fallback', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, role: 'viewer' });
+    renderWithRouter(
+      <ProtectedRoute requiredRole="admin"><div>Admin Content</div></ProtectedRoute>
+    );
+    expect(screen.queryByText('Admin Content')).not.toBeInTheDocument();
+    expect(screen.getByText('Home Page')).toBeInTheDocument();
+  });
+
+  it('renders fallback when role does not match and fallback provided', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, role: 'viewer' });
+    renderWithRouter(
+      <ProtectedRoute requiredRole="admin" fallback={<div>Access Denied</div>}>
+        <div>Admin Content</div>
+      </ProtectedRoute>
+    );
+    expect(screen.queryByText('Admin Content')).not.toBeInTheDocument();
+    expect(screen.getByText('Access Denied')).toBeInTheDocument();
+  });
+
+  it('redirects to /login even when requiredRole is set but not authenticated', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, role: 'viewer' });
+    renderWithRouter(
+      <ProtectedRoute requiredRole="admin"><div>Admin Content</div></ProtectedRoute>
+    );
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/feedback/protected-route.tsx
+++ b/frontend/src/shared/components/feedback/protected-route.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth, type UserRole } from '@/providers/auth-provider';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+  requiredRole?: UserRole;
+  fallback?: React.ReactNode;
+}
+
+export function ProtectedRoute({ children, requiredRole, fallback }: ProtectedRouteProps) {
+  const { isAuthenticated, role } = useAuth();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (requiredRole && role !== requiredRole) {
+    return fallback ?? <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- Created `ProtectedRoute` component with auth + role checking
- Wrapped admin routes (`/settings`, `/backups`) with `requiredRole="admin"` guard
- Unauthenticated users redirected to `/login`, non-admin users redirected to `/`

## Changes
- **New**: `frontend/src/shared/components/feedback/protected-route.tsx`
- **New**: `frontend/src/shared/components/feedback/protected-route.test.tsx` (6 tests)
- **Modified**: `frontend/src/router.tsx` — admin routes wrapped with `ProtectedRoute`

## Test plan
- [x] 6 unit tests covering: authenticated render, unauthenticated redirect, role match, role mismatch, custom fallback, combined auth+role
- [ ] CI pipeline passes

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)