### PR TITLE
refactor+test: deduplicate containers handler and add missing route test files

### DIFF
--- a/packages/ai-intelligence/src/__tests__/investigations-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/investigations-route.test.ts
@@ -97,12 +97,12 @@ describe('Investigation Routes', () => {
 
       await app.inject({
         method: 'GET',
-        url: '/api/investigations?status=completed',
+        url: '/api/investigations?status=complete',
         headers: { authorization: 'Bearer test' },
       });
 
       expect(mockGetInvestigations).toHaveBeenCalledWith(
-        expect.objectContaining({ status: 'completed' }),
+        expect.objectContaining({ status: 'complete' }),
       );
     });
 

--- a/packages/ai-intelligence/src/__tests__/investigations-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/investigations-route.test.ts
@@ -31,7 +31,7 @@ const sampleInvestigation = {
   endpoint_id: 1,
   container_id: 'abc123',
   container_name: 'web',
-  status: 'completed' as const,
+  status: 'complete' as const,
   created_at: '2026-01-01T00:00:00.000Z',
   insight_title: 'High CPU usage',
   insight_severity: 'critical',
@@ -148,7 +148,7 @@ describe('Investigation Routes', () => {
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
       expect(body.id).toBe('inv-001');
-      expect(body.status).toBe('completed');
+      expect(body.status).toBe('complete');
     });
 
     it('returns 404 when investigation not found', async () => {

--- a/packages/ai-intelligence/src/__tests__/investigations-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/investigations-route.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
+import { investigationRoutes } from '../routes/investigations.js';
+
+// Kept: investigation-store mock — no PostgreSQL in CI
+const mockGetInvestigations = vi.fn();
+const mockGetInvestigation = vi.fn();
+const mockGetInvestigationByInsightId = vi.fn();
+
+vi.mock('../services/investigation-store.js', () => ({
+  getInvestigations: (...args: unknown[]) => mockGetInvestigations(...args),
+  getInvestigation: (...args: unknown[]) => mockGetInvestigation(...args),
+  getInvestigationByInsightId: (...args: unknown[]) => mockGetInvestigationByInsightId(...args),
+}));
+
+// Kept: DB router mock — investigation-store imports getDbForDomain at module level
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => ({
+    query: vi.fn().mockResolvedValue([]),
+    queryOne: vi.fn().mockResolvedValue(null),
+    execute: vi.fn().mockResolvedValue({ changes: 0 }),
+    transaction: vi.fn(),
+    healthCheck: vi.fn().mockResolvedValue(true),
+  }),
+}));
+
+const sampleInvestigation = {
+  id: 'inv-001',
+  insight_id: 'ins-abc',
+  endpoint_id: 1,
+  container_id: 'abc123',
+  container_name: 'web',
+  status: 'completed' as const,
+  created_at: '2026-01-01T00:00:00.000Z',
+  insight_title: 'High CPU usage',
+  insight_severity: 'critical',
+  insight_category: 'anomaly',
+};
+
+describe('Investigation Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', () => async () => undefined);
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'admin', sessionId: 's1', role: 'admin' as const };
+    });
+    await app.register(investigationRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/investigations', () => {
+    it('returns list of investigations', async () => {
+      mockGetInvestigations.mockResolvedValue([sampleInvestigation]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/investigations',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.investigations).toHaveLength(1);
+      expect(body.investigations[0].id).toBe('inv-001');
+    });
+
+    it('returns empty list when no investigations', async () => {
+      mockGetInvestigations.mockResolvedValue([]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/investigations',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.investigations).toEqual([]);
+    });
+
+    it('passes status filter to store', async () => {
+      mockGetInvestigations.mockResolvedValue([]);
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/investigations?status=completed',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(mockGetInvestigations).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'completed' }),
+      );
+    });
+
+    it('passes container_id filter to store', async () => {
+      mockGetInvestigations.mockResolvedValue([]);
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/investigations?container_id=abc123',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(mockGetInvestigations).toHaveBeenCalledWith(
+        expect.objectContaining({ container_id: 'abc123' }),
+      );
+    });
+
+    it('passes limit and offset', async () => {
+      mockGetInvestigations.mockResolvedValue([]);
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/investigations?limit=10&offset=5',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(mockGetInvestigations).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 10, offset: 5 }),
+      );
+    });
+  });
+
+  describe('GET /api/investigations/:id', () => {
+    it('returns a single investigation by id', async () => {
+      mockGetInvestigation.mockResolvedValue(sampleInvestigation);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/investigations/inv-001',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.id).toBe('inv-001');
+      expect(body.status).toBe('completed');
+    });
+
+    it('returns 404 when investigation not found', async () => {
+      mockGetInvestigation.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/investigations/non-existent',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('Investigation not found');
+    });
+  });
+
+  describe('GET /api/investigations/by-insight/:insightId', () => {
+    it('returns investigation linked to an insight', async () => {
+      mockGetInvestigationByInsightId.mockResolvedValue(sampleInvestigation);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/investigations/by-insight/ins-abc',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.id).toBe('inv-001');
+      expect(mockGetInvestigationByInsightId).toHaveBeenCalledWith('ins-abc');
+    });
+
+    it('returns 404 when no investigation exists for insight', async () => {
+      mockGetInvestigationByInsightId.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/investigations/by-insight/ins-missing',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('No investigation found for this insight');
+    });
+  });
+});

