### PR TITLE
fix: add concurrency guard to Harbor sync to prevent duplicate runs

### DIFF
--- a/packages/security/src/__tests__/harbor-sync.test.ts
+++ b/packages/security/src/__tests__/harbor-sync.test.ts
@@ -44,7 +44,7 @@ vi.mock('../services/image-staleness.js', () => ({
   }),
 }));
 
-import { runFullSync } from '../services/harbor-sync.js';
+import { runFullSync, getIsSyncing } from '../services/harbor-sync.js';
 import * as harborClient from '../services/harbor-client.js';
 import * as store from '../services/harbor-vulnerability-store.js';
 import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
@@ -298,6 +298,67 @@ describe('harbor-sync', () => {
       const result = await runFullSync();
       expect(result.vulnerabilitiesSynced).toBe(342);
       expect(harborClient.listVulnerabilities).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe('concurrency guard (#975)', () => {
+    it('rejects concurrent calls — second caller returns early with error', async () => {
+      // Make listVulnerabilities hang until we resolve it, so the first sync stays "in progress"
+      let resolveFirst!: (value: unknown) => void;
+      const firstCallPromise = new Promise((resolve) => { resolveFirst = resolve; });
+
+      vi.mocked(harborClient.listVulnerabilities).mockImplementationOnce(
+        () => firstCallPromise as any,
+      );
+
+      // Start the first sync (it will block on listVulnerabilities)
+      const first = runFullSync();
+
+      // Allow microtasks to settle so the guard is set
+      await vi.waitFor(() => expect(getIsSyncing()).toBe(true));
+
+      // Second call should return immediately with "already in progress"
+      const second = await runFullSync();
+      expect(second.error).toBe('Sync already in progress');
+      expect(second.vulnerabilitiesSynced).toBe(0);
+      expect(second.durationMs).toBe(0);
+
+      // Unblock the first sync
+      resolveFirst({ items: [], total: 0 });
+      const firstResult = await first;
+      expect(firstResult.error).toBeUndefined();
+    });
+
+    it('clears the guard after a successful sync', async () => {
+      vi.mocked(harborClient.listVulnerabilities).mockResolvedValueOnce({
+        items: [],
+        total: 0,
+      });
+
+      expect(getIsSyncing()).toBe(false);
+      await runFullSync();
+      expect(getIsSyncing()).toBe(false);
+    });
+
+    it('clears the guard after a failed sync', async () => {
+      vi.mocked(harborClient.listVulnerabilities).mockRejectedValueOnce(
+        new Error('Network failure'),
+      );
+
+      expect(getIsSyncing()).toBe(false);
+      const result = await runFullSync();
+      expect(result.error).toContain('Network failure');
+      // Guard must be cleared so subsequent syncs can proceed
+      expect(getIsSyncing()).toBe(false);
+    });
+
+    it('clears the guard when Harbor is not configured', async () => {
+      vi.mocked(harborClient.isHarborConfiguredAsync).mockResolvedValueOnce(false);
+
+      expect(getIsSyncing()).toBe(false);
+      await runFullSync();
+      // Guard must be cleared even when the sync bails out early
+      expect(getIsSyncing()).toBe(false);
     });
   });
 });

