### PR TITLE
docs: fix SKILL.md npm ci and compose version

### DIFF
--- a/.codex/skills/pr-reviewer/SKILL.md
+++ b/.codex/skills/pr-reviewer/SKILL.md
@@ -38,7 +38,6 @@ source /tmp/pr-review-<PR_NUMBER>.state && cd "$REPO_ROOT"
 
    # Compose overlay to isolate named volumes from user's dev stack
    cat > "$VOLUMES_FILE" <<'VOLEOF'
-   version: "3"
    volumes:
      postgres-app-data:
        name: "PRPREFIX-pg-app"
@@ -93,7 +92,7 @@ source /tmp/pr-review-<PR_NUMBER>.state && cd "$REPO_ROOT"
 
 6. **Checkout the PR branch**: `gh pr checkout $PR_NUMBER`
 
-7. **Install dependencies**: `npm ci 2>&1 | tail -20`
+7. **Install dependencies**: `npm install 2>&1 | tail -20`
 
 ### Phase 2: Static Checks
 


### PR DESCRIPTION
## Summary
- Replace `npm ci` with `npm install` in `.codex/skills/pr-reviewer/SKILL.md` to align with CLAUDE.md's mandate to always run `npm install` from the repo root (npm workspaces requires a single root lock file)
- Remove deprecated `version: "3"` from the Docker Compose overlay template

Closes #1021

## Test plan
- [x] Verify `npm ci` replaced with `npm install` (line 95)
- [x] Verify `version: "3"` removed from compose overlay (line 41)
- [x] Confirm no other occurrences of `npm ci` remain in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)