### PR TITLE
fix(ci): unblock Package Tests + vitest --coverage; ignore lucide-react majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     labels:
       - dependencies
       - javascript
+    ignore:
+      # lucide-react 1.x is a rewrite with renamed/removed icons; major bumps require
+      # manual migration across 75+ frontend files. Allow minor/patch only.
+      - dependency-name: "lucide-react"
+        update-types: ["version-update:semver-major"]
     groups:
       fastify:
         patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14848,6 +14848,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.3.tgz",
+      "integrity": "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -18705,20 +18719,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/core/node_modules/protobufjs": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.3.tgz",
-      "integrity": "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "packages/core/node_modules/typescript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
@@ -18851,6 +18851,7 @@
       "devDependencies": {
         "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.1.0",
+        "protobufjs": "^8.0.3",
         "typescript": "^6.0.2",
         "vitest": "^4.0.18"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,11 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@vitest/coverage-v8": "^4.1.0",
         "concurrently": "^9.1.0",
         "eslint": "^10.1.0",
-        "husky": "^9.1.7"
+        "husky": "^9.1.7",
+        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-"concurrently": "^9.1.0",
+    "@vitest/coverage-v8": "^4.1.0",
+    "concurrently": "^9.1.0",
     "eslint": "^10.1.0",
-    "husky": "^9.1.7"
+    "husky": "^9.1.7",
+    "vitest": "^4.1.0"
   },
   "dependencies": {
     "zod": "^4.3.6"

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.1.0",
+    "protobufjs": "^8.0.3",
     "typescript": "^6.0.2",
     "vitest": "^4.0.18"
   }


### PR DESCRIPTION
## Summary
Three follow-ups to #1153, addressing the three PRs you asked me to tackle (#1126, #1138, #1152):

1. **`chore(dependabot): ignore lucide-react major bumps`** — `lucide-react` 1.x is a rewrite with renamed/removed icons; major bumps require a deliberate migration across 75+ frontend files. Closed #1126 already; this stops Dependabot from reopening it weekly.
2. **`chore: hoist vitest and @vitest/coverage-v8 to root devDeps`** — Unblocks #1138 (testing group / vitest 4.1.0 → 4.1.5). Vitest 4.1.5 dynamically `import('@vitest/coverage-v8')` from `node_modules/vitest/...` and Node's ESM resolver only walks parent directories. Without coverage-v8 hoisted to root, every workspace's `npm test -- --coverage` blows up on CI. Adding both packages to root devDeps forces them to hoist together. Verified locally on both 4.1.0 and 4.1.5.
3. **`fix(observability): declare protobufjs as devDep`** — Unblocks #1152 → #1155 (npm_and_yarn group). Side-effect of #1153 that I missed: bumping `protobufjs` `^8.0.0 → ^8.0.3` changed npm's hoisting from root to `packages/core/node_modules/protobufjs/`. `packages/observability/src/__tests__/traces-ingest-route.test.ts` directly imports `protobufjs` and was relying on the root hoist. Declaring `protobufjs` as a devDep on observability fixes the resolution and removes the implicit cross-workspace coupling.

## Why this matters
After #1153 merged, every rebased PR was showing **Security Audit ✅** but **Package Tests ❌** because of the protobufjs hoist regression. This third commit clears that systemic Package Tests failure.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test -w @dashboard/observability` no longer fails with `Cannot find package 'protobufjs'`
- [x] `npm run test -w frontend -- --coverage` works on vitest 4.1.0 and 4.1.5
- [x] `npm run test -w backend -- --coverage` works on vitest 4.1.5
- [ ] CI Package Tests goes green on this PR
- [ ] CI on rebased Dependabot PRs (#1155, #1138 after recreate) goes green

## Already done outside this PR
- #1126 closed with explanation referencing this ignore rule.
- `@dependabot recreate` was already posted on the conflicted PRs (#1148, #1152 → #1155, #1138, #1125); they'll re-rebase against this fix once it lands.

https://claude.ai/code/session_014ZBP3ebncA3rZVd4kppKtA

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZBP3ebncA3rZVd4kppKtA)_