--- a/packages/foundation/src/__tests__/endpoints-route.test.ts
+++ b/packages/foundation/src/__tests__/endpoints-route.test.ts
@@ -41,8 +41,11 @@ describe('Endpoints Routes', () => {
     await app.close();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.restoreAllMocks();
+    // Clear the in-memory cache between tests to prevent cross-test leakage
+    // (cachedFetch stores results in the HybridCache singleton)
+    await portainerCache.cache.clear();
   });
 
   describe('GET /api/endpoints', () => {

--- a/packages/foundation/src/__tests__/endpoints-route.test.ts
+++ b/packages/foundation/src/__tests__/endpoints-route.test.ts
@@ -5,10 +5,17 @@ import { endpointsRoutes } from '../routes/endpoints.js';
 
 // Passthrough mock: keeps real normalizer logic but makes the module writable for spying
 vi.mock('@dashboard/core/portainer/portainer-client.js', async (importOriginal) => await importOriginal());
-vi.mock('@dashboard/core/portainer/portainer-cache.js', async (importOriginal) => await importOriginal());
+// Cache mock: bypass caching so each test gets a fresh fetch (prevents cross-test contamination)
+vi.mock('@dashboard/core/portainer/portainer-cache.js', async (importOriginal) => {
+  const real = await importOriginal() as typeof import('@dashboard/core/portainer/portainer-cache.js');
+  return {
+    ...real,
+    cachedFetch: <T>(_key: string, _ttl: number, fn: () => Promise<T>) => fn(),
+    cachedFetchSWR: <T>(_key: string, _ttl: number, fn: () => Promise<T>) => fn(),
+  };
+});
 
 import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
-import * as portainerCache from '@dashboard/core/portainer/portainer-cache.js';
 
 const fakeEndpoint = (id: number, name: string, type = 1, status = 1) => ({
   Id: id,

--- a/packages/foundation/src/__tests__/endpoints-route.test.ts
+++ b/packages/foundation/src/__tests__/endpoints-route.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
+import { endpointsRoutes } from '../routes/endpoints.js';
+
+// Passthrough mock: keeps real normalizer logic but makes the module writable for spying
+vi.mock('@dashboard/core/portainer/portainer-client.js', async (importOriginal) => await importOriginal());
+vi.mock('@dashboard/core/portainer/portainer-cache.js', async (importOriginal) => await importOriginal());
+
+import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
+import * as portainerCache from '@dashboard/core/portainer/portainer-cache.js';
+
+const fakeEndpoint = (id: number, name: string, type = 1, status = 1) => ({
+  Id: id,
+  Name: name,
+  Type: type,
+  Status: status,
+  Snapshots: [],
+  EdgeID: null,
+  LastCheckInDate: null,
+  EdgeCheckinInterval: null,
+});
+
+describe('Endpoints Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', () => async () => undefined);
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'admin', sessionId: 's1', role: 'admin' as const };
+    });
+    await app.register(endpointsRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('GET /api/endpoints', () => {
+    it('returns normalized endpoint list', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeEndpoint(1, 'prod'),
+        fakeEndpoint(2, 'staging'),
+      ] as any);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/endpoints',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveLength(2);
+      expect(body[0]).toHaveProperty('id');
+      expect(body[0]).toHaveProperty('name');
+      expect(body[0]).toHaveProperty('status');
+    });
+
+    it('returns empty array when no endpoints', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/endpoints',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toEqual([]);
+    });
+
+    it('requires authentication', async () => {
+      const unauthApp = Fastify({ logger: false });
+      unauthApp.setValidatorCompiler(validatorCompiler);
+      // authenticate throws to simulate real auth check
+      unauthApp.decorate('authenticate', async (_req: any, reply: any) => {
+        reply.code(401).send({ error: 'Unauthorized' });
+      });
+      unauthApp.decorate('requireRole', () => async () => undefined);
+      await unauthApp.register(endpointsRoutes);
+      await unauthApp.ready();
+
+      const response = await unauthApp.inject({
+        method: 'GET',
+        url: '/api/endpoints',
+      });
+
+      expect(response.statusCode).toBe(401);
+      await unauthApp.close();
+    });
+  });
+
+  describe('GET /api/endpoints/:id', () => {
+    it('returns a single endpoint by id', async () => {
+      vi.spyOn(portainerClient, 'getEndpoint').mockResolvedValue(
+        fakeEndpoint(1, 'prod') as any,
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/endpoints/1',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.id).toBe(1);
+      expect(body.name).toBe('prod');
+    });
+
+    it('propagates errors from portainer client', async () => {
+      vi.spyOn(portainerClient, 'getEndpoint').mockRejectedValue(
+        Object.assign(new Error('Not Found'), { statusCode: 404 }),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/endpoints/999',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      // Fastify propagates the error; exact status depends on error type
+      expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe('GET /api/endpoints/debug/edge-status', () => {
+    it('returns raw edge endpoint data', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        fakeEndpoint(1, 'edge-node', 4, 1), // type 4 = edge async
+      ] as any);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/endpoints/debug/edge-status',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveLength(1);
+      expect(body[0]).toHaveProperty('id');
+      expect(body[0]).toHaveProperty('normalizedStatus');
+      expect(body[0]).toHaveProperty('nowUnix');
+    });
+  });
+});

--- a/packages/foundation/src/__tests__/endpoints-route.test.ts
+++ b/packages/foundation/src/__tests__/endpoints-route.test.ts
@@ -48,11 +48,8 @@ describe('Endpoints Routes', () => {
     await app.close();
   });
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.restoreAllMocks();
-    // Clear the in-memory cache between tests to prevent cross-test leakage
-    // (cachedFetch stores results in the HybridCache singleton)
-    await portainerCache.cache.clear();
   });
 
   describe('GET /api/endpoints', () => {

--- a/packages/foundation/src/routes/containers.ts
+++ b/packages/foundation/src/routes/containers.ts
@@ -78,13 +78,9 @@ export async function containersRoutes(fastify: FastifyInstance) {
   }, async (request, reply) => {
     const { page, pageSize, search, state, endpointId } = request.query as z.infer<typeof ContainerListQuerySchema>;
 
-    let endpoints;
+    let fetched: Awaited<ReturnType<typeof fetchAllContainers>>;
     try {
-      endpoints = await cachedFetchSWR(
-        getCacheKey('endpoints'),
-        TTL.ENDPOINTS,
-        () => portainer.getEndpoints(),
-      );
+      fetched = await fetchAllContainers(endpointId);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
       log.error({ err }, 'Failed to fetch endpoints from Portainer');
@@ -94,37 +90,9 @@ export async function containersRoutes(fastify: FastifyInstance) {
       });
     }
 
-    // Only target Docker endpoints — K8s endpoints use separate /api/kubernetes/ routes
-    const dockerEndpoints = endpoints.filter((e) => isDockerEndpoint(e.Type));
-    const targetEndpoints = endpointId
-      ? dockerEndpoints.filter((e) => e.Id === endpointId)
-      : dockerEndpoints;
-
-    const allContainers: ReturnType<typeof normalizeContainer>[] = [];
-    const errors: string[] = [];
-    const upEndpoints = targetEndpoints.filter((ep) => normalizeEndpoint(ep).status === 'up');
-    const settled = await Promise.allSettled(
-      upEndpoints.map((ep) =>
-        cachedFetchSWR(
-          getCacheKey('containers', ep.Id),
-          TTL.CONTAINERS,
-          () => portainer.getContainers(ep.Id),
-        ).then((containers) => ({ ep, containers })),
-      ),
-    );
-    for (let i = 0; i < settled.length; i++) {
-      const result = settled[i];
-      if (result.status === 'fulfilled') {
-        const { ep, containers } = result.value;
-        allContainers.push(...containers.map((c) => normalizeContainer(c, ep.Id, ep.Name)));
-      } else {
-        const ep = upEndpoints[i];
-        const msg = result.reason instanceof Error ? result.reason.message : 'Unknown error';
-        log.warn({ endpointId: ep.Id, endpointName: ep.Name, err: result.reason }, 'Failed to fetch containers for endpoint');
-        errors.push(`${ep.Name}: ${msg}`);
-      }
-    }
-
+    // errors contains endpoint-name-prefixed strings (e.g. "staging: Connection refused")
+    // used in the response's failedEndpoints field (API contract: string array of names)
+    const { results: allContainers, errors, upEndpoints } = fetched;
     const partial = errors.length > 0;
 
     if (upEndpoints.length > 0 && allContainers.length === 0 && errors.length > 0) {

--- a/packages/foundation/vitest.config.ts
+++ b/packages/foundation/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    clearMocks: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    fileParallelism: false,
+    env: {
+      DASHBOARD_USERNAME: 'admin',
+      DASHBOARD_PASSWORD: 'test-password-12345',
+      JWT_SECRET: 'a'.repeat(64),
+      REDIS_URL: 'redis://localhost:6379',
+      PORTAINER_API_URL: 'http://localhost:9000',
+      PORTAINER_API_KEY: 'test-api-key-placeholder',
+      OLLAMA_BASE_URL: 'http://localhost:11434',
+      OLLAMA_MODEL: 'tinyllama',
+      CACHE_ENABLED: 'true',
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+      thresholds: { lines: 50, functions: 50, branches: 50, statements: 50 },
+    },
+  },
+});

