### PR TITLE
test(containers): expand image-footprint treemap a11y and interaction coverage

### DIFF
--- a/frontend/src/features/containers/pages/__tests__/image-footprint-a11y.test.tsx
+++ b/frontend/src/features/containers/pages/__tests__/image-footprint-a11y.test.tsx
@@ -2,7 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
+import { axe } from 'vitest-axe';
+import * as axeMatchers from 'vitest-axe/matchers';
 import ImageFootprintPage from '../image-footprint';
+
+// Register vitest-axe matchers (toHaveNoViolations) in this test file.
+// Mirrors the pattern used by frontend/src/test/a11y-pages.test.tsx — the
+// shipped vitest-axe/extend-expect entry is empty in this version, and the
+// linter strips bare expect.extend() from vitest.setup.ts.
+expect.extend(axeMatchers);
 
 // Recharts ResponsiveContainer needs layout measurements unavailable in jsdom.
 vi.mock('recharts', async (importOriginal) => {
@@ -154,5 +162,208 @@ describe('ImageFootprintPage accessibility', () => {
     const dialog = screen.getByRole('dialog');
     expect(dialog).toBeInTheDocument();
     expect(dialog.getAttribute('aria-label')).toMatch(/nginx/i);
+  });
+
+  // ---------------------------------------------------------------------
+  // Page-level wiring tests for the treemap.
+  //
+  // recharts' Treemap reports 0×0 in jsdom (no layout engine) and therefore
+  // never paints its <CustomContent> cells. The cell-level ARIA contract
+  // (role="button", aria-label "<name>, <bytes>", tabIndex=0, Enter/Space
+  // activation, focus ring) is exhaustively covered by the dedicated
+  // component test at src/shared/components/charts/image-treemap.test.tsx.
+  //
+  // To exercise the *page-level* wiring (ImageFootprint -> ImageTreemap
+  // onCellClick -> setSelectedImage -> detail panel) we substitute
+  // ImageTreemap with a faithful but jsdom-friendly stand-in that exposes
+  // one focusable button per data row carrying the same ARIA contract the
+  // real component renders. This lets us assert the page propagates clicks
+  // and keyboard activation through to the detail panel, without depending
+  // on recharts' SVG layout behaviour.
+  // ---------------------------------------------------------------------
+  describe('treemap wiring (with fake treemap)', () => {
+    beforeEach(() => {
+      vi.resetModules();
+      mockUseImages.mockReturnValue({
+        data: sampleImages,
+        isLoading: false,
+        isPending: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+        isFetching: false,
+      } as any);
+    });
+
+    async function renderWithFakeTreemap() {
+      vi.doMock('@/shared/components/charts/image-treemap', () => ({
+        ImageTreemap: ({
+          data,
+          onCellClick,
+        }: {
+          data: { name: string; size: number }[];
+          onCellClick?: (name: string) => void;
+        }) => (
+          <div role="group" aria-label="Image size treemap">
+            {data.map((d) => (
+              <button
+                key={d.name}
+                type="button"
+                role="button"
+                tabIndex={0}
+                aria-label={`${d.name}, ${d.size} bytes`}
+                onClick={() => onCellClick?.(d.name)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onCellClick?.(d.name);
+                  }
+                }}
+                data-testid={`treemap-cell-${d.name}`}
+              >
+                {d.name}
+              </button>
+            ))}
+          </div>
+        ),
+      }));
+
+      // Re-import the page so it picks up the fake treemap.
+      const Page = (await import('../image-footprint')).default;
+      return renderWithProviders(<Page />);
+    }
+
+    it('renders one focusable treemap cell per non-empty image, each with role=button, aria-label, and tabIndex=0', async () => {
+      await renderWithFakeTreemap();
+
+      const group = screen.getByRole('group', { name: 'Image size treemap' });
+      const nginxCell = screen.getByTestId('treemap-cell-nginx');
+      const redisCell = screen.getByTestId('treemap-cell-redis');
+
+      expect(group).toContainElement(nginxCell);
+      expect(group).toContainElement(redisCell);
+
+      for (const cell of [nginxCell, redisCell]) {
+        expect(cell).toHaveAttribute('role', 'button');
+        expect(cell).toHaveAttribute('tabindex', '0');
+        const label = cell.getAttribute('aria-label') ?? '';
+        // <name>, <size> contract — same shape ImageTreemap produces.
+        expect(label).toMatch(/^(nginx|redis), \d+ bytes$/);
+      }
+    });
+
+    it('opens the detail panel when a treemap cell is clicked', async () => {
+      await renderWithFakeTreemap();
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('treemap-cell-nginx'));
+      });
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(dialog.getAttribute('aria-label')).toMatch(/nginx/i);
+    });
+
+    it('opens the detail panel when Enter is pressed on a focused treemap cell', async () => {
+      await renderWithFakeTreemap();
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      const cell = screen.getByTestId('treemap-cell-nginx');
+      await act(async () => {
+        cell.focus();
+        fireEvent.keyDown(cell, { key: 'Enter' });
+      });
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(dialog.getAttribute('aria-label')).toMatch(/nginx/i);
+    });
+
+    it('opens the detail panel when Space is pressed on a focused treemap cell', async () => {
+      await renderWithFakeTreemap();
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      const cell = screen.getByTestId('treemap-cell-redis');
+      await act(async () => {
+        cell.focus();
+        fireEvent.keyDown(cell, { key: ' ' });
+      });
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(dialog.getAttribute('aria-label')).toMatch(/redis/i);
+    });
+
+    it('does not open the detail panel for unrelated keys (Tab, Escape)', async () => {
+      await renderWithFakeTreemap();
+
+      const cell = screen.getByTestId('treemap-cell-nginx');
+      await act(async () => {
+        cell.focus();
+        fireEvent.keyDown(cell, { key: 'Tab' });
+        fireEvent.keyDown(cell, { key: 'Escape' });
+      });
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('axe audit', () => {
+    it('has no WCAG 2.1 AA violations when images are loaded', async () => {
+      mockUseImages.mockReturnValue({
+        data: sampleImages,
+        isLoading: false,
+        isPending: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+        isFetching: false,
+      } as any);
+
+      const { container } = renderWithProviders(<ImageFootprintPage />);
+
+      // Excluded rules:
+      //   - color-contrast: jsdom has no layout/CSS engine; contrast cannot
+      //     be evaluated. Covered by Playwright visual checks (Issue #435).
+      //   - button-name: ThemedSelect (Radix combobox) trigger is a known
+      //     pre-existing violation tracked in a11y-pages.test.tsx.
+      //   - heading-order: page jumps h1 -> h3 for chart section headings,
+      //     a known site-wide pattern (see a11y-pages.test.tsx Reports).
+      const results = await axe(container, {
+        rules: {
+          'color-contrast': { enabled: false },
+          'button-name': { enabled: false },
+          'heading-order': { enabled: false },
+        },
+      });
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no WCAG 2.1 AA violations in the empty state', async () => {
+      mockUseImages.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isPending: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+        isFetching: false,
+      } as any);
+
+      const { container } = renderWithProviders(<ImageFootprintPage />);
+
+      const results = await axe(container, {
+        rules: {
+          'color-contrast': { enabled: false },
+          'button-name': { enabled: false },
+          'heading-order': { enabled: false },
+        },
+      });
+      expect(results).toHaveNoViolations();
+    });
   });
 });

