### PR TITLE
fix: use TARGETARCH for hadolint download in kali-mcp Dockerfile

### DIFF
--- a/tools/kali-mcp/Dockerfile
+++ b/tools/kali-mcp/Dockerfile
@@ -1,5 +1,7 @@
 FROM kalilinux/kali-rolling
 
+ARG TARGETARCH
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Core utilities + Python + Go + Node.js
@@ -45,7 +47,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Container security tools (install scripts for trivy/grype, binary for hadolint)
 RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
     && curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin \
-    && curl -L https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-arm64 -o /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint
+    && HADOLINT_ARCH=$(case "${TARGETARCH:-arm64}" in amd64) echo "x86_64";; arm64) echo "arm64";; *) echo "x86_64";; esac) \
+    && curl -sL "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-${HADOLINT_ARCH}" -o /usr/local/bin/hadolint \
+    && chmod +x /usr/local/bin/hadolint
 
 # Go-based tools (nuclei, dive, gitleaks)
 ENV GOPATH=/opt/go


### PR DESCRIPTION
## Summary
- Replace hardcoded `hadolint-Linux-arm64` binary download with architecture-aware download using Docker's `TARGETARCH` build argument
- Maps `amd64` to `x86_64` (hadolint's naming convention) and `arm64` to `arm64`
- Pins hadolint to v2.12.0 instead of using `latest` tag for reproducible builds

Closes #1009

## Test plan
- [ ] Build image on amd64: `docker build --platform linux/amd64 tools/kali-mcp/` — verify hadolint binary is x86_64
- [ ] Build image on arm64: `docker build --platform linux/arm64 tools/kali-mcp/` — verify hadolint binary is arm64
- [ ] Run `hadolint --version` inside the resulting container on both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)