--- a/packages/operations/src/__tests__/logs-route.test.ts
+++ b/packages/operations/src/__tests__/logs-route.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
+import { logsRoutes } from '../routes/logs.js';
+
+// Kept: infrastructure mock — no Elasticsearch in CI
+const mockGetElasticsearchConfig = vi.fn();
+
+vi.mock('@dashboard/infrastructure', () => ({
+  getElasticsearchConfig: (...args: unknown[]) => mockGetElasticsearchConfig(...args),
+}));
+
+const defaultEsConfig = {
+  endpoint: 'https://elasticsearch.example.com',
+  apiKey: 'test-api-key',
+  indexPattern: 'logs-*',
+  verifySsl: true,
+};
+
+describe('Logs Routes', () => {
+  let app: FastifyInstance;
+  let currentRole: 'viewer' | 'operator' | 'admin';
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    currentRole = 'admin';
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request: any, reply: any) => {
+      const rank = { viewer: 0, operator: 1, admin: 2 };
+      const userRole = request.user?.role ?? 'viewer';
+      if (rank[userRole] < rank[minRole]) {
+        reply.code(403).send({ error: 'Insufficient permissions' });
+      }
+    });
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'admin', sessionId: 's1', role: currentRole };
+    });
+    await app.register(logsRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentRole = 'admin';
+    mockGetElasticsearchConfig.mockResolvedValue(defaultEsConfig);
+    // Mock global fetch used by the route for ES queries
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+  });
+
+  describe('GET /api/logs/search', () => {
+    it('returns 503 when Elasticsearch is not configured', async () => {
+      mockGetElasticsearchConfig.mockResolvedValue(null);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/logs/search',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(503);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Elasticsearch');
+    });
+
+    it('returns log hits on successful search', async () => {
+      const esResponse = {
+        hits: {
+          total: { value: 1 },
+          hits: [{
+            _id: 'log-1',
+            _source: {
+              '@timestamp': '2026-01-01T00:00:00.000Z',
+              message: 'Container started',
+              host: { name: 'server-01' },
+              log: { level: 'info' },
+            },
+          }],
+        },
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => esResponse,
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/logs/search?query=started',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.logs).toHaveLength(1);
+      expect(body.logs[0].id).toBe('log-1');
+      expect(body.logs[0].message).toBe('Container started');
+      expect(body.total).toBe(1);
+    });
+
+    it('returns 502 when Elasticsearch query fails', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/logs/search',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(502);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Elasticsearch');
+    });
+
+    it('returns 502 when fetch throws (connection error)', async () => {
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/logs/search',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(502);
+    });
+
+    it('applies query filters correctly', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ hits: { total: { value: 0 }, hits: [] } }),
+      });
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/logs/search?query=error&hostname=server-01&level=error',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('logs-*/_search');
+      const body = JSON.parse(opts.body);
+      expect(body.query.bool.must).toContainEqual({ query_string: { query: 'error' } });
+      expect(body.query.bool.must).toContainEqual({ match: { 'host.name': 'server-01' } });
+      expect(body.query.bool.must).toContainEqual({ match: { 'log.level': 'error' } });
+    });
+  });
+
+  describe('GET /api/logs/config', () => {
+    it('returns configured=true when ES is set up', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/logs/config',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.configured).toBe(true);
+      expect(body.indexPattern).toBe('logs-*');
+    });
+
+    it('returns configured=false when ES is not set up', async () => {
+      mockGetElasticsearchConfig.mockResolvedValue(null);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/logs/config',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.configured).toBe(false);
+      expect(body.endpoint).toBeNull();
+    });
+
+    it('redacts credentials from endpoint URL', async () => {
+      mockGetElasticsearchConfig.mockResolvedValue({
+        ...defaultEsConfig,
+        endpoint: 'https://user:password@elasticsearch.example.com',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/logs/config',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.endpoint).not.toContain('password');
+      expect(body.endpoint).toContain('***');
+    });
+  });
+
+  describe('POST /api/logs/test-connection', () => {
+    it('returns success when cluster health check passes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          cluster_name: 'my-cluster',
+          status: 'green',
+          number_of_nodes: 3,
+        }),
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/logs/test-connection',
+        headers: { authorization: 'Bearer test' },
+        payload: { endpoint: 'https://elasticsearch.example.com', apiKey: 'key123', verifySsl: true },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(body.cluster_name).toBe('my-cluster');
+      expect(body.status).toBe('green');
+    });
+
+    it('returns 400 when cluster health check fails', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => 'Unauthorized',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/logs/test-connection',
+        headers: { authorization: 'Bearer test' },
+        payload: { endpoint: 'https://elasticsearch.example.com' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(false);
+    });
+
+    it('returns 400 when connection throws', async () => {
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/logs/test-connection',
+        headers: { authorization: 'Bearer test' },
+        payload: { endpoint: 'https://unreachable.example.com' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('ECONNREFUSED');
+    });
+
+    it('requires endpoint field', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/logs/test-connection',
+        headers: { authorization: 'Bearer test' },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+});

