### PR TITLE
ci: add Python MCP tools test job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,14 +222,14 @@ jobs:
       matrix:
         tool: [grype-mcp, snyk-mcp, nvd-mcp]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies
         working-directory: tools/${{ matrix.tool }}
         run: |
-          pip install -r requirements.txt 2>/dev/null || true
+          [ -f requirements.txt ] && pip install -r requirements.txt
           pip install pytest pytest-asyncio mcp
       - name: Run tests
         working-directory: tools/${{ matrix.tool }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,10 +215,30 @@ jobs:
           path: frontend/coverage/
           retention-days: 14
 
+  test-tools:
+    name: Test MCP Tools (Python)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tool: [grype-mcp, snyk-mcp, nvd-mcp]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        working-directory: tools/${{ matrix.tool }}
+        run: |
+          pip install -r requirements.txt 2>/dev/null || true
+          pip install pytest pytest-asyncio mcp
+      - name: Run tests
+        working-directory: tools/${{ matrix.tool }}
+        run: python -m pytest test_server.py -v
+
   test-gate:
     name: Test Gate (Required)
     runs-on: ubuntu-latest
-    needs: [test-packages, test-backend, test-frontend]
+    needs: [test-packages, test-backend, test-frontend, test-tools]
     steps:
       - name: All tests passed
         run: echo "All package, backend, and frontend tests passed. PR is eligible for merge."


### PR DESCRIPTION
## Summary
- Adds a `test-tools` CI job that runs Python tests for the three MCP tools (grype-mcp, snyk-mcp, nvd-mcp) using a matrix strategy
- Installs `pytest`, `pytest-asyncio`, and `mcp` (for server imports) in each matrix run
- Adds `test-tools` to the `test-gate` job's `needs` array so Python test failures block merge

Closes #1010

## Test plan
- [ ] Verify CI triggers the new `test-tools` job on the PR
- [ ] Confirm all three matrix entries (grype-mcp, snyk-mcp, nvd-mcp) pass
- [ ] Confirm `test-gate` waits for `test-tools` before reporting success

🤖 Generated with [Claude Code](https://claude.com/claude-code)