### PR TITLE
fix: resolve 2 flaky CI test failures

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -1358,9 +1358,11 @@ describe('Rate Limiting Verification', () => {
     llmApp.setSerializerCompiler(serializerCompiler);
 
     await llmApp.register(rateLimitPlugin);
-    await llmApp.register(authPlugin);
 
-    // Bypass auth — we are testing the rate limiter, not auth
+    // Bypass auth — we are testing the rate limiter, not auth.
+    // Do NOT register authPlugin (it adds a real requireRole that would
+    // reject requests). Instead, stub the decorators that llmRoutes expects.
+    llmApp.decorate('authenticate', async () => undefined);
     llmApp.decorate('requireRole', () => async () => undefined);
     llmApp.decorateRequest('user', undefined);
     llmApp.addHook('preHandler', async (request) => {

--- a/packages/ai-intelligence/src/__tests__/llm-chat.test.ts
+++ b/packages/ai-intelligence/src/__tests__/llm-chat.test.ts
@@ -418,6 +418,8 @@ function baseLlmConfig(overrides: Record<string, any> = {}) {
 describe('setupLlmNamespace — tool iteration limit graceful degradation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Clear per-user throttle map so tests don't interfere with each other
+    chatThrottleMap.clear();
     // Phase 1 is skipped because collectAllTools returns [] (no native tools)
     mockCollectAllTools.mockReturnValue([]);
     mockRouteToolCalls.mockResolvedValue([]);


### PR DESCRIPTION
## Summary
- **llm-chat.test.ts**: Clear `chatThrottleMap` in `beforeEach` — the 2-second per-user throttle was bleeding between tests, causing 5 false failures in the "tool iteration limit graceful degradation" suite
- **security-regression.test.ts**: Don't register `authPlugin` for the LLM rate-limit test — stub decorators manually instead. `authPlugin`'s real `requireRole` was conflicting (duplicate decorator error in CI)

## Root Causes
1. **Throttle bleed**: `chatThrottleMap` is module-level state. Test 1 sets throttle for `test-user`, then tests 2-6 run within the 2s window and get silently throttled — no status events emitted, assertions fail.
2. **Decorator conflict**: `authPlugin` registers `requireRole`, then the test tried to `decorate('requireRole', ...)` again → `FST_ERR_DEC_ALREADY_PRESENT`. Fix: skip `authPlugin` entirely and stub the decorators the LLM routes need.

## Test plan
- [x] All 46 llm-chat.test.ts tests pass locally (was 5 failing)
- [x] LLM rate-limit test in security-regression.test.ts passes locally (was 1 failing)
- [x] TypeScript typecheck passes
- [x] All 1585 frontend tests pass
- [ ] CI should now pass Backend Tests and Package Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)