### PR TITLE
test(ai-intelligence): expand calculateHealthStats coverage

### DIFF
--- a/frontend/src/features/ai-intelligence/components/fleet-health-summary.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/fleet-health-summary.test.tsx
@@ -127,4 +127,205 @@ describe('calculateHealthStats', () => {
 
     expect(stats.total).toBe(3);
   });
+
+  // -------------------------------------------------------------------------
+  // #1025 regression — running containers without a healthcheck must be
+  // counted as `unknown`, never as `healthy`. The pre-fix code path had:
+  //   else if (container.state === 'running') stats.healthy++;
+  // which inflated the healthy count and overall health percentage.
+  // These tests pin the corrected behaviour.
+  // -------------------------------------------------------------------------
+
+  it('regression #1025: a running container with no healthStatus must NOT be counted as healthy', () => {
+    const containers = [
+      makeContainer({ state: 'running', healthStatus: undefined }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+
+    // The bug: running + no healthcheck used to increment stats.healthy.
+    // The fix: it must increment stats.unknown instead.
+    expect(stats.healthy).toBe(0);
+    expect(stats.unknown).toBe(1);
+    expect(stats.running).toBe(1);
+  });
+
+  it('regression #1025: running containers with non-healthy/non-unhealthy healthStatus values fall through to unknown, not healthy', () => {
+    // Docker can report intermediate values like "starting" or "none" that
+    // are neither "healthy" nor "unhealthy". The fix must not treat these
+    // as healthy via the `state === 'running'` fallback.
+    const containers = [
+      makeContainer({ id: 'a', state: 'running', healthStatus: 'starting' }),
+      makeContainer({ id: 'b', state: 'running', healthStatus: 'none' }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+
+    expect(stats.healthy).toBe(0);
+    expect(stats.unhealthy).toBe(0);
+    expect(stats.unknown).toBe(2);
+    expect(stats.running).toBe(2);
+  });
+
+  it('regression #1025: a fleet of only running-no-healthcheck containers must report 0% healthy', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: undefined }),
+      makeContainer({ id: '2', state: 'running', healthStatus: undefined }),
+      makeContainer({ id: '3', state: 'running', healthStatus: undefined }),
+      makeContainer({ id: '4', state: 'running', healthStatus: undefined }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+    const healthPercentage = stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0;
+
+    // Pre-fix: this returned 100% (all running counted as healthy).
+    // Post-fix: must be 0% — none have an explicit healthy status.
+    expect(stats.healthy).toBe(0);
+    expect(stats.unknown).toBe(4);
+    expect(healthPercentage).toBe(0);
+  });
+
+  it('regression #1025: running, paused, and exited containers without healthStatus all flow to unknown (not healthy)', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: undefined }),
+      makeContainer({ id: '2', state: 'paused', healthStatus: undefined }),
+      makeContainer({ id: '3', state: 'exited', healthStatus: undefined }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+
+    expect(stats.healthy).toBe(0);
+    expect(stats.unhealthy).toBe(0);
+    expect(stats.unknown).toBe(3);
+    expect(stats.running).toBe(1);
+    expect(stats.paused).toBe(1);
+    expect(stats.stopped).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Percentage calculation — acceptance criterion: verify percentage math
+  // for a mixed fleet. The component computes:
+  //   healthPercentage = stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0
+  // Tests pin the expected health percentage so that future refactors of
+  // either the stats logic or the percentage formula stay in sync.
+  // -------------------------------------------------------------------------
+
+  it('mixed fleet: derives a 50% health percentage from 2 healthy out of 4 total', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
+      makeContainer({ id: '2', state: 'running', healthStatus: 'healthy' }),
+      makeContainer({ id: '3', state: 'running', healthStatus: 'unhealthy' }),
+      makeContainer({ id: '4', state: 'exited', healthStatus: undefined }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+    const healthPercentage = stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0;
+
+    expect(stats.total).toBe(4);
+    expect(stats.healthy).toBe(2);
+    expect(healthPercentage).toBe(50);
+  });
+
+  it('mixed fleet: derives ~33.3% health percentage from 1 healthy out of 3 total', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
+      makeContainer({ id: '2', state: 'running', healthStatus: 'unhealthy' }),
+      makeContainer({ id: '3', state: 'running', healthStatus: undefined }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+    const healthPercentage = stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0;
+
+    expect(stats.healthy).toBe(1);
+    expect(stats.unhealthy).toBe(1);
+    expect(stats.unknown).toBe(1);
+    expect(healthPercentage).toBeCloseTo(33.333, 2);
+  });
+
+  it('empty fleet: percentage formula evaluates to 0 (no division-by-zero)', () => {
+    const stats = calculateHealthStats([]);
+    const healthPercentage = stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0;
+
+    expect(stats.total).toBe(0);
+    expect(healthPercentage).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Branch precedence and edge cases — healthStatus takes priority over the
+  // state-based fallback when explicitly set, and the function should be
+  // pure (no input mutation, deterministic across calls).
+  // -------------------------------------------------------------------------
+
+  it('healthStatus takes precedence over state: an exited container with healthStatus="healthy" still counts as healthy', () => {
+    // Defensive branch: if a non-running container somehow carries an
+    // explicit healthy/unhealthy status (e.g. last-known status surfaced by
+    // the API), the explicit value wins over the state-based fallback.
+    const containers = [
+      makeContainer({ state: 'exited', healthStatus: 'healthy' }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+
+    expect(stats.healthy).toBe(1);
+    expect(stats.stopped).toBe(1);
+    expect(stats.unknown).toBe(0);
+  });
+
+  it('healthStatus takes precedence over state: an exited container with healthStatus="unhealthy" counts as unhealthy', () => {
+    const containers = [
+      makeContainer({ state: 'exited', healthStatus: 'unhealthy' }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+
+    expect(stats.unhealthy).toBe(1);
+    expect(stats.stopped).toBe(1);
+    expect(stats.unknown).toBe(0);
+  });
+
+  it('unrecognised state values flow through to unknown without affecting other counters', () => {
+    // Docker exposes additional states (created, restarting, removing, dead).
+    // None of these match running/exited/paused; with no healthStatus they
+    // should still be counted as unknown via the final `else` branch.
+    const containers = [
+      makeContainer({ id: '1', state: 'created', healthStatus: undefined }),
+      makeContainer({ id: '2', state: 'restarting', healthStatus: undefined }),
+      makeContainer({ id: '3', state: 'dead', healthStatus: undefined }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+
+    expect(stats.total).toBe(3);
+    expect(stats.running).toBe(0);
+    expect(stats.stopped).toBe(0);
+    expect(stats.paused).toBe(0);
+    expect(stats.healthy).toBe(0);
+    expect(stats.unhealthy).toBe(0);
+    expect(stats.unknown).toBe(3);
+  });
+
+  it('does not mutate the input containers array', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
+      makeContainer({ id: '2', state: 'running', healthStatus: undefined }),
+    ];
+    const snapshot = JSON.parse(JSON.stringify(containers));
+
+    calculateHealthStats(containers);
+
+    expect(containers).toEqual(snapshot);
+  });
+
+  it('is deterministic: repeated calls with the same input return equivalent stats', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
+      makeContainer({ id: '2', state: 'exited', healthStatus: undefined }),
+      makeContainer({ id: '3', state: 'running', healthStatus: 'unhealthy' }),
+    ];
+
+    const first = calculateHealthStats(containers);
+    const second = calculateHealthStats(containers);
+
+    expect(first).toEqual(second);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #1047.

Appends 12 new unit tests to the existing `fleet-health-summary.test.tsx` so every branch of `calculateHealthStats()` listed in the acceptance criteria is exercised — with particular emphasis on the #1025 double-count regression.

### File-path correction

The issue body (split from #1022) lists the target as `containers/pages/container-health.tsx`. That file does not exist. The actual `calculateHealthStats()` helper and its component live at:

`frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx`

(verified by the critic recheck — `container-health.tsx` was renamed/relocated when fleet-health-summary was introduced under `ai-intelligence/components/`). This PR targets the real file. No source-file edits were required: `calculateHealthStats` is already exported from `fleet-health-summary.tsx`.

### Test cases added

Inside the existing top-level `describe('calculateHealthStats')` block (no new file, no new test infra):

**#1025 regression (4 tests)** — pin the corrected branch where running containers without an explicit healthcheck are counted as `unknown`, never `healthy`:
- `regression #1025: a running container with no healthStatus must NOT be counted as healthy`
- `regression #1025: running containers with non-healthy/non-unhealthy healthStatus values fall through to unknown, not healthy` (covers `'starting'` and `'none'`)
- `regression #1025: a fleet of only running-no-healthcheck containers must report 0% healthy` (pre-fix: 100%)
- `regression #1025: running, paused, and exited containers without healthStatus all flow to unknown (not healthy)`

**Percentage calculation (3 tests)** — explicit acceptance criterion #5:
- `mixed fleet: derives a 50% health percentage from 2 healthy out of 4 total`
- `mixed fleet: derives ~33.3% health percentage from 1 healthy out of 3 total`
- `empty fleet: percentage formula evaluates to 0 (no division-by-zero)`

**Branch precedence + edge cases (5 tests)**:
- `healthStatus takes precedence over state: an exited container with healthStatus="healthy" still counts as healthy`
- `healthStatus takes precedence over state: an exited container with healthStatus="unhealthy" counts as unhealthy`
- `unrecognised state values flow through to unknown without affecting other counters` (`created`, `restarting`, `dead`)
- `does not mutate the input containers array`
- `is deterministic: repeated calls with the same input return equivalent stats`

The existing 8 tests already covered the happy paths from the issue's acceptance criteria (healthy / unhealthy / running-no-healthcheck / stopped / mixed-fleet totals / empty array). The new tests deepen the #1025 coverage, add explicit percentage-math assertions, and lock down precedence + purity.

Per CLAUDE.md "Never mock pure utility functions" — `calculateHealthStats` is called directly with fixture data; no mocks introduced.

## Test plan

- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npx vitest run src/features/ai-intelligence/components/fleet-health-summary.test.tsx` — 20/20 pass (8 existing + 12 new)
- [x] `cd frontend && npx vitest run` — full suite 1623/1623 pass, no regressions
- [ ] CI green on this branch