### PR TITLE
security: add admin role to PCAP list/get endpoints

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -1046,6 +1046,26 @@ describe('PCAP Admin RBAC Enforcement', () => {
     expect(res.statusCode).toBe(403);
   });
 
+  it('denies list-captures for non-admin users (#1020 regression)', async () => {
+    currentRole = 'viewer';
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/pcap/captures',
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('denies get-capture for non-admin users (#1020 regression)', async () => {
+    currentRole = 'operator';
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/pcap/captures/c1',
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
   it('denies stop/analyze/delete for non-admin users', async () => {
     currentRole = 'operator';
 

--- a/packages/security/src/__tests__/pcap-route.test.ts
+++ b/packages/security/src/__tests__/pcap-route.test.ts
@@ -235,6 +235,8 @@ describe('PCAP Routes', () => {
         expect.objectContaining({ status: 'complete' }),
       );
     });
+
+    testAdminOnly(() => app, (r) => { currentRole = r; }, 'GET', '/api/pcap/captures');
   });
 
   describe('GET /api/pcap/captures/:id', () => {
@@ -263,6 +265,8 @@ describe('PCAP Routes', () => {
 
       expect(response.statusCode).toBe(404);
     });
+
+    testAdminOnly(() => app, (r) => { currentRole = r; }, 'GET', '/api/pcap/captures/c1');
   });
 
   describe('POST /api/pcap/captures/:id/stop', () => {

--- a/packages/security/src/routes/pcap.ts
+++ b/packages/security/src/routes/pcap.ts
@@ -81,7 +81,7 @@ export async function pcapRoutes(fastify: FastifyInstance, opts: { llm: LLMInter
       security: [{ bearerAuth: [] }],
       querystring: CaptureListQuerySchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request) => {
     const query = request.query as Record<string, unknown>;
     const parsed = CaptureListQuerySchema.safeParse(query);
@@ -99,7 +99,7 @@ export async function pcapRoutes(fastify: FastifyInstance, opts: { llm: LLMInter
       security: [{ bearerAuth: [] }],
       params: ActionIdParamsSchema,
     },
-    preHandler: [fastify.authenticate],
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const capture = await getCaptureById(id);


### PR DESCRIPTION
## Summary
- Add `fastify.requireRole('admin')` to `GET /api/pcap/captures` and `GET /api/pcap/captures/:id` preHandler arrays — these two endpoints were missing RBAC enforcement after #951 refactored the route structure
- Add `testAdminOnly()` RBAC tests for both endpoints in `pcap-route.test.ts`
- Add two regression tests in `security-regression.test.ts` tagged with `#1020 regression`

Closes #1020

## Test plan
- [x] `npx vitest run packages/security/src/__tests__/pcap-route.test.ts` — 29 tests pass (4 new RBAC tests via `testAdminOnly`)
- [x] Pre-push hook runs full frontend test suite (1565 tests pass)
- [ ] CI runs full backend + frontend test suites
- [ ] Verify `security-regression.test.ts` passes in CI (requires env vars + PostgreSQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)