### PR TITLE
security: harden beyla eBPF container (#1026)

### DIFF
--- a/docker/docker-compose.beyla-edge-test.yml
+++ b/docker/docker-compose.beyla-edge-test.yml
@@ -1,6 +1,6 @@
 services:
   beyla:
-    image: grafana/beyla:latest
+    image: grafana/beyla:1.8
     container_name: beyla-edge-test
     restart: unless-stopped
     privileged: true

--- a/docker/docker-compose.beyla.yml
+++ b/docker/docker-compose.beyla.yml
@@ -12,7 +12,7 @@
 
 services:
   beyla:
-    image: grafana/beyla:latest
+    image: grafana/beyla:1.8
     privileged: true
     pid: "host"
     init: true
@@ -28,8 +28,8 @@ services:
       # Header format: key=value (no spaces, no colon)
       OTEL_EXPORTER_OTLP_HEADERS: "X-API-Key=${TRACES_INGESTION_API_KEY:-}"
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup
-      - /sys/kernel/security:/sys/kernel/security
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/kernel/security:/sys/kernel/security:ro
     networks:
       - dashboard-net
     depends_on:

--- a/workloads/web-platform.yml
+++ b/workloads/web-platform.yml
@@ -94,7 +94,7 @@ services:
 
   # Grafana Beyla — eBPF auto-instrumentation for all HTTP services in this stack
   beyla:
-    image: grafana/beyla:latest
+    image: grafana/beyla:1.8
     container_name: web-platform-beyla
     # privileged is required for eBPF — Beyla needs CAP_SYS_ADMIN + kernel tracing
     # access that cannot be granted via cap_add alone (bpf(), perf_event_open(), kprobes).
@@ -119,8 +119,8 @@ services:
       - /tmp:size=10M
       - /run:size=10M
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup
-      - /sys/kernel/security:/sys/kernel/security
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/kernel/security:/sys/kernel/security:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:6060/metrics || exit 1"]
       interval: 30s

--- a/workloads/web-platform.yml
+++ b/workloads/web-platform.yml
@@ -96,9 +96,16 @@ services:
   beyla:
     image: grafana/beyla:latest
     container_name: web-platform-beyla
+    # privileged is required for eBPF — Beyla needs CAP_SYS_ADMIN + kernel tracing
+    # access that cannot be granted via cap_add alone (bpf(), perf_event_open(), kprobes).
     privileged: true
     pid: "host"
     init: true
+    read_only: true
+    mem_limit: 256m
+    cpus: '0.5'
+    security_opt:
+      - "no-new-privileges:true"
     environment:
       BEYLA_OPEN_PORT: "80"
       BEYLA_SERVICE_NAMESPACE: "web-platform"
@@ -107,9 +114,19 @@ services:
       OTEL_METRICS_EXPORTER: "none"
       OTEL_EXPORTER_OTLP_HEADERS: "X-API-Key=ebpf-trace-key-change-me"
       BEYLA_TRACE_PRINTER: "disabled"
+      BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT: "6060"
+    tmpfs:
+      - /tmp:size=10M
+      - /run:size=10M
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
       - /sys/kernel/security:/sys/kernel/security
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:6060/metrics || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     labels:
       app.tier: "observability"
       app.env: "production"

--- a/workloads/web-platform.yml
+++ b/workloads/web-platform.yml
@@ -122,7 +122,7 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /sys/kernel/security:/sys/kernel/security:ro
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:6060/metrics || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:6060/internal/metrics || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- Add resource limits (`mem_limit: 256m`, `cpus: 0.5`) to prevent runaway resource consumption
- Enable `read_only: true` filesystem with tmpfs mounts for `/tmp` and `/run` to reduce attack surface
- Add `security_opt: ["no-new-privileges:true"]` to prevent privilege escalation
- Add healthcheck via Beyla's internal Prometheus metrics endpoint (`/metrics` on port 6060)
- Document why `privileged: true` must remain (eBPF requires `bpf()`, `perf_event_open()`, kprobes)

## Test plan
- [ ] Deploy updated `web-platform.yml` stack and verify beyla container starts successfully
- [ ] Confirm healthcheck transitions to `healthy` within the 15s start period
- [ ] Verify `docker inspect web-platform-beyla` shows resource limits, read-only rootfs, and no-new-privileges
- [ ] Confirm eBPF tracing still works (check OTLP traces are exported)
- [ ] Validate `wget -qO- http://localhost:6060/metrics` returns Prometheus metrics from inside the container

Closes #1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)