### PR TITLE
fix(security): input validation — limit caps, ES hardening, SSRF guard (#949,#961,#962)

### DIFF
--- a/packages/core/src/models/api-schemas.ts
+++ b/packages/core/src/models/api-schemas.ts
@@ -182,14 +182,14 @@ export const MetricsResponseSchema = z.object({
 });
 
 export const AnomaliesQuerySchema = z.object({
-  limit: z.coerce.number().default(50),
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
 });
 
 // ─── Monitoring schemas ─────────────────────────────────────────────
 export const InsightsQuerySchema = z.object({
   severity: z.enum(['critical', 'warning', 'info']).optional(),
   acknowledged: z.coerce.boolean().optional(),
-  limit: z.coerce.number().default(50),
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
   offset: z.coerce.number().default(0),
   cursor: z.string().optional(),
 });
@@ -201,7 +201,7 @@ export const InsightIdParamsSchema = z.object({
 // ─── Remediation schemas ────────────────────────────────────────────
 export const RemediationQuerySchema = z.object({
   status: z.string().optional(),
-  limit: z.coerce.number().default(50),
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
   offset: z.coerce.number().default(0),
 });
 
@@ -262,7 +262,7 @@ export const TracesQuerySchema = z.object({
   telemetrySdkVersion: z.string().optional(),
   otelScopeName: z.string().optional(),
   otelScopeVersion: z.string().optional(),
-  limit: z.coerce.number().default(50),
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
 });
 
 export const TraceIdParamsSchema = z.object({
@@ -307,23 +307,23 @@ export const PreferencesUpdateBodySchema = z.object({
 export const AuditLogQuerySchema = z.object({
   action: z.string().optional(),
   userId: z.string().optional(),
-  limit: z.coerce.number().default(100),
+  limit: z.coerce.number().int().min(1).max(1000).default(100),
   offset: z.coerce.number().default(0),
   cursor: z.string().optional(),
 });
 
 // ─── Logs schemas ───────────────────────────────────────────────────
 export const LogsSearchQuerySchema = z.object({
-  query: z.string().optional(),
+  query: z.string().max(500).optional(),
   hostname: z.string().optional(),
   level: z.string().optional(),
   from: z.string().optional(),
   to: z.string().optional(),
-  limit: z.coerce.number().default(100),
+  limit: z.coerce.number().int().min(1).max(1000).default(100),
 });
 
 export const LogsTestBodySchema = z.object({
-  endpoint: z.string(),
+  endpoint: z.string().url(),
   apiKey: z.string().optional(),
   verifySsl: z.coerce.boolean().optional().default(true),
 });
@@ -342,7 +342,7 @@ export const NormalizedImageSchema = z.object({
 
 // ─── Container Logs schemas ─────────────────────────────────────────
 export const ContainerLogsQuerySchema = z.object({
-  tail: z.coerce.number().default(100),
+  tail: z.coerce.number().int().min(1).max(10000).default(100),
   since: z.coerce.number().optional(),
   until: z.coerce.number().optional(),
   timestamps: QueryBooleanSchema.default(true),
@@ -371,7 +371,7 @@ export const DashboardKpisSchema = z.object({
 export const InvestigationsQuerySchema = z.object({
   status: z.enum(['pending', 'gathering', 'analyzing', 'complete', 'failed']).optional(),
   container_id: z.string().optional(),
-  limit: z.coerce.number().default(50),
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
   offset: z.coerce.number().default(0),
 });
 
@@ -386,7 +386,7 @@ export const InsightIdParamsForInvestigationSchema = z.object({
 // ─── Search schemas ─────────────────────────────────────────────────
 export const SearchQuerySchema = z.object({
   query: z.string().optional(),
-  limit: z.coerce.number().default(8),
+  limit: z.coerce.number().int().min(1).max(100).default(8),
   logLimit: z.coerce.number().default(8),
   includeLogs: QueryBooleanSchema.optional().default(false),
 });
@@ -394,7 +394,7 @@ export const SearchQuerySchema = z.object({
 // ─── Notification schemas ───────────────────────────────────────────
 export const NotificationHistoryQuerySchema = z.object({
   channel: z.enum(['teams', 'email', 'discord', 'telegram']).optional(),
-  limit: z.coerce.number().default(50),
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
   offset: z.coerce.number().default(0),
 });
 
@@ -448,7 +448,7 @@ export const WebhookUpdateBodySchema = z.object({
 });
 
 export const WebhookDeliveriesQuerySchema = z.object({
-  limit: z.coerce.number().default(50),
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
   offset: z.coerce.number().default(0),
 });
 
@@ -475,7 +475,7 @@ export const LlmTestPromptBodySchema = z.object({
 });
 
 export const LlmTracesQuerySchema = z.object({
-  limit: z.coerce.number().optional().default(50),
+  limit: z.coerce.number().int().min(1).max(1000).optional().default(50),
 });
 
 export const LlmStatsQuerySchema = z.object({

--- a/packages/core/src/models/api-schemas.ts
+++ b/packages/core/src/models/api-schemas.ts
@@ -387,7 +387,7 @@ export const InsightIdParamsForInvestigationSchema = z.object({
 export const SearchQuerySchema = z.object({
   query: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(100).default(8),
-  logLimit: z.coerce.number().default(8),
+  logLimit: z.coerce.number().int().min(1).max(100).default(8),
   includeLogs: QueryBooleanSchema.optional().default(false),
 });
 

--- a/packages/operations/src/routes/logs.ts
+++ b/packages/operations/src/routes/logs.ts
@@ -69,7 +69,7 @@ export async function logsRoutes(fastify: FastifyInstance) {
 
     try {
       const must: unknown[] = [];
-      if (query) must.push({ query_string: { query, fields: ['message', 'log.level', 'host.name', '@timestamp'], allow_leading_wildcard: false, max_determinized_states: 10000 } });
+      if (query) must.push({ query_string: { query, fields: ['message', 'log.level', 'host.name'], allow_leading_wildcard: false, max_determinized_states: 1000 } });
       if (hostname) must.push({ match: { 'host.name': hostname } });
       if (level) must.push({ match: { 'log.level': level } });
 

--- a/packages/operations/src/routes/logs.ts
+++ b/packages/operations/src/routes/logs.ts
@@ -6,6 +6,7 @@ import '@fastify/swagger';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { LogsSearchQuerySchema, LogsTestBodySchema } from '@dashboard/core/models/api-schemas.js';
 import { getElasticsearchConfig } from '@dashboard/infrastructure';
+import { validateOutboundWebhookUrl } from '@dashboard/core/utils/network-security.js';
 
 const log = createChildLogger('logs-route');
 
@@ -68,7 +69,7 @@ export async function logsRoutes(fastify: FastifyInstance) {
 
     try {
       const must: unknown[] = [];
-      if (query) must.push({ query_string: { query } });
+      if (query) must.push({ query_string: { query, fields: ['message', 'log.level', 'host.name', '@timestamp'], allow_leading_wildcard: false, max_determinized_states: 10000 } });
       if (hostname) must.push({ match: { 'host.name': hostname } });
       if (level) must.push({ match: { 'log.level': level } });
 
@@ -138,9 +139,16 @@ export async function logsRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       body: LogsTestBodySchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { endpoint, apiKey, verifySsl = true } = request.body as { endpoint: string; apiKey?: string; verifySsl?: boolean };
+
+    try {
+      validateOutboundWebhookUrl(endpoint);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Invalid endpoint URL';
+      return reply.code(400).send({ error: msg });
+    }
 
     try {
       const controller = new AbortController();

--- a/packages/operations/src/routes/logs.ts
+++ b/packages/operations/src/routes/logs.ts
@@ -143,11 +143,9 @@ export async function logsRoutes(fastify: FastifyInstance) {
   }, async (request, reply) => {
     const { endpoint, apiKey, verifySsl = true } = request.body as { endpoint: string; apiKey?: string; verifySsl?: boolean };
 
-    try {
-      validateOutboundWebhookUrl(endpoint);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Invalid endpoint URL';
-      return reply.code(400).send({ error: msg });
+    const urlError = validateOutboundWebhookUrl(endpoint);
+    if (urlError) {
+      return reply.code(400).send({ error: urlError });
     }
 
     try {


### PR DESCRIPTION
## Summary
- **#961** — `packages/core/src/models/api-schemas.ts`: adds `.max(1000)` to all 11 unbounded `limit` fields, `.max(10000)` to `tail`, `.max(500)` to log search `query` string. Because `fastify-type-provider-zod` is the validator compiler, these constraints automatically produce HTTP 400 with no route handler changes.
- **#962** — `packages/operations/src/routes/logs.ts`: restricts Elasticsearch `query_string` to named fields (`message`, `log.level`, `host.name`, `@timestamp`) with `allow_leading_wildcard: false` and `max_determinized_states: 10000` to prevent regex/wildcard DoS.
- **#949** — `packages/operations/src/routes/logs.ts`: adds `requireRole('admin')` to `POST /api/logs/test-connection` and calls `validateOutboundWebhookUrl()` (already in `@dashboard/core/utils/network-security`) to block SSRF to private IP ranges and non-http(s) schemes. Also adds `.url()` constraint to `LogsTestBodySchema.endpoint`.

## Test plan
- [x] `tsc --build tsconfig.build.json` passes
- [ ] CI runs backend tests

Closes #949
Closes #961
Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)