### PR TITLE
test(containers): expand workload-explorer chip and stale-closure coverage

### DIFF
--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -540,4 +540,141 @@ describe('WorkloadExplorerPage', () => {
       state: 'running',
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #1046 — Filter chip render + removal coverage
+  // (locks in regressions for #1031 stale-closure and #1035 state-chip)
+  // -------------------------------------------------------------------------
+
+  it('renders all four filter chips (endpoint, stack, group, state) simultaneously when active (#1046)', () => {
+    mockQueryString = 'endpoint=1&stack=workers&group=workload&state=running';
+    render(<WorkloadExplorerPage />);
+
+    // All four chip labels must render
+    expect(screen.getByText('Endpoint:')).toBeInTheDocument();
+    expect(screen.getByText('Stack:')).toBeInTheDocument();
+    expect(screen.getByText('Group:')).toBeInTheDocument();
+    expect(screen.getByText('State:')).toBeInTheDocument();
+
+    // Each chip should have a corresponding "Remove ... filter" dismiss button
+    expect(
+      screen.getByRole('button', { name: 'Remove Endpoint filter' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remove Stack filter' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remove Group filter' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remove State filter' })
+    ).toBeInTheDocument();
+
+    // With 4 active filters, "Clear all" is also present
+    expect(screen.getByText('Clear all')).toBeInTheDocument();
+  });
+
+  it('renders state filter chip with capitalized value matching #1035 implementation', () => {
+    // #1035 added the state chip; before the fix, the chip never rendered.
+    // The chip value should be the capitalized state name (e.g. "Running").
+    mockQueryString = 'endpoint=1&state=paused';
+    render(<WorkloadExplorerPage />);
+
+    expect(screen.getByText('State:')).toBeInTheDocument();
+    // Capitalized value (state.charAt(0).toUpperCase() + state.slice(1))
+    expect(screen.getByText('Paused')).toBeInTheDocument();
+    // Removable via dismiss button (regression for the #1035 bug —
+    // before the fix, the chip wasn't rendered at all so couldn't be removed)
+    expect(
+      screen.getByRole('button', { name: 'Remove State filter' })
+    ).toBeInTheDocument();
+  });
+
+  it('removes endpoint filter from URL params when endpoint chip dismiss is clicked', () => {
+    mockQueryString = 'endpoint=1&stack=workers&group=workload&state=running';
+    render(<WorkloadExplorerPage />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Endpoint filter' })
+    );
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+    const params = mockSetSearchParams.mock.calls[0][0];
+    // endpoint is dropped, all other active filters remain
+    expect(params).toEqual({
+      stack: 'workers',
+      group: 'workload',
+      state: 'running',
+    });
+    expect(params).not.toHaveProperty('endpoint');
+  });
+
+  it('removes group filter from URL params when group chip dismiss is clicked', () => {
+    mockQueryString = 'endpoint=1&stack=workers&group=workload&state=running';
+    render(<WorkloadExplorerPage />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Group filter' })
+    );
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+    const params = mockSetSearchParams.mock.calls[0][0];
+    // group is dropped, all other active filters remain
+    expect(params).toEqual({
+      endpoint: '1',
+      stack: 'workers',
+      state: 'running',
+    });
+    expect(params).not.toHaveProperty('group');
+  });
+
+  it('preserves state filter when clicking a stack column cell with only endpoint+state active (#1031 + #1035)', () => {
+    // Tighter regression: #1035 added state to the URL params, and #1031 fixed
+    // the stale closure in the stack column's onClick handler. This test asserts
+    // that even when only endpoint+state are active (no group), clicking a stack
+    // cell preserves the state param — the case that #1035 introduced and #1031
+    // had to learn about.
+    mockQueryString = 'endpoint=1&state=running';
+    render(<WorkloadExplorerPage />);
+
+    const stackColumn = mockColumns?.find(
+      (col: { id?: string }) => col.id === 'stack'
+    );
+    expect(stackColumn).toBeDefined();
+
+    const workerContainer = {
+      id: 'c-workers',
+      name: 'workers-api-1',
+      image: 'workers:latest',
+      state: 'running',
+      status: 'Up',
+      endpointId: 1,
+      endpointName: 'local',
+      ports: [],
+      created: 1700000000,
+      labels: { 'com.docker.compose.project': 'workers' },
+      networks: [],
+    };
+
+    const cellResult = stackColumn.cell({
+      row: { original: workerContainer },
+      getValue: () => undefined,
+    });
+
+    const { container } = render(cellResult);
+    const stackButton = container.querySelector('button');
+    expect(stackButton).not.toBeNull();
+    fireEvent.click(stackButton!);
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+    const params = mockSetSearchParams.mock.calls[0][0];
+    // Both endpoint and state must be preserved — pre-#1031 the closure
+    // dropped them; pre-#1035 the state chip wouldn't have been visible
+    // even if the state param were preserved.
+    expect(params).toEqual({
+      endpoint: '1',
+      stack: 'workers',
+      state: 'running',
+    });
+  });
 });


### PR DESCRIPTION
Closes #1046

## Summary

Adds 5 regression tests to `frontend/src/features/containers/pages/workload-explorer.test.tsx` covering the four acceptance criteria from #1046:

1. **Filter chip rendering (all 4 types)** — locks in that endpoint, stack, group, and state chips render together when their URL params are active, and that each has a `Remove <label> filter` dismiss button.
2. **State filter chip (#1035)** — verifies the chip added by #1035 renders the capitalized state value (e.g. `Running`, `Paused`) and is removable. Before #1035 the chip wasn't rendered at all.
3. **Stale-closure regression (#1031)** — adds a tighter case to the existing `#1031` test: clicking a stack column cell when only `endpoint` + `state` are active still preserves both. This pins the interaction between #1031 (closure fix) and #1035 (the state param it has to know about).
4. **Filter chip removal** — adds dismiss tests for the endpoint and group chips (stack and state were already covered). Each asserts the URL params are updated correctly with only the relevant filter dropped.

## New test cases

- `renders all four filter chips (endpoint, stack, group, state) simultaneously when active (#1046)`
- `renders state filter chip with capitalized value matching #1035 implementation`
- `removes endpoint filter from URL params when endpoint chip dismiss is clicked`
- `removes group filter from URL params when group chip dismiss is clicked`
- `preserves state filter when clicking a stack column cell with only endpoint+state active (#1031 + #1035)`

Total file count: 25 → 30 tests.

## Source modifications

**None.** The component already exposes the necessary `aria-label="Remove ${filter.label} filter"` and `data-testid` attributes for assertion. Test-only change.

## Originating bugs locked in

- #1031 — `WorkloadExplorer` stack column cell used a stale closure; clicking the stack chip after changing other filters dropped them. Fix used `setSelectedStack` which composes from current state via `setFilters`.
- #1035 — `WorkloadExplorer` state filter chip never rendered. Fix added the `state` entry to the `activeFilters` memo with a dedicated `onRemove` that uses `navigate({ search })` (rather than `setSearchParams`) — both behaviours are now under test.

## Test plan

- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npx vitest run src/features/containers/pages/workload-explorer.test.tsx` — 30/30 passed
- [x] `cd frontend && npx vitest run` — 1616/1616 passed (169 files), no regressions