### PR TITLE
refactor: replace request.user! assertions with typed assertUser helper

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -2661,6 +2661,88 @@ describe('HSTS preload + CORS_ALLOWED_ORIGINS (#1108, #1115)', () => {
   });
 });
 
+// =====================================================================
+//  17. USERS ROUTE — assertUser DEFENSIVE FAIL-LOUD (issue #1110)
+// =====================================================================
+//
+// `users.ts` replaced `request.user!` non-null assertions with the typed
+// `assertUser` helper. Under correct configuration the helper is a no-op
+// — preHandler `[fastify.authenticate, fastify.requireRole('admin')]`
+// guarantees `request.user` is populated before the handler body runs.
+//
+// These tests verify the defensive branch: if the `authenticate`
+// preHandler is removed/misconfigured and never sets `request.user`, the
+// helper must throw (producing a 5xx) rather than silently letting the
+// audit log write `undefined` for `user_id` / `username`. This is the
+// "loud failure beats silent admin auth bypass" guarantee.
+//
+// We do NOT test "handler returns 401 when request.user is missing under
+// normal operation" — that scenario is unreachable in production and a
+// test asserting it would be misleading. The legitimate test is the
+// fail-loud-on-misconfiguration test below.
+// =====================================================================
+describe('Users route — assertUser defensive fail-loud (issue #1110)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    // Intentionally misconfigured: `authenticate` does NOT set `request.user`.
+    // This simulates a future refactor that accidentally removes the real
+    // preHandler chain. `assertUser` must catch this and throw rather than
+    // letting the handler audit-log `undefined`.
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', () => async () => undefined);
+    app.decorateRequest('user', undefined);
+
+    await app.register(userRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /api/users fails loudly (5xx) when authenticate preHandler does not set request.user', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      payload: { username: 'newuser', password: 'password123', role: 'viewer' },
+      headers: { 'content-type': 'application/json' },
+    });
+
+    // Helper threw → Fastify converts to 500. Anything in the 5xx range
+    // proves the defensive branch fired (vs. a silent 200/201 with a
+    // `user_id: undefined` audit log entry, which would be the bug).
+    expect(res.statusCode).toBeGreaterThanOrEqual(500);
+    expect(res.statusCode).toBeLessThan(600);
+  });
+
+  it('PATCH /api/users/:id fails loudly (5xx) when authenticate preHandler does not set request.user', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/users/some-id',
+      payload: { username: 'renamed' },
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(res.statusCode).toBeGreaterThanOrEqual(500);
+    expect(res.statusCode).toBeLessThan(600);
+  });
+
+  it('DELETE /api/users/:id fails loudly (5xx) when authenticate preHandler does not set request.user', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/users/some-id',
+    });
+
+    expect(res.statusCode).toBeGreaterThanOrEqual(500);
+    expect(res.statusCode).toBeLessThan(600);
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Issue #1106 — JWT_TOKEN_EXPIRY_MINUTES env-var boundary regression.
 // Confirms the schema rejects out-of-bound values at boot, and that the in-test

--- a/packages/core/src/utils/auth-helpers.test.ts
+++ b/packages/core/src/utils/auth-helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import type { FastifyRequest } from 'fastify';
+import { assertUser } from './auth-helpers.js';
+
+describe('assertUser', () => {
+  it('returns request.user when present', () => {
+    const user = { sub: 'u1', username: 'alice', sessionId: 's1', role: 'admin' as const };
+    const request = { user } as unknown as FastifyRequest;
+
+    expect(assertUser(request)).toBe(user);
+  });
+
+  it('throws a loud error when request.user is undefined', () => {
+    const request = { user: undefined } as unknown as FastifyRequest;
+
+    expect(() => assertUser(request)).toThrow(
+      /assertUser called without authenticate preHandler/,
+    );
+  });
+
+  it('throws when request.user is missing entirely', () => {
+    // Simulate a request that has never been touched by an `authenticate`
+    // preHandler — the property may be absent rather than explicitly
+    // undefined.
+    const request = {} as unknown as FastifyRequest;
+
+    expect(() => assertUser(request)).toThrow(
+      /assertUser called without authenticate preHandler/,
+    );
+  });
+});

