### PR TITLE
security: add admin role to LLM traces and stats endpoints

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -1606,7 +1606,32 @@ describe('Nginx Security Header Consistency', () => {
 });
 
 // =====================================================================
-//  14. REMEDIATION WEBSOCKET NAMESPACE ADMIN ROLE (issue #977, CWE-862)
+//  14. LLM OBSERVABILITY ADMIN RBAC (issue #1029, CWE-862)
+// =====================================================================
+describe('LLM Observability Admin RBAC Enforcement', () => {
+  it('GET /api/llm/traces route source must include requireRole admin', () => {
+    const file = path.resolve(process.cwd(), '..', 'packages', 'ai-intelligence', 'src', 'routes', 'llm-observability.ts');
+    const content = readFileSync(file, 'utf8');
+
+    // The traces route must have requireRole('admin') in its preHandler
+    const tracesBlock = content.match(/get\s*\(\s*'\/api\/llm\/traces'[\s\S]*?preHandler:\s*\[([^\]]+)\]/);
+    expect(tracesBlock).not.toBeNull();
+    expect(tracesBlock![1]).toContain("requireRole('admin')");
+  });
+
+  it('GET /api/llm/stats route source must include requireRole admin', () => {
+    const file = path.resolve(process.cwd(), '..', 'packages', 'ai-intelligence', 'src', 'routes', 'llm-observability.ts');
+    const content = readFileSync(file, 'utf8');
+
+    // The stats route must have requireRole('admin') in its preHandler
+    const statsBlock = content.match(/get\s*\(\s*'\/api\/llm\/stats'[\s\S]*?preHandler:\s*\[([^\]]+)\]/);
+    expect(statsBlock).not.toBeNull();
+    expect(statsBlock![1]).toContain("requireRole('admin')");
+  });
+});
+
+// =====================================================================
+//  15. REMEDIATION WEBSOCKET NAMESPACE ADMIN ROLE (issue #977, CWE-862)
 // =====================================================================
 describe('Remediation WebSocket namespace admin role enforcement', () => {
   it('socket-io plugin must apply admin role middleware to the /remediation namespace', () => {

--- a/packages/ai-intelligence/src/__tests__/llm-observability.test.ts
+++ b/packages/ai-intelligence/src/__tests__/llm-observability.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Fastify from 'fastify';
 import { validatorCompiler } from 'fastify-type-provider-zod';
 import { llmObservabilityRoutes } from '../routes/llm-observability.js';
+import { testAdminOnly, type Role } from '@dashboard/core/test-utils/rbac-test-helper.js';
 
 const mockGetRecentTraces = vi.fn();
 const mockGetLlmStats = vi.fn();
@@ -14,14 +15,31 @@ vi.mock('../services/llm-trace-store.js', () => ({
 
 describe('LLM Observability Routes', () => {
   let app: ReturnType<typeof Fastify>;
+  let currentRole: Role = 'admin';
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    currentRole = 'admin';
     app = Fastify();
     app.setValidatorCompiler(validatorCompiler);
     app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', (minRole: Role) => async (request: any, reply: any) => {
+      const rank = { viewer: 0, operator: 1, admin: 2 };
+      const userRole = request.user?.role ?? 'viewer';
+      if (rank[userRole] < rank[minRole]) {
+        reply.code(403).send({ error: 'Insufficient permissions' });
+      }
+    });
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      (request as any).user = { sub: 'u1', username: 'admin', sessionId: 's1', role: currentRole };
+    });
     await app.register(llmObservabilityRoutes);
     await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
   });
 
   it('GET /api/llm/traces returns recent traces', async () => {
@@ -50,5 +68,10 @@ describe('LLM Observability Routes', () => {
     const body = res.json();
     expect(body.totalQueries).toBe(100);
     expect(body.modelBreakdown).toHaveLength(1);
+  });
+
+  describe('RBAC', () => {
+    testAdminOnly(() => app, (r) => { currentRole = r; }, 'GET', '/api/llm/traces');
+    testAdminOnly(() => app, (r) => { currentRole = r; }, 'GET', '/api/llm/stats');
   });
 });

--- a/packages/ai-intelligence/src/routes/llm-observability.ts
+++ b/packages/ai-intelligence/src/routes/llm-observability.ts
@@ -13,7 +13,7 @@ export async function llmObservabilityRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       querystring: LlmTracesQuerySchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request) => {
     const { limit } = request.query as { limit: number };
     return getRecentTraces(limit);
@@ -26,7 +26,7 @@ export async function llmObservabilityRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       querystring: LlmStatsQuerySchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request) => {
     const { hours } = request.query as { hours: number };
     return getLlmStats(hours);


### PR DESCRIPTION
## Summary
- Add `fastify.requireRole('admin')` to `GET /api/llm/traces` and `GET /api/llm/stats` endpoints, which previously only required authentication without role checks (CWE-862)
- Add RBAC unit tests using `testAdminOnly()` helper to verify viewer and operator roles are rejected with 403
- Add source-code regression tests in `security-regression.test.ts` to prevent future removal of the admin guard

Closes #1029

## Test plan
- [x] `packages/ai-intelligence/src/__tests__/llm-observability.test.ts` -- 6 tests pass (2 functional + 4 RBAC)
- [x] `backend/src/routes/security-regression.test.ts` -- 2 new regression tests pass
- [x] All 1565 frontend tests pass (pre-push hook)
- [ ] CI pipeline passes

:robot: Generated with [Claude Code](https://claude.com/claude-code)