### PR TITLE
security: replace hardcoded eBPF API key with env var

### DIFF
--- a/workloads/web-platform.yml
+++ b/workloads/web-platform.yml
@@ -105,7 +105,7 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: "https://host.docker.internal:443/api/traces/otlp"
       OTEL_EXPORTER_OTLP_PROTOCOL: "http/json"
       OTEL_METRICS_EXPORTER: "none"
-      OTEL_EXPORTER_OTLP_HEADERS: "X-API-Key=ebpf-trace-key-change-me"
+      OTEL_EXPORTER_OTLP_HEADERS: "X-API-Key=${TRACES_INGESTION_API_KEY:?TRACES_INGESTION_API_KEY must be set}"
       BEYLA_TRACE_PRINTER: "disabled"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup


### PR DESCRIPTION
## Summary
- Replace hardcoded `ebpf-trace-key-change-me` API key in `workloads/web-platform.yml` with `${TRACES_INGESTION_API_KEY:?TRACES_INGESTION_API_KEY must be set}` environment variable reference
- The env var is already defined in `backend/src/config/env.schema.ts` and documented in `docker/.env.example`
- Uses bash parameter expansion with `:?` to fail fast with a clear error if the variable is not set

Closes #1017

## Test plan
- [x] Verified `TRACES_INGESTION_API_KEY` exists in `packages/core/src/config/env.schema.ts`
- [x] Verified `TRACES_INGESTION_API_KEY` is documented in `docker/.env.example`
- [x] Confirmed the only change is in `workloads/web-platform.yml` (1 line)
- [ ] Deploy with `TRACES_INGESTION_API_KEY` set and verify Beyla sends traces successfully
- [ ] Deploy without `TRACES_INGESTION_API_KEY` and verify the container fails to start with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)