--- a/packages/core/src/utils/auth-helpers.ts
+++ b/packages/core/src/utils/auth-helpers.ts
@@ -1,0 +1,52 @@
+/**
+ * Auth helpers — typed accessors for `request.user`.
+ *
+ * The `FastifyRequest['user']` type is declared as optional (see
+ * `packages/core/src/plugins/auth.ts`) because not every request carries an
+ * authenticated user. Routes guarded by the `authenticate` preHandler are
+ * guaranteed to have `request.user` populated at runtime, but TypeScript has
+ * no way to express that a preHandler has already run by the time the
+ * handler body executes — so handlers historically used the non-null
+ * assertion (`request.user!.sub`) to satisfy the compiler.
+ *
+ * That assertion is brittle: if a future refactor removes or reorders the
+ * preHandler chain, the `!` silently masks the bug and the handler will
+ * crash on `undefined.sub` or, worse, write `undefined` to an audit log.
+ *
+ * `assertUser` replaces the assertion with a defensive runtime check that
+ * throws a loud error if the preHandler chain is misconfigured. The throw
+ * is unreachable under correct configuration; its purpose is to fail
+ * loudly during development rather than silently bypass admin auth.
+ *
+ * See issue #1110.
+ */
+
+import type { FastifyRequest } from 'fastify';
+
+/**
+ * The user shape attached to authenticated requests. Mirrors the
+ * augmentation in `packages/core/src/plugins/auth.ts`.
+ */
+export type AuthenticatedUser = NonNullable<FastifyRequest['user']>;
+
+/**
+ * Narrow `request.user` from `T | undefined` to `T`.
+ *
+ * Throws if called on a request that has not been through the
+ * `fastify.authenticate` preHandler. Under correct configuration this
+ * branch is unreachable; the throw exists so that future refactors that
+ * accidentally remove the preHandler fail loudly rather than silently
+ * bypassing admin authentication.
+ *
+ * @param request - the Fastify request to read `user` from.
+ * @returns the authenticated user, narrowed to non-null.
+ * @throws Error if `request.user` is undefined.
+ */
+export function assertUser(request: FastifyRequest): AuthenticatedUser {
+  if (!request.user) {
+    // Defensive: only reachable if the `authenticate` preHandler is missing
+    // or misconfigured. Loud failure beats silent admin auth bypass.
+    throw new Error('assertUser called without authenticate preHandler');
+  }
+  return request.user;
+}

--- a/packages/foundation/src/routes/users.ts
+++ b/packages/foundation/src/routes/users.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { listUsers, createUser, updateUser, deleteUser, type Role } from '@dashboard/core/services/user-store.js';
 import { writeAuditLog } from '@dashboard/core/services/audit-logger.js';
 import { UserCreateBodySchema, UserIdParamsSchema, UserUpdateBodySchema } from '@dashboard/core/models/api-schemas.js';
