### PR TITLE
fix: align session-store test mock with expiry guard in refreshSession

### DIFF
--- a/packages/core/src/services/session-store.integration.test.ts
+++ b/packages/core/src/services/session-store.integration.test.ts
@@ -71,6 +71,40 @@ describe('session-store integration (real PostgreSQL)', () => {
     expect(retrieved).toBeUndefined(); // Invalid sessions are not returned
   });
 
+  it('refreshSession returns undefined for an expired but valid session', async () => {
+    const pool = await getTestPool();
+
+    // Insert an expired session directly (is_valid = true, but expires_at in the past)
+    await pool.query(`
+      INSERT INTO sessions (id, user_id, username, created_at, expires_at, last_active, is_valid)
+      VALUES ('expired-refresh-test', 'user-expired', 'dave',
+              NOW() - INTERVAL '2 hours',
+              NOW() - INTERVAL '1 hour',
+              NOW() - INTERVAL '90 minutes',
+              true)
+    `);
+
+    const result = await refreshSession('expired-refresh-test');
+    expect(result).toBeUndefined();
+
+    // Verify expires_at was NOT updated in the database
+    const { rows } = await pool.query('SELECT expires_at FROM sessions WHERE id = $1', ['expired-refresh-test']);
+    expect(rows).toHaveLength(1);
+    // The expires_at should still be in the past (not refreshed)
+    expect(new Date(rows[0].expires_at).getTime()).toBeLessThan(Date.now());
+  });
+
+  it('refreshSession succeeds for a valid non-expired session', async () => {
+    const session = await createSession('user-fresh', 'frank');
+
+    const result = await refreshSession(session.id);
+    expect(result).toBeDefined();
+    expect(result?.id).toBe(session.id);
+    expect(new Date(result!.expires_at).getTime()).toBeGreaterThanOrEqual(
+      new Date(session.expires_at).getTime()
+    );
+  });
+
   it('cleans expired sessions', async () => {
     const pool = await getTestPool();
 

--- a/packages/core/src/services/session-store.test.ts
+++ b/packages/core/src/services/session-store.test.ts
@@ -25,12 +25,14 @@ vi.mock('../db/app-db-router.js', () => {
         const expiresAt = params[0];
         const lastActive = params[1];
         const id = params[2] as string;
+        const nowParam = params[3] as string;
         const existing = sessionStore.get(id);
-        if (existing && existing.is_valid === 1) {
+        if (existing && existing.is_valid === 1 && (existing.expires_at as string) > nowParam) {
           existing.expires_at = expiresAt;
           existing.last_active = lastActive;
+          return { changes: 1 };
         }
-        return { changes: existing ? 1 : 0 };
+        return { changes: 0 };
       }
       if (sql.includes('UPDATE sessions SET is_valid = 0')) {
         const id = params[0] as string;
@@ -179,6 +181,53 @@ describe('session-store expiration semantics', () => {
 
     const session = await getSession('boundary-session');
     expect(session).toBeUndefined();
+  });
+
+  it('refreshSession returns undefined for an expired but valid session', async () => {
+    // Insert an already-expired session (is_valid = true but expires_at in the past)
+    sessionStore.set('expired-but-valid', {
+      id: 'expired-but-valid',
+      user_id: 'user-10',
+      username: 'dave',
+      created_at: '2026-02-07T09:00:00.000Z',
+      expires_at: '2026-02-07T09:30:00.000Z',
+      last_active: '2026-02-07T09:15:00.000Z',
+      is_valid: 1,
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-07T10:00:00.000Z'));
+
+    const result = await refreshSession('expired-but-valid');
+    expect(result).toBeUndefined();
+
+    // Verify the session was NOT updated (expires_at should remain unchanged)
+    const stored = sessionStore.get('expired-but-valid');
+    expect(stored?.expires_at).toBe('2026-02-07T09:30:00.000Z');
+  });
+
+  it('refreshSession succeeds for a valid non-expired session', async () => {
+    // Insert a valid, non-expired session
+    sessionStore.set('valid-session', {
+      id: 'valid-session',
+      user_id: 'user-11',
+      username: 'eve',
+      created_at: '2026-02-07T09:00:00.000Z',
+      expires_at: '2026-02-07T11:00:00.000Z',
+      last_active: '2026-02-07T09:15:00.000Z',
+      is_valid: 1,
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-07T10:00:00.000Z'));
+
+    const result = await refreshSession('valid-session');
+    expect(result).toBeDefined();
+    expect(result?.id).toBe('valid-session');
+    // expires_at should be updated to ~1 hour from now
+    expect(new Date(result!.expires_at).getTime()).toBeGreaterThan(
+      new Date('2026-02-07T10:00:00.000Z').getTime()
+    );
   });
 
   it('cleans expired and invalid sessions while preserving active ones', async () => {


### PR DESCRIPTION
## Summary
- Fixed unit test mock inconsistency: the `UPDATE sessions SET expires_at` handler now checks `expires_at > now` parameter, matching the actual SQL's `AND expires_at > ?` clause
- Added 2 unit tests: expired-but-valid session refresh returns undefined, valid non-expired session refresh succeeds
- Added 2 integration tests (real PostgreSQL): same scenarios verified against real database

Closes #960

## Test plan
- [x] Verify `refreshSession` on expired `is_valid=true` session returns `undefined` (unit test)
- [x] Verify `refreshSession` on valid non-expired session succeeds (unit test)
- [x] Verify `refreshSession` on expired session leaves `expires_at` unchanged (integration test with real PostgreSQL)
- [x] Verify `refreshSession` on valid session updates `expires_at` (integration test)
- [x] All 8 session-store unit tests pass
- [x] All frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)