### PR TITLE
fix: edge endpoints no longer show 'up' for 15 min after going offline

### DIFF
--- a/packages/core/src/portainer/portainer-normalizers-edge.test.ts
+++ b/packages/core/src/portainer/portainer-normalizers-edge.test.ts
@@ -205,19 +205,31 @@ describe('normalizeEndpoint — Edge Agent fields', () => {
       expect(normalizeEndpoint(ep).status).toBe('up');
     });
 
-    it('keeps Edge endpoint "up" even at cache expiry (15 min after check-in)', () => {
+    it('marks Edge endpoint as "down" when check-in is 900s ago (regression: was "up" before #1006)', () => {
       const ep = makeEndpoint({
         Type: 4,
         EdgeID: 'edge-3',
         Status: 2,
-        LastCheckInDate: Math.floor(Date.now() / 1000) - 900, // 15 min ago (cache TTL)
+        LastCheckInDate: Math.floor(Date.now() / 1000) - 900, // 15 min ago
         EdgeCheckinInterval: 5,
       });
-      // Threshold = max((5*2)+20, 60) + 900 = 960s. 900 < 960 → still up
+      // Threshold = max((5*2)+20, 60) + 30 = 90s. 900 > 90 → down (issue #1006)
+      expect(normalizeEndpoint(ep).status).toBe('down');
+    });
+
+    it('marks Edge endpoint as "up" when check-in is within jitter threshold', () => {
+      const ep = makeEndpoint({
+        Type: 4,
+        EdgeID: 'edge-3b',
+        Status: 2,
+        LastCheckInDate: Math.floor(Date.now() / 1000) - 85, // 85s ago
+        EdgeCheckinInterval: 5,
+      });
+      // Threshold = max((5*2)+20, 60) + 30 = 90s. 85 <= 90 → up
       expect(normalizeEndpoint(ep).status).toBe('up');
     });
 
-    it('marks Edge endpoint as "down" when check-in exceeds cache-aware threshold', () => {
+    it('marks Edge endpoint as "down" when check-in exceeds heartbeat + jitter threshold', () => {
       const ep = makeEndpoint({
         Type: 4,
         EdgeID: 'edge-4',
@@ -225,7 +237,7 @@ describe('normalizeEndpoint — Edge Agent fields', () => {
         LastCheckInDate: Math.floor(Date.now() / 1000) - 1200, // 20 min ago
         EdgeCheckinInterval: 5,
       });
-      // Threshold = max((5*2)+20, 60) + 900 = 960s. 1200 > 960 → down
+      // Threshold = max((5*2)+20, 60) + 30 = 90s. 1200 > 90 → down
       expect(normalizeEndpoint(ep).status).toBe('down');
     });
 

--- a/packages/core/src/portainer/portainer-normalizers.ts
+++ b/packages/core/src/portainer/portainer-normalizers.ts
@@ -84,15 +84,16 @@ function buildCapabilities(edgeMode: 'standard' | 'async' | null): EdgeCapabilit
 }
 
 /**
- * Determine Edge endpoint status using a cache-aware heartbeat check.
+ * Determine Edge endpoint status using a heartbeat check with a small jitter buffer.
  *
  * For Edge Agent Standard, Portainer's API `Status` field represents the
  * **tunnel state** (usually 2 = closed), NOT the agent's connectivity.
  * Portainer's own UI uses `LastCheckInDate` to show the green dot.
  *
- * We use the heartbeat with a generous threshold: the Portainer heartbeat
- * window PLUS the cache TTL (15 min). This ensures that an endpoint which
- * was "up" when cached won't drift to "down" before the cache expires.
+ * We apply the Portainer heartbeat formula plus a 30-second jitter buffer
+ * (one L1 cache cycle) to tolerate minor clock skew and poll latency.
+ * The previous 900-second (full Redis cache TTL) buffer masked real outages
+ * for up to 16 minutes and has been removed (issue #1006).
  */
 function determineEdgeStatus(ep: Endpoint): 'up' | 'down' {
   // If Portainer explicitly says up, trust it
@@ -104,9 +105,9 @@ function determineEdgeStatus(ep: Endpoint): 'up' | 'down' {
   const interval = ep.EdgeCheckinInterval ?? 5;
   // Portainer's heartbeat formula: (interval * 2) + 20, minimum 60s
   const heartbeatThreshold = Math.max((interval * 2) + 20, 60);
-  // Add cache TTL so the status doesn't drift to "down" while cached
-  const CACHE_TTL_SECONDS = 900;
-  const generousThreshold = heartbeatThreshold + CACHE_TTL_SECONDS;
+  // Add a small jitter buffer (one L1 cache cycle) to tolerate clock skew
+  const JITTER_SECONDS = 30;
+  const generousThreshold = heartbeatThreshold + JITTER_SECONDS;
 
   const elapsed = Math.floor(Date.now() / 1000) - lastCheckIn;
   return elapsed <= generousThreshold ? 'up' : 'down';


### PR DESCRIPTION
## Summary

- Replaces the 900-second cache-TTL buffer in `determineEdgeStatus()` with a 30-second jitter buffer (`JITTER_SECONDS`), cutting the false-positive "up" window from ~16 minutes to ~90 seconds
- Updates the JSDoc comment to explain the new rationale and reference the issue
- Replaces the regression test that asserted the old (buggy) "up at 900s" behaviour; adds a boundary test for the new 90-second threshold

Closes #1006

## Root Cause

`determineEdgeStatus()` in `packages/core/src/portainer/portainer-normalizers.ts` computed its threshold as:

```typescript
const CACHE_TTL_SECONDS = 900;
const generousThreshold = heartbeatThreshold + CACHE_TTL_SECONDS; // e.g. 60 + 900 = 960s
```

The intent was to prevent a cached "up" from drifting to "down" mid-cache-window, but adding the full Redis TTL (15 min) meant a genuinely offline edge server stayed green for up to 16 minutes — far beyond Portainer's own heartbeat detection window.

## Fix

```typescript
// Before
const CACHE_TTL_SECONDS = 900;
const generousThreshold = heartbeatThreshold + CACHE_TTL_SECONDS;

// After
const JITTER_SECONDS = 30; // one L1 cache cycle
const generousThreshold = heartbeatThreshold + JITTER_SECONDS;
```

Detection latency by check-in interval:

| Interval | Old threshold | New threshold |
|---|---|---|
| 5s (default) | ~960s (16 min) | ~90s (1.5 min) |
| 30s | ~1010s (17 min) | ~110s (1.8 min) |
| 60s | ~1060s (18 min) | ~170s (2.8 min) |

## Test plan

- [x] `npx vitest run src/portainer/portainer-normalizers-edge.test.ts` — 19/19 pass
- [x] Full `@dashboard/core` test suite — 510 passed, 0 failures (24 skipped = DB integration tests requiring PostgreSQL)
- [x] Pre-push hooks: typecheck + 1561 frontend tests — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)