### PR TITLE
refactor: centralize AUTH_TOKEN_KEY and deduplicate hasAuthToken (#953)

### DIFF
--- a/frontend/src/features/core/hooks/use-dashboard-auth-gating.test.tsx
+++ b/frontend/src/features/core/hooks/use-dashboard-auth-gating.test.tsx
@@ -4,6 +4,7 @@ import { QueryProvider } from '@/providers/query-provider';
 import { AuthProvider } from '@/providers/auth-provider';
 import { useDashboard } from '@/features/core/hooks/use-dashboard';
 import { api } from '@/shared/lib/api';
+import { AUTH_TOKEN_KEY } from '@/shared/lib/auth-constants';
 
 function createJwtWithFutureExpiry(): string {
   const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
@@ -62,7 +63,7 @@ describe('useDashboard auth gating', () => {
   });
 
   it('fetches dashboard data immediately when a valid stored token exists', async () => {
-    window.localStorage.setItem('auth_token', createJwtWithFutureExpiry());
+    window.localStorage.setItem(AUTH_TOKEN_KEY, createJwtWithFutureExpiry());
     window.localStorage.setItem('auth_username', 'admin');
     window.localStorage.setItem('auth_role', 'admin');
 

--- a/frontend/src/features/core/hooks/use-dashboard-full.ts
+++ b/frontend/src/features/core/hooks/use-dashboard-full.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { api } from '@/shared/lib/api';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { STALE_TIMES } from '@/shared/lib/query-constants';
+import { hasAuthToken } from '@/shared/lib/auth-constants';
 import type { DashboardSummary } from '@/features/core/hooks/use-dashboard';
 import type { DashboardResources } from '@/features/core/hooks/use-dashboard-resources';
 import type { Endpoint } from '@/features/containers/hooks/use-endpoints';
@@ -13,18 +14,6 @@ export interface DashboardFull {
   resources: DashboardResources;
   endpoints: Endpoint[];
   kpiHistory?: KpiSnapshot[];
-}
-
-function hasAuthToken(): boolean {
-  const apiToken = typeof (api as { getToken?: () => string | null }).getToken === 'function'
-    ? api.getToken()
-    : null;
-  if (apiToken) return true;
-  try {
-    return !!window.localStorage.getItem('auth_token');
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/frontend/src/features/core/hooks/use-dashboard-resources.ts
+++ b/frontend/src/features/core/hooks/use-dashboard-resources.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { STALE_TIMES } from '@/shared/lib/query-constants';
+import { hasAuthToken } from '@/shared/lib/auth-constants';
 
 export interface StackResourceUsage {
   name: string;
@@ -17,18 +18,6 @@ export interface DashboardResources {
   fleetCpuPercent: number;
   fleetMemoryPercent: number;
   topStacks: StackResourceUsage[];
-}
-
-function hasAuthToken(): boolean {
-  const apiToken = typeof (api as { getToken?: () => string | null }).getToken === 'function'
-    ? api.getToken()
-    : null;
-  if (apiToken) return true;
-  try {
-    return !!window.localStorage.getItem('auth_token');
-  } catch {
-    return false;
-  }
 }
 
 export function useDashboardResources(topN: number = 10) {

--- a/frontend/src/features/core/hooks/use-dashboard.ts
+++ b/frontend/src/features/core/hooks/use-dashboard.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { STALE_TIMES } from '@/shared/lib/query-constants';
+import { hasAuthToken } from '@/shared/lib/auth-constants';
 
 export interface DashboardKpis {
   endpoints: number;
@@ -57,18 +58,6 @@ export interface DashboardSummary {
     ignored: number;
   };
   timestamp: string;
-}
-
-function hasAuthToken(): boolean {
-  const apiToken = typeof (api as { getToken?: () => string | null }).getToken === 'function'
-    ? api.getToken()
-    : null;
-  if (apiToken) return true;
-  try {
-    return !!window.localStorage.getItem('auth_token');
-  } catch {
-    return false;
-  }
 }
 
 export function useDashboard() {

--- a/frontend/src/features/observability/hooks/use-log-stream.ts
+++ b/frontend/src/features/observability/hooks/use-log-stream.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { detectLevel, lintLogLine, type ParsedLogEntry } from '@/features/observability/lib/log-viewer';
+import { AUTH_TOKEN_KEY } from '@/shared/lib/auth-constants';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
-const AUTH_TOKEN_KEY = 'auth_token';
 
 interface LogStreamContainer {
   id: string;

--- a/frontend/src/providers/auth-provider.tsx
+++ b/frontend/src/providers/auth-provider.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import { api } from '@/shared/lib/api';
-
-const AUTH_TOKEN_KEY = 'auth_token';
+import { AUTH_TOKEN_KEY } from '@/shared/lib/auth-constants';
 const AUTH_USERNAME_KEY = 'auth_username';
 const AUTH_ROLE_KEY = 'auth_role';
 
@@ -31,7 +30,7 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
   }
 }
 
-function isTokenValid(token: string | null): token is string {
+export function isTokenValid(token: string | null): token is string {
   if (!token) return false;
   const payload = decodeJwtPayload(token);
   if (!payload) return false;

--- a/frontend/src/shared/lib/api.test.ts
+++ b/frontend/src/shared/lib/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { api } from './api';
+import { AUTH_TOKEN_KEY } from './auth-constants';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -14,7 +15,7 @@ describe('ApiClient', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     api.setToken(null);
-    window.localStorage.removeItem('auth_token');
+    window.localStorage.removeItem(AUTH_TOKEN_KEY);
   });
 
   afterEach(() => {
@@ -151,7 +152,7 @@ describe('ApiClient', () => {
 
   describe('authentication', () => {
     it('should hydrate token from localStorage on client initialization', async () => {
-      window.localStorage.setItem('auth_token', 'persisted-token');
+      window.localStorage.setItem(AUTH_TOKEN_KEY, 'persisted-token');
       vi.resetModules();
       const { api: freshApi } = await import('./api');
 

--- a/frontend/src/shared/lib/api.ts
+++ b/frontend/src/shared/lib/api.ts
@@ -1,7 +1,7 @@
 import { ApiError } from './api-error';
+import { AUTH_TOKEN_KEY } from './auth-constants';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
-const AUTH_TOKEN_KEY = 'auth_token';
 
 function describeHttpError(status: number): string {
   switch (status) {

--- a/frontend/src/shared/lib/auth-constants.ts
+++ b/frontend/src/shared/lib/auth-constants.ts
@@ -1,0 +1,20 @@
+import { api } from './api';
+
+export const AUTH_TOKEN_KEY = 'auth_token';
+
+/**
+ * Checks whether a valid auth token is currently held — first checks the in-memory
+ * API client token, then falls back to localStorage. Preserves the two-step pattern
+ * used across the dashboard hooks.
+ */
+export function hasAuthToken(): boolean {
+  const apiToken = typeof (api as { getToken?: () => string | null }).getToken === 'function'
+    ? api.getToken()
+    : null;
+  if (apiToken) return true;
+  try {
+    return !!window.localStorage.getItem(AUTH_TOKEN_KEY);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `frontend/src/shared/lib/auth-constants.ts` as single source of truth for `AUTH_TOKEN_KEY = 'auth_token'` and shared `hasAuthToken()` utility (with two-step api.getToken() + localStorage fallback)
- Removes 6 hardcoded `'auth_token'` string literals and 3 duplicate `hasAuthToken()` implementations across dashboard hooks
- Exports `isTokenValid()` from `auth-provider.tsx` to enable expired-token pre-flight checks in consumers
- Updates test files to use the constant

Also discovered and fixed a missing npm workspace symlink: `@dashboard/foundation` was not linked in `node_modules` causing `tsc --build` to fail globally. Running `npm install` from root resolves this.

## Files changed
- `frontend/src/shared/lib/auth-constants.ts` (new)
- `frontend/src/shared/lib/api.ts`
- `frontend/src/providers/auth-provider.tsx`
- `frontend/src/features/core/hooks/use-dashboard.ts`
- `frontend/src/features/core/hooks/use-dashboard-full.ts`
- `frontend/src/features/core/hooks/use-dashboard-resources.ts`
- `frontend/src/features/observability/hooks/use-log-stream.ts`
- `frontend/src/shared/lib/api.test.ts`
- `frontend/src/features/core/hooks/use-dashboard-auth-gating.test.tsx`

## Test plan
- [x] `api.test.ts` — 20 tests passing
- [x] `use-dashboard-auth-gating.test.tsx` — 2 tests passing
- [x] No remaining `'auth_token'` string literals in `frontend/src` (except canonical definition)
- [x] `tsc --build tsconfig.build.json` passes

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)