### PR TITLE
fix: remove hardcoded credentials from workload data-services.yml

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -1294,8 +1294,8 @@ describe('Infrastructure Exposure Defaults', () => {
     const file = path.resolve(process.cwd(), '..', 'workloads', 'data-services.yml');
     const content = readFileSync(file, 'utf8');
 
-    expect(content).toContain('--requirepass ${REDIS_PASSWORD:-changeme-redis}');
-    expect(content).toMatch(/redis-cli -a \\"\$\{REDIS_PASSWORD:-changeme-redis\}\\" ping/);
+    expect(content).toContain('--requirepass ${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}');
+    expect(content).toMatch(/redis-cli -a \\"\$\{REDIS_PASSWORD\}\\" ping/);
   });
 
   it('should document localhost-bound Ollama startup in README', () => {

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -159,6 +159,14 @@ REDIS_KEY_PREFIX=aidash:cache:
 # Redis server memory limit — evicts least-recently-used keys when full (allkeys-lru)
 REDIS_MAXMEMORY=512mb
 
+# Workload stack credentials (workloads/data-services.yml)
+# POSTGRES_PASSWORD and RABBITMQ_DEFAULT_PASS are required (no defaults).
+POSTGRES_PASSWORD=CHANGE_ME_BEFORE_PRODUCTION
+# POSTGRES_USER=app                      # Optional (default: app)
+# POSTGRES_DB=appdb                      # Optional (default: appdb)
+RABBITMQ_DEFAULT_PASS=CHANGE_ME_BEFORE_PRODUCTION
+# RABBITMQ_DEFAULT_USER=admin            # Optional (default: admin)
+
 # App PostgreSQL (app data: users, sessions, settings, audit logs, insights, etc.)
 # Separate from TimescaleDB (metrics). Both run PostgreSQL 17.
 POSTGRES_APP_PASSWORD=CHANGE_ME_BEFORE_PRODUCTION

--- a/scripts/lint-workload-secrets.sh
+++ b/scripts/lint-workload-secrets.sh
@@ -43,7 +43,7 @@ for file in "${FILES[@]}"; do
   while IFS= read -r line; do
     FOUND=$((FOUND + 1))
     echo "ERROR: Hardcoded credential in $(basename "$file"): $line"
-  done < <(grep -inE '(PASSWORD|_PASS|_SECRET|_KEY)\s*[:=]' "$file" \
+  done < <(grep -iE '(PASSWORD|_PASS|_SECRET|_KEY)\s*[:=]' "$file" \
     | grep -v '^\s*#' \
     | grep -vF '${' \
     || true)

--- a/scripts/lint-workload-secrets.sh
+++ b/scripts/lint-workload-secrets.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# lint-workload-secrets.sh — Detect hardcoded credentials in workload YAML files.
+# Exits non-zero if any literal password/secret values are found.
+#
+# Usage:
+#   ./scripts/lint-workload-secrets.sh                # scan workloads/*.yml
+#   ./scripts/lint-workload-secrets.sh path/to/file    # scan a specific file
+#
+# What it checks:
+#   Lines containing PASSWORD, _PASS, _SECRET, or _KEY (case-insensitive)
+#   whose value is a bare literal (not a ${...} variable substitution).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Determine files to scan
+if [[ $# -gt 0 ]]; then
+  FILES=("$@")
+else
+  shopt -s nullglob
+  FILES=("$REPO_ROOT"/workloads/*.yml "$REPO_ROOT"/workloads/*.yaml)
+  shopt -u nullglob
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "No workload YAML files found."
+  exit 0
+fi
+
+FOUND=0
+
+for file in "${FILES[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Warning: $file not found, skipping."
+    continue
+  fi
+
+  # Match lines like:  SOME_PASSWORD: literal_value
+  # but NOT lines like: SOME_PASSWORD: ${VAR...}
+  # Ignore comment lines (starting with #)
+  while IFS= read -r line; do
+    FOUND=$((FOUND + 1))
+    echo "ERROR: Hardcoded credential in $(basename "$file"): $line"
+  done < <(grep -inE '(PASSWORD|_PASS|_SECRET|_KEY)\s*[:=]' "$file" \
+    | grep -v '^\s*#' \
+    | grep -vF '${' \
+    || true)
+done
+
+if [[ $FOUND -gt 0 ]]; then
+  echo ""
+  echo "Found $FOUND hardcoded credential(s). Use \${VAR:?msg} or \${VAR:-default} substitution."
+  exit 1
+fi
+
+echo "OK: No hardcoded credentials found in workload files."
+exit 0

--- a/scripts/lint-workload-secrets.sh
+++ b/scripts/lint-workload-secrets.sh
@@ -30,6 +30,9 @@ if [[ ${#FILES[@]} -eq 0 ]]; then
 fi
 
 FOUND=0
+# Literal '${' substring marking a Compose variable substitution; ANSI-C
+# quoting avoids triggering shellcheck SC2016 (single-quote expansion warning).
+SUBST_MARKER=$'\x24{'
 
 for file in "${FILES[@]}"; do
   if [[ ! -f "$file" ]]; then
@@ -45,7 +48,7 @@ for file in "${FILES[@]}"; do
     echo "ERROR: Hardcoded credential in $(basename "$file"): $line"
   done < <(grep -iE '(PASSWORD|_PASS|_SECRET|_KEY)\s*[:=]' "$file" \
     | grep -v '^\s*#' \
-    | grep -vF '${' \
+    | grep -vF "$SUBST_MARKER" \
     || true)
 done
 

--- a/workloads/data-services.yml
+++ b/workloads/data-services.yml
@@ -7,16 +7,16 @@ services:
     image: postgres:16-alpine
     container_name: db-postgres
     environment:
-      POSTGRES_USER: app
-      POSTGRES_PASSWORD: secret123
-      POSTGRES_DB: appdb
+      POSTGRES_USER: ${POSTGRES_USER:-app}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+      POSTGRES_DB: ${POSTGRES_DB:-appdb}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     labels:
       app.tier: "database"
       app.env: "production"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U app -d appdb"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-app} -d $${POSTGRES_DB:-appdb}"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -50,10 +50,10 @@ services:
     image: rabbitmq:3-management-alpine
     container_name: mq-rabbitmq
     ports:
-      - "15672:15672"
+      - "127.0.0.1:15672:15672"
     environment:
-      RABBITMQ_DEFAULT_USER: admin
-      RABBITMQ_DEFAULT_PASS: admin123
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-admin}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:?RABBITMQ_DEFAULT_PASS must be set}
     labels:
       app.tier: "messaging"
       app.env: "production"

--- a/workloads/data-services.yml
+++ b/workloads/data-services.yml
@@ -32,12 +32,12 @@ services:
       redis-server
       --maxmemory 64mb
       --maxmemory-policy allkeys-lru
-      --requirepass ${REDIS_PASSWORD:-changeme-redis}
+      --requirepass ${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}
     labels:
       app.tier: "cache"
       app.env: "production"
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a \"${REDIS_PASSWORD:-changeme-redis}\" ping | grep -q PONG"]
+      test: ["CMD-SHELL", "redis-cli -a \"$${REDIS_PASSWORD}\" ping | grep -q PONG"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/workloads/data-services.yml
+++ b/workloads/data-services.yml
@@ -37,7 +37,7 @@ services:
       app.tier: "cache"
       app.env: "production"
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a \"$${REDIS_PASSWORD}\" ping | grep -q PONG"]
+      test: ["CMD-SHELL", "redis-cli -a \"${REDIS_PASSWORD}\" ping | grep -q PONG"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

- Fixes #1016: removes hardcoded credentials from `workloads/data-services.yml`

## Test plan

- [ ] Verify the workload file no longer contains plaintext credentials
- [ ] Confirm data-services stack still deploys with environment variable substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)