### PR TITLE
fix: add error handling to deactivateUser and removeUser

### DIFF
--- a/frontend/src/features/core/pages/users.test.tsx
+++ b/frontend/src/features/core/pages/users.test.tsx
@@ -173,4 +173,88 @@ describe('UsersPanel', () => {
       expect(mockDeleteUser).toHaveBeenCalledWith('u1');
     });
   });
+
+  it('shows error message when deactivateUser mutation fails', async () => {
+    mockUpdateUser.mockRejectedValueOnce(new Error('Permission denied'));
+    render(<UsersPanel />);
+
+    const adminRow = screen
+      .getAllByRole('row')
+      .find(
+        (row) =>
+          within(row).queryAllByText('admin').length > 0 &&
+          within(row).queryByRole('button', { name: 'Deactivate' }),
+      );
+    expect(adminRow).toBeDefined();
+    if (!adminRow) return;
+
+    fireEvent.click(within(adminRow).getByRole('button', { name: 'Deactivate' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Permission denied')).toBeInTheDocument();
+    });
+  });
+
+  it('shows fallback error message when deactivateUser throws non-Error', async () => {
+    mockUpdateUser.mockRejectedValueOnce('network failure');
+    render(<UsersPanel />);
+
+    const adminRow = screen
+      .getAllByRole('row')
+      .find(
+        (row) =>
+          within(row).queryAllByText('admin').length > 0 &&
+          within(row).queryByRole('button', { name: 'Deactivate' }),
+      );
+    expect(adminRow).toBeDefined();
+    if (!adminRow) return;
+
+    fireEvent.click(within(adminRow).getByRole('button', { name: 'Deactivate' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to deactivate user')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message when removeUser mutation fails', async () => {
+    mockDeleteUser.mockRejectedValueOnce(new Error('Cannot delete last admin'));
+    render(<UsersPanel />);
+
+    const adminRow = screen
+      .getAllByRole('row')
+      .find(
+        (row) =>
+          within(row).queryAllByText('admin').length > 0 &&
+          within(row).queryByRole('button', { name: 'Delete' }),
+      );
+    expect(adminRow).toBeDefined();
+    if (!adminRow) return;
+
+    fireEvent.click(within(adminRow).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Cannot delete last admin')).toBeInTheDocument();
+    });
+  });
+
+  it('shows fallback error message when removeUser throws non-Error', async () => {
+    mockDeleteUser.mockRejectedValueOnce(42);
+    render(<UsersPanel />);
+
+    const adminRow = screen
+      .getAllByRole('row')
+      .find(
+        (row) =>
+          within(row).queryAllByText('admin').length > 0 &&
+          within(row).queryByRole('button', { name: 'Delete' }),
+      );
+    expect(adminRow).toBeDefined();
+    if (!adminRow) return;
+
+    fireEvent.click(within(adminRow).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to delete user')).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/features/core/pages/users.tsx
+++ b/frontend/src/features/core/pages/users.tsx
@@ -97,12 +97,20 @@ export function UsersPanel() {
 
   const deactivateUser = async (userId: string) => {
     if (!window.confirm('Deactivate this account by changing role to Viewer?')) return;
-    await updateUser.mutateAsync({ id: userId, payload: { role: 'viewer' } });
+    try {
+      await updateUser.mutateAsync({ id: userId, payload: { role: 'viewer' } });
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to deactivate user');
+    }
   };
 
   const removeUser = async (userId: string) => {
     if (!window.confirm('Delete this account permanently?')) return;
-    await deleteUser.mutateAsync(userId);
+    try {
+      await deleteUser.mutateAsync(userId);
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to delete user');
+    }
   };
 
   if (role !== 'admin') {


### PR DESCRIPTION
## Summary
- Wrapped `deactivateUser` and `removeUser` in try/catch blocks, matching the existing `saveUser` error handling pattern that calls `setErrorMessage()`
- `deactivateUser` errors display the error message or fallback "Failed to deactivate user"
- `removeUser` errors display the error message or fallback "Failed to delete user"
- Added 4 tests covering Error and non-Error rejection paths for both functions

Closes #1036

## Test plan
- [x] Existing tests still pass (9/9 in users.test.tsx, 1569/1569 total)
- [x] New test: deactivateUser shows `err.message` when mutation rejects with Error
- [x] New test: deactivateUser shows fallback string when mutation rejects with non-Error
- [x] New test: removeUser shows `err.message` when mutation rejects with Error
- [x] New test: removeUser shows fallback string when mutation rejects with non-Error

🤖 Generated with [Claude Code](https://claude.com/claude-code)