### PR TITLE
fix: add missing state filter chip to WorkloadExplorer

### DIFF
--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -328,6 +328,25 @@ describe('WorkloadExplorerPage', () => {
     expect(params).toEqual({ endpoint: '1', group: 'workload' });
   });
 
+  it('renders state filter chip when state param is set', () => {
+    mockQueryString = 'endpoint=1&state=running';
+    render(<WorkloadExplorerPage />);
+
+    expect(screen.getByText('State:')).toBeInTheDocument();
+    expect(screen.getByText('Running')).toBeInTheDocument();
+  });
+
+  it('removes state filter chip when dismiss button is clicked', () => {
+    mockQueryString = 'endpoint=1&state=running';
+    render(<WorkloadExplorerPage />);
+
+    const dismissStateButton = screen.getByRole('button', { name: 'Remove State filter' });
+    fireEvent.click(dismissStateButton);
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith({ search: 'endpoint=1' });
+  });
+
   it('clears all filters when Clear all is clicked', () => {
     mockQueryString = 'endpoint=1&stack=workers&group=workload';
     render(<WorkloadExplorerPage />);

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -159,6 +159,18 @@ export default function WorkloadExplorerPage() {
         onRemove: () => setFilters(selectedEndpoint, selectedStack, undefined, selectedState),
       });
     }
+    if (selectedState) {
+      filters.push({
+        key: 'state',
+        label: 'State',
+        value: selectedState.charAt(0).toUpperCase() + selectedState.slice(1),
+        onRemove: () => {
+          const newParams = new URLSearchParams(searchParams);
+          newParams.delete('state');
+          navigate({ search: newParams.toString() });
+        },
+      });
+    }
     return filters;
   }, [selectedEndpoint, selectedStack, selectedGroup, selectedState, endpoints]);
 


### PR DESCRIPTION
## Summary
- The `activeFilters` useMemo in WorkloadExplorer built filter chips for endpoint, stack, and group, but was missing the state filter chip despite `selectedState` being in the dependency array
- Added the missing state chip block following the same pattern as the other three filters
- The chip displays "State: Running" (capitalized) and its dismiss button removes the `state` URL param while preserving other params

## Test plan
- [x] Added test: state filter chip renders with correct label when `state` URL param is set
- [x] Added test: clicking dismiss button removes the state param from the URL
- [x] All 1567 existing tests continue to pass

Closes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)