### PR TITLE
fix: deploy-workload.sh safe env loading

### DIFF
--- a/scripts/deploy-workload.sh
+++ b/scripts/deploy-workload.sh
@@ -27,7 +27,7 @@ EXTERNAL_NETWORKS=("app-frontend-net" "app-backend-net")
 if [ -f "$PROJECT_DIR/.env" ]; then
   while IFS='=' read -r key value; do
     # Skip comments and empty lines
-    [[ -z "$key" || "$key" =~ ^# ]] && continue
+    [[ -z "$key" || "$key" =~ ^[[:space:]]*(#|$) ]] && continue
     # Remove surrounding quotes from value
     value="${value%\"}"
     value="${value#\"}"
@@ -38,7 +38,7 @@ if [ -f "$PROJECT_DIR/.env" ]; then
 fi
 
 PORTAINER_URL="${PORTAINER_API_URL:-http://localhost:9000}"
-API_KEY="${PORTAINER_API_KEY}"
+API_KEY="${PORTAINER_API_KEY:-}"
 
 if [ -z "$API_KEY" ]; then
   echo "Error: PORTAINER_API_KEY not set in .env file"

--- a/scripts/deploy-workload.sh
+++ b/scripts/deploy-workload.sh
@@ -13,7 +13,7 @@
 #   app-frontend-net — web-platform <-> issue-simulators (net-chatter)
 #   app-backend-net  — data-services <-> workers <-> web-platform (gateway)
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -23,10 +23,18 @@ COMPOSE_DIR="$PROJECT_DIR/workloads"
 STACK_NAMES=("data-services" "web-platform" "workers" "staging-dev" "issue-simulators")
 EXTERNAL_NETWORKS=("app-frontend-net" "app-backend-net")
 
-# Load environment variables
+# Load environment variables (safe: handles spaces, quotes, and special chars)
 if [ -f "$PROJECT_DIR/.env" ]; then
-  # shellcheck disable=SC2046
-  export $(grep -v '^#' "$PROJECT_DIR/.env" | xargs)
+  while IFS='=' read -r key value; do
+    # Skip comments and empty lines
+    [[ -z "$key" || "$key" =~ ^# ]] && continue
+    # Remove surrounding quotes from value
+    value="${value%\"}"
+    value="${value#\"}"
+    value="${value%\'}"
+    value="${value#\'}"
+    export "$key=$value"
+  done < "$PROJECT_DIR/.env"
 fi
 
 PORTAINER_URL="${PORTAINER_API_URL:-http://localhost:9000}"

--- a/scripts/deploy-workload.sh
+++ b/scripts/deploy-workload.sh
@@ -25,7 +25,7 @@ EXTERNAL_NETWORKS=("app-frontend-net" "app-backend-net")
 
 # Load environment variables (safe: handles spaces, quotes, and special chars)
 if [ -f "$PROJECT_DIR/.env" ]; then
-  while IFS='=' read -r key value; do
+  while IFS='=' read -r key value || [[ -n "$key" ]]; do
     # Skip comments and empty lines
     [[ -z "$key" || "$key" =~ ^[[:space:]]*(#|$) ]] && continue
     # Remove surrounding quotes from value


### PR DESCRIPTION
## Summary

- Replace unsafe `export $(grep -v '^#' .env | xargs)` with a safe `while IFS='=' read` loop that correctly handles values containing spaces, quotes, and special characters
- Upgrade `set -e` to `set -euo pipefail` for stricter error handling (catches pipe failures and unset variable references)

Closes #1015

## Test plan

- [ ] Verify `.env` files with spaces in values (e.g., `APP_NAME=My App`) are loaded correctly
- [ ] Verify `.env` files with quoted values (e.g., `SECRET="my secret"`) have quotes stripped
- [ ] Verify commented lines and blank lines are skipped
- [ ] Verify the script still deploys stacks successfully with a valid `.env`
- [ ] Verify the script exits with an error if `PORTAINER_API_KEY` is unset (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)