### PR TITLE
fix(security): admin role guards for 8 endpoints + TOCTOU fix (#951,#952,#954,#955,#956,#958,#959,#976)

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -27,7 +27,7 @@ let mockRemediationAction: Record<string, unknown> | undefined;
 vi.mock('@dashboard/core/db/app-db-router.js', () => ({
   getDbForDomain: vi.fn(() => ({
     queryOne: vi.fn(async (sql: string) => {
-      if (sql.includes('SELECT * FROM actions WHERE id = ?')) {
+      if (sql.includes('FROM actions WHERE id = ?')) {
         return mockRemediationAction;
       }
       if (sql.includes('SELECT COUNT(*)')) {
@@ -38,10 +38,12 @@ vi.mock('@dashboard/core/db/app-db-router.js', () => ({
     query: vi.fn(async () => []),
     execute: vi.fn(async (sql: string, params: unknown[] = []) => {
       if (sql.includes('UPDATE actions') && sql.includes("status = 'executing'")) {
-        if (mockRemediationAction) {
+        // Real DB: WHERE id = ? AND status = 'approved'
+        if (mockRemediationAction && mockRemediationAction.status === 'approved') {
           mockRemediationAction = { ...mockRemediationAction, status: 'executing' };
+          return { changes: 1 };
         }
-        return { changes: 1 };
+        return { changes: 0 };
       }
       if (sql.includes('UPDATE actions') && sql.includes("status = 'completed'")) {
         if (mockRemediationAction) {
@@ -66,10 +68,12 @@ vi.mock('@dashboard/core/db/app-db-router.js', () => ({
         return { changes: 1 };
       }
       if (sql.includes('UPDATE actions') && sql.includes("status = 'approved'")) {
-        if (mockRemediationAction) {
+        // Real DB: WHERE id = ? AND status = 'pending'
+        if (mockRemediationAction && mockRemediationAction.status === 'pending') {
           mockRemediationAction = { ...mockRemediationAction, status: 'approved' };
+          return { changes: 1 };
         }
-        return { changes: 1 };
+        return { changes: 0 };
       }
       return { changes: 0 };
     }),

--- a/packages/ai-intelligence/src/routes/monitoring.ts
+++ b/packages/ai-intelligence/src/routes/monitoring.ts
@@ -218,7 +218,7 @@ export async function monitoringRoutes(fastify: FastifyInstance, opts: Monitorin
       summary: 'Get capability security audit for all endpoints',
       security: [{ bearerAuth: [] }],
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (_request, reply) => {
     try {
       const entries = await opts.getSecurityAudit();
@@ -236,7 +236,7 @@ export async function monitoringRoutes(fastify: FastifyInstance, opts: Monitorin
       summary: 'Get capability security audit for one endpoint',
       security: [{ bearerAuth: [] }],
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { endpointId } = request.params as { endpointId: string };
     const parsedEndpointId = Number(endpointId);
@@ -256,7 +256,7 @@ export async function monitoringRoutes(fastify: FastifyInstance, opts: Monitorin
       summary: 'Get security audit ignore list',
       security: [{ bearerAuth: [] }],
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (_request, reply) => {
     try {
       return {

--- a/packages/operations/src/__tests__/remediation-route.test.ts
+++ b/packages/operations/src/__tests__/remediation-route.test.ts
@@ -33,7 +33,7 @@ let mockStartContainer: any;
 vi.mock('@dashboard/core/db/app-db-router.js', () => ({
   getDbForDomain: () => ({
     queryOne: vi.fn(async (sql: string, params: unknown[] = []) => {
-      if (sql.includes('SELECT * FROM actions WHERE id = ?')) {
+      if (sql.includes('FROM actions WHERE id = ?')) {
         return state.action;
       }
       if (sql.includes('SELECT COUNT(*)')) {
@@ -43,12 +43,27 @@ vi.mock('@dashboard/core/db/app-db-router.js', () => ({
     }),
     query: vi.fn(async () => []),
     execute: vi.fn(async (sql: string, params: unknown[] = []) => {
-      if (sql.includes("status = 'approved'")) {
-        state.action = { ...state.action, status: 'approved' };
+      if (sql.includes("status = 'executing'")) {
+        // Execute: real DB uses WHERE status = 'approved'
+        if (state.action && state.action.status === 'approved') {
+          state.action = { ...state.action, status: 'executing' };
+          return { changes: 1 };
+        }
+        return { changes: 0 };
+      } else if (sql.includes("SET status = 'approved'")) {
+        // Approve: real DB uses WHERE status = 'pending'
+        if (state.action && state.action.status === 'pending') {
+          state.action = { ...state.action, status: 'approved' };
+          return { changes: 1 };
+        }
+        return { changes: 0 };
       } else if (sql.includes("status = 'rejected'")) {
-        state.action = { ...state.action, status: 'rejected' };
-      } else if (sql.includes("status = 'executing'")) {
-        state.action = { ...state.action, status: 'executing' };
+        // Reject: real DB uses WHERE status = 'pending'
+        if (state.action && state.action.status === 'pending') {
+          state.action = { ...state.action, status: 'rejected' };
+          return { changes: 1 };
+        }
+        return { changes: 0 };
       } else if (sql.includes("status = 'completed'")) {
         state.action = {
           ...state.action,
@@ -56,6 +71,7 @@ vi.mock('@dashboard/core/db/app-db-router.js', () => ({
           execution_result: params[0],
           execution_duration_ms: params[1],
         };
+        return { changes: 1 };
       } else if (sql.includes("status = 'failed'")) {
         state.action = {
           ...state.action,
@@ -63,8 +79,9 @@ vi.mock('@dashboard/core/db/app-db-router.js', () => ({
           execution_result: params[0],
           execution_duration_ms: params[1],
         };
+        return { changes: 1 };
       }
-      return { changes: 1 };
+      return { changes: 0 };
     }),
   }),
 }));

--- a/packages/operations/src/routes/notifications.ts
+++ b/packages/operations/src/routes/notifications.ts
@@ -15,7 +15,7 @@ export async function notificationRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       querystring: NotificationHistoryQuerySchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request) => {
     const { channel, limit = 50, offset = 0 } = request.query as {
       channel?: string;

--- a/packages/operations/src/routes/remediation.ts
+++ b/packages/operations/src/routes/remediation.ts
@@ -17,7 +17,7 @@ export async function remediationRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       querystring: RemediationQuerySchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request) => {
     const { status, limit = 50, offset = 0 } = request.query as {
       status?: string;
@@ -65,20 +65,20 @@ export async function remediationRoutes(fastify: FastifyInstance) {
     const { id } = request.params as { id: string };
     const db = getDbForDomain('actions');
 
-    const action = await db.queryOne<any>('SELECT * FROM actions WHERE id = ?', [id]);
-    if (!action) return reply.code(404).send({ error: 'Action not found' });
-    if (action.status !== 'pending') {
+    const result = await db.execute(`
+      UPDATE actions SET status = 'approved', approved_by = ?, approved_at = NOW()
+      WHERE id = ? AND status = 'pending'
+    `, [request.user?.username, id]);
+
+    if (result.changes === 0) {
+      const existing = await db.queryOne<{ status: string } | null>('SELECT status FROM actions WHERE id = ?', [id]);
+      if (!existing) return reply.code(404).send({ error: 'Action not found' });
       return reply.code(409).send({
-        error: `Action is already ${action.status}. Refresh to see latest status.`,
+        error: `Action is already ${existing.status}. Refresh to see latest status.`,
         actionId: id,
-        currentStatus: action.status,
+        currentStatus: existing.status,
       });
     }
-
-    await db.execute(`
-      UPDATE actions SET status = 'approved', approved_by = ?, approved_at = NOW()
-      WHERE id = ?
-    `, [request.user?.username, id]);
 
     writeAuditLog({
       user_id: request.user?.sub,
@@ -160,6 +160,21 @@ export async function remediationRoutes(fastify: FastifyInstance) {
     const { id } = request.params as { id: string };
     const db = getDbForDomain('actions');
 
+    const execResult = await db.execute(`
+      UPDATE actions SET status = 'executing', executed_at = NOW()
+      WHERE id = ? AND status = 'approved'
+    `, [id]);
+
+    if (execResult.changes === 0) {
+      const existing = await db.queryOne<{ id: string; status: string; action_type: string; endpoint_id: number; container_id: string } | null>('SELECT id, status, action_type, endpoint_id, container_id FROM actions WHERE id = ?', [id]);
+      if (!existing) return reply.code(404).send({ error: 'Action not found' });
+      return reply.code(409).send({
+        error: `Action must be approved before execution. Current status: ${existing.status}.`,
+        actionId: id,
+        currentStatus: existing.status,
+      });
+    }
+
     const action = await db.queryOne<{
       id: string;
       status: string;
@@ -167,25 +182,9 @@ export async function remediationRoutes(fastify: FastifyInstance) {
       endpoint_id: number;
       container_id: string;
     }>('SELECT * FROM actions WHERE id = ?', [id]);
+    if (!action) return reply.code(404).send({ error: 'Action not found after update' });
 
-    if (!action) return reply.code(404).send({ error: 'Action not found' });
-    if (action.status !== 'approved') {
-      return reply.code(409).send({
-        error: `Action must be approved before execution. Current status: ${action.status}.`,
-        actionId: id,
-        currentStatus: action.status,
-      });
-    }
-
-    await db.execute(`
-      UPDATE actions SET status = 'executing', executed_at = NOW()
-      WHERE id = ?
-    `, [id]);
-
-    const executing = await db.queryOne<Record<string, unknown>>('SELECT * FROM actions WHERE id = ?', [id]);
-    if (executing) {
-      broadcastActionUpdate(executing);
-    }
+    broadcastActionUpdate(action as unknown as Record<string, unknown>);
 
     const startedAt = Date.now();
     try {

--- a/packages/operations/src/routes/remediation.ts
+++ b/packages/operations/src/routes/remediation.ts
@@ -113,20 +113,20 @@ export async function remediationRoutes(fastify: FastifyInstance) {
     const { reason } = (request.body as { reason?: string }) || {};
     const db = getDbForDomain('actions');
 
-    const action = await db.queryOne<any>('SELECT * FROM actions WHERE id = ?', [id]);
-    if (!action) return reply.code(404).send({ error: 'Action not found' });
-    if (action.status !== 'pending') {
+    const rejectResult = await db.execute(`
+      UPDATE actions SET status = 'rejected', rejected_by = ?, rejected_at = NOW(), rejection_reason = ?
+      WHERE id = ? AND status = 'pending'
+    `, [request.user?.username, reason || null, id]);
+
+    if (rejectResult.changes === 0) {
+      const existing = await db.queryOne<{ status: string } | null>('SELECT status FROM actions WHERE id = ?', [id]);
+      if (!existing) return reply.code(404).send({ error: 'Action not found' });
       return reply.code(409).send({
-        error: `Action is already ${action.status}. Refresh to see latest status.`,
+        error: `Action is already ${existing.status}. Refresh to see latest status.`,
         actionId: id,
-        currentStatus: action.status,
+        currentStatus: existing.status,
       });
     }
-
-    await db.execute(`
-      UPDATE actions SET status = 'rejected', rejected_by = ?, rejected_at = NOW(), rejection_reason = ?
-      WHERE id = ?
-    `, [request.user?.username, reason || null, id]);
 
     writeAuditLog({
       user_id: request.user?.sub,

--- a/packages/operations/src/routes/webhooks.ts
+++ b/packages/operations/src/routes/webhooks.ts
@@ -49,7 +49,7 @@ export async function webhookRoutes(fastify: FastifyInstance) {
       summary: 'List all configured webhooks',
       security: [{ bearerAuth: [] }],
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async () => {
     const webhooks = await listWebhooks();
     return webhooks.map(sanitizeWebhook);
@@ -97,7 +97,7 @@ export async function webhookRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       params: WebhookIdParamsSchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const webhook = await getWebhookById(id);
@@ -170,7 +170,7 @@ export async function webhookRoutes(fastify: FastifyInstance) {
       params: WebhookIdParamsSchema,
       querystring: WebhookDeliveriesQuerySchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const { limit = 50, offset = 0 } = request.query as { limit?: number; offset?: number };
@@ -247,7 +247,7 @@ export async function webhookRoutes(fastify: FastifyInstance) {
       summary: 'Server-Sent Events stream of dashboard events',
       security: [{ bearerAuth: [] }],
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     reply.raw.writeHead(200, {
       'Content-Type': 'text/event-stream',
@@ -282,7 +282,7 @@ export async function webhookRoutes(fastify: FastifyInstance) {
       summary: 'List available webhook event types',
       security: [{ bearerAuth: [] }],
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async () => {
     return VALID_EVENT_TYPES.map((type) => ({
       type,

--- a/packages/security/src/routes/harbor-vulnerabilities.ts
+++ b/packages/security/src/routes/harbor-vulnerabilities.ts
@@ -204,7 +204,7 @@ export async function harborVulnerabilityRoutes(fastify: FastifyInstance) {
         activeOnly: z.coerce.boolean().default(true),
       }),
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request) => {
     const { activeOnly } = request.query as { activeOnly: boolean };
     return vulnStore.getExceptions(activeOnly);

--- a/packages/security/src/routes/pcap.ts
+++ b/packages/security/src/routes/pcap.ts
@@ -155,7 +155,7 @@ export async function pcapRoutes(fastify: FastifyInstance, opts: { llm: LLMInter
       security: [{ bearerAuth: [] }],
       params: ActionIdParamsSchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const filePath = await getCaptureFilePath(id);


### PR DESCRIPTION
## Summary
Adds missing `requireRole('admin')` guards to 8 endpoints that were only behind `authenticate`, and fixes a TOCTOU race condition in the remediation workflow.

### RBAC fixes (auth-only → admin-required)
| Endpoint | Issue |
|---|---|
| `GET /api/remediation/actions` | #952 |
| `GET /api/webhooks` | #954 |
| `GET /api/webhooks/:id` | #954 |
| `GET /api/webhooks/:id/deliveries` | #954 |
| `GET /api/webhooks/event-types` | #954 |
| `GET /api/events/stream` (SSE) | #956 |
| `GET /api/notifications/history` | #959 |
| `GET /api/security/audit` | #955 |
| `GET /api/security/audit/:endpointId` | #955 |
| `GET /api/security/ignore-list` | #955 |
| `GET /api/pcap/captures/:id/download` | #951 |
| `GET /api/harbor/exceptions` | #976 |

### TOCTOU fix (#958)
Approve and execute handlers now use a single atomic `UPDATE ... WHERE id = ? AND status = 'pending/approved'` instead of SELECT-then-UPDATE. Checks `result.changes === 0` to detect race and returns 409.

## Test plan
- [x] `tsc --build tsconfig.build.json` passes
- [ ] CI runs backend tests

Closes #951
Closes #952
Closes #954
Closes #955
Closes #956
Closes #958
Closes #959
Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)