### PR TITLE
fix(ai): declare undici dependency in @dashboard/ai

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18654,6 +18654,7 @@
         "fastify-plugin": "^5.0.1",
         "fastify-type-provider-zod": "^6.1.0",
         "socket.io": "^4.8.1",
+        "undici": "^8.2.0",
         "uuid": "^14.0.0",
         "zod": "^4.3.6"
       },
@@ -18663,6 +18664,15 @@
         "@vitest/coverage-v8": "^4.1.5",
         "typescript": "^6.0.3",
         "vitest": "^4.0.18"
+      }
+    },
+    "packages/ai-intelligence/node_modules/undici": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.2.0.tgz",
+      "integrity": "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "packages/ai-intelligence/node_modules/uuid": {

--- a/packages/ai-intelligence/package.json
+++ b/packages/ai-intelligence/package.json
@@ -26,6 +26,7 @@
     "fastify-plugin": "^5.0.1",
     "fastify-type-provider-zod": "^6.1.0",
     "socket.io": "^4.8.1",
+    "undici": "^8.2.0",
     "uuid": "^14.0.0",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary

- `packages/ai-intelligence/src/services/llm-client.ts` imports `undici` directly, but `@dashboard/ai` never declared it as a dependency.
- Locally this worked via npm hoisting from sibling workspaces (backend, core, etc. all declare `undici ^8.2.0`).
- The backend Docker image runs `npm ci -w backend -w @dashboard/contracts ... -w @dashboard/ai ...` which only installs each workspace's *declared* deps. Without `undici` declared, `npm run build -w @dashboard/ai` fails with `Cannot find module 'undici'`.
- Pre-existing bug on `dev` — surfaced as a Docker Build failure on every PR (#1040, #1057, …).

## Fix

- Add `"undici": "^8.2.0"` to `packages/ai-intelligence/package.json` dependencies, matching the version pinned in other workspaces.

## Test plan

- [x] `npm install` from root succeeds.
- [x] `npx tsc -p tsconfig.build.json` in `packages/ai-intelligence` succeeds.
- [ ] Docker Build job goes green on this PR.

## Follow-up

- Rebase #1040 and #1057 once merged so their Docker Build jobs pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)