### PR TITLE
feat: dynamic monitoring scheduler — live reload from Settings DB

### DIFF
--- a/frontend/src/features/core/components/settings/shared.test.ts
+++ b/frontend/src/features/core/components/settings/shared.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_SETTINGS, SETTING_CATEGORY_BY_KEY } from './shared';
+
+describe('DEFAULT_SETTINGS — monitoring.scheduler_interval_minutes', () => {
+  const monitoringSettings = DEFAULT_SETTINGS.monitoring;
+  const schedulerSetting = monitoringSettings.find(
+    (s) => s.key === 'monitoring.scheduler_interval_minutes',
+  );
+
+  it('exists in the monitoring category', () => {
+    expect(schedulerSetting).toBeDefined();
+  });
+
+  it('has type number with min=1 and max=60', () => {
+    expect(schedulerSetting!.type).toBe('number');
+    expect((schedulerSetting as any).min).toBe(1);
+    expect((schedulerSetting as any).max).toBe(60);
+  });
+
+  it('defaults to 5 minutes', () => {
+    expect(schedulerSetting!.defaultValue).toBe('5');
+  });
+
+  it('is mapped to the monitoring category in SETTING_CATEGORY_BY_KEY', () => {
+    expect(SETTING_CATEGORY_BY_KEY['monitoring.scheduler_interval_minutes']).toBe('monitoring');
+  });
+
+  it('monitoring.enabled still exists', () => {
+    const enabledSetting = monitoringSettings.find(
+      (s) => s.key === 'monitoring.enabled',
+    );
+    expect(enabledSetting).toBeDefined();
+    expect(enabledSetting!.type).toBe('boolean');
+  });
+});

