### PR TITLE
feat: parallelize dashboard summary Portainer calls

### DIFF
--- a/backend/src/routes/dashboard-summary.test.ts
+++ b/backend/src/routes/dashboard-summary.test.ts
@@ -76,6 +76,65 @@ describe('Dashboard Summary Route', () => {
     await app.close();
   });
 
+  it('runs security audit concurrently with endpoint fetch (#375)', async () => {
+    const app = Fastify();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.decorate('authenticate', async () => undefined);
+    await app.register(dashboardRoutes);
+    await app.ready();
+
+    const callOrder: string[] = [];
+
+    // Track when each mock is invoked (before it resolves)
+    mockGetEndpoints.mockImplementation(() => {
+      callOrder.push('getEndpoints:start');
+      return Promise.resolve([{
+        Id: 1, Name: 'ep-1', Type: 1, URL: 'http://ep-1', Status: 1,
+        Snapshots: [{ RunningContainerCount: 1, StoppedContainerCount: 0, HealthyContainerCount: 1, UnhealthyContainerCount: 0, StackCount: 0, TotalCPU: 0, TotalMemory: 0 }],
+      }]);
+    });
+    mockGetSecurityAudit.mockImplementation(() => {
+      callOrder.push('getSecurityAudit:start');
+      return Promise.resolve([]);
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/dashboard/summary' });
+
+    expect(res.statusCode).toBe(200);
+    // Security audit should be initiated before endpoint fetch completes
+    expect(callOrder).toContain('getSecurityAudit:start');
+    expect(callOrder).toContain('getEndpoints:start');
+    // Both should be called (concurrently)
+    expect(mockGetSecurityAudit).toHaveBeenCalledTimes(1);
+    expect(mockGetEndpoints).toHaveBeenCalledTimes(1);
+
+    await app.close();
+  });
+
+  it('returns fallback security data when audit fails (#375)', async () => {
+    const app = Fastify();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.decorate('authenticate', async () => undefined);
+    await app.register(dashboardRoutes);
+    await app.ready();
+
+    mockGetEndpoints.mockResolvedValue([{
+      Id: 1, Name: 'ep-1', Type: 1, URL: 'http://ep-1', Status: 1,
+      Snapshots: [{ RunningContainerCount: 1, StoppedContainerCount: 0, HealthyContainerCount: 1, UnhealthyContainerCount: 0, StackCount: 0, TotalCPU: 0, TotalMemory: 0 }],
+    }]);
+    mockGetSecurityAudit.mockRejectedValue(new Error('DB unavailable'));
+
+    const res = await app.inject({ method: 'GET', url: '/api/dashboard/summary' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.security).toEqual({ totalAudited: 0, flagged: 0, ignored: 0 });
+
+    await app.close();
+  });
+
   it('returns 502 when endpoint list cannot be fetched', async () => {
     const app = Fastify();
     app.setValidatorCompiler(validatorCompiler);

--- a/backend/src/routes/dashboard-summary.test.ts
+++ b/backend/src/routes/dashboard-summary.test.ts
@@ -86,13 +86,22 @@ describe('Dashboard Summary Route', () => {
 
     const callOrder: string[] = [];
 
-    // Track when each mock is invoked (before it resolves)
+    // getSecurityAudit is kicked off but won't resolve until the next microtask.
+    // getEndpoints adds artificial latency so the handler must await it.
+    // If security audit were started *after* awaiting endpoints, we'd see
+    // 'getEndpoints:resolved' before 'getSecurityAudit:start' — the assertion
+    // below catches that ordering violation.
     mockGetEndpoints.mockImplementation(() => {
       callOrder.push('getEndpoints:start');
-      return Promise.resolve([{
-        Id: 1, Name: 'ep-1', Type: 1, URL: 'http://ep-1', Status: 1,
-        Snapshots: [{ RunningContainerCount: 1, StoppedContainerCount: 0, HealthyContainerCount: 1, UnhealthyContainerCount: 0, StackCount: 0, TotalCPU: 0, TotalMemory: 0 }],
-      }]);
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          callOrder.push('getEndpoints:resolved');
+          resolve([{
+            Id: 1, Name: 'ep-1', Type: 1, URL: 'http://ep-1', Status: 1,
+            Snapshots: [{ RunningContainerCount: 1, StoppedContainerCount: 0, HealthyContainerCount: 1, UnhealthyContainerCount: 0, StackCount: 0, TotalCPU: 0, TotalMemory: 0 }],
+          }]);
+        }, 10);
+      });
     });
     mockGetSecurityAudit.mockImplementation(() => {
       callOrder.push('getSecurityAudit:start');
@@ -102,12 +111,13 @@ describe('Dashboard Summary Route', () => {
     const res = await app.inject({ method: 'GET', url: '/api/dashboard/summary' });
 
     expect(res.statusCode).toBe(200);
-    // Security audit should be initiated before endpoint fetch completes
-    expect(callOrder).toContain('getSecurityAudit:start');
-    expect(callOrder).toContain('getEndpoints:start');
-    // Both should be called (concurrently)
-    expect(mockGetSecurityAudit).toHaveBeenCalledTimes(1);
-    expect(mockGetEndpoints).toHaveBeenCalledTimes(1);
+    // Security audit must be initiated before the endpoint fetch resolves,
+    // proving they run concurrently rather than sequentially.
+    const auditIdx = callOrder.indexOf('getSecurityAudit:start');
+    const endpointsResolvedIdx = callOrder.indexOf('getEndpoints:resolved');
+    expect(auditIdx).toBeGreaterThanOrEqual(0);
+    expect(endpointsResolvedIdx).toBeGreaterThanOrEqual(0);
+    expect(auditIdx).toBeLessThan(endpointsResolvedIdx);
 
     await app.close();
   });

--- a/packages/foundation/src/routes/dashboard.ts
+++ b/packages/foundation/src/routes/dashboard.ts
@@ -9,7 +9,13 @@ import { getKpiHistory, getLatestMetricsBatch } from '@dashboard/observability';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { buildSecurityAuditSummary, getSecurityAudit } from '@dashboard/security';
 
-/** Cap concurrent Portainer API calls to avoid overwhelming the upstream server. */
+/**
+ * Cap concurrent Portainer API calls per dashboard request to 5.
+ * The portainer-client has its own higher process-wide limit (default 30),
+ * but dashboard routes fan out across many endpoints simultaneously —
+ * this tighter cap prevents a single heavy page-load from saturating the
+ * shared pool and starving other routes (containers, stacks, etc.).
+ */
 const portainerLimit = pLimit(5);
 
 const log = createChildLogger('route:dashboard');
@@ -177,7 +183,7 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
           endpointName: ep.name,
         })));
       } else {
-        const ep = upEndpoints[i];
+        const ep = upDockerEndpoints[i];
         const msg = result.reason instanceof Error ? result.reason.message : 'Unknown error';
         log.warn({ endpointId: ep.id, endpointName: ep.name, err: result.reason }, 'Failed to fetch containers for endpoint');
         resourceErrors.push(`${ep.name}: ${msg}`);

--- a/packages/foundation/src/routes/dashboard.ts
+++ b/packages/foundation/src/routes/dashboard.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod/v4';
+import pLimit from 'p-limit';
 import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { normalizeEndpoint, normalizeContainer } from '@dashboard/core/portainer/portainer-normalizers.js';
@@ -7,6 +8,9 @@ import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { getKpiHistory, getLatestMetricsBatch } from '@dashboard/observability';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { buildSecurityAuditSummary, getSecurityAudit } from '@dashboard/security';
+
+/** Cap concurrent Portainer API calls to avoid overwhelming the upstream server. */
+const portainerLimit = pLimit(5);
 
 const log = createChildLogger('route:dashboard');
 
@@ -27,6 +31,12 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
     },
     preHandler: [fastify.authenticate],
   }, async (request, reply) => {
+    // Start security audit immediately — it doesn't depend on endpoints.
+    const securityPromise = getSecurityAudit().catch((err) => {
+      log.warn({ err }, 'Failed to fetch security audit summary');
+      return null;
+    });
+
     let endpoints;
     try {
       endpoints = await cachedFetchSWR(
@@ -70,13 +80,11 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
       },
     );
 
-    let security = { totalAudited: 0, flagged: 0, ignored: 0 };
-    try {
-      const auditEntries = await getSecurityAudit();
-      security = buildSecurityAuditSummary(auditEntries);
-    } catch (err) {
-      log.warn({ err }, 'Failed to fetch security audit summary');
-    }
+    // Await security audit that was started in parallel with endpoint fetch.
+    const auditEntries = await securityPromise;
+    const security = auditEntries
+      ? buildSecurityAuditSummary(auditEntries)
+      : { totalAudited: 0, flagged: 0, ignored: 0 };
 
     return {
       kpis: totals,
@@ -144,16 +152,18 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
     // Only fetch Docker containers — K8s pods are served by /api/kubernetes/ routes
     const upDockerEndpoints = upEndpoints.filter((e) => isDockerEndpoint(e.type));
 
-    // Get all containers from all up Docker endpoints
+    // Get all containers from all up Docker endpoints (concurrency-capped)
     const allContainers: Array<{ container: any; endpointId: number; endpointName: string }> = [];
     const resourceErrors: string[] = [];
     const settled = await Promise.allSettled(
       upDockerEndpoints.map((ep) =>
-        cachedFetchSWR(
-          getCacheKey('containers', ep.id),
-          TTL.CONTAINERS,
-          () => portainer.getContainers(ep.id),
-        ).then((containers) => ({ ep, containers })),
+        portainerLimit(() =>
+          cachedFetchSWR(
+            getCacheKey('containers', ep.id),
+            TTL.CONTAINERS,
+            () => portainer.getContainers(ep.id),
+          ).then((containers) => ({ ep, containers })),
+        ),
       ),
     );
 
@@ -349,11 +359,13 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
       const errors: string[] = [];
       const settled = await Promise.allSettled(
         upDockerEndpoints.map((ep) =>
-          cachedFetchSWR(
-            getCacheKey('containers', ep.id),
-            TTL.CONTAINERS,
-            () => portainer.getContainers(ep.id),
-          ).then((containers) => ({ ep, containers })),
+          portainerLimit(() =>
+            cachedFetchSWR(
+              getCacheKey('containers', ep.id),
+              TTL.CONTAINERS,
+              () => portainer.getContainers(ep.id),
+            ).then((containers) => ({ ep, containers })),
+          ),
         ),
       );
 


### PR DESCRIPTION
## Summary
- Run security audit concurrently with endpoint fetch in `/api/dashboard/summary` instead of sequentially
- Add `p-limit(5)` concurrency cap to container fetches in `/api/dashboard/resources` and `/api/dashboard/full` to avoid overwhelming Portainer
- Add 2 new tests verifying parallel execution and graceful audit failure handling

Closes #375

## Changes
- **`packages/foundation/src/routes/dashboard.ts`**: Import `p-limit`, create `portainerLimit = pLimit(5)`, wrap all `Promise.allSettled` container fetches with `portainerLimit()`, refactor `/summary` to fire security audit before awaiting endpoint fetch
- **`backend/src/routes/dashboard-summary.test.ts`**: Add test for concurrent execution ordering and audit failure fallback

## Test plan
- [x] All 32 dashboard tests pass (including 2 new)
- [x] Full test suite passes (1561 tests, 165 files)
- [x] TypeScript builds cleanly
- [ ] Verify p50 latency improvement under load (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)