### PR TITLE
feat(#917): add frontend global error handling strategy

### DIFF
--- a/frontend/src/providers/query-provider.test.tsx
+++ b/frontend/src/providers/query-provider.test.tsx
@@ -1,12 +1,44 @@
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
-import { useQueryClient } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { useQueryClient, useQuery, useMutation } from '@tanstack/react-query';
 import { QueryProvider } from './query-provider';
+import { ApiError } from '@/shared/lib/api-error';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function Inspector() {
   const client = useQueryClient();
   const defaults = client.getDefaultOptions();
   return <pre data-testid="defaults">{JSON.stringify(defaults)}</pre>;
+}
+
+function TestMutationComponent({
+  mutateFn,
+  onError,
+}: {
+  mutateFn: () => Promise<unknown>;
+  onError?: (err: Error) => void;
+}) {
+  const mutation = useMutation({
+    mutationFn: mutateFn,
+    onError,
+  });
+  return (
+    <button onClick={() => mutation.mutate()}>
+      {mutation.isError ? 'Error' : 'Mutate'}
+    </button>
+  );
 }
 
 describe('QueryProvider', () => {
@@ -35,5 +67,55 @@ describe('QueryProvider', () => {
 
     const defaults = JSON.parse(getByTestId('defaults').textContent ?? '{}');
     expect(defaults.mutations.retry).toBe(0);
+  });
+});
+
+describe('QueryProvider global error handling', () => {
+  it('toasts mutation errors when no local onError is provided', async () => {
+    const mutateFn = vi.fn().mockRejectedValue(new ApiError(500, 'Server error'));
+
+    const { getByText } = render(
+      <QueryProvider>
+        <TestMutationComponent mutateFn={mutateFn} />
+      </QueryProvider>
+    );
+
+    getByText('Mutate').click();
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Server error')
+    );
+  });
+
+  it('does not toast mutation errors when local onError handles them', async () => {
+    const mutateFn = vi.fn().mockRejectedValue(new ApiError(422, 'Validation failed'));
+    const localOnError = vi.fn();
+
+    const { getByText } = render(
+      <QueryProvider>
+        <TestMutationComponent mutateFn={mutateFn} onError={localOnError} />
+      </QueryProvider>
+    );
+
+    getByText('Mutate').click();
+
+    await waitFor(() => expect(localOnError).toHaveBeenCalled());
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('does not toast mutation 401 errors (handled by auth:expired)', async () => {
+    const mutateFn = vi.fn().mockRejectedValue(new ApiError(401, 'Session expired'));
+
+    const { getByText } = render(
+      <QueryProvider>
+        <TestMutationComponent mutateFn={mutateFn} />
+      </QueryProvider>
+    );
+
+    getByText('Mutate').click();
+
+    await waitFor(() => expect(mutateFn).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 50));
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/providers/query-provider.tsx
+++ b/frontend/src/providers/query-provider.tsx
@@ -1,5 +1,12 @@
-import { QueryClient, QueryClientProvider, keepPreviousData } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, QueryCache, MutationCache, keepPreviousData } from '@tanstack/react-query';
 import { useState } from 'react';
+import { toast } from 'sonner';
+import { ApiError } from '@/shared/lib/api-error';
+
+function shouldShowError(error: unknown): error is ApiError {
+  // Don't toast 401 errors — handled by auth:expired event
+  return error instanceof ApiError && error.status !== 401;
+}
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -19,6 +26,22 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             retry: 0,
           },
         },
+        queryCache: new QueryCache({
+          onError: (error, query) => {
+            // Only toast for background refetches that had previous data
+            if (query.state.data !== undefined && shouldShowError(error)) {
+              toast.error(`Background update failed: ${error.userMessage}`);
+            }
+          },
+        }),
+        mutationCache: new MutationCache({
+          onError: (error, _variables, _context, mutation) => {
+            // Only show global toast if the mutation didn't define its own onError
+            if (!mutation.options.onError && shouldShowError(error)) {
+              toast.error(error.userMessage);
+            }
+          },
+        }),
       })
   );
 

--- a/frontend/src/shared/lib/api-error.test.ts
+++ b/frontend/src/shared/lib/api-error.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { ApiError } from './api-error';
+
+describe('ApiError', () => {
+  it('stores status, userMessage, and requestId', () => {
+    const err = new ApiError(500, 'Internal server error', 'req-123');
+    expect(err.status).toBe(500);
+    expect(err.userMessage).toBe('Internal server error');
+    expect(err.requestId).toBe('req-123');
+    expect(err.message).toBe('Internal server error');
+    expect(err.name).toBe('ApiError');
+  });
+
+  it('is an instance of Error', () => {
+    const err = new ApiError(404, 'Not found');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ApiError);
+  });
+
+  it('works without requestId', () => {
+    const err = new ApiError(503, 'Service unavailable');
+    expect(err.requestId).toBeUndefined();
+  });
+});

--- a/frontend/src/shared/lib/api-error.ts
+++ b/frontend/src/shared/lib/api-error.ts
@@ -1,0 +1,10 @@
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly userMessage: string,
+    public readonly requestId?: string,
+  ) {
+    super(userMessage);
+    this.name = 'ApiError';
+  }
+}

--- a/frontend/src/shared/lib/api.ts
+++ b/frontend/src/shared/lib/api.ts
@@ -1,3 +1,5 @@
+import { ApiError } from './api-error';
+
 const API_BASE = import.meta.env.VITE_API_URL || '';
 const AUTH_TOKEN_KEY = 'auth_token';
 
@@ -87,16 +89,18 @@ class ApiClient {
       clearTimeout(timeout);
     }
 
+    const requestId = headers.get('X-Request-ID') ?? undefined;
+
     if (response.status === 401) {
       this.token = null;
       window.dispatchEvent(new CustomEvent('auth:expired'));
-      throw new Error('Session expired');
+      throw new ApiError(401, 'Session expired', requestId);
     }
 
     if (!response.ok) {
       const body = await response.json().catch(() => ({}));
       const fallback = describeHttpError(response.status);
-      throw new Error(body.error || fallback);
+      throw new ApiError(response.status, body.error || fallback, requestId);
     }
 
     return response.json();


### PR DESCRIPTION
## Summary
- Created `ApiError` class with status code, user message, and request ID
- Updated API client to throw `ApiError` instead of generic `Error`
- Added global `QueryCache` and `MutationCache` error handlers with toast notifications
- 401 errors excluded from toasts (handled by `auth:expired` event)
- Mutations with local `onError` skip the global toast

## Changes
- **New**: `frontend/src/shared/lib/api-error.ts` — structured error class
- **New**: `frontend/src/shared/lib/api-error.test.ts` (3 tests)
- **Modified**: `frontend/src/shared/lib/api.ts` — throws `ApiError` with request ID
- **Modified**: `frontend/src/providers/query-provider.tsx` — global `QueryCache`/`MutationCache` error handlers
- **Modified**: `frontend/src/providers/query-provider.test.tsx` (3 new tests, 5 total)

## Test plan
- [x] `ApiError` unit tests (3) — status, message, requestId, instanceof
- [x] `QueryProvider` tests (5) — default options, global mutation toast, local onError skip, 401 exclusion
- [ ] CI pipeline passes

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)