--- a/packages/security/src/__tests__/harbor-vulnerabilities-route.test.ts
+++ b/packages/security/src/__tests__/harbor-vulnerabilities-route.test.ts
@@ -36,9 +36,10 @@ vi.mock('../services/harbor-vulnerability-store.js', () => ({
 
 // Kept: harbor-sync mock — runs background jobs
 const mockRunFullSync = vi.fn();
+const mockGetIsSyncing = vi.fn();
 vi.mock('../services/harbor-sync.js', () => ({
   runFullSync: (...args: unknown[]) => mockRunFullSync(...args),
-  getIsSyncing: vi.fn().mockReturnValue(false),
+  getIsSyncing: (...args: unknown[]) => mockGetIsSyncing(...args),
 }));
 
 // Kept: settings-store mock — reads from DB
@@ -88,6 +89,7 @@ describe('Harbor Vulnerability Routes', () => {
     vi.clearAllMocks();
     currentRole = 'admin';
     mockIsHarborConfiguredAsync.mockResolvedValue(true);
+    mockGetIsSyncing.mockReturnValue(false);
     mockGetVulnerabilitySummary.mockResolvedValue({ critical: 0, high: 0, medium: 0, low: 0, total: 0 });
     mockGetVulnerabilities.mockResolvedValue([]);
     mockGetExceptions.mockResolvedValue([]);
@@ -246,6 +248,22 @@ describe('Harbor Vulnerability Routes', () => {
       });
 
       expect(response.statusCode).toBe(503);
+    });
+
+    it('returns 409 when a sync is already in progress', async () => {
+      mockGetIsSyncing.mockReturnValue(true);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/harbor/sync',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(409);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('already in progress');
+      // Should NOT have called runFullSync
+      expect(mockRunFullSync).not.toHaveBeenCalled();
     });
 
     testAdminOnly(

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -19,7 +19,7 @@ export {
 export type { SecurityAuditEntry } from './services/security-audit.js';
 
 // Harbor
-export { runFullSync as runHarborSync } from './services/harbor-sync.js';
+export { runFullSync as runHarborSync, getIsSyncing as isHarborSyncRunning } from './services/harbor-sync.js';
 export { isHarborConfigured, isHarborConfiguredAsync } from './services/harbor-client.js';
 export { cleanupOldVulnerabilities } from './services/harbor-vulnerability-store.js';
 

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -9,7 +9,7 @@ import { getSetting, getEffectiveHarborConfig, cleanExpiredSessions } from '@das
 import { runWithTraceContext } from '@dashboard/core/tracing/index.js';
 import { startCooldownSweep, stopCooldownSweep, cleanupOldInsights } from '@dashboard/ai';
 import { collectMetrics, insertMetrics, cleanOldMetrics, type MetricInsert, recordNetworkSample, insertKpiSnapshot, cleanOldKpiSnapshots } from '@dashboard/observability';
-import { cleanupOldCaptures, cleanupOrphanedSidecars, runStalenessChecks, runHarborSync, isHarborConfiguredAsync, cleanupOldVulnerabilities } from '@dashboard/security';
+import { cleanupOldCaptures, cleanupOrphanedSidecars, runStalenessChecks, runHarborSync, isHarborSyncRunning, isHarborConfiguredAsync, cleanupOldVulnerabilities } from '@dashboard/security';
 import { createPortainerBackup, cleanupOldPortainerBackups, startWebhookListener, stopWebhookListener, processRetries } from '@dashboard/operations';
 import { startElasticsearchLogForwarder, stopElasticsearchLogForwarder } from '@dashboard/infrastructure';
 
@@ -538,6 +538,8 @@ export async function startScheduler(runMonitoringCycle: () => Promise<void>): P
           if (!cfg.enabled || !(await isHarborConfiguredAsync())) return;
           const syncIntervalMs = cfg.syncIntervalMinutes * 60 * 1000;
           if (Date.now() - lastHarborSyncAt < syncIntervalMs) return;
+          // Skip silently if a sync is already in progress (e.g. triggered via POST /api/harbor/sync)
+          if (isHarborSyncRunning()) return;
           lastHarborSyncAt = Date.now();
           const result = await runHarborSync();
           if (result.error) {
@@ -556,6 +558,7 @@ export async function startScheduler(runMonitoringCycle: () => Promise<void>): P
         try {
           const cfg = await getEffectiveHarborConfig();
           if (!cfg.enabled || !(await isHarborConfiguredAsync())) return;
+          if (isHarborSyncRunning()) return;
           log.info({ intervalMinutes: cfg.syncIntervalMinutes }, 'Starting Harbor vulnerability sync scheduler');
           lastHarborSyncAt = Date.now();
           await runHarborSync();


### PR DESCRIPTION
## Summary
- Exports `getIsSyncing` as `isHarborSyncRunning` from `@dashboard/security` barrel
- Scheduler now checks `isHarborSyncRunning()` before calling `runHarborSync()`, silently skipping if already in progress
- Adds 5 new tests: concurrent call serialization, guard cleared after success/failure/early-bail, POST /api/harbor/sync returns 409 when sync running

Closes #975

## Test plan
- [x] Verify concurrent `runFullSync()` calls are serialized (second returns early with error)
- [x] Verify guard is cleared after successful sync
- [x] Verify guard is cleared after failed sync
- [x] Verify guard is cleared when Harbor is not configured
- [x] Verify POST /api/harbor/sync returns HTTP 409 with "already in progress" message
- [x] All 30 harbor tests pass (12 sync + 18 route)
- [x] All 278 backend tests pass
- [x] All frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)