### PR TITLE
chore: consolidate env vars and settings DB (#1043)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -63,6 +63,9 @@ LLM_PROMPT_GUARD_STRICT=true        # true = block on heuristic score >= 0.4; fa
 # KIBANA_API_KEY=your-kibana-key
 
 # Monitoring
+# [DEPRECATED] MONITORING_ENABLED and MONITORING_INTERVAL_MINUTES are now
+# configurable via Settings UI → Monitoring → General. These env vars still
+# work as fallbacks but will be removed in a future release.
 MONITORING_ENABLED=true
 MONITORING_INTERVAL_MINUTES=5
 # MAX_INSIGHTS_PER_CYCLE=500            # Cap insights per monitoring cycle (default: 500)
@@ -85,6 +88,9 @@ PROMETHEUS_METRICS_ENABLED=false
 # GRAFANA_HOST_PORT=3001
 
 # Anomaly Detection
+# [DEPRECATED] All ANOMALY_* vars below are now configurable via
+# Settings UI → AI & LLM → Advanced AI Tuning. Env vars still work
+# as fallbacks but will be removed in a future release.
 ANOMALY_ZSCORE_THRESHOLD=3.5
 ANOMALY_MOVING_AVERAGE_WINDOW=20
 ANOMALY_MIN_SAMPLES=10
@@ -102,6 +108,11 @@ ANOMALY_EXPLANATION_ENABLED=true
 ANOMALY_EXPLANATION_MAX_PER_CYCLE=5
 
 # Isolation Forest ML Anomaly Detection
+# [DEPRECATED] ISOLATION_FOREST_ENABLED and ISOLATION_FOREST_RETRAIN_HOURS
+# are now in Settings UI → AI & LLM → Advanced AI Tuning.
+# ISOLATION_FOREST_TREES, ISOLATION_FOREST_SAMPLE_SIZE, and
+# ISOLATION_FOREST_CONTAMINATION are intentionally env-only: they control
+# model structure and require a restart to retrain models safely.
 ISOLATION_FOREST_ENABLED=true
 ISOLATION_FOREST_TREES=100
 ISOLATION_FOREST_SAMPLE_SIZE=256
@@ -109,16 +120,19 @@ ISOLATION_FOREST_CONTAMINATION=0.15
 ISOLATION_FOREST_RETRAIN_HOURS=6
 
 # NLP Log Analysis — LLM analyzes container logs for error patterns
+# [DEPRECATED] Now in Settings UI → AI & LLM → Advanced AI Tuning.
 NLP_LOG_ANALYSIS_ENABLED=true
 NLP_LOG_ANALYSIS_MAX_PER_CYCLE=3
 NLP_LOG_ANALYSIS_TAIL_LINES=100
 
 # Smart Alert Grouping — text similarity + LLM incident summaries
+# [DEPRECATED] Now in Settings UI → AI & LLM → Advanced AI Tuning.
 SMART_GROUPING_ENABLED=true
 SMART_GROUPING_SIMILARITY_THRESHOLD=0.3
 INCIDENT_SUMMARY_ENABLED=true
 
 # Investigation (AI Root Cause Analysis)
+# [DEPRECATED] Now in Settings UI → AI & LLM → Advanced AI Tuning.
 INVESTIGATION_ENABLED=true
 INVESTIGATION_COOLDOWN_MINUTES=20
 INVESTIGATION_MAX_CONCURRENT=2
@@ -191,6 +205,9 @@ LOG_LEVEL=info
 # DASHBOARD_DOMAIN=dashboard.example.com
 
 # Notifications — Microsoft Teams
+# [DEPRECATED] Notification env vars are now configurable via
+# Settings UI → Monitoring → Notifications. Env vars still work
+# as fallbacks but will be removed in a future release.
 # TEAMS_WEBHOOK_URL=https://your-org.webhook.office.com/webhookb2/...
 # TEAMS_NOTIFICATIONS_ENABLED=false
 
@@ -204,6 +221,7 @@ LOG_LEVEL=info
 # TELEGRAM_NOTIFICATIONS_ENABLED=false
 
 # Notifications — Email (SMTP)
+# SMTP_HOST is intentionally env-only for SSRF protection (not configurable via UI).
 # SMTP_HOST=smtp.example.com
 # SMTP_PORT=587
 # SMTP_SECURE=true

--- a/frontend/src/features/core/components/settings/shared.tsx
+++ b/frontend/src/features/core/components/settings/shared.tsx
@@ -21,7 +21,8 @@ export const DEFAULT_SETTINGS = {
     { key: 'notifications.teams_enabled', label: 'Enable Teams Notifications', description: 'Send alerts to Microsoft Teams via webhook', type: 'boolean', defaultValue: 'false' },
     { key: 'notifications.teams_webhook_url', label: 'Teams Webhook URL', description: 'Microsoft Teams incoming webhook URL', type: 'password', defaultValue: '' },
     { key: 'notifications.email_enabled', label: 'Enable Email Notifications', description: 'Send alerts via SMTP email', type: 'boolean', defaultValue: 'false' },
-    { key: 'notifications.smtp_host', label: 'SMTP Host', description: 'SMTP server hostname', type: 'string', defaultValue: '' },
+    // SMTP Host is intentionally env-only (SMTP_HOST) for SSRF protection.
+    // The backend ignores DB overrides via getSafeSmtpHost().
     { key: 'notifications.smtp_port', label: 'SMTP Port', description: 'SMTP server port', type: 'number', defaultValue: '587', min: 1, max: 65535 },
     { key: 'notifications.smtp_user', label: 'SMTP Username', description: 'SMTP authentication username', type: 'string', defaultValue: '' },
     { key: 'notifications.smtp_password', label: 'SMTP Password', description: 'SMTP authentication password', type: 'password', defaultValue: '' },

--- a/frontend/src/features/core/pages/settings.tsx
+++ b/frontend/src/features/core/pages/settings.tsx
@@ -149,7 +149,6 @@ export default function SettingsPage() {
     'notifications.teams_enabled',
     'notifications.teams_webhook_url',
     'notifications.email_enabled',
-    'notifications.smtp_host',
     'notifications.smtp_port',
     'notifications.smtp_user',
     'notifications.smtp_password',

--- a/packages/core/src/config/env.schema.ts
+++ b/packages/core/src/config/env.schema.ts
@@ -83,6 +83,12 @@ export const envSchema = z.object({
   ANOMALY_EXPLANATION_MAX_PER_CYCLE: z.coerce.number().int().min(1).max(50).default(5),
 
   // Isolation Forest Anomaly Detection
+  // ISOLATION_FOREST_ENABLED and ISOLATION_FOREST_RETRAIN_HOURS are configurable
+  // via Settings UI (ai_tuning.*) and are deprecated as env vars.
+  // ISOLATION_FOREST_TREES, ISOLATION_FOREST_SAMPLE_SIZE, and
+  // ISOLATION_FOREST_CONTAMINATION are intentionally env-only: they control model
+  // structure and changing them at runtime would invalidate cached models without
+  // retraining. A restart ensures models are retrained with the new parameters.
   ISOLATION_FOREST_ENABLED: z.coerce.boolean().default(true),
   ISOLATION_FOREST_TREES: z.coerce.number().int().min(10).max(500).default(100),
   ISOLATION_FOREST_SAMPLE_SIZE: z.coerce.number().int().min(32).max(512).default(256),
@@ -162,6 +168,8 @@ export const envSchema = z.object({
   TELEGRAM_NOTIFICATIONS_ENABLED: z.coerce.boolean().default(false),
 
   // Notifications — Email
+  // SMTP_HOST is intentionally env-only for SSRF protection.
+  // getSafeSmtpHost() blocks private/loopback hosts and ignores DB overrides.
   SMTP_HOST: z.string().optional(),
   SMTP_PORT: z.coerce.number().int().min(1).max(65535).default(587),
   SMTP_SECURE: z.coerce.boolean().default(true),

--- a/packages/core/src/config/index.test.ts
+++ b/packages/core/src/config/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('config validation', () => {
   const originalEnv = { ...process.env };
@@ -331,6 +331,89 @@ describe('config validation', () => {
 
       const { getConfig } = await import('./index.js');
       expect(() => getConfig()).toThrowError(/JWT_PRIVATE_KEY_PATH.*file not found/i);
+    });
+  });
+
+  describe('deprecated env var warnings', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('logs a warning when a deprecated env var is set', async () => {
+      process.env.MONITORING_ENABLED = 'true';
+
+      const { getConfig } = await import('./index.js');
+      getConfig();
+
+      const monitoringWarning = warnSpy.mock.calls.find((call: unknown[]) =>
+        typeof call[0] === 'string' && call[0].includes('MONITORING_ENABLED'),
+      );
+      expect(monitoringWarning).toBeDefined();
+      expect(monitoringWarning![0]).toContain('[DEPRECATED]');
+      expect(monitoringWarning![0]).toContain('Settings');
+    });
+
+    it('logs a warning for MONITORING_INTERVAL_MINUTES when set', async () => {
+      process.env.MONITORING_INTERVAL_MINUTES = '10';
+
+      const { getConfig } = await import('./index.js');
+      getConfig();
+
+      const intervalWarning = warnSpy.mock.calls.find((call: unknown[]) =>
+        typeof call[0] === 'string' && call[0].includes('MONITORING_INTERVAL_MINUTES'),
+      );
+      expect(intervalWarning).toBeDefined();
+      expect(intervalWarning![0]).toContain('[DEPRECATED]');
+    });
+
+    it('does not log warnings for deprecated vars that are not set', async () => {
+      delete process.env.MONITORING_ENABLED;
+      delete process.env.MONITORING_INTERVAL_MINUTES;
+      delete process.env.TEAMS_WEBHOOK_URL;
+
+      const { getConfig } = await import('./index.js');
+      getConfig();
+
+      const deprecatedWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
+        typeof call[0] === 'string' && call[0].includes('[DEPRECATED]'),
+      );
+      // Should have no warnings for the vars we explicitly deleted.
+      // (Other deprecated vars may be set from the test env, so just check the specific ones.)
+      const monitoringWarnings = deprecatedWarnings.filter((call: unknown[]) =>
+        (call[0] as string).includes('MONITORING_ENABLED') || (call[0] as string).includes('MONITORING_INTERVAL_MINUTES'),
+      );
+      expect(monitoringWarnings).toHaveLength(0);
+    });
+
+    it('includes all expected vars in DEPRECATED_ENV_VARS', async () => {
+      const { DEPRECATED_ENV_VARS } = await import('./index.js');
+
+      // Monitoring vars added in #1043
+      expect(DEPRECATED_ENV_VARS).toHaveProperty('MONITORING_ENABLED');
+      expect(DEPRECATED_ENV_VARS).toHaveProperty('MONITORING_INTERVAL_MINUTES');
+
+      // Existing notification vars
+      expect(DEPRECATED_ENV_VARS).toHaveProperty('TEAMS_WEBHOOK_URL');
+      expect(DEPRECATED_ENV_VARS).toHaveProperty('EMAIL_NOTIFICATIONS_ENABLED');
+      expect(DEPRECATED_ENV_VARS).toHaveProperty('WEBHOOKS_ENABLED');
+
+      // AI tuning vars
+      expect(DEPRECATED_ENV_VARS).toHaveProperty('ANOMALY_ZSCORE_THRESHOLD');
+      expect(DEPRECATED_ENV_VARS).toHaveProperty('ISOLATION_FOREST_ENABLED');
+
+      // SMTP_HOST must NOT be in deprecated list (env-only for SSRF protection)
+      expect(DEPRECATED_ENV_VARS).not.toHaveProperty('SMTP_HOST');
+
+      // Isolation Forest structural params must NOT be deprecated (env-only tuning)
+      expect(DEPRECATED_ENV_VARS).not.toHaveProperty('ISOLATION_FOREST_TREES');
+      expect(DEPRECATED_ENV_VARS).not.toHaveProperty('ISOLATION_FOREST_SAMPLE_SIZE');
+      expect(DEPRECATED_ENV_VARS).not.toHaveProperty('ISOLATION_FOREST_CONTAMINATION');
     });
   });
 });

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -148,8 +148,20 @@ function validateServicePasswords(data: EnvConfig): void {
 
 // Category A + B env vars that are now configurable via Settings UI.
 // During the deprecation window, they still work as fallbacks but log a warning.
-const DEPRECATED_ENV_VARS: Record<string, string> = {
+//
+// ── Intentionally env-only vars (NOT deprecated) ───────────────────────────────
+// SMTP_HOST          – env-only for SSRF protection; getSafeSmtpHost() blocks
+//                      private/loopback hosts and ignores DB overrides.
+// ISOLATION_FOREST_TREES, ISOLATION_FOREST_SAMPLE_SIZE, ISOLATION_FOREST_CONTAMINATION
+//                    – low-level ML tuning parameters that affect model structure.
+//                      Changing at runtime would invalidate cached models without
+//                      retraining, leading to incorrect anomaly scores. Keep as
+//                      env-only so changes require a deliberate restart.
+// ────────────────────────────────────────────────────────────────────────────────
+export const DEPRECATED_ENV_VARS: Record<string, string> = {
   // Category A: already have Settings UI
+  MONITORING_ENABLED: 'Settings → Monitoring → General (monitoring.enabled)',
+  MONITORING_INTERVAL_MINUTES: 'Settings → Monitoring → General (monitoring.polling_interval)',
   TEAMS_WEBHOOK_URL: 'Settings → Monitoring → Notifications',
   TEAMS_NOTIFICATIONS_ENABLED: 'Settings → Monitoring → Notifications',
   DISCORD_WEBHOOK_URL: 'Settings → Monitoring → Notifications',


### PR DESCRIPTION
## Summary

- **Deprecate `MONITORING_ENABLED` and `MONITORING_INTERVAL_MINUTES`** as env vars — they now have Settings UI equivalents (`monitoring.enabled`, `monitoring.polling_interval`) and are added to `DEPRECATED_ENV_VARS` with migration messages
- **Document env-only vars** with clear rationale:
  - `SMTP_HOST` — env-only for SSRF protection (`getSafeSmtpHost()` blocks private/loopback hosts and ignores DB overrides)
  - `ISOLATION_FOREST_TREES`, `ISOLATION_FOREST_SAMPLE_SIZE`, `ISOLATION_FOREST_CONTAMINATION` — env-only ML tuning params that control model structure; runtime changes would invalidate cached models without retraining
- **Remove orphaned `notifications.smtp_host`** from frontend `DEFAULT_SETTINGS` and `restartKeys` — the backend ignores DB overrides for this field, making the UI control misleading
- **Add deprecation notices** to `docker/.env.example` for all deprecated env vars (monitoring, anomaly detection, notifications, investigation, NLP log analysis, smart grouping, isolation forest)
- **Add tests** verifying deprecated vars log warnings and that env-only vars (`SMTP_HOST`, IF structural params) are correctly excluded from the deprecated list

## Test plan

- [x] All 46 config tests pass (`packages/core/src/config/index.test.ts`)
- [x] All 1565 frontend tests pass
- [x] TypeScript strict mode passes (both frontend and core package)
- [ ] CI should run full test suite
- [ ] Verify `MONITORING_ENABLED=true` in `.env` logs `[DEPRECATED]` warning on startup
- [ ] Verify SMTP Host field no longer appears in Settings UI notifications section

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)