--- a/packages/security/src/__tests__/harbor-vulnerabilities-route.test.ts
+++ b/packages/security/src/__tests__/harbor-vulnerabilities-route.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { testAdminOnly } from '@dashboard/core/test-utils/rbac-test-helper.js';
+import Fastify, { FastifyInstance } from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
+import { harborVulnerabilityRoutes } from '../routes/harbor-vulnerabilities.js';
+
+// Kept: harbor-client mock — no Harbor registry in CI
+const mockIsHarborConfiguredAsync = vi.fn();
+const mockTestConnection = vi.fn();
+const mockGetSecuritySummary = vi.fn();
+const mockGetProjects = vi.fn();
+
+vi.mock('../services/harbor-client.js', () => ({
+  isHarborConfiguredAsync: (...args: unknown[]) => mockIsHarborConfiguredAsync(...args),
+  testConnection: (...args: unknown[]) => mockTestConnection(...args),
+  getSecuritySummary: (...args: unknown[]) => mockGetSecuritySummary(...args),
+  getProjects: (...args: unknown[]) => mockGetProjects(...args),
+}));
+
+// Kept: harbor-vulnerability-store mock — no PostgreSQL in CI
+const mockGetVulnerabilities = vi.fn();
+const mockGetVulnerabilitySummary = vi.fn();
+const mockGetExceptions = vi.fn();
+const mockCreateException = vi.fn();
+const mockDeactivateException = vi.fn();
+const mockGetLatestSyncStatus = vi.fn();
+
+vi.mock('../services/harbor-vulnerability-store.js', () => ({
+  getVulnerabilities: (...args: unknown[]) => mockGetVulnerabilities(...args),
+  getVulnerabilitySummary: (...args: unknown[]) => mockGetVulnerabilitySummary(...args),
+  getExceptions: (...args: unknown[]) => mockGetExceptions(...args),
+  createException: (...args: unknown[]) => mockCreateException(...args),
+  deactivateException: (...args: unknown[]) => mockDeactivateException(...args),
+  getLatestSyncStatus: (...args: unknown[]) => mockGetLatestSyncStatus(...args),
+}));
+
+// Kept: harbor-sync mock — runs background jobs
+const mockRunFullSync = vi.fn();
+vi.mock('../services/harbor-sync.js', () => ({
+  runFullSync: (...args: unknown[]) => mockRunFullSync(...args),
+}));
+
+// Kept: settings-store mock — reads from DB
+vi.mock('@dashboard/core/services/settings-store.js', () => ({
+  getEffectiveHarborConfig: vi.fn().mockResolvedValue({
+    enabled: true,
+    apiUrl: 'https://harbor.example.com',
+    robotName: 'robot$ci',
+    robotSecret: 'secret',
+  }),
+}));
+
+// Kept: audit-logger mock — side-effect isolation
+vi.mock('@dashboard/core/services/audit-logger.js', () => ({
+  writeAuditLog: vi.fn(),
+}));
+
+describe('Harbor Vulnerability Routes', () => {
+  let app: FastifyInstance;
+  let currentRole: 'viewer' | 'operator' | 'admin';
+
+  beforeAll(async () => {
+    currentRole = 'admin';
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request: any, reply: any) => {
+      const rank = { viewer: 0, operator: 1, admin: 2 };
+      const userRole = request.user?.role ?? 'viewer';
+      if (rank[userRole] < rank[minRole]) {
+        reply.code(403).send({ error: 'Insufficient permissions' });
+      }
+    });
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'admin', sessionId: 's1', role: currentRole };
+    });
+    await app.register(harborVulnerabilityRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentRole = 'admin';
+    mockIsHarborConfiguredAsync.mockResolvedValue(true);
+    mockGetVulnerabilitySummary.mockResolvedValue({ critical: 0, high: 0, medium: 0, low: 0, total: 0 });
+    mockGetVulnerabilities.mockResolvedValue([]);
+    mockGetExceptions.mockResolvedValue([]);
+    mockGetLatestSyncStatus.mockResolvedValue(null);
+  });
+
+  describe('GET /api/harbor/vulnerabilities', () => {
+    it('returns vulnerabilities and summary', async () => {
+      const vulns = [{ id: 1, cve_id: 'CVE-2024-0001', severity: 'HIGH', package_name: 'openssl' }];
+      const summary = { critical: 0, high: 1, medium: 0, low: 0, total: 1 };
+      mockGetVulnerabilities.mockResolvedValue(vulns);
+      mockGetVulnerabilitySummary.mockResolvedValue(summary);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/harbor/vulnerabilities',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.vulnerabilities).toHaveLength(1);
+      expect(body.vulnerabilities[0].cve_id).toBe('CVE-2024-0001');
+      expect(body.summary.high).toBe(1);
+    });
+
+    it('passes severity filter to store', async () => {
+      mockGetVulnerabilities.mockResolvedValue([]);
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/harbor/vulnerabilities?severity=CRITICAL',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(mockGetVulnerabilities).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'CRITICAL' }),
+      );
+    });
+
+    it('applies default pagination values', async () => {
+      mockGetVulnerabilities.mockResolvedValue([]);
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/harbor/vulnerabilities',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(mockGetVulnerabilities).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 200, offset: 0 }),
+      );
+    });
+  });
+
+  describe('POST /api/harbor/exceptions', () => {
+    const validBody = {
+      cve_id: 'CVE-2024-9999',
+      scope: 'global',
+      justification: 'False positive in test environment',
+    };
+
+    it('creates a CVE exception', async () => {
+      const created = { id: 1, cve_id: 'CVE-2024-9999', scope: 'global', active: true };
+      mockCreateException.mockResolvedValue(created);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/harbor/exceptions',
+        headers: { authorization: 'Bearer test' },
+        payload: validBody,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.cve_id).toBe('CVE-2024-9999');
+      expect(mockCreateException).toHaveBeenCalledWith(
+        expect.objectContaining({ cve_id: 'CVE-2024-9999', created_by: 'admin' }),
+      );
+    });
+
+    it('rejects missing justification', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/harbor/exceptions',
+        headers: { authorization: 'Bearer test' },
+        payload: { cve_id: 'CVE-2024-9999', scope: 'global', justification: 'short' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    testAdminOnly(
+      () => app, (r) => { currentRole = r; },
+      'POST', '/api/harbor/exceptions',
+      validBody,
+    );
+  });
+
+  describe('DELETE /api/harbor/exceptions/:id', () => {
+    it('deactivates an exception', async () => {
+      mockDeactivateException.mockResolvedValue(true);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/harbor/exceptions/42',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(mockDeactivateException).toHaveBeenCalledWith(42);
+    });
+
+    it('returns 404 when exception not found', async () => {
+      mockDeactivateException.mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/harbor/exceptions/999',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    testAdminOnly(
+      () => app, (r) => { currentRole = r; },
+      'DELETE', '/api/harbor/exceptions/1',
+    );
+  });
+
+  describe('POST /api/harbor/sync', () => {
+    it('triggers a sync and returns immediately', async () => {
+      mockRunFullSync.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/harbor/sync',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.status).toBe('running');
+    });
+
+    it('returns 503 when Harbor is not configured', async () => {
+      mockIsHarborConfiguredAsync.mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/harbor/sync',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(503);
+    });
+
+    testAdminOnly(
+      () => app, (r) => { currentRole = r; },
+      'POST', '/api/harbor/sync',
+    );
+  });
+
+  describe('GET /api/harbor/status', () => {
+    it('returns not-configured when Harbor is off', async () => {
+      mockIsHarborConfiguredAsync.mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/harbor/status',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.configured).toBe(false);
+    });
+
+    it('returns connection status when configured', async () => {
+      mockIsHarborConfiguredAsync.mockResolvedValue(true);
+      mockTestConnection.mockResolvedValue({ ok: true });
+      mockGetLatestSyncStatus.mockResolvedValue({ id: 1, status: 'completed' });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/harbor/status',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.configured).toBe(true);
+      expect(body.connected).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary - #950: refactored GET /api/containers to use fetchAllContainers(). #979: added 4 route test files. Closes #950. Closes #979.