--- a/frontend/src/features/core/components/settings/shared.tsx
+++ b/frontend/src/features/core/components/settings/shared.tsx
@@ -10,6 +10,7 @@ export const DEFAULT_SETTINGS = {
     { key: 'monitoring.polling_interval', label: 'Polling Interval', description: 'How often to fetch container metrics (seconds)', type: 'number', defaultValue: '30', min: 5, max: 300 },
     { key: 'monitoring.metric_retention_days', label: 'Metric Retention', description: 'How long to keep historical metrics (days)', type: 'number', defaultValue: '7', min: 1, max: 90 },
     { key: 'monitoring.enabled', label: 'Enable Monitoring', description: 'Enable background container monitoring', type: 'boolean', defaultValue: 'true' },
+    { key: 'monitoring.scheduler_interval_minutes', label: 'Scheduler Interval', description: 'How often the monitoring scheduler runs (minutes). Changes apply without restart.', type: 'number', defaultValue: '5', min: 1, max: 60 },
   ],
   anomaly: [
     { key: 'anomaly.cpu_threshold', label: 'CPU Threshold', description: 'CPU usage percentage to trigger anomaly alert', type: 'number', defaultValue: '85', min: 50, max: 100 },

--- a/frontend/src/features/core/components/settings/tab-monitoring.tsx
+++ b/frontend/src/features/core/components/settings/tab-monitoring.tsx
@@ -26,7 +26,6 @@ export function MonitoringTab({ editedValues, originalValues, onChange, isSaving
         values={editedValues}
         originalValues={originalValues}
         onChange={onChange}
-        requiresRestart
         disabled={isSaving}
         status={editedValues['monitoring.enabled'] === 'true' ? 'configured' : 'not-configured'}
         statusLabel={editedValues['monitoring.enabled'] === 'true' ? 'Enabled' : 'Disabled'}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -209,9 +209,6 @@ export const DEPRECATED_ENV_VARS: Record<string, string> = {
   AI_ANALYSIS_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
   MAX_INSIGHTS_PER_CYCLE: 'Settings → AI & LLM → Advanced AI Tuning',
   INSIGHTS_RETENTION_DAYS: 'Settings → Infrastructure → Metrics Retention',
-  // Category C: Monitoring scheduler (now in Settings → Monitoring)
-  MONITORING_ENABLED: 'Use Settings UI → Monitoring → Enable Monitoring instead',
-  MONITORING_INTERVAL_MINUTES: 'Use Settings UI → Monitoring → Scheduler Interval instead',
 };
 
 let deprecationWarned = false;

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -209,6 +209,9 @@ export const DEPRECATED_ENV_VARS: Record<string, string> = {
   AI_ANALYSIS_ENABLED: 'Settings → AI & LLM → Advanced AI Tuning',
   MAX_INSIGHTS_PER_CYCLE: 'Settings → AI & LLM → Advanced AI Tuning',
   INSIGHTS_RETENTION_DAYS: 'Settings → Infrastructure → Metrics Retention',
+  // Category C: Monitoring scheduler (now in Settings → Monitoring)
+  MONITORING_ENABLED: 'Use Settings UI → Monitoring → Enable Monitoring instead',
+  MONITORING_INTERVAL_MINUTES: 'Use Settings UI → Monitoring → Scheduler Interval instead',
 };
 
 let deprecationWarned = false;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,7 +30,7 @@ export { normalizeEndpoint, normalizeContainer, normalizeStack, normalizeNetwork
 export { CircuitBreaker } from './portainer/circuit-breaker.js';
 
 // Core Services
-export { getSetting, setSetting, getSettings, getEffectiveLlmConfig, getEffectiveMonitoringConfig } from './services/settings-store.js';
+export { getSetting, setSetting, getSettings, getEffectiveLlmConfig, getEffectiveMonitoringConfig, getEffectiveMonitoringSchedulerConfig } from './services/settings-store.js';
 export type { MonitoringConfig } from './services/settings-store.js';
 export { createSession, getSession, invalidateSession, refreshSession } from './services/session-store.js';
 export { getUserById, getUserByUsername, authenticateUser, hasMinRole } from './services/user-store.js';

--- a/packages/core/src/services/settings-store-monitoring-scheduler.test.ts
+++ b/packages/core/src/services/settings-store-monitoring-scheduler.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the DB router so getSetting hits an in-memory map
+const settingsMap = new Map<string, string>();
+
+vi.mock('../db/app-db-router.js', () => {
+  const mockDb = {
+    queryOne: vi.fn(async (_sql: string, params: unknown[]) => {
+      const key = params[0] as string;
+      const value = settingsMap.get(key);
+      if (value === undefined) return null;
+      return { key, value, category: 'monitoring', updated_at: new Date().toISOString() };
+    }),
+    query: vi.fn(async () => []),
+    execute: vi.fn(async () => ({ changes: 0 })),
+  };
+  return { getDbForDomain: () => mockDb };
+});
+
+// Must import after mocks are set up
+import { getEffectiveMonitoringSchedulerConfig } from './settings-store.js';
+
+beforeEach(() => {
+  settingsMap.clear();
+});
+
+describe('getEffectiveMonitoringSchedulerConfig', () => {
+  it('falls back to env config when no settings exist', async () => {
+    const result = await getEffectiveMonitoringSchedulerConfig();
+    // Defaults from env schema: MONITORING_ENABLED=true, MONITORING_INTERVAL_MINUTES=5
+    expect(result.enabled).toBe(true);
+    expect(result.intervalMinutes).toBe(5);
+  });
+
+  it('reads enabled=false from Settings DB', async () => {
+    settingsMap.set('monitoring.enabled', 'false');
+    const result = await getEffectiveMonitoringSchedulerConfig();
+    expect(result.enabled).toBe(false);
+  });
+
+  it('reads enabled=true from Settings DB', async () => {
+    settingsMap.set('monitoring.enabled', 'true');
+    const result = await getEffectiveMonitoringSchedulerConfig();
+    expect(result.enabled).toBe(true);
+  });
+
+  it('reads custom intervalMinutes from Settings DB', async () => {
+    settingsMap.set('monitoring.scheduler_interval_minutes', '10');
+    const result = await getEffectiveMonitoringSchedulerConfig();
+    expect(result.intervalMinutes).toBe(10);
+  });
+
+  it('falls back to env default when interval is empty string', async () => {
+    settingsMap.set('monitoring.scheduler_interval_minutes', '');
+    const result = await getEffectiveMonitoringSchedulerConfig();
+    expect(result.intervalMinutes).toBe(5);
+  });
+
+  it('falls back to env default when interval is non-numeric', async () => {
+    settingsMap.set('monitoring.scheduler_interval_minutes', 'abc');
+    const result = await getEffectiveMonitoringSchedulerConfig();
+    expect(result.intervalMinutes).toBe(5);
+  });
+
+  it('combines both settings correctly', async () => {
+    settingsMap.set('monitoring.enabled', 'false');
+    settingsMap.set('monitoring.scheduler_interval_minutes', '15');
+    const result = await getEffectiveMonitoringSchedulerConfig();
+    expect(result.enabled).toBe(false);
+    expect(result.intervalMinutes).toBe(15);
+  });
+});

--- a/packages/core/src/services/settings-store.ts
+++ b/packages/core/src/services/settings-store.ts
@@ -78,6 +78,20 @@ export async function getEffectiveHarborConfig() {
   return { enabled, apiUrl, robotName, robotSecret, verifySsl, syncIntervalMinutes };
 }
 
+// ── Monitoring scheduler config ──────────────────────────────────────────────
+
+/**
+ * Read monitoring scheduler config from the Settings DB, falling back to env vars.
+ * Called on each 1-minute tick so that Settings UI changes take effect without a restart.
+ */
+export async function getEffectiveMonitoringSchedulerConfig() {
+  const cfg = getConfig();
+  const enabledSetting = await getSetting('monitoring.enabled');
+  const enabled = enabledSetting ? enabledSetting.value === 'true' : cfg.MONITORING_ENABLED;
+  const intervalMinutes = parseInt((await getSetting('monitoring.scheduler_interval_minutes'))?.value || '', 10) || cfg.MONITORING_INTERVAL_MINUTES;
+  return { enabled, intervalMinutes };
+}
+
 // ── Monitoring / AI Tuning config ────────────────────────────────────────────
 
 export interface MonitoringConfig {

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -5,7 +5,7 @@ import { getEndpoints, getContainers, isEndpointDegraded, getImages } from '@das
 import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { cachedFetch, cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/index.js';
 import { normalizeEndpoint, type NormalizedEndpoint } from '@dashboard/core/portainer/index.js';
-import { getSetting, getEffectiveHarborConfig, cleanExpiredSessions } from '@dashboard/core/services/index.js';
+import { getSetting, getEffectiveHarborConfig, getEffectiveMonitoringSchedulerConfig, cleanExpiredSessions } from '@dashboard/core/services/index.js';
 import { runWithTraceContext } from '@dashboard/core/tracing/index.js';
 import { startCooldownSweep, stopCooldownSweep, cleanupOldInsights } from '@dashboard/ai';
 import { collectMetrics, insertMetrics, cleanOldMetrics, type MetricInsert, recordNetworkSample, insertKpiSnapshot, cleanOldKpiSnapshots } from '@dashboard/observability';
@@ -460,18 +460,35 @@ export async function startScheduler(runMonitoringCycle: () => Promise<void>): P
     runWithTraceContext({ source: 'scheduler' }, runMetricsCollection).catch(() => {});
   }
 
-  if (config.MONITORING_ENABLED) {
-    const monitoringIntervalMs = config.MONITORING_INTERVAL_MINUTES * 60 * 1000;
+  // Monitoring scheduler — re-reads config on each 1-minute tick so changes
+  // to enabled/intervalMinutes in the Settings UI take effect without a restart.
+  {
+    let lastMonitoringRunAt = 0;
     const runMonitoringWithErrorHandling = makeMonitoringRunner(runMonitoringCycle);
-    log.info(
-      { intervalMinutes: config.MONITORING_INTERVAL_MINUTES },
-      'Starting monitoring scheduler',
-    );
     const monitoringInterval = setInterval(
-      () => runWithTraceContext({ source: 'scheduler' }, runMonitoringWithErrorHandling),
-      monitoringIntervalMs,
+      () => runWithTraceContext({ source: 'scheduler' }, async () => {
+        try {
+          const cfg = await getEffectiveMonitoringSchedulerConfig();
+          if (!cfg.enabled) return;
+          const intervalMs = cfg.intervalMinutes * 60 * 1000;
+          if (Date.now() - lastMonitoringRunAt < intervalMs) return;
+          lastMonitoringRunAt = Date.now();
+          log.debug({ intervalMinutes: cfg.intervalMinutes }, 'Running monitoring cycle');
+          await runMonitoringWithErrorHandling();
+        } catch (err) {
+          log.error({ err }, 'Monitoring scheduler tick failed');
+        }
+      }),
+      60_000, // poll every minute; actual cadence controlled by intervalMinutes
     );
     intervals.push(monitoringInterval);
+    // Log once at startup with current config
+    getEffectiveMonitoringSchedulerConfig().then((cfg) => {
+      log.info(
+        { enabled: cfg.enabled, intervalMinutes: cfg.intervalMinutes },
+        'Starting dynamic monitoring scheduler (1-min poll)',
+      );
+    }).catch(() => {});
   }
 
   // Webhook retry processing


### PR DESCRIPTION
## Summary
- Add `getEffectiveMonitoringSchedulerConfig()` to `settings-store.ts` that reads `monitoring.enabled` and `monitoring.scheduler_interval_minutes` from the Settings DB, falling back to env vars
- Refactor the monitoring scheduler in `scheduler.ts` from a static `setInterval` to a Harbor-style 1-minute polling tick that re-reads config on each tick, enabling live changes without restart
- Add `monitoring.scheduler_interval_minutes` setting to the frontend Settings UI (default: 5 min, range: 1-60)
- Remove the `requiresRestart` badge from the Monitoring settings section since changes now apply dynamically

## Test plan
- [x] Backend: 7 unit tests for `getEffectiveMonitoringSchedulerConfig` (DB fallback, enabled/disabled, custom interval, empty/non-numeric input)
- [x] Frontend: 5 tests for `DEFAULT_SETTINGS` (new setting exists, correct type/min/max/default, category mapping)
- [x] Existing scheduler tests (23) pass with no regressions
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] All 1570 frontend tests pass

Closes #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)