### PR TITLE
Fix stale LLM socket connection state in reconnecting banner

### DIFF
--- a/frontend/src/features/ai-intelligence/pages/llm-assistant.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-assistant.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -33,10 +33,44 @@ vi.mock('@/features/ai-intelligence/hooks/use-mcp', () => ({
   useMcpServers: vi.fn().mockReturnValue({ data: undefined }),
 }));
 
-const mockLlmSocket = { connected: true, emit: vi.fn(), on: vi.fn(), off: vi.fn() };
-vi.mock('@/providers/socket-provider', () => ({
-  useSockets: () => ({ llmSocket: mockLlmSocket }),
-}));
+const llmSocketHandlers: Record<string, (...args: unknown[]) => void> = {};
+const mockLlmSocket = {
+  connected: true,
+  emit: vi.fn(),
+  on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    llmSocketHandlers[event] = handler;
+  }),
+  off: vi.fn((event: string) => {
+    delete llmSocketHandlers[event];
+  }),
+};
+vi.mock('@/providers/socket-provider', async () => {
+  const { useEffect, useState } = await import('react');
+  return {
+    useSockets: () => ({ llmSocket: mockLlmSocket }),
+    // Real implementation against the mocked socket so tests exercise the
+    // event subscription path that fixes the stale "Reconnecting" banner.
+    useSocketConnected: (socket: typeof mockLlmSocket | null) => {
+      const [connected, setConnected] = useState(socket?.connected ?? false);
+      useEffect(() => {
+        if (!socket) {
+          setConnected(false);
+          return;
+        }
+        setConnected(socket.connected);
+        const onConnect = () => setConnected(true);
+        const onDisconnect = () => setConnected(false);
+        socket.on('connect', onConnect);
+        socket.on('disconnect', onDisconnect);
+        return () => {
+          socket.off('connect', onConnect);
+          socket.off('disconnect', onDisconnect);
+        };
+      }, [socket]);
+      return connected;
+    },
+  };
+});
 
 vi.mock('@/features/ai-intelligence/hooks/use-llm-feedback', () => ({
   useSubmitFeedback: () => ({
@@ -639,6 +673,28 @@ describe('Connection status indicator', () => {
 
     // Restore for other tests
     mockLlmSocket.connected = true;
+  });
+
+  // Regression: previously the page read `llmSocket.connected` directly during
+  // render. socket.io mutates that flag asynchronously, so when the LLM socket
+  // connected after the first paint (e.g. after the monitoring socket already
+  // flipped the SocketProvider's aggregated `connected` state to true), the
+  // banner stayed stuck on "Reconnecting to AI service..." even though the
+  // socket was healthy and chat worked. The fix subscribes to the socket's
+  // own `connect` event so the page re-renders on the namespace's transition.
+  it('clears reconnecting banner when socket connects after initial render', async () => {
+    mockLlmSocket.connected = false;
+
+    renderPage();
+    expect(screen.getByText('Reconnecting to AI service...')).toBeTruthy();
+
+    // Simulate socket.io emitting the connect event on this namespace.
+    mockLlmSocket.connected = true;
+    await act(async () => {
+      llmSocketHandlers['connect']?.();
+    });
+
+    expect(screen.queryByText('Reconnecting to AI service...')).toBeNull();
   });
 
   describe('ContextBanner (Discuss with AI navigation)', () => {

--- a/frontend/src/features/ai-intelligence/pages/llm-assistant.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-assistant.tsx
@@ -9,7 +9,7 @@ import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/github-dark.css';
 import { useLlmChat, type ToolCallEvent } from '@/features/ai-intelligence/hooks/use-llm-chat';
-import { useSockets } from '@/providers/socket-provider';
+import { useSockets, useSocketConnected } from '@/providers/socket-provider';
 import { useLlmModels } from '@/features/ai-intelligence/hooks/use-llm-models';
 import { getModelUseCase } from '@/features/core/components/settings/model-use-cases';
 import { useMcpServers } from '@/features/ai-intelligence/hooks/use-mcp';
@@ -78,6 +78,7 @@ export default function LlmAssistantPage() {
   const inputRef = useRef<HTMLInputElement>(null);
   const { messages, isStreaming, currentResponse, activeToolCalls, statusMessage, sendMessage, cancelGeneration, clearHistory } = useLlmChat();
   const { llmSocket } = useSockets();
+  const isLlmConnected = useSocketConnected(llmSocket);
   const { data: modelsData } = useLlmModels();
   const { data: mcpServers } = useMcpServers();
   const { role } = useAuth();
@@ -360,7 +361,7 @@ export default function LlmAssistantPage() {
 
           {/* Input Area */}
           <div className="border-t bg-background/80 backdrop-blur-sm p-4">
-            {!llmSocket?.connected && (
+            {!isLlmConnected && (
               <div className="flex items-center gap-2 mb-2 rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
                 <WifiOff className="h-3.5 w-3.5 flex-shrink-0" />
                 <span>Reconnecting to AI service...</span>
@@ -373,12 +374,12 @@ export default function LlmAssistantPage() {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="Ask about your infrastructure..."
-                disabled={isStreaming || isSending || !llmSocket?.connected}
+                disabled={isStreaming || isSending || !isLlmConnected}
                 className="flex-1 rounded-xl border border-input bg-background px-4 py-3 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 transition-all"
               />
               <button
                 type="submit"
-                disabled={!input.trim() || isStreaming || isSending || !llmSocket?.connected}
+                disabled={!input.trim() || isStreaming || isSending || !isLlmConnected}
                 className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-blue-600 to-purple-600 px-6 py-3 text-sm font-medium text-white shadow-lg shadow-blue-500/25 transition-all hover:shadow-xl hover:shadow-blue-500/30 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
               >
                 <Send className="h-4 w-4" />

--- a/frontend/src/providers/socket-provider.tsx
+++ b/frontend/src/providers/socket-provider.tsx
@@ -79,3 +79,39 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
 export function useSockets() {
   return useContext(SocketContext);
 }
+
+/**
+ * Tracks the live connection state of a specific socket.
+ *
+ * Reading `socket.connected` directly during render is stale: socket.io
+ * mutates that flag asynchronously and React has no way to know. The
+ * SocketProvider's aggregated `connected` field only re-renders consumers
+ * when the OR-of-all-sockets actually flips, so a single namespace coming
+ * up after another is already connected produces no re-render and the
+ * stale `false` from the first paint persists.
+ */
+export function useSocketConnected(socket: Socket | null): boolean {
+  const [connected, setConnected] = useState(socket?.connected ?? false);
+
+  useEffect(() => {
+    if (!socket) {
+      setConnected(false);
+      return;
+    }
+
+    setConnected(socket.connected);
+
+    const onConnect = () => setConnected(true);
+    const onDisconnect = () => setConnected(false);
+
+    socket.on('connect', onConnect);
+    socket.on('disconnect', onDisconnect);
+
+    return () => {
+      socket.off('connect', onConnect);
+      socket.off('disconnect', onDisconnect);
+    };
+  }, [socket]);
+
+  return connected;
+}


### PR DESCRIPTION
## Summary
Fixes a bug where the "Reconnecting to AI service..." banner would remain visible even after the LLM socket successfully connected, because the component was reading `socket.connected` directly during render, which is stale due to socket.io's asynchronous state mutations.

## Key Changes
- **New hook `useSocketConnected()`** in `socket-provider.tsx`: Tracks live connection state of a specific socket by subscribing to its `connect` and `disconnect` events, ensuring React re-renders when the socket's actual connection state changes
- **Updated `llm-assistant.tsx`**: Replaced direct reads of `llmSocket?.connected` with the new `useSocketConnected()` hook for the connection status indicator and input field disabled state
- **Enhanced test coverage**: Added comprehensive mocking of socket event handlers and a regression test that verifies the banner clears when the socket connects after initial render

## Implementation Details
The root cause was that `SocketProvider`'s aggregated `connected` state only re-renders when the OR-of-all-sockets flips. When the LLM socket connects after another socket is already connected, the aggregated state doesn't change, so consumers reading `socket.connected` directly see stale data from the first paint.

The fix subscribes to the socket's own `connect` and `disconnect` events, allowing React to properly track and re-render on the specific namespace's state transitions. The test mocks these event handlers to simulate and verify this behavior.

https://claude.ai/code/session_01BfL2wgHdsodaGcZdNM7r1t