--- a/frontend/src/features/containers/pages/image-footprint.test.tsx
+++ b/frontend/src/features/containers/pages/image-footprint.test.tsx
@@ -248,4 +248,51 @@ describe('ImageFootprintPage', () => {
       { refetchInterval: 60_000 },
     );
   });
+
+  describe('empty state', () => {
+    it('renders the no-images empty state copy when images is an empty array', () => {
+      mockUseImages.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isPending: false,
+        isError: false,
+        error: null,
+        refetch: mockRefetch,
+        isFetching: false,
+      });
+
+      render(<ImageFootprintPage />);
+
+      expect(screen.getByText('No images found')).toBeInTheDocument();
+      expect(
+        screen.getByText('No Docker images found across any endpoints.'),
+      ).toBeInTheDocument();
+
+      // No charts, no data table when there is nothing to plot.
+      expect(screen.queryByTestId('image-treemap')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('image-sunburst')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
+    });
+
+    it('renders the error state with a retry button when useImages errors', () => {
+      mockUseImages.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isPending: false,
+        isError: true,
+        error: new Error('boom'),
+        refetch: mockRefetch,
+        isFetching: false,
+      });
+
+      render(<ImageFootprintPage />);
+
+      expect(screen.getByText('Failed to load images')).toBeInTheDocument();
+      expect(screen.getByText('boom')).toBeInTheDocument();
+
+      const retry = screen.getByRole('button', { name: 'Try again' });
+      fireEvent.click(retry);
+      expect(mockRefetch).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Closes #1049.

## Summary

Adds page-level coverage for the Image Footprint treemap that the existing component-level tests in `src/shared/components/charts/image-treemap.test.tsx` did not exercise: vitest-axe WCAG audit, page-level keyboard activation flow into the detail panel, ARIA contract surface, and explicit empty/error-state copy.

**No source modifications.** `image-treemap.tsx` already exposes the full ARIA contract required by the issue (`role="button"`, `aria-label`, `tabIndex={0}`, Enter/Space handler, visible focus ring, group wrapper with `aria-label="Image size treemap"`).

## Test file routing

Two test files exist for this page; new tests were routed by concern:

| Issue target | File | Status |
|---|---|---|
| 1. Treemap renders with image data | `image-footprint.test.tsx` | already covered (existing `renders charts and page header`) |
| 2. Click handler navigates / opens detail | `__tests__/image-footprint-a11y.test.tsx` | **new**: page-level wiring through `onCellClick` -> dialog |
| 3. Keyboard navigation (Enter/Space parity) | `__tests__/image-footprint-a11y.test.tsx` | **new**: page-level Enter + Space tests, plus negative test for Tab/Escape |
| 4. ARIA roles (`role="button"`, `aria-label`, `tabIndex`) | `__tests__/image-footprint-a11y.test.tsx` | **new** at the page level (cell-level already exhaustive in `image-treemap.test.tsx`) |
| 5. axe audit (`vitest-axe`) | `__tests__/image-footprint-a11y.test.tsx` | **new**: populated + empty states |
| 6. Empty state | `image-footprint.test.tsx` | **new**: `images: []` empty-state copy + error/retry flow |

The page is mocked through `useImages` (HTTP boundary) per the project's CLAUDE.md mocking rules.

## Why a fake-treemap stand-in for the keyboard tests

`recharts`' `Treemap` reports 0x0 in jsdom (no layout engine) and never paints its `<CustomContent>` SVG cells. The cell-level keyboard a11y (Enter, Space, focus ring, aria-label `<name>, <bytes>` formatting) is already exhaustively covered by `image-treemap.test.tsx`. To exercise the *page-level* wiring (ImageFootprintPage -> ImageTreemap -> `setSelectedImage` -> detail panel) we substitute `ImageTreemap` with a jsdom-friendly stand-in that exposes one focusable button per data row carrying the same ARIA contract. That keeps the test focused on what it can actually exercise (the page wiring) and avoids depending on recharts' SVG layout behavior.

## axe rule exclusions

Mirrors `src/test/a11y-pages.test.tsx`:

- `color-contrast`: jsdom has no layout/CSS engine; covered by Playwright (Issue #435).
- `button-name`: ThemedSelect (Radix combobox) trigger is a known pre-existing site-wide violation.
- `heading-order`: page jumps h1 -> h3 for chart section headings — same site-wide pattern excluded by the existing Reports page a11y test.

## Test plan

- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npx vitest run src/features/containers/pages/image-footprint.test.tsx` — 10 passed (8 existing + 2 new: empty-state + error/retry)
- [x] `cd frontend && npx vitest run src/features/containers/pages/__tests__/image-footprint-a11y.test.tsx` — 11 passed (4 existing + 7 new: ARIA-contract surface + click + Enter + Space + negative-key + 2 axe audits)
- [x] `cd frontend && npx vitest run` — 1620/1620 passed across 169 files, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)