### PR TITLE
security: add profiles gate and hardening to kali-mcp

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -277,7 +277,10 @@ services:
     build:
       context: ../tools/kali-mcp
       dockerfile: Dockerfile
+    profiles: ["pentest"]
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     cap_add:
       - NET_RAW
       - NET_ADMIN


### PR DESCRIPTION
## Summary
- Add `profiles: ["pentest"]` to kali-mcp in `docker/docker-compose.yml` so it no longer starts automatically with every `docker compose up` in production — matching the existing gate in `docker-compose.dev.yml`
- Add `security_opt: ["no-new-privileges:true"]` to match hardening applied to all other production services (postgres-app, timescaledb, timescale-backup)

Closes #1023

## Test plan
- [ ] Run `docker compose -f docker/docker-compose.yml config` and verify kali-mcp has `profiles: [pentest]` and `security_opt: [no-new-privileges:true]`
- [ ] Run `docker compose -f docker/docker-compose.yml up -d` and confirm kali-mcp does NOT start
- [ ] Run `docker compose -f docker/docker-compose.yml --profile pentest up -d` and confirm kali-mcp starts with the pentest profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)