### PR TITLE
fix: require DASHBOARD_PASS env var in load tests

### DIFF
--- a/docker/docker-compose.loadtest.yml
+++ b/docker/docker-compose.loadtest.yml
@@ -22,7 +22,7 @@ x-loadtest: &loadtest
   environment: &loadtest-env
     BASE_URL: http://backend:3051
     DASHBOARD_USER: ${LOADTEST_USER:-admin}
-    DASHBOARD_PASS: ${LOADTEST_PASS:-changeme12345}
+    DASHBOARD_PASS: ${LOADTEST_PASS:-changeme123changeme123}
   networks:
     - dashboard-net
 

--- a/loadtests/artillery-helpers.cjs
+++ b/loadtests/artillery-helpers.cjs
@@ -17,7 +17,10 @@ function doLogin() {
   loginPromise = (async () => {
     const baseUrl = process.env.BASE_URL;
     const username = process.env.DASHBOARD_USER || 'admin';
-    const password = process.env.DASHBOARD_PASS || 'admin';
+    const password = process.env.DASHBOARD_PASS;
+    if (!password) {
+      throw new Error('DASHBOARD_PASS env var required. See docker-compose.dev.yml for the dev password.');
+    }
 
     const res = await fetch(`${baseUrl}/api/auth/login`, {
       method: 'POST',

--- a/loadtests/artillery-rest.yml
+++ b/loadtests/artillery-rest.yml
@@ -12,7 +12,7 @@
 # Env vars (set by docker/docker-compose.loadtest.yml):
 #   BASE_URL          http://backend:3051
 #   DASHBOARD_USER    admin
-#   DASHBOARD_PASS    changeme123
+#   DASHBOARD_PASS    (see docker-compose.dev.yml for dev credentials)
 
 config:
   target: "{{ $processEnvironment.BASE_URL }}"

--- a/loadtests/autocannon-benchmarks.mjs
+++ b/loadtests/autocannon-benchmarks.mjs
@@ -13,7 +13,7 @@
  * Env vars (with defaults):
  *   BASE_URL          http://localhost:3051
  *   DASHBOARD_USER    admin
- *   DASHBOARD_PASS    admin
+ *   DASHBOARD_PASS    (required — see docker-compose.dev.yml)
  *   BENCH_CONNECTIONS  10
  *   BENCH_DURATION     30
  */
@@ -22,7 +22,11 @@ import autocannon from 'autocannon';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3051';
 const USERNAME = process.env.DASHBOARD_USER || 'admin';
-const PASSWORD = process.env.DASHBOARD_PASS || 'admin';
+const PASSWORD = process.env.DASHBOARD_PASS;
+if (!PASSWORD) {
+  console.error('Error: DASHBOARD_PASS env var required. See docker-compose.dev.yml for the dev password.');
+  process.exit(1);
+}
 const CONNECTIONS = parseInt(process.env.BENCH_CONNECTIONS || '10', 10);
 const DURATION = parseInt(process.env.BENCH_DURATION || '30', 10);
 

--- a/loadtests/llm-load-test.mjs
+++ b/loadtests/llm-load-test.mjs
@@ -17,7 +17,7 @@
  * Env vars (with defaults):
  *   BASE_URL          http://localhost:3051
  *   DASHBOARD_USER    admin
- *   DASHBOARD_PASS    admin
+ *   DASHBOARD_PASS    (required — see docker-compose.dev.yml)
  *   LLM_SESSIONS      5
  *   LLM_MESSAGES       3
  */
@@ -26,7 +26,11 @@ import { io } from 'socket.io-client';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3051';
 const USERNAME = process.env.DASHBOARD_USER || 'admin';
-const PASSWORD = process.env.DASHBOARD_PASS || 'admin';
+const PASSWORD = process.env.DASHBOARD_PASS;
+if (!PASSWORD) {
+  console.error('Error: DASHBOARD_PASS env var required. See docker-compose.dev.yml for the dev password.');
+  process.exit(1);
+}
 const NUM_SESSIONS = parseInt(process.env.LLM_SESSIONS || '5', 10);
 const MSGS_PER_SESSION = parseInt(process.env.LLM_MESSAGES || '3', 10);
 const THINK_MS = 2_000;

--- a/loadtests/socket-io-load-test.mjs
+++ b/loadtests/socket-io-load-test.mjs
@@ -16,7 +16,7 @@
  * Env vars (with defaults):
  *   BASE_URL          http://localhost:3051
  *   DASHBOARD_USER    admin
- *   DASHBOARD_PASS    admin
+ *   DASHBOARD_PASS    (required — see docker-compose.dev.yml)
  *   SOCKETIO_USERS    10
  */
 
@@ -24,7 +24,11 @@ import { io } from 'socket.io-client';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3051';
 const USERNAME = process.env.DASHBOARD_USER || 'admin';
-const PASSWORD = process.env.DASHBOARD_PASS || 'admin';
+const PASSWORD = process.env.DASHBOARD_PASS;
+if (!PASSWORD) {
+  console.error('Error: DASHBOARD_PASS env var required. See docker-compose.dev.yml for the dev password.');
+  process.exit(1);
+}
 const NUM_USERS = parseInt(process.env.SOCKETIO_USERS || '10', 10);
 const HOLD_DURATION_MS = 30_000;
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `'admin'` password fallback from all four load test files (`autocannon-benchmarks.mjs`, `socket-io-load-test.mjs`, `llm-load-test.mjs`, `artillery-helpers.cjs`) — the backend enforces a 12-character minimum so `'admin'` always fails
- Each file now fails fast with a clear error message when `DASHBOARD_PASS` is not set
- Fix `docker-compose.loadtest.yml` default password from `changeme12345` to `changeme123changeme123` to match `docker-compose.dev.yml`

## Test plan
- [ ] Run `node loadtests/autocannon-benchmarks.mjs` without `DASHBOARD_PASS` set — should exit with error message
- [ ] Run `DASHBOARD_PASS=changeme123changeme123 node loadtests/autocannon-benchmarks.mjs` against dev stack — should authenticate successfully
- [ ] Verify `docker compose -f docker/docker-compose.loadtest.yml run --rm bench` authenticates without extra env overrides

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)