### PR TITLE
security: bind grype-mcp and snyk-mcp to 127.0.0.1 by default

### DIFF
--- a/docker/docker-compose.security-mcp.yml
+++ b/docker/docker-compose.security-mcp.yml
@@ -14,7 +14,7 @@ services:
       dockerfile: ../docker/nvd-mcp/Dockerfile
     restart: unless-stopped
     ports:
-      - "9090:8000"
+      - "127.0.0.1:9090:8000"
     environment:
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8000
@@ -33,7 +33,7 @@ services:
       dockerfile: ../docker/grype-mcp/Dockerfile
     restart: unless-stopped
     ports:
-      - "8788:8000"
+      - "127.0.0.1:8788:8000"
     environment:
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8000
@@ -51,7 +51,7 @@ services:
       dockerfile: ../docker/snyk-mcp/Dockerfile
     restart: unless-stopped
     ports:
-      - "8789:8000"
+      - "127.0.0.1:8789:8000"
     environment:
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8000

--- a/tools/grype-mcp/server.py
+++ b/tools/grype-mcp/server.py
@@ -6,7 +6,7 @@ import subprocess
 
 from mcp.server.fastmcp import FastMCP
 
-HOST = os.getenv("MCP_HOST", "0.0.0.0")
+HOST = os.getenv("MCP_HOST", "127.0.0.1")
 PORT = int(os.getenv("MCP_PORT", "8000"))
 SCAN_TIMEOUT = 120
 

--- a/tools/grype-mcp/test_server.py
+++ b/tools/grype-mcp/test_server.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from server import scan_image, scan_dir, scan_sbom, db_status, db_update
+from server import HOST, scan_image, scan_dir, scan_sbom, db_status, db_update
 
 
 SAMPLE_GRYPE_OUTPUT = json.dumps({
@@ -33,6 +33,12 @@ def _mock_run(stdout=SAMPLE_GRYPE_OUTPUT, returncode=0, stderr=""):
     result.returncode = returncode
     result.stderr = stderr
     return result
+
+
+class TestDefaultConfig:
+    def test_default_host_is_localhost(self):
+        """Default host must be 127.0.0.1 (not 0.0.0.0) to avoid exposing on all interfaces."""
+        assert HOST == "127.0.0.1"
 
 
 class TestScanImage:

--- a/tools/snyk-mcp/server.py
+++ b/tools/snyk-mcp/server.py
@@ -6,7 +6,7 @@ import subprocess
 
 from mcp.server.fastmcp import FastMCP
 
-HOST = os.getenv("MCP_HOST", "0.0.0.0")
+HOST = os.getenv("MCP_HOST", "127.0.0.1")
 PORT = int(os.getenv("MCP_PORT", "8000"))
 SCAN_TIMEOUT = 120
 

--- a/tools/snyk-mcp/test_server.py
+++ b/tools/snyk-mcp/test_server.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from server import (
+    HOST,
     snyk_test,
     snyk_code_test,
     snyk_container_test,
@@ -37,6 +38,12 @@ def _mock_run(stdout=SAMPLE_SNYK_OUTPUT, returncode=0, stderr=""):
     result.returncode = returncode
     result.stderr = stderr
     return result
+
+
+class TestDefaultConfig:
+    def test_default_host_is_localhost(self):
+        """Default host must be 127.0.0.1 (not 0.0.0.0) to avoid exposing on all interfaces."""
+        assert HOST == "127.0.0.1"
 
 
 class TestSnykTest:


### PR DESCRIPTION
## Summary
- Change default `MCP_HOST` from `0.0.0.0` to `127.0.0.1` in `tools/grype-mcp/server.py` and `tools/snyk-mcp/server.py` to prevent accidental exposure on all network interfaces
- Update `docker/docker-compose.security-mcp.yml` to bind all three MCP server port mappings (nvd, grype, snyk) to `127.0.0.1`
- Add `TestDefaultConfig` host binding regression tests to both `tools/grype-mcp/test_server.py` and `tools/snyk-mcp/test_server.py`

Closes #1008

## Test plan
- [x] `test_default_host_is_localhost` added to grype-mcp and snyk-mcp test suites
- [x] Verify `tools/nvd-mcp/server.py` already defaults to `127.0.0.1` (confirmed, no change needed)
- [ ] `docker compose -f docker/docker-compose.security-mcp.yml config` shows `127.0.0.1:PORT:PORT` for all three services

🤖 Generated with [Claude Code](https://claude.com/claude-code)