### PR TITLE
fix(#957,#960,#975,#977,#978): misc backend security and correctness fixes

### DIFF
--- a/frontend/src/providers/auth-provider.tsx
+++ b/frontend/src/providers/auth-provider.tsx
@@ -120,6 +120,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
     setToken(null);
     setUsername(null);
+    setRole('viewer');
     clearStoredAuth();
     api.setToken(null);
   }, []);

--- a/packages/core/src/plugins/socket-io.ts
+++ b/packages/core/src/plugins/socket-io.ts
@@ -13,6 +13,7 @@ interface SocketUser {
   sub: string;
   username: string;
   sessionId: string;
+  role?: string;
 }
 
 export async function authenticateSocketToken(token: unknown): Promise<SocketUser | null> {
@@ -38,6 +39,7 @@ export async function authenticateSocketToken(token: unknown): Promise<SocketUse
     sub: payload.sub,
     username: payload.username,
     sessionId: payload.sessionId,
+    role: payload.role,
   };
 }
 
@@ -143,6 +145,14 @@ async function socketIoPlugin(fastify: FastifyInstance) {
       next();
     });
   }
+
+  // Remediation namespace requires admin role
+  remediationNamespace.use((socket, next) => {
+    if (socket.data.user?.role !== 'admin') {
+      return next(new Error('Admin role required'));
+    }
+    next();
+  });
 
   fastify.decorate('io', io);
   fastify.decorate('ioNamespaces', {

--- a/packages/core/src/services/session-store.ts
+++ b/packages/core/src/services/session-store.ts
@@ -60,8 +60,8 @@ export async function refreshSession(sessionId: string): Promise<Session | undef
 
   await db.execute(`
     UPDATE sessions SET expires_at = ?, last_active = ?
-    WHERE id = ? AND is_valid = true
-  `, [expiresAt, now, sessionId]);
+    WHERE id = ? AND is_valid = true AND expires_at > ?
+  `, [expiresAt, now, sessionId, now]);
 
   return getSession(sessionId);
 }

--- a/packages/observability/src/routes/reports.ts
+++ b/packages/observability/src/routes/reports.ts
@@ -32,8 +32,9 @@ function isStatementTimeoutError(err: unknown): boolean {
 // accuracy. 5-minute TTL gives a meaningful perf win without stale UX.
 // ---------------------------------------------------------------------------
 const REPORT_CACHE_TTL_MS = 5 * 60 * 1_000;
+const REPORT_CACHE_MAX_ENTRIES = 500;
 
-interface CacheEntry { payload: unknown; expiresAt: number }
+interface CacheEntry { payload: unknown; expiresAt: number; timestamp: number }
 const reportCache = new Map<string, CacheEntry>();
 
 function getCachedReport<T>(key: string): T | null {
@@ -47,12 +48,26 @@ function getCachedReport<T>(key: string): T | null {
 }
 
 function setCachedReport(key: string, payload: unknown): void {
-  reportCache.set(key, { payload, expiresAt: Date.now() + REPORT_CACHE_TTL_MS });
+  if (reportCache.size >= REPORT_CACHE_MAX_ENTRIES) {
+    let oldestKey: string | undefined;
+    let oldestTs = Infinity;
+    for (const [k, v] of reportCache) {
+      if (v.timestamp < oldestTs) { oldestTs = v.timestamp; oldestKey = k; }
+    }
+    if (oldestKey !== undefined) reportCache.delete(oldestKey);
+  }
+  const now = Date.now();
+  reportCache.set(key, { payload, expiresAt: now + REPORT_CACHE_TTL_MS, timestamp: now });
 }
 
 /** Clear the report cache (for testing) */
 export function clearReportCache(): void {
   reportCache.clear();
+}
+
+/** Returns current cache size (for testing) */
+export function getReportCacheSize(): number {
+  return reportCache.size;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/operations/src/__tests__/remediation-socket.test.ts
+++ b/packages/operations/src/__tests__/remediation-socket.test.ts
@@ -36,9 +36,10 @@ import {
 
 interface MockSocket {
   id: string;
-  data: { user: { sub: string } };
+  data: { user: { sub: string; role: string } };
   on: ReturnType<typeof vi.fn>;
   emit: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
 }
 
 function createMockSocket(): {
@@ -48,11 +49,12 @@ function createMockSocket(): {
   const handlers = new Map<string, (...args: any[]) => any>();
   const socket: MockSocket = {
     id: 'test-socket-1',
-    data: { user: { sub: 'test-user' } },
+    data: { user: { sub: 'test-user', role: 'admin' } },
     on: vi.fn((event: string, handler: (...args: any[]) => any) => {
       handlers.set(event, handler);
     }),
     emit: vi.fn(),
+    disconnect: vi.fn(),
   };
   return { socket, handlers };
 }
@@ -79,6 +81,22 @@ function createMockNamespace() {
 describe('setupRemediationNamespace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('admin role enforcement', () => {
+    it('disconnects non-admin sockets with an error', () => {
+      const { ns } = createMockNamespace();
+      const { socket } = createMockSocket();
+      socket.data.user.role = 'viewer';
+
+      setupRemediationNamespace(ns);
+      ns.emit('connection', socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', { message: 'Admin role required' });
+      expect(socket.disconnect).toHaveBeenCalled();
+      // Should not register any event handlers
+      expect(socket.on).not.toHaveBeenCalled();
+    });
   });
 
   describe('actions:list', () => {

--- a/packages/operations/src/sockets/remediation.ts
+++ b/packages/operations/src/sockets/remediation.ts
@@ -9,6 +9,15 @@ export function setupRemediationNamespace(ns: Namespace) {
   remediationNamespace = ns;
   ns.on('connection', (socket) => {
     const userId = socket.data.user?.sub || 'unknown';
+
+    // Defence-in-depth: enforce admin role at the handler level as well
+    if (socket.data.user?.role !== 'admin') {
+      log.warn({ userId }, 'Remediation socket connection rejected: admin role required');
+      socket.emit('error', { message: 'Admin role required' });
+      socket.disconnect();
+      return;
+    }
+
     log.info({ userId }, 'Remediation client connected');
 
     // Send pending actions on connect

--- a/packages/security/src/routes/harbor-vulnerabilities.ts
+++ b/packages/security/src/routes/harbor-vulnerabilities.ts
@@ -8,7 +8,7 @@ import { writeAuditLog } from '@dashboard/core/services/audit-logger.js';
 import * as harborClient from '../services/harbor-client.js';
 import { getEffectiveHarborConfig } from '@dashboard/core/services/settings-store.js';
 import * as vulnStore from '../services/harbor-vulnerability-store.js';
-import { runFullSync } from '../services/harbor-sync.js';
+import { runFullSync, getIsSyncing } from '../services/harbor-sync.js';
 
 const log = createChildLogger('route:harbor-vulnerabilities');
 
@@ -170,6 +170,10 @@ export async function harborVulnerabilityRoutes(fastify: FastifyInstance) {
   }, async (request, reply) => {
     if (!await harborClient.isHarborConfiguredAsync()) {
       return reply.code(503).send({ error: 'Harbor is not configured' });
+    }
+
+    if (getIsSyncing()) {
+      return reply.code(409).send({ error: 'Sync already in progress' });
     }
 
     writeAuditLog({

--- a/packages/security/src/services/harbor-sync.ts
+++ b/packages/security/src/services/harbor-sync.ts
@@ -109,105 +109,107 @@ export async function runFullSync(): Promise<SyncResult> {
     return { vulnerabilitiesSynced: 0, inUseMatched: 0, durationMs: 0, error: 'Sync already in progress' };
   }
   isSyncing = true;
-  return withSpan('harbor-sync.full', 'harbor-sync', 'internal', async () => {
-    const startTime = Date.now();
-    const syncId = await store.createSyncStatus('full');
+  try {
+    return await withSpan('harbor-sync.full', 'harbor-sync', 'internal', async () => {
+      const startTime = Date.now();
+      const syncId = await store.createSyncStatus('full');
 
-    try {
-      if (!(await harbor.isHarborConfiguredAsync())) {
-        throw new Error('Harbor is not configured — set HARBOR_API_URL, HARBOR_ROBOT_NAME, HARBOR_ROBOT_SECRET or configure via Settings UI');
-      }
-
-      log.info('Starting full Harbor vulnerability sync');
-
-      // Step 1: Collect running container images from Portainer
-      const runningImages = await collectRunningImages();
-      log.debug({ runningImageCount: runningImages.length }, 'Collected running images from Portainer');
-
-      // Step 2: Fetch all vulnerabilities from Harbor Security Hub
-      const allVulns: harbor.HarborVulnerabilityItem[] = [];
-      let page = 1;
-      const pageSize = 100;
-      const maxPages = 500;
-      let hasMore = true;
-
-      while (hasMore) {
-        const result = await harbor.listVulnerabilities({ page, pageSize });
-        allVulns.push(...result.items);
-
-        // Primary termination: fewer items than page size means last page
-        if (result.items.length < pageSize) {
-          hasMore = false;
-        } else if (result.total > 0 && allVulns.length >= result.total) {
-          // Secondary termination: total count from header (when available)
-          hasMore = false;
-        } else {
-          page++;
+      try {
+        if (!(await harbor.isHarborConfiguredAsync())) {
+          throw new Error('Harbor is not configured — set HARBOR_API_URL, HARBOR_ROBOT_NAME, HARBOR_ROBOT_SECRET or configure via Settings UI');
         }
 
-        // Safety limit — configurable via maxPages (default 500 = 50k items)
-        if (page > maxPages) {
-          log.warn({ maxPages, fetched: allVulns.length }, 'Hit pagination safety limit, stopping fetch');
-          break;
+        log.info('Starting full Harbor vulnerability sync');
+
+        // Step 1: Collect running container images from Portainer
+        const runningImages = await collectRunningImages();
+        log.debug({ runningImageCount: runningImages.length }, 'Collected running images from Portainer');
+
+        // Step 2: Fetch all vulnerabilities from Harbor Security Hub
+        const allVulns: harbor.HarborVulnerabilityItem[] = [];
+        let page = 1;
+        const pageSize = 100;
+        const maxPages = 500;
+        let hasMore = true;
+
+        while (hasMore) {
+          const result = await harbor.listVulnerabilities({ page, pageSize });
+          allVulns.push(...result.items);
+
+          // Primary termination: fewer items than page size means last page
+          if (result.items.length < pageSize) {
+            hasMore = false;
+          } else if (result.total > 0 && allVulns.length >= result.total) {
+            // Secondary termination: total count from header (when available)
+            hasMore = false;
+          } else {
+            page++;
+          }
+
+          // Safety limit — configurable via maxPages (default 500 = 50k items)
+          if (page > maxPages) {
+            log.warn({ maxPages, fetched: allVulns.length }, 'Hit pagination safety limit, stopping fetch');
+            break;
+          }
         }
+
+        log.info({ vulnCount: allVulns.length, pages: page }, 'Fetched vulnerabilities from Harbor');
+
+        // Step 3: Correlate with running containers and build insert records
+        let inUseCount = 0;
+        const inserts: VulnerabilityInsert[] = allVulns.map((v) => {
+          const tags = v.tags ?? [];
+          const matches = matchVulnToRunning(v.repository_name, tags, runningImages);
+          const inUse = matches.length > 0;
+          if (inUse) inUseCount++;
+
+          return {
+            cve_id: v.cve_id,
+            severity: v.severity || 'Unknown',
+            cvss_v3_score: v.cvss_v3_score ?? null,
+            package: v.package || '',
+            version: v.version || '',
+            fixed_version: v.fixed_version || null,
+            status: v.status || null,
+            description: v.desc || null,
+            links: v.links ? JSON.stringify(v.links) : null,
+            project_id: v.project_id,
+            repository_name: v.repository_name,
+            digest: v.digest,
+            tags: tags.length > 0 ? JSON.stringify(tags) : null,
+            in_use: inUse,
+            matching_containers: matches.length > 0
+              ? JSON.stringify(matches.map((m) => ({
+                  id: m.containerId.slice(0, 12),
+                  name: m.containerName,
+                  endpoint: m.endpointId,
+                })))
+              : null,
+          };
+        });
+
+        // Step 4: Replace all records in DB
+        const synced = await store.replaceAllVulnerabilities(inserts);
+
+        const durationMs = Date.now() - startTime;
+        await store.completeSyncStatus(syncId, synced, inUseCount);
+
+        log.info(
+          { vulnerabilitiesSynced: synced, inUseMatched: inUseCount, durationMs },
+          'Harbor vulnerability sync completed',
+        );
+
+        return { vulnerabilitiesSynced: synced, inUseMatched: inUseCount, durationMs };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Unknown error';
+        await store.failSyncStatus(syncId, msg);
+        const durationMs = Date.now() - startTime;
+
+        log.error({ err, durationMs }, 'Harbor vulnerability sync failed');
+        return { vulnerabilitiesSynced: 0, inUseMatched: 0, durationMs, error: msg };
       }
-
-      log.info({ vulnCount: allVulns.length, pages: page }, 'Fetched vulnerabilities from Harbor');
-
-      // Step 3: Correlate with running containers and build insert records
-      let inUseCount = 0;
-      const inserts: VulnerabilityInsert[] = allVulns.map((v) => {
-        const tags = v.tags ?? [];
-        const matches = matchVulnToRunning(v.repository_name, tags, runningImages);
-        const inUse = matches.length > 0;
-        if (inUse) inUseCount++;
-
-        return {
-          cve_id: v.cve_id,
-          severity: v.severity || 'Unknown',
-          cvss_v3_score: v.cvss_v3_score ?? null,
-          package: v.package || '',
-          version: v.version || '',
-          fixed_version: v.fixed_version || null,
-          status: v.status || null,
-          description: v.desc || null,
-          links: v.links ? JSON.stringify(v.links) : null,
-          project_id: v.project_id,
-          repository_name: v.repository_name,
-          digest: v.digest,
-          tags: tags.length > 0 ? JSON.stringify(tags) : null,
-          in_use: inUse,
-          matching_containers: matches.length > 0
-            ? JSON.stringify(matches.map((m) => ({
-                id: m.containerId.slice(0, 12),
-                name: m.containerName,
-                endpoint: m.endpointId,
-              })))
-            : null,
-        };
-      });
-
-      // Step 4: Replace all records in DB
-      const synced = await store.replaceAllVulnerabilities(inserts);
-
-      const durationMs = Date.now() - startTime;
-      await store.completeSyncStatus(syncId, synced, inUseCount);
-
-      log.info(
-        { vulnerabilitiesSynced: synced, inUseMatched: inUseCount, durationMs },
-        'Harbor vulnerability sync completed',
-      );
-
-      return { vulnerabilitiesSynced: synced, inUseMatched: inUseCount, durationMs };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Unknown error';
-      await store.failSyncStatus(syncId, msg);
-      const durationMs = Date.now() - startTime;
-
-      log.error({ err, durationMs }, 'Harbor vulnerability sync failed');
-      return { vulnerabilitiesSynced: 0, inUseMatched: 0, durationMs, error: msg };
-    } finally {
-      isSyncing = false;
-    }
-  });
+    });
+  } finally {
+    isSyncing = false;
+  }
 }

--- a/packages/security/src/services/harbor-sync.ts
+++ b/packages/security/src/services/harbor-sync.ts
@@ -95,8 +95,20 @@ export interface SyncResult {
   error?: string;
 }
 
+let isSyncing = false;
+
+/** Returns true if a Harbor sync is currently in progress */
+export function getIsSyncing(): boolean {
+  return isSyncing;
+}
+
 /** Run a full vulnerability sync from Harbor → local DB with Portainer correlation */
 export async function runFullSync(): Promise<SyncResult> {
+  if (isSyncing) {
+    log.warn('Harbor sync already in progress — skipping duplicate run');
+    return { vulnerabilitiesSynced: 0, inUseMatched: 0, durationMs: 0, error: 'Sync already in progress' };
+  }
+  isSyncing = true;
   return withSpan('harbor-sync.full', 'harbor-sync', 'internal', async () => {
     const startTime = Date.now();
     const syncId = await store.createSyncStatus('full');
@@ -194,6 +206,8 @@ export async function runFullSync(): Promise<SyncResult> {
 
       log.error({ err, durationMs }, 'Harbor vulnerability sync failed');
       return { vulnerabilitiesSynced: 0, inUseMatched: 0, durationMs, error: msg };
+    } finally {
+      isSyncing = false;
     }
   });
 }


### PR DESCRIPTION
## Summary

- **#957** — Reset `role` to `'viewer'` on logout to prevent stale admin privileges in the React auth context
- **#960** — Add `AND expires_at > ?` to `refreshSession()` WHERE clause so expired sessions cannot be silently re-activated
- **#975** — Add `isSyncing` boolean guard to Harbor sync to prevent concurrent duplicate runs from racing against each other
- **#977** — Add admin role guard to the Socket.io `/remediation` namespace: middleware rejects non-admin tokens before connection is established, plus defence-in-depth check in the connection handler
- **#978** — Add LRU eviction (max 500 entries, oldest-timestamp) to the in-memory report cache to prevent unbounded memory growth

Closes #957, #960, #975, #977, #978

## Test plan

- [ ] Auth provider: log in as admin, log out, verify `useAuth().role` returns `'viewer'` (not `'admin'`) immediately after logout
- [ ] Session refresh: manually expire a session row in DB, call `/api/auth/refresh`, confirm it returns 401 instead of silently extending the expired session
- [ ] Harbor sync: trigger two concurrent syncs via `/api/harbor/sync`; confirm second returns 409 "Sync already in progress"
- [ ] Remediation WebSocket: connect to `/remediation` namespace with viewer-role JWT, confirm `error: Admin role required` and socket disconnects
- [ ] Report cache: run 501 distinct report queries, confirm `getReportCacheSize()` stays ≤ 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)