+import { assertUser } from '@dashboard/core/utils/auth-helpers.js';
 
 export async function userRoutes(fastify: FastifyInstance) {
   // List all users (admin only)
@@ -26,13 +27,14 @@ export async function userRoutes(fastify: FastifyInstance) {
     },
     preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
+    const actor = assertUser(request);
     const { username, password, role } = request.body as { username: string; password: string; role: Role };
 
     try {
       const user = await createUser(username, password, role);
       writeAuditLog({
-        user_id: request.user!.sub,
-        username: request.user!.username,
+        user_id: actor.sub,
+        username: actor.username,
         action: 'user.create',
         target_type: 'user',
         target_id: user.id,
@@ -61,6 +63,7 @@ export async function userRoutes(fastify: FastifyInstance) {
     },
     preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
+    const actor = assertUser(request);
     const { id } = request.params as { id: string };
     const body = request.body as { username?: string; password?: string; role?: Role };
 
@@ -77,8 +80,8 @@ export async function userRoutes(fastify: FastifyInstance) {
     if (!user) return reply.status(404).send({ error: 'User not found' });
 
     writeAuditLog({
-      user_id: request.user!.sub,
-      username: request.user!.username,
+      user_id: actor.sub,
+      username: actor.username,
       action: 'user.update',
       target_type: 'user',
       target_id: id,
@@ -100,9 +103,10 @@ export async function userRoutes(fastify: FastifyInstance) {
     },
     preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {
+    const actor = assertUser(request);
     const { id } = request.params as { id: string };
 
-    if (request.user!.sub === id) {
+    if (actor.sub === id) {
       return reply.status(400).send({ error: 'Cannot delete your own account' });
     }
 
@@ -110,8 +114,8 @@ export async function userRoutes(fastify: FastifyInstance) {
     if (!deleted) return reply.status(404).send({ error: 'User not found' });
 
     writeAuditLog({
-      user_id: request.user!.sub,
-      username: request.user!.username,
+      user_id: actor.sub,
+      username: actor.username,
       action: 'user.delete',
       target_type: 'user',
       target_id: id,


### PR DESCRIPTION
Closes #1110

## Summary

Replaces 7 `request.user!` non-null assertions in `packages/foundation/src/routes/users.ts` (POST/PATCH/DELETE handlers) with a typed `assertUser` helper that narrows `FastifyRequest['user']` from `T | undefined` to `T`.

## Deviation from issue text

The issue body proposes runtime `if (!user) return reply.code(401)` guards inside each handler. **Per the planning critic ([CRITIC-FINDINGS.md §C4](https://github.com/kenhaesler/ai-portainer-dashboard/blob/dev/docs/issue-plans/CRITIC-FINDINGS.md)), those runtime guards are dead code** — every handler in `users.ts` already has `preHandler: [fastify.authenticate, fastify.requireRole('admin')]`, which guarantees `request.user` is populated before the handler body executes. The `if (!user) return 401` branch can never fire in production, and a test that asserts that branch under "normal operation" would be testing an unreachable code path.

This PR ships a **type-only refactor** with a defensive helper instead:

- New `assertUser` helper in `packages/core/src/utils/auth-helpers.ts` narrows `request.user` to non-null and **throws a loud error** if called on a request that has not been through `fastify.authenticate`.
- The throw is unreachable under correct configuration. Its purpose is to ensure that future preHandler removal becomes a **loud failure** rather than a silent admin auth bypass that audit-logs `undefined` for `user_id`/`username`.

## Changes

- `packages/core/src/utils/auth-helpers.ts` (new, ~50 LOC) — `assertUser(request)` helper + `AuthenticatedUser` type.
- `packages/foundation/src/routes/users.ts` — 7 sites: replace `request.user!.sub`/`request.user!.username` with `actor.sub`/`actor.username`, where `const actor = assertUser(request)` is called once at the top of each of the 3 handlers.
- `packages/core/src/utils/auth-helpers.test.ts` (new) — 3 unit tests for `assertUser`.
- `backend/src/routes/security-regression.test.ts` — 3 integration tests under a new "Users route — assertUser defensive fail-loud" describe block. They register `userRoutes` with an `authenticate` decorator that does **not** set `request.user`, then assert POST/PATCH/DELETE return 5xx — proving the helper throws loudly instead of letting the audit log write `undefined`.

## Why a helper instead of a local alias?

The Fastify type augmentation in `packages/core/src/plugins/auth.ts` declares `user?: { sub; username; sessionId; role }` — explicitly **optional**. There is no Fastify-native type narrowing available at the handler level. A helper centralises the unreachable-branch defense and the "loud failure" message, and makes future routes that need the same pattern trivial to update without re-deriving the type.

## Tests

- 3 unit tests in `packages/core/src/utils/auth-helpers.test.ts`: returns user when present, throws when `user` is `undefined`, throws when `user` is missing entirely.
- 3 integration tests in `backend/src/routes/security-regression.test.ts`: POST/PATCH/DELETE on `userRoutes` return 5xx when `authenticate` preHandler is misconfigured.

We deliberately do **not** test "handler returns 401 when `request.user` is missing under normal operation" — that scenario cannot occur in production and the test would be misleading. The fail-loud-on-misconfiguration test is the legitimate guarantee.

## Verification

```bash
npm run lint          # passes
npm run typecheck     # zero TS2532 errors after removing 7× `!`
npx vitest run -w packages/core src/utils/auth-helpers.test.ts        # 3 passed
npx vitest run -w backend src/routes/security-regression.test.ts      # 89 passed (was 86; +3 new)
npm test -w packages/foundation                                       # 6 passed
npm test -w backend                                                   # 296 passed
```

Pre-push hook ran the full test matrix (1611 tests) and passed.

## Rebase note

`backend/src/routes/security-regression.test.ts` is also touched by Lane 1 PR (#1109+#1120 on `feature/1109-1120-verifyjwt-hardening`, currently in flight). When that PR lands first, this branch will need a rebase against `dev`. The new describe block is appended at the end of the file (after the existing rank-16 block) so the conflict surface should be minimal.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test -w backend` — 296/296 pass
- [x] `npm test -w packages/foundation` — 6/6 pass
- [x] `npx vitest run packages/core/src/utils/` — 114/114 pass
- [x] Pre-push hook full test matrix — 1611/1611 pass
- [ ] CI green on PR
- [ ] Rebase against `dev` after #1109/#1120 merges (security-regression.test.ts conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)