### PR TITLE
feat: reduce env var surface — Settings DB as primary config source

### DIFF
--- a/frontend/src/features/core/components/settings/shared.tsx
+++ b/frontend/src/features/core/components/settings/shared.tsx
@@ -82,6 +82,54 @@ export const DEFAULT_SETTINGS = {
     { key: 'mcp.tool_timeout', label: 'Tool Timeout', description: 'Maximum execution time for MCP tool calls (seconds)', type: 'number', defaultValue: '60', min: 1, max: 600 },
     { key: 'llm.max_tool_iterations', label: 'Max Tool Iterations', description: 'Maximum number of tool call rounds the LLM can perform per message (higher = more complex tasks)', type: 'number', defaultValue: '3', min: 1, max: 20 },
   ],
+  aiTuning: [
+    // Anomaly Detection
+    { key: 'ai_tuning.anomaly_detection_method', label: 'Detection Method', description: 'Algorithm for statistical anomaly detection (zscore, bollinger, adaptive)', type: 'string', defaultValue: 'adaptive' },
+    { key: 'ai_tuning.anomaly_zscore_threshold', label: 'Z-Score Threshold', description: 'Standard deviations from the mean to trigger an anomaly alert', type: 'number', defaultValue: '3.5', min: 0.5, max: 10, step: 0.1 },
+    { key: 'ai_tuning.anomaly_moving_average_window', label: 'Moving Average Window', description: 'Number of data points for the rolling average baseline', type: 'number', defaultValue: '20', min: 5, max: 200 },
+    { key: 'ai_tuning.anomaly_min_samples', label: 'Min Samples', description: 'Minimum data points required before anomaly detection activates', type: 'number', defaultValue: '10', min: 3, max: 100 },
+    { key: 'ai_tuning.anomaly_cooldown_minutes', label: 'Alert Cooldown (min)', description: 'Minutes to suppress repeated alerts for the same container+metric', type: 'number', defaultValue: '30', min: 0, max: 1440 },
+    { key: 'ai_tuning.anomaly_threshold_pct', label: 'Hard Threshold %', description: 'Absolute usage percentage that always triggers a warning', type: 'number', defaultValue: '85', min: 50, max: 100 },
+    { key: 'ai_tuning.anomaly_hard_threshold_enabled', label: 'Hard Threshold Enabled', description: 'Flag values above the hard threshold regardless of statistical detection', type: 'boolean', defaultValue: 'true' },
+    { key: 'ai_tuning.bollinger_bands_enabled', label: 'Bollinger Bands', description: 'Enable Bollinger Bands for low-variance workload detection', type: 'boolean', defaultValue: 'true' },
+    // Predictive Alerting
+    { key: 'ai_tuning.predictive_alerting_enabled', label: 'Predictive Alerting', description: 'Proactively warn about resource exhaustion trends', type: 'boolean', defaultValue: 'true' },
+    { key: 'ai_tuning.predictive_alert_threshold_hours', label: 'Prediction Horizon (hours)', description: 'Alert when resource exhaustion is predicted within this timeframe', type: 'number', defaultValue: '24', min: 1, max: 168 },
+    // Anomaly Explanation
+    { key: 'ai_tuning.anomaly_explanation_enabled', label: 'LLM Anomaly Explanations', description: 'Use LLM to generate plain-English explanations of anomalies', type: 'boolean', defaultValue: 'true' },
+    { key: 'ai_tuning.anomaly_explanation_max_per_cycle', label: 'Max Explanations / Cycle', description: 'Maximum number of anomalies explained by LLM per monitoring cycle', type: 'number', defaultValue: '5', min: 1, max: 50 },
+    // Isolation Forest
+    { key: 'ai_tuning.isolation_forest_enabled', label: 'Isolation Forest ML', description: 'Enable multivariate ML-based anomaly detection', type: 'boolean', defaultValue: 'true' },
+    { key: 'ai_tuning.isolation_forest_retrain_hours', label: 'Retrain Interval (hours)', description: 'Hours between Isolation Forest model retraining', type: 'number', defaultValue: '6', min: 1, max: 168 },
+    // NLP Log Analysis
+    { key: 'ai_tuning.nlp_log_analysis_enabled', label: 'NLP Log Analysis', description: 'LLM-powered container log error pattern detection', type: 'boolean', defaultValue: 'true' },
+    { key: 'ai_tuning.nlp_log_analysis_max_per_cycle', label: 'Max Containers / Cycle', description: 'Maximum containers to analyze logs for per cycle', type: 'number', defaultValue: '3', min: 1, max: 20 },
+    { key: 'ai_tuning.nlp_log_analysis_tail_lines', label: 'Log Tail Lines', description: 'Number of recent log lines to send to the LLM', type: 'number', defaultValue: '100', min: 10, max: 500 },
+    // Smart Grouping
+    { key: 'ai_tuning.smart_grouping_enabled', label: 'Smart Alert Grouping', description: 'Group semantically similar anomalies into incidents', type: 'boolean', defaultValue: 'true' },
+    { key: 'ai_tuning.smart_grouping_similarity_threshold', label: 'Similarity Threshold', description: 'Text similarity threshold for grouping (0-1, lower = more aggressive)', type: 'number', defaultValue: '0.3', min: 0.1, max: 1.0, step: 0.05 },
+    { key: 'ai_tuning.incident_summary_enabled', label: 'LLM Incident Summaries', description: 'Generate LLM-powered summaries for correlated incidents', type: 'boolean', defaultValue: 'true' },
+    // Investigation
+    { key: 'ai_tuning.investigation_enabled', label: 'Root Cause Investigation', description: 'Auto-trigger LLM-powered root cause analysis for anomalies', type: 'boolean', defaultValue: 'true' },
+    { key: 'ai_tuning.investigation_cooldown_minutes', label: 'Investigation Cooldown (min)', description: 'Minimum minutes between investigations for the same container', type: 'number', defaultValue: '20', min: 1, max: 1440 },
+    { key: 'ai_tuning.investigation_max_concurrent', label: 'Max Concurrent', description: 'Maximum investigations running simultaneously', type: 'number', defaultValue: '2', min: 1, max: 10 },
+    { key: 'ai_tuning.investigation_log_tail_lines', label: 'Evidence Log Lines', description: 'Log lines collected as evidence for investigations', type: 'number', defaultValue: '50', min: 10, max: 500 },
+    { key: 'ai_tuning.investigation_metrics_window_minutes', label: 'Metrics Window (min)', description: 'Time window for metrics evidence collection', type: 'number', defaultValue: '60', min: 5, max: 1440 },
+    { key: 'ai_tuning.investigation_min_severity', label: 'Min Severity', description: 'Minimum insight severity to trigger investigation (critical, warning, info)', type: 'string', defaultValue: 'warning' },
+    // General AI
+    { key: 'ai_tuning.ai_analysis_enabled', label: 'AI Infrastructure Analysis', description: 'Fire-and-forget LLM analysis each monitoring cycle', type: 'boolean', defaultValue: 'true' },
+    { key: 'ai_tuning.max_insights_per_cycle', label: 'Max Insights / Cycle', description: 'Cap on total insights generated per monitoring cycle', type: 'number', defaultValue: '500', min: 1, max: 10000 },
+    { key: 'ai_tuning.log_analysis_concurrency', label: 'Log Analysis Concurrency', description: 'Parallel container log analysis tasks', type: 'number', defaultValue: '3', min: 1, max: 20 },
+    { key: 'ai_tuning.insights_retention_days', label: 'Insights Retention (days)', description: 'How long to keep generated insights', type: 'number', defaultValue: '7', min: 1, max: 365 },
+  ],
+  metricsRetention: [
+    { key: 'infrastructure.metrics_retention_days', label: 'Metrics Retention (days)', description: 'Default retention period for container metrics', type: 'number', defaultValue: '7', min: 1, max: 365 },
+    { key: 'infrastructure.metrics_raw_retention_days', label: 'Raw Metrics Retention (days)', description: 'Retention for raw per-minute metrics', type: 'number', defaultValue: '7', min: 1, max: 90 },
+    { key: 'infrastructure.metrics_rollup_5min_retention_days', label: '5min Rollup Retention (days)', description: 'Retention for 5-minute aggregated metrics', type: 'number', defaultValue: '30', min: 1, max: 365 },
+    { key: 'infrastructure.metrics_rollup_1hour_retention_days', label: '1h Rollup Retention (days)', description: 'Retention for hourly aggregated metrics', type: 'number', defaultValue: '90', min: 1, max: 730 },
+    { key: 'infrastructure.metrics_rollup_1day_retention_days', label: '1d Rollup Retention (days)', description: 'Retention for daily aggregated metrics', type: 'number', defaultValue: '365', min: 1, max: 1825 },
+    { key: 'infrastructure.insights_retention_days', label: 'Insights Retention (days)', description: 'How long to keep AI-generated insights', type: 'number', defaultValue: '7', min: 1, max: 365 },
+  ],
   portainerBackup: [
     { key: 'portainer_backup.enabled', label: 'Enable Scheduled Backups', description: 'Automatically back up Portainer server configuration on a schedule', type: 'boolean', defaultValue: 'false' },
     { key: 'portainer_backup.interval_hours', label: 'Backup Interval (hours)', description: 'Hours between automated Portainer backups', type: 'number', defaultValue: '24', min: 1, max: 168 },

--- a/frontend/src/features/core/components/settings/shared.tsx
+++ b/frontend/src/features/core/components/settings/shared.tsx
@@ -120,7 +120,6 @@ export const DEFAULT_SETTINGS = {
     { key: 'ai_tuning.ai_analysis_enabled', label: 'AI Infrastructure Analysis', description: 'Fire-and-forget LLM analysis each monitoring cycle', type: 'boolean', defaultValue: 'true' },
     { key: 'ai_tuning.max_insights_per_cycle', label: 'Max Insights / Cycle', description: 'Cap on total insights generated per monitoring cycle', type: 'number', defaultValue: '500', min: 1, max: 10000 },
     { key: 'ai_tuning.log_analysis_concurrency', label: 'Log Analysis Concurrency', description: 'Parallel container log analysis tasks', type: 'number', defaultValue: '3', min: 1, max: 20 },
-    { key: 'ai_tuning.insights_retention_days', label: 'Insights Retention (days)', description: 'How long to keep generated insights', type: 'number', defaultValue: '7', min: 1, max: 365 },
   ],
   metricsRetention: [
     { key: 'infrastructure.metrics_retention_days', label: 'Metrics Retention (days)', description: 'Default retention period for container metrics', type: 'number', defaultValue: '7', min: 1, max: 365 },

--- a/frontend/src/features/core/components/settings/tab-ai-llm.tsx
+++ b/frontend/src/features/core/components/settings/tab-ai-llm.tsx
@@ -34,7 +34,7 @@ import {
   X,
   Zap,
 } from 'lucide-react';
-import { SettingsSection, DEFAULT_SETTINGS, type SettingsTabProps } from './shared';
+import { SettingsSection, SettingRow, DEFAULT_SETTINGS, type SettingsTabProps } from './shared';
 import { useLlmModels, useLlmTestConnection, useLlmTestPrompt } from '@/features/ai-intelligence/hooks/use-llm-models';
 import {
   useMcpServers,
@@ -190,6 +190,16 @@ export function AiLlmTab({
         <Suspense fallback={<div className="flex items-center justify-center py-12"><Loader2 className="h-6 w-6 animate-spin text-muted-foreground" /></div>}>
           <LazyAiFeedbackPanel />
         </Suspense>
+      )}
+
+      {/* Advanced AI Tuning — Category B env vars moved to Settings DB (#993) */}
+      {role === 'admin' && (
+        <AdvancedAiTuningSection
+          editedValues={editedValues}
+          originalValues={originalValues}
+          onChange={onChange}
+          isSaving={isSaving}
+        />
       )}
     </div>
   );
@@ -2149,6 +2159,46 @@ export function AiPromptsTab({
               </div>
             )}
           </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Collapsible section for AI tuning knobs (Category B env vars moved to Settings DB). */
+function AdvancedAiTuningSection({ editedValues, originalValues, onChange, isSaving }: SettingsTabProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center justify-between p-4 text-left hover:bg-muted/30 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          {expanded ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+          <Wrench className="h-4 w-4" />
+          <span className="font-medium">Advanced AI Tuning</span>
+          <span className="text-xs text-muted-foreground">Anomaly detection, investigation, and ML parameters</span>
+        </div>
+      </button>
+      {expanded && (
+        <div className="border-t border-border px-4">
+          {DEFAULT_SETTINGS.aiTuning.map((setting) => (
+            <SettingRow
+              key={setting.key}
+              setting={setting}
+              value={editedValues[setting.key] ?? setting.defaultValue}
+              onChange={(value) => onChange(setting.key, value)}
+              hasChanges={editedValues[setting.key] !== originalValues[setting.key]}
+              disabled={isSaving}
+            />
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/features/core/components/settings/tab-infrastructure.tsx
+++ b/frontend/src/features/core/components/settings/tab-infrastructure.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import {
   Archive,
+  BarChart3,
   Clock,
   Database,
   Download,
@@ -50,6 +51,19 @@ export function InfrastructureTab({ editedValues, originalValues, onChange, isSa
         disabled={isSaving}
         status={editedValues['portainer_backup.enabled'] === 'true' ? 'configured' : 'not-configured'}
         statusLabel={editedValues['portainer_backup.enabled'] === 'true' ? 'Enabled' : 'Disabled'}
+      />
+
+      {/* Metrics Retention — moved from env vars to Settings DB (#993) */}
+      <SettingsSection
+        title="Metrics Retention"
+        icon={<BarChart3 className="h-5 w-5" />}
+        category="metricsRetention"
+        settings={DEFAULT_SETTINGS.metricsRetention}
+        values={editedValues}
+        originalValues={originalValues}
+        onChange={onChange}
+        disabled={isSaving}
+        status="configured"
       />
 
       {/* Backup Management */}

--- a/packages/ai-intelligence/src/__tests__/incident-correlator.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-correlator.test.ts
@@ -11,6 +11,19 @@ vi.mock('../services/incident-store.js', () => ({
   getActiveIncidentForContainer: vi.fn(() => Promise.resolve(undefined)),
 }));
 
+// Mock getEffectiveMonitoringConfig to avoid DB access in CI
+vi.mock('@dashboard/core/services/settings-store.js', async (importOriginal) => {
+  const orig = await importOriginal() as Record<string, unknown>;
+  return {
+    ...orig,
+    getEffectiveMonitoringConfig: vi.fn().mockResolvedValue({
+      smartGroupingEnabled: true,
+      smartGroupingSimilarityThreshold: 0.3,
+      incidentSummaryEnabled: false,
+    }),
+  };
+});
+
 // DI pattern — findSimilarInsights is passed as optional 3rd param to correlateInsights;
 // not passing it defaults to no smart grouping (same as SMART_GROUPING_ENABLED: false).
 

--- a/packages/ai-intelligence/src/__tests__/investigation-service.test.ts
+++ b/packages/ai-intelligence/src/__tests__/investigation-service.test.ts
@@ -21,6 +21,22 @@ vi.mock('../services/investigation-store.js', () => ({
   getRecentInvestigationForContainer: (...args: unknown[]) => mockGetRecentInvestigationForContainer(...args),
 }));
 
+// Mock getEffectiveMonitoringConfig to avoid DB access in CI
+vi.mock('@dashboard/core/services/settings-store.js', async (importOriginal) => {
+  const orig = await importOriginal() as Record<string, unknown>;
+  return {
+    ...orig,
+    getEffectiveMonitoringConfig: vi.fn().mockResolvedValue({
+      investigationEnabled: true,
+      investigationCooldownMinutes: 30,
+      investigationMaxConcurrent: 2,
+      investigationLogTailLines: 50,
+      investigationMetricsWindowMinutes: 60,
+      investigationMinSeverity: 'warning',
+    }),
+  };
+});
+
 // Import after mocks are set up
 const { parseInvestigationResponse, buildInvestigationPrompt, triggerInvestigation, initInvestigationDeps } =
   await import('../services/investigation-service.js');

--- a/packages/ai-intelligence/src/__tests__/log-analyzer.test.ts
+++ b/packages/ai-intelligence/src/__tests__/log-analyzer.test.ts
@@ -5,6 +5,17 @@ vi.mock('../services/prompt-store.js', () => ({
   getEffectivePrompt: vi.fn().mockResolvedValue('You are a test assistant.'),
 }));
 
+// Mock getEffectiveMonitoringConfig to avoid DB access in CI
+vi.mock('@dashboard/core/services/settings-store.js', async (importOriginal) => {
+  const orig = await importOriginal() as Record<string, unknown>;
+  return {
+    ...orig,
+    getEffectiveMonitoringConfig: vi.fn().mockResolvedValue({
+      logAnalysisConcurrency: 3,
+    }),
+  };
+});
+
 import { analyzeContainerLogs, analyzeLogsForContainers } from '../services/log-analyzer.js';
 import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
 import * as portainerCache from '@dashboard/core/portainer/portainer-cache.js';

--- a/packages/ai-intelligence/src/__tests__/monitoring-service.test.ts
+++ b/packages/ai-intelligence/src/__tests__/monitoring-service.test.ts
@@ -23,6 +23,40 @@ const defaultConfig = {
   AI_ANALYSIS_ENABLED: false, // disabled by default in tests to avoid async side-effects
 };
 
+// MonitoringConfig shape used by getEffectiveMonitoringConfig mock (matches defaultConfig values)
+const defaultMonitoringConfig = {
+  aiAnalysisEnabled: false,
+  maxInsightsPerCycle: 500,
+  logAnalysisConcurrency: 3,
+  maxLlmHistoryMessages: 50,
+  anomalyDetectionMethod: 'adaptive' as const,
+  anomalyZscoreThreshold: 3.5,
+  anomalyMovingAverageWindow: 20,
+  anomalyMinSamples: 10,
+  anomalyCooldownMinutes: 0,
+  anomalyThresholdPct: 80,
+  anomalyHardThresholdEnabled: true,
+  bollingerBandsEnabled: true,
+  predictiveAlertingEnabled: true,
+  predictiveAlertThresholdHours: 24,
+  anomalyExplanationEnabled: true,
+  anomalyExplanationMaxPerCycle: 5,
+  isolationForestEnabled: false,
+  isolationForestRetrainHours: 6,
+  nlpLogAnalysisEnabled: false,
+  nlpLogAnalysisMaxPerCycle: 3,
+  nlpLogAnalysisTailLines: 100,
+  smartGroupingEnabled: true,
+  smartGroupingSimilarityThreshold: 0.3,
+  incidentSummaryEnabled: true,
+  investigationEnabled: true,
+  investigationCooldownMinutes: 30,
+  investigationMaxConcurrent: 2,
+  investigationLogTailLines: 50,
+  investigationMetricsWindowMinutes: 60,
+  investigationMinSeverity: 'warning' as const,
+};
+
 // Kept mocks — internal services the monitoring cycle depends on
 
 // Real portainer-normalizers used (pure function, no external deps)
@@ -112,13 +146,57 @@ vi.mock('@dashboard/core/services/typed-event-bus.js', () => ({
   eventBus: { emit: vi.fn(), on: vi.fn(() => vi.fn()), onAny: vi.fn(() => vi.fn()), emitAsync: vi.fn() },
 }));
 
+// Mock getEffectiveMonitoringConfig to avoid hitting the real DB in CI.
+// Values must be inlined (not reference defaultConfig) because vi.mock is hoisted.
+vi.mock('@dashboard/core/services/settings-store.js', async (importOriginal) => {
+  const orig = await importOriginal() as Record<string, unknown>;
+  return {
+    ...orig,
+    getEffectiveMonitoringConfig: vi.fn().mockResolvedValue({
+      aiAnalysisEnabled: false,
+      maxInsightsPerCycle: 500,
+      logAnalysisConcurrency: 3,
+      maxLlmHistoryMessages: 50,
+      anomalyDetectionMethod: 'adaptive',
+      anomalyZscoreThreshold: 3.5,
+      anomalyMovingAverageWindow: 20,
+      anomalyMinSamples: 10,
+      anomalyCooldownMinutes: 0,
+      anomalyThresholdPct: 80,
+      anomalyHardThresholdEnabled: true,
+      bollingerBandsEnabled: true,
+      predictiveAlertingEnabled: true,
+      predictiveAlertThresholdHours: 24,
+      anomalyExplanationEnabled: true,
+      anomalyExplanationMaxPerCycle: 5,
+      isolationForestEnabled: false,
+      isolationForestRetrainHours: 6,
+      nlpLogAnalysisEnabled: false,
+      nlpLogAnalysisMaxPerCycle: 3,
+      nlpLogAnalysisTailLines: 100,
+      smartGroupingEnabled: true,
+      smartGroupingSimilarityThreshold: 0.3,
+      incidentSummaryEnabled: true,
+      investigationEnabled: true,
+      investigationCooldownMinutes: 30,
+      investigationMaxConcurrent: 2,
+      investigationLogTailLines: 50,
+      investigationMetricsWindowMinutes: 60,
+      investigationMinSeverity: 'warning',
+    }),
+  };
+});
+
 const mockCorrelateInsights = vi.fn().mockResolvedValue({ incidentsCreated: 0, insightsGrouped: 0 });
 vi.mock('../services/incident-correlator.js', () => ({
   correlateInsights: (...args: unknown[]) => mockCorrelateInsights(...args),
 }));
 
 const { createMonitoringService, setMonitoringNamespace, sweepExpiredCooldowns, resetAnomalyCooldowns, startCooldownSweep, stopCooldownSweep, resetPreviousCycleStats } = await import('../services/monitoring-service.js');
+import { getEffectiveMonitoringConfig } from '@dashboard/core/services/settings-store.js';
 import { eventBus } from '@dashboard/core/services/typed-event-bus.js';
+
+const mockGetEffectiveMonitoringConfig = vi.mocked(getEffectiveMonitoringConfig);
 import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
 import * as portainerCache from '@dashboard/core/portainer/portainer-cache.js';
 import { cache } from '@dashboard/core/portainer/portainer-cache.js';
@@ -294,6 +372,9 @@ describe('monitoring-service', () => {
         MAX_INSIGHTS_PER_CYCLE: 2,
         ANOMALY_COOLDOWN_MINUTES: 0,
       });
+      mockGetEffectiveMonitoringConfig.mockResolvedValueOnce(
+        { ...defaultMonitoringConfig, maxInsightsPerCycle: 2, anomalyCooldownMinutes: 0 },
+      );
 
       mockGetEndpoints.mockResolvedValue([{ Id: 1, Name: 'local', Status: 1, Type: 1, URL: 'tcp://localhost' }]);
       mockGetContainers.mockResolvedValue([
@@ -459,6 +540,9 @@ describe('monitoring-service', () => {
         PREDICTIVE_ALERTING_ENABLED: false,
         ANOMALY_EXPLANATION_ENABLED: false,
       });
+      mockGetEffectiveMonitoringConfig.mockResolvedValueOnce(
+        { ...defaultMonitoringConfig, predictiveAlertingEnabled: false, anomalyExplanationEnabled: false },
+      );
 
       mockGetCapacityForecasts.mockReturnValue([
         {
@@ -537,6 +621,9 @@ describe('monitoring-service', () => {
       setConfigForTest({
         ANOMALY_EXPLANATION_ENABLED: false,
       });
+      mockGetEffectiveMonitoringConfig.mockResolvedValueOnce(
+        { ...defaultMonitoringConfig, anomalyExplanationEnabled: false },
+      );
       mockGetEndpoints.mockResolvedValue([{ Id: 1, Name: 'local', Status: 1, Type: 1, URL: 'tcp://localhost' }]);
       mockGetContainers.mockResolvedValue([
         { Id: 'c1', Names: ['/web-app'], State: 'running', Image: 'node:18' },
@@ -577,6 +664,9 @@ describe('monitoring-service', () => {
         PREDICTIVE_ALERTING_ENABLED: false,
         ANOMALY_EXPLANATION_ENABLED: false,
       });
+      mockGetEffectiveMonitoringConfig.mockResolvedValueOnce(
+        { ...defaultMonitoringConfig, anomalyHardThresholdEnabled: false, predictiveAlertingEnabled: false, anomalyExplanationEnabled: false },
+      );
       mockGetEndpoints.mockResolvedValue([{ Id: 1, Name: 'local', Status: 1, Type: 1, URL: 'tcp://localhost' }]);
       mockGetContainers.mockResolvedValue([
         { Id: 'c1', Names: ['/web-app'], State: 'running', Image: 'node:18' },

--- a/packages/ai-intelligence/src/services/incident-correlator.ts
+++ b/packages/ai-intelligence/src/services/incident-correlator.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
-import { getConfig } from '@dashboard/core/config/index.js';
+import { getEffectiveMonitoringConfig } from '@dashboard/core/services/settings-store.js';
 import { isOllamaAvailable } from './llm-client.js';
 import type { Insight } from '@dashboard/core/models/monitoring.js';
 import {
@@ -82,12 +82,12 @@ export async function correlateInsights(
   const grouped = groupByCorrelation(anomalyInsights, correlationWindowMinutes);
 
   // Semantic grouping pass: group ungrouped singles by text similarity
-  const config = getConfig();
-  if (config.SMART_GROUPING_ENABLED && findSimilarInsights) {
+  const monCfg = await getEffectiveMonitoringConfig();
+  if (monCfg.smartGroupingEnabled && findSimilarInsights) {
     const ungroupedSingles = grouped.filter((g) => g.insights.length === 1);
     if (ungroupedSingles.length >= 2) {
       const ungroupedInsights = ungroupedSingles.map((g) => g.insights[0]);
-      const semanticGroups = findSimilarInsights(ungroupedInsights, config.SMART_GROUPING_SIMILARITY_THRESHOLD);
+      const semanticGroups = findSimilarInsights(ungroupedInsights, monCfg.smartGroupingSimilarityThreshold);
 
       for (const semanticGroup of semanticGroups) {
         // Remove the individual entries from grouped
@@ -116,7 +116,7 @@ export async function correlateInsights(
   }
 
   // LLM summary enrichment for multi-insight groups
-  const ollamaAvailable = config.INCIDENT_SUMMARY_ENABLED ? await isOllamaAvailable() : false;
+  const ollamaAvailable = monCfg.incidentSummaryEnabled ? await isOllamaAvailable() : false;
   if (ollamaAvailable) {
     for (const group of grouped) {
       if (group.insights.length >= 2) {

--- a/packages/ai-intelligence/src/services/investigation-service.ts
+++ b/packages/ai-intelligence/src/services/investigation-service.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Namespace } from 'socket.io';
 import { getConfig } from '@dashboard/core/config/index.js';
+import { getEffectiveMonitoringConfig } from '@dashboard/core/services/settings-store.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { getContainerLogs, getContainers } from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
@@ -231,7 +232,7 @@ async function gatherEvidence(insight: Insight): Promise<{
   forecasts?: CapacityForecast[];
   evidenceSummary: EvidenceSummary;
 }> {
-  const config = getConfig();
+  const monCfg = await getEffectiveMonitoringConfig();
   const evidence: {
     logs?: string;
     metrics?: MetricSnapshot[];
@@ -250,7 +251,7 @@ async function gatherEvidence(insight: Insight): Promise<{
           const rawLogs = await getContainerLogs(
             insight.endpoint_id!,
             insight.container_id!,
-            { tail: config.INVESTIGATION_LOG_TAIL_LINES, timestamps: true },
+            { tail: monCfg.investigationLogTailLines, timestamps: true },
           );
           // Cap at 5KB
           evidence.logs = rawLogs.slice(0, 5120);
@@ -269,7 +270,7 @@ async function gatherEvidence(insight: Insight): Promise<{
       (async () => {
         try {
           const deps = requireMetricsDeps();
-          const metricsWindow = config.INVESTIGATION_METRICS_WINDOW_MINUTES;
+          const metricsWindow = monCfg.investigationMetricsWindowMinutes;
           const now = new Date();
           const from = new Date(now.getTime() - metricsWindow * 60 * 1000);
           const snapshots: MetricSnapshot[] = [];
@@ -456,10 +457,10 @@ async function broadcastInvestigationComplete(investigationId: string): Promise<
 const SEVERITY_ORDER: Record<string, number> = { critical: 0, warning: 1, info: 2 };
 
 export async function triggerInvestigation(insight: Insight): Promise<void> {
-  const config = getConfig();
+  const monCfg = await getEffectiveMonitoringConfig();
 
   // Guard: feature flag
-  if (!config.INVESTIGATION_ENABLED) {
+  if (!monCfg.investigationEnabled) {
     log.debug('Investigation disabled by configuration');
     return;
   }
@@ -471,7 +472,7 @@ export async function triggerInvestigation(insight: Insight): Promise<void> {
   }
 
   // Guard: severity threshold (#697) — skip low-severity insights
-  const minSeverity = (config as Record<string, unknown>).INVESTIGATION_MIN_SEVERITY as string ?? 'warning';
+  const minSeverity = monCfg.investigationMinSeverity;
   const insightOrder = SEVERITY_ORDER[insight.severity] ?? 2;
   const minOrder = SEVERITY_ORDER[minSeverity] ?? 1;
   if (insightOrder > minOrder) {
@@ -483,9 +484,9 @@ export async function triggerInvestigation(insight: Insight): Promise<void> {
   }
 
   // Guard: concurrency limit
-  if (activeInvestigations >= config.INVESTIGATION_MAX_CONCURRENT) {
+  if (activeInvestigations >= monCfg.investigationMaxConcurrent) {
     log.debug(
-      { activeInvestigations, max: config.INVESTIGATION_MAX_CONCURRENT },
+      { activeInvestigations, max: monCfg.investigationMaxConcurrent },
       'Skipping investigation: concurrency limit reached',
     );
     return;
@@ -493,7 +494,7 @@ export async function triggerInvestigation(insight: Insight): Promise<void> {
 
   // Guard: in-memory cooldown
   const lastRun = cooldownMap.get(insight.container_id);
-  const cooldownMs = config.INVESTIGATION_COOLDOWN_MINUTES * 60 * 1000;
+  const cooldownMs = monCfg.investigationCooldownMinutes * 60 * 1000;
   if (lastRun && Date.now() - lastRun < cooldownMs) {
     log.debug(
       { containerId: insight.container_id },
@@ -505,7 +506,7 @@ export async function triggerInvestigation(insight: Insight): Promise<void> {
   // Guard: DB cooldown (for durability across restarts)
   const recent = await getRecentInvestigationForContainer(
     insight.container_id,
-    config.INVESTIGATION_COOLDOWN_MINUTES,
+    monCfg.investigationCooldownMinutes,
   );
   if (recent) {
     log.debug(

--- a/packages/ai-intelligence/src/services/log-analyzer.ts
+++ b/packages/ai-intelligence/src/services/log-analyzer.ts
@@ -1,6 +1,5 @@
 import pLimit from 'p-limit';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
-import { getConfig } from '@dashboard/core/config/index.js';
 import { chatStream } from './llm-client.js';
 import { getEffectivePrompt } from './prompt-store.js';
 import { getContainerLogs } from '@dashboard/core/portainer/portainer-client.js';
@@ -98,8 +97,9 @@ export async function analyzeLogsForContainers(
   }
 
   const toAnalyze = ordered.slice(0, maxContainers);
-  const config = getConfig();
-  const limit = pLimit(config.LOG_ANALYSIS_CONCURRENCY);
+  const { getEffectiveMonitoringConfig } = await import('@dashboard/core/services/settings-store.js');
+  const monCfg = await getEffectiveMonitoringConfig();
+  const limit = pLimit(monCfg.logAnalysisConcurrency);
 
   const settled = await Promise.allSettled(
     toAnalyze.map((container) =>

--- a/packages/ai-intelligence/src/services/log-analyzer.ts
+++ b/packages/ai-intelligence/src/services/log-analyzer.ts
@@ -1,5 +1,6 @@
 import pLimit from 'p-limit';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
+import { getEffectiveMonitoringConfig } from '@dashboard/core/services/settings-store.js';
 import { chatStream } from './llm-client.js';
 import { getEffectivePrompt } from './prompt-store.js';
 import { getContainerLogs } from '@dashboard/core/portainer/portainer-client.js';
@@ -97,7 +98,6 @@ export async function analyzeLogsForContainers(
   }
 
   const toAnalyze = ordered.slice(0, maxContainers);
-  const { getEffectiveMonitoringConfig } = await import('@dashboard/core/services/settings-store.js');
   const monCfg = await getEffectiveMonitoringConfig();
   const limit = pLimit(monCfg.logAnalysisConcurrency);
 

--- a/packages/ai-intelligence/src/services/monitoring-service.ts
+++ b/packages/ai-intelligence/src/services/monitoring-service.ts
@@ -1,6 +1,8 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Namespace } from 'socket.io';
 import { getConfig } from '@dashboard/core/config/index.js';
+import { getEffectiveMonitoringConfig } from '@dashboard/core/services/settings-store.js';
+import type { MonitoringConfig } from '@dashboard/core/services/settings-store.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { getEndpoints, getContainers, isEndpointDegraded, isCircuitOpen } from '@dashboard/core/portainer/portainer-client.js';
 import { CircuitBreakerOpenError } from '@dashboard/core/portainer/circuit-breaker.js';
@@ -293,7 +295,8 @@ export function createMonitoringService(deps: MonitoringDeps) {
       }
 
       // 4. Run anomaly detection on recent metrics (batched)
-      const config = getConfig();
+      // Fetch AI tuning config from Settings DB (single batch query, env var fallback).
+      const monCfg = await getEffectiveMonitoringConfig();
       const anomalyInsights: InsightInsert[] = [];
 
       // Build batch items for all running containers × metric types
@@ -322,7 +325,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
       // Run batch anomaly detection
       const batchResults = await detectAnomaliesBatch(
         batchItems,
-        config.ANOMALY_DETECTION_METHOD,
+        monCfg.anomalyDetectionMethod,
         deps.metrics.getMovingAverage,
       );
 
@@ -334,11 +337,11 @@ export function createMonitoringService(deps: MonitoringDeps) {
 
         // Cooldown check: skip if this container+metric was recently flagged
         const cooldownKey = key;
-        const cooldownMs = config.ANOMALY_COOLDOWN_MINUTES * 60_000;
+        const cooldownMs = monCfg.anomalyCooldownMinutes * 60_000;
         const lastAlerted = anomalyCooldowns.get(cooldownKey);
         if (cooldownMs > 0 && lastAlerted && Date.now() - lastAlerted < cooldownMs) {
           log.debug(
-            { containerId: item.containerId, metricType: item.metricType, cooldownMinutes: config.ANOMALY_COOLDOWN_MINUTES },
+            { containerId: item.containerId, metricType: item.metricType, cooldownMinutes: monCfg.anomalyCooldownMinutes },
             'Anomaly suppressed by cooldown',
           );
           continue;
@@ -367,7 +370,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
 
       // 4.05. Threshold-based detection — flag values above ANOMALY_THRESHOLD_PCT.
       // This catches high values that z-score misses (e.g. container consistently at 100%).
-      if (config.ANOMALY_HARD_THRESHOLD_ENABLED !== false) {
+      if (monCfg.anomalyHardThresholdEnabled !== false) {
         for (const container of runningContainers) {
           const containerName =
             container.raw.Names?.[0]?.replace(/^\//, '') || container.raw.Id.slice(0, 12);
@@ -376,7 +379,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
             const metric = metricsFromDb.find(
               (m) => m.container_id === container.raw.Id && m.metric_type === metricType,
             );
-            if (!metric || metric.value <= config.ANOMALY_THRESHOLD_PCT) continue;
+            if (!metric || metric.value <= monCfg.anomalyThresholdPct) continue;
 
             // Skip if already flagged by statistical detection
             if (anomalyInsights.some(
@@ -385,7 +388,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
 
             // Cooldown check
             const cooldownKey = `${container.raw.Id}:${metricType}:threshold`;
-            const cooldownMs = config.ANOMALY_COOLDOWN_MINUTES * 60_000;
+            const cooldownMs = monCfg.anomalyCooldownMinutes * 60_000;
             const lastAlerted = anomalyCooldowns.get(cooldownKey);
             if (cooldownMs > 0 && lastAlerted && Date.now() - lastAlerted < cooldownMs) continue;
             anomalyCooldowns.set(cooldownKey, Date.now());
@@ -401,7 +404,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
               title: `High ${metricType} usage on "${containerName}"`,
               description:
                 `Current ${metricType}: ${metric.value.toFixed(1)}% ` +
-                `(threshold: ${config.ANOMALY_THRESHOLD_PCT}%). ` +
+                `(threshold: ${monCfg.anomalyThresholdPct}%). ` +
                 `Value exceeds the configured warning threshold.`,
               suggested_action: metricType === 'memory'
                 ? 'Check for memory leaks or increase memory limit'
@@ -412,7 +415,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
       }
 
       // 4.1. Isolation Forest anomaly detection — multivariate ML-based detection
-      if (config.ISOLATION_FOREST_ENABLED) {
+      if (monCfg.isolationForestEnabled) {
         for (const container of runningContainers) {
           const containerName =
             container.raw.Names?.[0]?.replace(/^\//, '') || container.raw.Id.slice(0, 12);
@@ -471,14 +474,14 @@ export function createMonitoringService(deps: MonitoringDeps) {
 
       // 4.5. Predictive alerting — proactive resource exhaustion warnings
       const predictiveInsights: InsightInsert[] = [];
-      if (config.PREDICTIVE_ALERTING_ENABLED) {
+      if (monCfg.predictiveAlertingEnabled) {
         try {
           const forecasts = await deps.metrics.getCapacityForecasts(20);
           for (const forecast of forecasts) {
             if (
               forecast.trend === 'increasing' &&
               forecast.timeToThreshold != null &&
-              forecast.timeToThreshold <= config.PREDICTIVE_ALERT_THRESHOLD_HOURS &&
+              forecast.timeToThreshold <= monCfg.predictiveAlertThresholdHours &&
               forecast.confidence !== 'low'
             ) {
               const severity: 'critical' | 'warning' | 'info' =
@@ -514,13 +517,13 @@ export function createMonitoringService(deps: MonitoringDeps) {
 
       // 4.75. Anomaly explanations — LLM explains anomalies in plain English
       const ollamaAvailable = await isOllamaAvailable();
-      if (config.ANOMALY_EXPLANATION_ENABLED && ollamaAvailable && anomalyInsights.length > 0) {
+      if (monCfg.anomalyExplanationEnabled && ollamaAvailable && anomalyInsights.length > 0) {
         try {
           const anomalyData = anomalyInsights.map((ins) => ({
             insight: ins,
             description: ins.description,
           }));
-          const explanations = await explainAnomalies(anomalyData, config.ANOMALY_EXPLANATION_MAX_PER_CYCLE);
+          const explanations = await explainAnomalies(anomalyData, monCfg.anomalyExplanationMaxPerCycle);
           for (const [insightId, explanation] of explanations) {
             const insight = anomalyInsights.find((i) => i.id === insightId);
             if (insight) {
@@ -537,7 +540,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
 
       // 4.8. NLP Log Analysis — LLM analyzes container logs for error patterns
       const logAnalysisInsights: InsightInsert[] = [];
-      if (config.NLP_LOG_ANALYSIS_ENABLED && ollamaAvailable && runningContainers.length > 0) {
+      if (monCfg.nlpLogAnalysisEnabled && ollamaAvailable && runningContainers.length > 0) {
         try {
           const containersForLogAnalysis = runningContainers.map((c) => ({
             endpointId: c.endpointId,
@@ -546,8 +549,8 @@ export function createMonitoringService(deps: MonitoringDeps) {
           }));
           const logResults = await analyzeLogsForContainers(
             containersForLogAnalysis,
-            config.NLP_LOG_ANALYSIS_MAX_PER_CYCLE,
-            config.NLP_LOG_ANALYSIS_TAIL_LINES,
+            monCfg.nlpLogAnalysisMaxPerCycle,
+            monCfg.nlpLogAnalysisTailLines,
           );
           for (const result of logResults) {
             const container = runningContainers.find((c) => c.raw.Id === result.containerId);
@@ -591,7 +594,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
       }));
 
       // 6. Attempt AI analysis (fire-and-forget, gated by AI_ANALYSIS_ENABLED)
-      if (config.AI_ANALYSIS_ENABLED && ollamaAvailable) {
+      if (monCfg.aiAnalysisEnabled && ollamaAvailable) {
         // Fire-and-forget: AI analysis inserts its own insight when complete
         (async () => {
           try {
@@ -632,7 +635,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
             log.warn({ err }, 'AI analysis failed (async), using rule-based analysis only');
           }
         })();
-      } else if (!config.AI_ANALYSIS_ENABLED) {
+      } else if (!monCfg.aiAnalysisEnabled) {
         log.debug('AI analysis disabled via AI_ANALYSIS_ENABLED');
       } else {
         log.info('Ollama unavailable, using rule-based analysis only');
@@ -642,12 +645,12 @@ export function createMonitoringService(deps: MonitoringDeps) {
       let allInsights = [...anomalyInsights, ...predictiveInsights, ...logAnalysisInsights, ...securityInsights];
 
       // Cap at MAX_INSIGHTS_PER_CYCLE to prevent unbounded growth
-      if (allInsights.length > config.MAX_INSIGHTS_PER_CYCLE) {
+      if (allInsights.length > monCfg.maxInsightsPerCycle) {
         log.warn(
-          { total: allInsights.length, cap: config.MAX_INSIGHTS_PER_CYCLE },
+          { total: allInsights.length, cap: monCfg.maxInsightsPerCycle },
           'Insight count exceeds MAX_INSIGHTS_PER_CYCLE, truncating',
         );
-        allInsights = allInsights.slice(0, config.MAX_INSIGHTS_PER_CYCLE);
+        allInsights = allInsights.slice(0, monCfg.maxInsightsPerCycle);
       }
 
       // Batch insert all insights in a single transaction

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -146,6 +146,75 @@ function validateServicePasswords(data: EnvConfig): void {
   }
 }
 
+// Category A + B env vars that are now configurable via Settings UI.
+// During the deprecation window, they still work as fallbacks but log a warning.
+const DEPRECATED_ENV_VARS: Record<string, string> = {
+  // Category A: already have Settings UI
+  TEAMS_WEBHOOK_URL: 'Settings → Monitoring → Notifications',
+  TEAMS_NOTIFICATIONS_ENABLED: 'Settings → Monitoring → Notifications',
+  DISCORD_WEBHOOK_URL: 'Settings → Monitoring → Notifications',
+  DISCORD_NOTIFICATIONS_ENABLED: 'Settings → Monitoring → Notifications',
+  TELEGRAM_BOT_TOKEN: 'Settings → Monitoring → Notifications',
+  TELEGRAM_CHAT_ID: 'Settings → Monitoring → Notifications',
+  TELEGRAM_NOTIFICATIONS_ENABLED: 'Settings → Monitoring → Notifications',
+  SMTP_PORT: 'Settings → Monitoring → Notifications',
+  SMTP_SECURE: 'Settings → Monitoring → Notifications',
+  SMTP_USER: 'Settings → Monitoring → Notifications',
+  SMTP_PASSWORD: 'Settings → Monitoring → Notifications',
+  SMTP_FROM: 'Settings → Monitoring → Notifications',
+  EMAIL_NOTIFICATIONS_ENABLED: 'Settings → Monitoring → Notifications',
+  EMAIL_RECIPIENTS: 'Settings → Monitoring → Notifications',
+  WEBHOOKS_ENABLED: 'Settings → Integrations → Webhooks',
+  WEBHOOKS_MAX_RETRIES: 'Settings → Integrations → Webhooks',
+  WEBHOOKS_RETRY_INTERVAL_SECONDS: 'Settings → Integrations → Webhooks',
+  // Category B: AI tuning (now in Settings → AI & LLM → Advanced)
+  ANOMALY_ZSCORE_THRESHOLD: 'Settings → AI & LLM → Advanced AI Tuning',
+  ANOMALY_MOVING_AVERAGE_WINDOW: 'Settings → AI & LLM → Advanced AI Tuning',
+  ANOMALY_MIN_SAMPLES: 'Settings → AI & LLM → Advanced AI Tuning',
+  ANOMALY_DETECTION_METHOD: 'Settings → AI & LLM → Advanced AI Tuning',
+  ANOMALY_COOLDOWN_MINUTES: 'Settings → AI & LLM → Advanced AI Tuning',
+  ANOMALY_THRESHOLD_PCT: 'Settings → AI & LLM → Advanced AI Tuning',
+  ANOMALY_HARD_THRESHOLD_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  BOLLINGER_BANDS_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  PREDICTIVE_ALERTING_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  PREDICTIVE_ALERT_THRESHOLD_HOURS: 'Settings → AI & LLM → Advanced AI Tuning',
+  ANOMALY_EXPLANATION_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  ANOMALY_EXPLANATION_MAX_PER_CYCLE: 'Settings → AI & LLM → Advanced AI Tuning',
+  ISOLATION_FOREST_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  ISOLATION_FOREST_RETRAIN_HOURS: 'Settings → AI & LLM → Advanced AI Tuning',
+  NLP_LOG_ANALYSIS_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  NLP_LOG_ANALYSIS_MAX_PER_CYCLE: 'Settings → AI & LLM → Advanced AI Tuning',
+  NLP_LOG_ANALYSIS_TAIL_LINES: 'Settings → AI & LLM → Advanced AI Tuning',
+  SMART_GROUPING_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  SMART_GROUPING_SIMILARITY_THRESHOLD: 'Settings → AI & LLM → Advanced AI Tuning',
+  INCIDENT_SUMMARY_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  INVESTIGATION_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  INVESTIGATION_COOLDOWN_MINUTES: 'Settings → AI & LLM → Advanced AI Tuning',
+  INVESTIGATION_MAX_CONCURRENT: 'Settings → AI & LLM → Advanced AI Tuning',
+  INVESTIGATION_LOG_TAIL_LINES: 'Settings → AI & LLM → Advanced AI Tuning',
+  INVESTIGATION_METRICS_WINDOW_MINUTES: 'Settings → AI & LLM → Advanced AI Tuning',
+  INVESTIGATION_MIN_SEVERITY: 'Settings → AI & LLM → Advanced AI Tuning',
+  AI_ANALYSIS_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
+  MAX_INSIGHTS_PER_CYCLE: 'Settings → AI & LLM → Advanced AI Tuning',
+  INSIGHTS_RETENTION_DAYS: 'Settings → AI & LLM → Advanced AI Tuning',
+};
+
+let deprecationWarned = false;
+
+function warnDeprecatedEnvVars(): void {
+  if (deprecationWarned) return;
+  deprecationWarned = true;
+
+  for (const [envVar, uiLocation] of Object.entries(DEPRECATED_ENV_VARS)) {
+    if (process.env[envVar] !== undefined) {
+      console.warn(
+        `[DEPRECATED] Env var ${envVar} is now configurable via ${uiLocation} and will be removed in a future release. ` +
+        `Migrate to the Settings UI and remove it from your .env file.`,
+      );
+    }
+  }
+}
+
 export function getConfig(): EnvConfig {
   if (!config) {
     const result = envSchema.safeParse(process.env);
@@ -160,6 +229,7 @@ export function getConfig(): EnvConfig {
     validateDashboardCredentials(result.data.DASHBOARD_USERNAME, result.data.DASHBOARD_PASSWORD);
     validateServicePasswords(result.data);
     validatePrometheusToken(result.data);
+    warnDeprecatedEnvVars();
     config = result.data;
   }
   return config;

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -196,7 +196,7 @@ const DEPRECATED_ENV_VARS: Record<string, string> = {
   INVESTIGATION_MIN_SEVERITY: 'Settings → AI & LLM → Advanced AI Tuning',
   AI_ANALYSIS_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
   MAX_INSIGHTS_PER_CYCLE: 'Settings → AI & LLM → Advanced AI Tuning',
-  INSIGHTS_RETENTION_DAYS: 'Settings → AI & LLM → Advanced AI Tuning',
+  INSIGHTS_RETENTION_DAYS: 'Settings → Infrastructure → Metrics Retention',
 };
 
 let deprecationWarned = false;

--- a/packages/core/src/db/postgres-migrations/027_monitoring_ai_settings_seed.sql
+++ b/packages/core/src/db/postgres-migrations/027_monitoring_ai_settings_seed.sql
@@ -2,10 +2,11 @@
 -- These settings move from env vars to the Settings UI as the primary source of truth.
 
 -- Category A: Webhook settings (already have UI, but may not have DB seeds)
+-- Keys match the frontend Settings UI (webhooks.* prefix)
 INSERT INTO settings (key, value, category, updated_at) VALUES
-  ('notifications.webhooks_enabled', 'false', 'webhooks', NOW()),
-  ('notifications.webhooks_max_retries', '5', 'webhooks', NOW()),
-  ('notifications.webhooks_retry_interval_seconds', '60', 'webhooks', NOW())
+  ('webhooks.enabled', 'false', 'webhooks', NOW()),
+  ('webhooks.max_retries', '5', 'webhooks', NOW()),
+  ('webhooks.retry_interval', '60', 'webhooks', NOW())
 ON CONFLICT (key) DO NOTHING;
 
 -- Category B: AI Tuning — Anomaly Detection

--- a/packages/core/src/db/postgres-migrations/027_monitoring_ai_settings_seed.sql
+++ b/packages/core/src/db/postgres-migrations/027_monitoring_ai_settings_seed.sql
@@ -1,0 +1,92 @@
+-- Migration: Seed monitoring + AI tuning settings for issue #993
+-- These settings move from env vars to the Settings UI as the primary source of truth.
+
+-- Category A: Webhook settings (already have UI, but may not have DB seeds)
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('notifications.webhooks_enabled', 'false', 'webhooks', NOW()),
+  ('notifications.webhooks_max_retries', '5', 'webhooks', NOW()),
+  ('notifications.webhooks_retry_interval_seconds', '60', 'webhooks', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Category B: AI Tuning — Anomaly Detection
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('ai_tuning.anomaly_detection_method', 'adaptive', 'ai_tuning', NOW()),
+  ('ai_tuning.anomaly_zscore_threshold', '3.5', 'ai_tuning', NOW()),
+  ('ai_tuning.anomaly_moving_average_window', '20', 'ai_tuning', NOW()),
+  ('ai_tuning.anomaly_min_samples', '10', 'ai_tuning', NOW()),
+  ('ai_tuning.anomaly_cooldown_minutes', '30', 'ai_tuning', NOW()),
+  ('ai_tuning.anomaly_threshold_pct', '85', 'ai_tuning', NOW()),
+  ('ai_tuning.anomaly_hard_threshold_enabled', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.bollinger_bands_enabled', 'true', 'ai_tuning', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Category B: AI Tuning — Predictive Alerting
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('ai_tuning.predictive_alerting_enabled', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.predictive_alert_threshold_hours', '24', 'ai_tuning', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Category B: AI Tuning — Anomaly Explanation
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('ai_tuning.anomaly_explanation_enabled', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.anomaly_explanation_max_per_cycle', '5', 'ai_tuning', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Category B: AI Tuning — Isolation Forest
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('ai_tuning.isolation_forest_enabled', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.isolation_forest_retrain_hours', '6', 'ai_tuning', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Category B: AI Tuning — NLP Log Analysis
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('ai_tuning.nlp_log_analysis_enabled', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.nlp_log_analysis_max_per_cycle', '3', 'ai_tuning', NOW()),
+  ('ai_tuning.nlp_log_analysis_tail_lines', '100', 'ai_tuning', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Category B: AI Tuning — Smart Grouping & Incidents
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('ai_tuning.smart_grouping_enabled', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.smart_grouping_similarity_threshold', '0.3', 'ai_tuning', NOW()),
+  ('ai_tuning.incident_summary_enabled', 'true', 'ai_tuning', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Category B: AI Tuning — Investigation
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('ai_tuning.investigation_enabled', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.investigation_cooldown_minutes', '20', 'ai_tuning', NOW()),
+  ('ai_tuning.investigation_max_concurrent', '2', 'ai_tuning', NOW()),
+  ('ai_tuning.investigation_log_tail_lines', '50', 'ai_tuning', NOW()),
+  ('ai_tuning.investigation_metrics_window_minutes', '60', 'ai_tuning', NOW()),
+  ('ai_tuning.investigation_min_severity', 'warning', 'ai_tuning', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Category B: AI Tuning — General AI
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('ai_tuning.ai_analysis_enabled', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.max_insights_per_cycle', '500', 'ai_tuning', NOW()),
+  ('ai_tuning.log_analysis_concurrency', '3', 'ai_tuning', NOW()),
+  ('ai_tuning.max_llm_history_messages', '50', 'ai_tuning', NOW()),
+  ('ai_tuning.insights_retention_days', '7', 'ai_tuning', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Category B: AI Tuning — LLM Safety
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('ai_tuning.llm_prompt_guard_strict', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.ai_search_model', 'llama3.2:latest', 'ai_tuning', NOW()),
+  ('ai_tuning.llm_verify_ssl', 'true', 'ai_tuning', NOW()),
+  ('ai_tuning.llm_request_timeout', '120000', 'ai_tuning', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Metrics retention (infrastructure category)
+INSERT INTO settings (key, value, category, updated_at) VALUES
+  ('infrastructure.metrics_retention_days', '7', 'infrastructure', NOW()),
+  ('infrastructure.metrics_raw_retention_days', '7', 'infrastructure', NOW()),
+  ('infrastructure.metrics_rollup_5min_retention_days', '30', 'infrastructure', NOW()),
+  ('infrastructure.metrics_rollup_1hour_retention_days', '90', 'infrastructure', NOW()),
+  ('infrastructure.metrics_rollup_1day_retention_days', '365', 'infrastructure', NOW()),
+  ('infrastructure.insights_retention_days', '7', 'infrastructure', NOW()),
+  ('infrastructure.image_staleness_check_enabled', 'true', 'infrastructure', NOW()),
+  ('infrastructure.image_staleness_check_interval_hours', '24', 'infrastructure', NOW())
+ON CONFLICT (key) DO NOTHING;

--- a/packages/core/src/db/postgres-migrations/027_monitoring_ai_settings_seed.sql
+++ b/packages/core/src/db/postgres-migrations/027_monitoring_ai_settings_seed.sql
@@ -63,21 +63,16 @@ INSERT INTO settings (key, value, category, updated_at) VALUES
 ON CONFLICT (key) DO NOTHING;
 
 -- Category B: AI Tuning — General AI
+-- Note: insights_retention_days lives in the infrastructure category (below), not here.
 INSERT INTO settings (key, value, category, updated_at) VALUES
   ('ai_tuning.ai_analysis_enabled', 'true', 'ai_tuning', NOW()),
   ('ai_tuning.max_insights_per_cycle', '500', 'ai_tuning', NOW()),
   ('ai_tuning.log_analysis_concurrency', '3', 'ai_tuning', NOW()),
-  ('ai_tuning.max_llm_history_messages', '50', 'ai_tuning', NOW()),
-  ('ai_tuning.insights_retention_days', '7', 'ai_tuning', NOW())
+  ('ai_tuning.max_llm_history_messages', '50', 'ai_tuning', NOW())
 ON CONFLICT (key) DO NOTHING;
 
--- Category B: AI Tuning — LLM Safety
-INSERT INTO settings (key, value, category, updated_at) VALUES
-  ('ai_tuning.llm_prompt_guard_strict', 'true', 'ai_tuning', NOW()),
-  ('ai_tuning.ai_search_model', 'llama3.2:latest', 'ai_tuning', NOW()),
-  ('ai_tuning.llm_verify_ssl', 'true', 'ai_tuning', NOW()),
-  ('ai_tuning.llm_request_timeout', '120000', 'ai_tuning', NOW())
-ON CONFLICT (key) DO NOTHING;
+-- LLM_PROMPT_GUARD_STRICT, LLM_VERIFY_SSL, LLM_REQUEST_TIMEOUT, AI_SEARCH_MODEL
+-- are Category C (security/performance knobs) — they stay env-only.
 
 -- Metrics retention (infrastructure category)
 INSERT INTO settings (key, value, category, updated_at) VALUES

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,7 +30,8 @@ export { normalizeEndpoint, normalizeContainer, normalizeStack, normalizeNetwork
 export { CircuitBreaker } from './portainer/circuit-breaker.js';
 
 // Core Services
-export { getSetting, setSetting, getSettings, getEffectiveLlmConfig } from './services/settings-store.js';
+export { getSetting, setSetting, getSettings, getEffectiveLlmConfig, getEffectiveMonitoringConfig } from './services/settings-store.js';
+export type { MonitoringConfig } from './services/settings-store.js';
 export { createSession, getSession, invalidateSession, refreshSession } from './services/session-store.js';
 export { getUserById, getUserByUsername, authenticateUser, hasMinRole } from './services/user-store.js';
 export { writeAuditLog, getAuditLogs } from './services/audit-logger.js';

--- a/packages/core/src/services/settings-store.ts
+++ b/packages/core/src/services/settings-store.ts
@@ -138,7 +138,9 @@ export async function getEffectiveMonitoringConfig(): Promise<MonitoringConfig> 
   const str = (key: string, fallback: string): string => m.get(key) || fallback;
   const num = (key: string, fallback: number): number => {
     const v = m.get(key);
-    return v ? (parseFloat(v) || fallback) : fallback;
+    if (v === undefined || v === '') return fallback;
+    const parsed = parseFloat(v);
+    return Number.isNaN(parsed) ? fallback : parsed;
   };
   const bool = (key: string, fallback: boolean): boolean => {
     const v = m.get(key);

--- a/packages/core/src/services/settings-store.ts
+++ b/packages/core/src/services/settings-store.ts
@@ -78,6 +78,117 @@ export async function getEffectiveHarborConfig() {
   return { enabled, apiUrl, robotName, robotSecret, verifySsl, syncIntervalMinutes };
 }
 
+// ── Monitoring / AI Tuning config ────────────────────────────────────────────
+
+export interface MonitoringConfig {
+  // General
+  aiAnalysisEnabled: boolean;
+  maxInsightsPerCycle: number;
+  logAnalysisConcurrency: number;
+  maxLlmHistoryMessages: number;
+  insightsRetentionDays: number;
+  // Anomaly detection
+  anomalyDetectionMethod: 'zscore' | 'bollinger' | 'adaptive';
+  anomalyZscoreThreshold: number;
+  anomalyMovingAverageWindow: number;
+  anomalyMinSamples: number;
+  anomalyCooldownMinutes: number;
+  anomalyThresholdPct: number;
+  anomalyHardThresholdEnabled: boolean;
+  bollingerBandsEnabled: boolean;
+  // Predictive alerting
+  predictiveAlertingEnabled: boolean;
+  predictiveAlertThresholdHours: number;
+  // Anomaly explanation
+  anomalyExplanationEnabled: boolean;
+  anomalyExplanationMaxPerCycle: number;
+  // Isolation Forest
+  isolationForestEnabled: boolean;
+  isolationForestRetrainHours: number;
+  // NLP Log Analysis
+  nlpLogAnalysisEnabled: boolean;
+  nlpLogAnalysisMaxPerCycle: number;
+  nlpLogAnalysisTailLines: number;
+  // Smart grouping
+  smartGroupingEnabled: boolean;
+  smartGroupingSimilarityThreshold: number;
+  incidentSummaryEnabled: boolean;
+  // Investigation
+  investigationEnabled: boolean;
+  investigationCooldownMinutes: number;
+  investigationMaxConcurrent: number;
+  investigationLogTailLines: number;
+  investigationMetricsWindowMinutes: number;
+  investigationMinSeverity: 'critical' | 'warning' | 'info';
+}
+
+/**
+ * Read AI tuning / monitoring config from the Settings DB (single batch query),
+ * falling back to env vars for any missing keys.
+ *
+ * Designed to be called once at the top of each monitoring cycle — the cycle
+ * itself acts as the cache boundary, so no TTL cache is needed.
+ */
+export async function getEffectiveMonitoringConfig(): Promise<MonitoringConfig> {
+  const envCfg = getConfig();
+
+  // Single batch query for all ai_tuning rows
+  const rows = await getSettings('ai_tuning');
+  const m = new Map(rows.map((r) => [r.key, r.value]));
+
+  const str = (key: string, fallback: string): string => m.get(key) || fallback;
+  const num = (key: string, fallback: number): number => {
+    const v = m.get(key);
+    return v ? (parseFloat(v) || fallback) : fallback;
+  };
+  const bool = (key: string, fallback: boolean): boolean => {
+    const v = m.get(key);
+    if (v === undefined || v === '') return fallback;
+    return v === 'true';
+  };
+
+  return {
+    aiAnalysisEnabled: bool('ai_tuning.ai_analysis_enabled', envCfg.AI_ANALYSIS_ENABLED),
+    maxInsightsPerCycle: num('ai_tuning.max_insights_per_cycle', envCfg.MAX_INSIGHTS_PER_CYCLE),
+    logAnalysisConcurrency: num('ai_tuning.log_analysis_concurrency', envCfg.LOG_ANALYSIS_CONCURRENCY),
+    maxLlmHistoryMessages: num('ai_tuning.max_llm_history_messages', envCfg.MAX_LLM_HISTORY_MESSAGES),
+    insightsRetentionDays: num('ai_tuning.insights_retention_days', envCfg.INSIGHTS_RETENTION_DAYS),
+
+    anomalyDetectionMethod: str('ai_tuning.anomaly_detection_method', envCfg.ANOMALY_DETECTION_METHOD) as MonitoringConfig['anomalyDetectionMethod'],
+    anomalyZscoreThreshold: num('ai_tuning.anomaly_zscore_threshold', envCfg.ANOMALY_ZSCORE_THRESHOLD),
+    anomalyMovingAverageWindow: num('ai_tuning.anomaly_moving_average_window', envCfg.ANOMALY_MOVING_AVERAGE_WINDOW),
+    anomalyMinSamples: num('ai_tuning.anomaly_min_samples', envCfg.ANOMALY_MIN_SAMPLES),
+    anomalyCooldownMinutes: num('ai_tuning.anomaly_cooldown_minutes', envCfg.ANOMALY_COOLDOWN_MINUTES),
+    anomalyThresholdPct: num('ai_tuning.anomaly_threshold_pct', envCfg.ANOMALY_THRESHOLD_PCT),
+    anomalyHardThresholdEnabled: bool('ai_tuning.anomaly_hard_threshold_enabled', envCfg.ANOMALY_HARD_THRESHOLD_ENABLED),
+    bollingerBandsEnabled: bool('ai_tuning.bollinger_bands_enabled', envCfg.BOLLINGER_BANDS_ENABLED),
+
+    predictiveAlertingEnabled: bool('ai_tuning.predictive_alerting_enabled', envCfg.PREDICTIVE_ALERTING_ENABLED),
+    predictiveAlertThresholdHours: num('ai_tuning.predictive_alert_threshold_hours', envCfg.PREDICTIVE_ALERT_THRESHOLD_HOURS),
+
+    anomalyExplanationEnabled: bool('ai_tuning.anomaly_explanation_enabled', envCfg.ANOMALY_EXPLANATION_ENABLED),
+    anomalyExplanationMaxPerCycle: num('ai_tuning.anomaly_explanation_max_per_cycle', envCfg.ANOMALY_EXPLANATION_MAX_PER_CYCLE),
+
+    isolationForestEnabled: bool('ai_tuning.isolation_forest_enabled', envCfg.ISOLATION_FOREST_ENABLED),
+    isolationForestRetrainHours: num('ai_tuning.isolation_forest_retrain_hours', envCfg.ISOLATION_FOREST_RETRAIN_HOURS),
+
+    nlpLogAnalysisEnabled: bool('ai_tuning.nlp_log_analysis_enabled', envCfg.NLP_LOG_ANALYSIS_ENABLED),
+    nlpLogAnalysisMaxPerCycle: num('ai_tuning.nlp_log_analysis_max_per_cycle', envCfg.NLP_LOG_ANALYSIS_MAX_PER_CYCLE),
+    nlpLogAnalysisTailLines: num('ai_tuning.nlp_log_analysis_tail_lines', envCfg.NLP_LOG_ANALYSIS_TAIL_LINES),
+
+    smartGroupingEnabled: bool('ai_tuning.smart_grouping_enabled', envCfg.SMART_GROUPING_ENABLED),
+    smartGroupingSimilarityThreshold: num('ai_tuning.smart_grouping_similarity_threshold', envCfg.SMART_GROUPING_SIMILARITY_THRESHOLD),
+    incidentSummaryEnabled: bool('ai_tuning.incident_summary_enabled', envCfg.INCIDENT_SUMMARY_ENABLED),
+
+    investigationEnabled: bool('ai_tuning.investigation_enabled', envCfg.INVESTIGATION_ENABLED),
+    investigationCooldownMinutes: num('ai_tuning.investigation_cooldown_minutes', envCfg.INVESTIGATION_COOLDOWN_MINUTES),
+    investigationMaxConcurrent: num('ai_tuning.investigation_max_concurrent', envCfg.INVESTIGATION_MAX_CONCURRENT),
+    investigationLogTailLines: num('ai_tuning.investigation_log_tail_lines', envCfg.INVESTIGATION_LOG_TAIL_LINES),
+    investigationMetricsWindowMinutes: num('ai_tuning.investigation_metrics_window_minutes', envCfg.INVESTIGATION_METRICS_WINDOW_MINUTES),
+    investigationMinSeverity: str('ai_tuning.investigation_min_severity', envCfg.INVESTIGATION_MIN_SEVERITY) as MonitoringConfig['investigationMinSeverity'],
+  };
+}
+
 export async function deleteSetting(key: string): Promise<boolean> {
   const result = await db().execute('DELETE FROM settings WHERE key = ?', [key]);
 

--- a/packages/core/src/services/settings-store.ts
+++ b/packages/core/src/services/settings-store.ts
@@ -86,7 +86,6 @@ export interface MonitoringConfig {
   maxInsightsPerCycle: number;
   logAnalysisConcurrency: number;
   maxLlmHistoryMessages: number;
-  insightsRetentionDays: number;
   // Anomaly detection
   anomalyDetectionMethod: 'zscore' | 'bollinger' | 'adaptive';
   anomalyZscoreThreshold: number;
@@ -152,7 +151,6 @@ export async function getEffectiveMonitoringConfig(): Promise<MonitoringConfig> 
     maxInsightsPerCycle: num('ai_tuning.max_insights_per_cycle', envCfg.MAX_INSIGHTS_PER_CYCLE),
     logAnalysisConcurrency: num('ai_tuning.log_analysis_concurrency', envCfg.LOG_ANALYSIS_CONCURRENCY),
     maxLlmHistoryMessages: num('ai_tuning.max_llm_history_messages', envCfg.MAX_LLM_HISTORY_MESSAGES),
-    insightsRetentionDays: num('ai_tuning.insights_retention_days', envCfg.INSIGHTS_RETENTION_DAYS),
 
     anomalyDetectionMethod: str('ai_tuning.anomaly_detection_method', envCfg.ANOMALY_DETECTION_METHOD) as MonitoringConfig['anomalyDetectionMethod'],
     anomalyZscoreThreshold: num('ai_tuning.anomaly_zscore_threshold', envCfg.ANOMALY_ZSCORE_THRESHOLD),

--- a/packages/operations/src/services/webhook-service.ts
+++ b/packages/operations/src/services/webhook-service.ts
@@ -128,8 +128,8 @@ export async function createDelivery(webhookId: string, event: WebhookEvent): Pr
   const id = crypto.randomUUID();
   const payload = JSON.stringify(event);
 
-  const maxRetriesSetting = await getSetting('notifications.webhooks_max_retries');
-  const maxRetries = maxRetriesSetting ? parseInt(maxRetriesSetting.value, 10) || 5 : 5;
+  const maxRetriesSetting = await getSetting('webhooks.max_retries');
+  const maxRetries = maxRetriesSetting?.value ? parseInt(maxRetriesSetting.value, 10) : 5;
 
   await db().execute(`
     INSERT INTO webhook_deliveries (id, webhook_id, event_type, payload, status, attempt, max_attempts)

--- a/packages/operations/src/services/webhook-service.ts
+++ b/packages/operations/src/services/webhook-service.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { eventBus } from '@dashboard/core/services/typed-event-bus.js';
+import { getSetting } from '@dashboard/core/services/settings-store.js';
 import { toWebhookEvent, type WebhookEvent } from '@dashboard/contracts';
 import { withSpan } from '@dashboard/core/tracing/trace-context.js';
 
@@ -127,10 +128,13 @@ export async function createDelivery(webhookId: string, event: WebhookEvent): Pr
   const id = crypto.randomUUID();
   const payload = JSON.stringify(event);
 
+  const maxRetriesSetting = await getSetting('notifications.webhooks_max_retries');
+  const maxRetries = maxRetriesSetting ? parseInt(maxRetriesSetting.value, 10) || 5 : 5;
+
   await db().execute(`
     INSERT INTO webhook_deliveries (id, webhook_id, event_type, payload, status, attempt, max_attempts)
-    VALUES (?, ?, ?, ?, 'pending', 0, 5)
-  `, [id, webhookId, event.type, payload]);
+    VALUES (?, ?, ?, ?, 'pending', 0, ?)
+  `, [id, webhookId, event.type, payload, maxRetries]);
 
   return id;
 }


### PR DESCRIPTION
## Summary
- Move ~65 env vars (Category A + B) to Settings DB as primary source, with env var fallback during deprecation window
- Add `getEffectiveMonitoringConfig()` batch function — single DB query per monitoring cycle for all AI tuning settings
- Wire dead `WEBHOOKS_MAX_RETRIES` env var into `createDelivery()` before migrating it
- Add deprecation console warnings for operators still using the old env vars
- Add collapsible "Advanced AI Tuning" section in Settings → AI & LLM (30 settings)
- Add metrics retention settings in frontend

Closes #993

## Files Changed (11 files)
- **`packages/core/src/db/postgres-migrations/027_monitoring_ai_settings_seed.sql`** — Seeds ai_tuning, webhooks, infrastructure settings with env var defaults
- **`packages/core/src/services/settings-store.ts`** — New `MonitoringConfig` interface + `getEffectiveMonitoringConfig()` batch function
- **`packages/core/src/config/index.ts`** — Deprecation warnings for Category A + B env vars
- **`packages/core/src/index.ts`** — Export new function/type from barrel
- **`packages/ai-intelligence/src/services/monitoring-service.ts`** — Replace `getConfig()` with `getEffectiveMonitoringConfig()` for all Category B vars
- **`packages/ai-intelligence/src/services/incident-correlator.ts`** — Same migration
- **`packages/ai-intelligence/src/services/investigation-service.ts`** — Same migration
- **`packages/ai-intelligence/src/services/log-analyzer.ts`** — Same migration
- **`packages/operations/src/services/webhook-service.ts`** — Wire `WEBHOOKS_MAX_RETRIES` from Settings DB
- **`frontend/src/features/core/components/settings/shared.tsx`** — Add `aiTuning` (30 settings) + `metricsRetention` (6 settings) categories
- **`frontend/src/features/core/components/settings/tab-ai-llm.tsx`** — Add collapsible Advanced AI Tuning section

## Design Decisions
- **SMTP_HOST stays env-only** — SSRF guard in notification-service.ts uses it as a trust anchor
- **Scheduler intervals stay env-only** — `setInterval()` set at boot, can't change without restart
- **No TTL cache** — monitoring cycle is the cache boundary; config fetched once per cycle
- **Deprecation window** — env vars still work as fallbacks; removal in a follow-up PR

## Test plan
- [x] All 283 backend tests pass (1 pre-existing skip)
- [x] All 1561 frontend tests pass
- [x] Full TypeScript build passes (backend + frontend + all packages)
- [x] Production build (Vite) succeeds
- [ ] Manual: verify Settings → AI & LLM shows Advanced AI Tuning section
- [ ] Manual: verify deprecation warnings appear when env vars are set

🤖 Generated with [Claude Code](https://claude.com/claude-code)