### PR TITLE
security: add admin role to incident resolve endpoint

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -1781,3 +1781,69 @@ describe('WebSocket Chat Throttle', () => {
     expect(content).toMatch(/export\s+\{[^}]*CHAT_THROTTLE_MS/);
   });
 });
+
+// =====================================================================
+//  16. INCIDENT RESOLVE ADMIN RBAC ENFORCEMENT (issue #1028, CWE-862)
+// =====================================================================
+describe('Incident Resolve Admin RBAC Enforcement', () => {
+  let app: FastifyInstance;
+  let currentRole: 'viewer' | 'operator' | 'admin';
+
+  beforeAll(async () => {
+    currentRole = 'admin';
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request, reply) => {
+      const rank = { viewer: 0, operator: 1, admin: 2 };
+      const userRole = request.user?.role ?? 'viewer';
+      if (rank[userRole] < rank[minRole]) {
+        reply.code(403).send({ error: 'Insufficient permissions' });
+      }
+    });
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'user', sessionId: 's1', role: currentRole };
+    });
+    await app.register(incidentsRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('denies POST /api/incidents/:id/resolve for viewer', async () => {
+    currentRole = 'viewer';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/incidents/inc-1/resolve',
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('denies POST /api/incidents/:id/resolve for operator', async () => {
+    currentRole = 'operator';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/incidents/inc-1/resolve',
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('allows POST /api/incidents/:id/resolve for admin', async () => {
+    currentRole = 'admin';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/incidents/inc-1/resolve',
+    });
+
+    expect(res.statusCode).not.toBe(403);
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/incidents-jsonb.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-jsonb.test.ts
@@ -72,6 +72,7 @@ describe('Incidents JSONB Type Regression Tests', () => {
     vi.clearAllMocks();
     app = Fastify();
     app.decorate('authenticate', async () => {});
+    app.decorate('requireRole', () => async () => undefined);
     await app.register(incidentsRoutes);
     await app.ready();
   });

--- a/packages/ai-intelligence/src/__tests__/incidents.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
-import Fastify from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyRequest, type FastifyReply } from 'fastify';
 import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
 import type { AppDb } from '@dashboard/core/db/app-db.js';
+import { testAdminOnly } from '@dashboard/core/test-utils/rbac-test-helper.js';
 import { incidentsRoutes } from '../routes/incidents.js';
 import { getIncidents, getIncident, resolveIncident, getIncidentCount } from '../services/incident-store.js';
 
@@ -128,4 +129,38 @@ describe('incidents routes', () => {
       expect(mockedResolveIncident).toHaveBeenCalledWith('inc-1');
     });
   });
+});
+
+describe('incidents RBAC', () => {
+  let rbacApp: FastifyInstance;
+  let currentRole: 'viewer' | 'operator' | 'admin';
+
+  beforeAll(async () => {
+    currentRole = 'admin';
+    rbacApp = Fastify({ logger: false });
+    rbacApp.decorate('authenticate', async () => undefined);
+    rbacApp.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request: FastifyRequest, reply: FastifyReply) => {
+      const rank = { viewer: 0, operator: 1, admin: 2 };
+      const userRole = request.user?.role ?? 'viewer';
+      if (rank[userRole as keyof typeof rank] < rank[minRole]) {
+        reply.code(403).send({ error: 'Insufficient permissions' });
+      }
+    });
+    rbacApp.decorateRequest('user', undefined);
+    rbacApp.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'tester', sessionId: 's1', role: currentRole };
+    });
+    await rbacApp.register(incidentsRoutes);
+    await rbacApp.ready();
+  });
+
+  afterAll(async () => {
+    await rbacApp.close();
+  });
+
+  beforeEach(() => {
+    currentRole = 'admin';
+  });
+
+  testAdminOnly(() => rbacApp, (r) => { currentRole = r; }, 'POST', '/api/incidents/inc-1/resolve');
 });

--- a/packages/ai-intelligence/src/__tests__/incidents.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents.test.ts
@@ -39,6 +39,7 @@ describe('incidents routes', () => {
 
     // Mock auth decorator
     app.decorate('authenticate', async () => {});
+    app.decorate('requireRole', () => async () => undefined);
     await app.register(incidentsRoutes);
     await app.ready();
   });

--- a/packages/ai-intelligence/src/routes/incidents.ts
+++ b/packages/ai-intelligence/src/routes/incidents.ts
@@ -78,7 +78,7 @@ export async function incidentsRoutes(fastify: FastifyInstance) {
       summary: 'Resolve an incident',
       security: [{ bearerAuth: [] }],
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const incident = await getIncident(id);


### PR DESCRIPTION
## Summary
- Added `fastify.requireRole('admin')` to `POST /api/incidents/:id/resolve` preHandler, closing the missing authorization gap (CWE-862)
- Added RBAC unit tests in `packages/ai-intelligence/src/__tests__/incidents.test.ts` using `testAdminOnly` helper
- Added regression test section (#15) in `backend/src/routes/security-regression.test.ts` verifying viewer/operator denial and admin access

## Test plan
- [x] `testAdminOnly` generates denial tests for viewer and operator roles on `POST /api/incidents/:id/resolve`
- [x] Security regression test verifies viewer gets 403, operator gets 403, admin does not get 403
- [x] Existing incident resolve test still passes (admin path)
- [ ] CI runs all backend tests on PR

Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)