### PR TITLE
security: harden verifyJwt error handling and explicit JWT algorithms

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -93,12 +93,13 @@ vi.mock('@dashboard/core/db/timescale.js', () => ({
   isMetricsDbHealthy: vi.fn().mockResolvedValue(true),
 }));
 
-vi.mock('@dashboard/core/utils/crypto.js', () => ({
-  verifyJwt: vi.fn().mockResolvedValue(null),
-  signJwt: vi.fn().mockResolvedValue('mock-token'),
-  hashPassword: vi.fn().mockResolvedValue('hashed'),
-  verifyPassword: vi.fn().mockResolvedValue(false),
-}));
+// Passthrough mock for crypto: keeps the real implementations so that the
+// verifyJwt-hardening tests below (#1109, #1120) can exercise actual behaviour,
+// while still allowing other tests to spy on / override individual functions
+// via vi.spyOn. Auth-sweep tests don't pass JWTs, so real verifyJwt(undefined)
+// naturally returns null without needing a stub.
+vi.mock('@dashboard/core/utils/crypto.js', async (importOriginal) => await importOriginal());
+
 
 vi.mock('@dashboard/core/services/session-store.js', () => ({
   createSession: vi.fn(() => ({ id: 'sess-1', user_id: 'u1', username: 'admin' })),
@@ -1845,5 +1846,148 @@ describe('Incident Resolve Admin RBAC Enforcement', () => {
     });
 
     expect(res.statusCode).not.toBe(403);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// verifyJwt hardening — Issues #1109, #1120 (regression contract tests)
+//
+// Two related security fixes verified together:
+//   #1109: bare `catch {}` in verifyJwt swallowed unexpected errors (e.g. key
+//          import failure, missing PEM file). These must surface in logs at
+//          'error' level so operators can react. Routine "invalid token"
+//          failures (jose-class errors) must remain silent — no log spam on
+//          every failed login attempt.
+//   #1120: jwtVerify was called without explicit `algorithms` and
+//          `requiredClaims`. Adds defense-in-depth against algorithm-confusion
+//          attacks and tokens missing standard claims (`sub`, `exp`, `iat`).
+//
+// These regression tests verify the OBSERVABLE contract (verifyJwt returns
+// null and never throws) for each failure mode. The "logs error vs. silent"
+// assertion is covered alongside the implementation in
+// packages/core/src/utils/crypto.test.ts where the logger is directly
+// observable — Vitest's module-mock chain in this workspace does not
+// reliably intercept the `createChildLogger('crypto')` call inside
+// crypto.ts when imported transitively, so log-call assertions are kept
+// at the unit-test layer, while behaviour is anchored here.
+// ─────────────────────────────────────────────────────────────────────────
+describe('verifyJwt hardening (#1109, #1120)', () => {
+  let realCrypto: typeof import('@dashboard/core/utils/crypto.js');
+  let jose: typeof import('jose');
+  const JWT_SECRET = 'a'.repeat(64);
+
+  beforeAll(async () => {
+    // The crypto mock at the top of the file is a passthrough
+    // (await importOriginal()), so a normal dynamic import yields the real
+    // module — exactly what we want for these regression tests.
+    realCrypto = await import('@dashboard/core/utils/crypto.js');
+    jose = await import('jose');
+  });
+
+  beforeEach(() => {
+    realCrypto._resetKeyCache();
+    setConfigForTest({
+      JWT_ALGORITHM: 'HS256',
+      JWT_SECRET,
+    });
+  });
+
+  afterAll(() => {
+    realCrypto._resetKeyCache();
+  });
+
+  it('returns null when signature is tampered (#1109)', async () => {
+    const validToken = await realCrypto.signJwt({
+      sub: 'user-1',
+      username: 'admin',
+      sessionId: 'sess-1',
+    });
+    const tampered = validToken.slice(0, -5) + 'XXXXX';
+
+    const result = await realCrypto.verifyJwt(tampered);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for token signed with wrong algorithm (#1120 — algorithm-confusion defence)', async () => {
+    // Sign a token with HS512 while verifyJwt is configured for HS256.
+    // Without the explicit `algorithms` option (issue #1120), jose v5 would
+    // accept this token because the signature is valid for the same key.
+    // With the option, jose throws JOSEAlgNotAllowed — verifyJwt returns null.
+    const key = new TextEncoder().encode(JWT_SECRET);
+    const wrongAlgToken = await new jose.SignJWT({
+      sub: 'user-1',
+      username: 'admin',
+      sessionId: 'sess-1',
+    })
+      .setProtectedHeader({ alg: 'HS512' })
+      .setIssuedAt()
+      .setExpirationTime('60m')
+      .sign(key);
+
+    const result = await realCrypto.verifyJwt(wrongAlgToken);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for an expired token (#1109)', async () => {
+    const key = new TextEncoder().encode(JWT_SECRET);
+    const expiredToken = await new jose.SignJWT({
+      sub: 'user-1',
+      username: 'admin',
+      sessionId: 'sess-1',
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 7200) // iat 2h ago
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 3600) // exp 1h ago
+      .sign(key);
+
+    const result = await realCrypto.verifyJwt(expiredToken);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for token missing the required `sub` claim (#1120)', async () => {
+    // requiredClaims: ['sub', 'exp', 'iat'] — omitting `sub` should trip
+    // JWTClaimValidationFailed; verifyJwt swallows and returns null.
+    const key = new TextEncoder().encode(JWT_SECRET);
+    const tokenNoSub = await new jose.SignJWT({
+      username: 'admin',
+      sessionId: 'sess-1',
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt()
+      .setExpirationTime('60m')
+      .sign(key);
+
+    const result = await realCrypto.verifyJwt(tokenNoSub);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null without throwing when an unexpected (non-JOSE) error occurs (#1109)', async () => {
+    // Force getVerifyKey to throw a non-JOSE error by switching JWT_ALGORITHM
+    // to RS256 and pointing at a non-existent public-key file. readFileSync
+    // will throw ENOENT (a Node SystemError, NOT a JOSEError). Pre-fix, the
+    // bare `catch {}` would still return null but silently — the logger
+    // assertion lives in crypto.test.ts. Here we only verify the contract:
+    // verifyJwt must NOT throw, and must return null, even on operational
+    // failures.
+    realCrypto._resetKeyCache();
+    setConfigForTest({
+      JWT_ALGORITHM: 'RS256',
+      JWT_PUBLIC_KEY_PATH: '/nonexistent/path/to/public-key.pem',
+    });
+
+    let threw = false;
+    let result: unknown = 'not-set';
+    try {
+      result = await realCrypto.verifyJwt('any-token-value');
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+    expect(result).toBeNull();
   });
 });

--- a/packages/core/src/utils/crypto.test.ts
+++ b/packages/core/src/utils/crypto.test.ts
@@ -1,7 +1,37 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { SignJWT } from 'jose';
 import { signJwt, verifyJwt, hashPassword, comparePassword, _resetKeyCache } from './crypto.js';
+import { setConfigForTest, resetConfig } from '../config/index.js';
 
-// Mock the config module — default HS256
+// Mock the relative logger module so that crypto.ts's `createChildLogger('crypto')`
+// returns a vi.fn-backed object whose `error` calls are captured for assertion.
+// vi.hoisted() ensures the captured child loggers map exists BEFORE the mock
+// factory runs (vi.mock is hoisted above ordinary const declarations).
+const { __cryptoLoggerHandle } = vi.hoisted(() => {
+  const handle: { current: { error: ReturnType<typeof vi.fn> } | null } = { current: null };
+  return { __cryptoLoggerHandle: handle };
+});
+vi.mock('./logger.js', () => {
+  const make = () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(() => make()),
+  });
+  return {
+    logger: make(),
+    createChildLogger: vi.fn((name: string) => {
+      const child = make();
+      if (name === 'crypto') {
+        __cryptoLoggerHandle.current = child;
+      }
+      return child;
+    }),
+  };
+});
 
 describe('crypto', () => {
   beforeEach(() => {
@@ -101,6 +131,151 @@ describe('crypto', () => {
       it('should return null for malformed JWT', async () => {
         const result = await verifyJwt('not.a.valid.jwt');
         expect(result).toBeNull();
+      });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // verifyJwt hardening — Issues #1109 (error discrimination) and
+    // #1120 (explicit algorithms + requiredClaims). Unit-level coverage of
+    // the new behaviour, including the "log.error on unexpected failure"
+    // branch that issue #1109 introduces. The matching contract test in
+    // backend/src/routes/security-regression.test.ts covers the same
+    // failure modes from a black-box perspective; this block adds the
+    // logger-introspection assertion that requires direct access to the
+    // crypto module's logger.
+    // ─────────────────────────────────────────────────────────────────────
+    describe('verifyJwt hardening (#1109, #1120)', () => {
+      const JWT_SECRET = 'a'.repeat(64);
+
+      beforeEach(() => {
+        _resetKeyCache();
+        setConfigForTest({
+          JWT_ALGORITHM: 'HS256',
+          JWT_SECRET,
+        });
+      });
+
+      afterAll(() => {
+        _resetKeyCache();
+        resetConfig();
+      });
+
+      it('returns null when signature is tampered (#1109)', async () => {
+        const token = await signJwt({ sub: 'u', username: 'a', sessionId: 's' });
+        const tampered = token.slice(0, -5) + 'XXXXX';
+        expect(await verifyJwt(tampered)).toBeNull();
+      });
+
+      it('rejects token signed with wrong algorithm (#1120 — algorithm-confusion defence)', async () => {
+        // jose v5 with explicit `algorithms: ['HS256']` rejects HS512-signed
+        // tokens even though the secret matches. Without #1120's option, the
+        // token would have been accepted (jose's default behaviour permits
+        // any algorithm matching the key type).
+        const key = new TextEncoder().encode(JWT_SECRET);
+        const wrongAlgToken = await new SignJWT({ sub: 'u', username: 'a', sessionId: 's' })
+          .setProtectedHeader({ alg: 'HS512' })
+          .setIssuedAt()
+          .setExpirationTime('60m')
+          .sign(key);
+
+        expect(await verifyJwt(wrongAlgToken)).toBeNull();
+      });
+
+      it('rejects an expired token silently (#1109)', async () => {
+        const key = new TextEncoder().encode(JWT_SECRET);
+        const expiredToken = await new SignJWT({ sub: 'u', username: 'a', sessionId: 's' })
+          .setProtectedHeader({ alg: 'HS256' })
+          .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+          .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+          .sign(key);
+
+        expect(await verifyJwt(expiredToken)).toBeNull();
+      });
+
+      it('rejects token missing required `sub` claim (#1120)', async () => {
+        const key = new TextEncoder().encode(JWT_SECRET);
+        const tokenNoSub = await new SignJWT({ username: 'a', sessionId: 's' })
+          .setProtectedHeader({ alg: 'HS256' })
+          .setIssuedAt()
+          .setExpirationTime('60m')
+          .sign(key);
+
+        expect(await verifyJwt(tokenNoSub)).toBeNull();
+      });
+
+      it('rejects token missing required `exp` claim (#1120)', async () => {
+        const key = new TextEncoder().encode(JWT_SECRET);
+        const tokenNoExp = await new SignJWT({ sub: 'u', username: 'a', sessionId: 's' })
+          .setProtectedHeader({ alg: 'HS256' })
+          .setIssuedAt()
+          // intentionally no setExpirationTime
+          .sign(key);
+
+        expect(await verifyJwt(tokenNoExp)).toBeNull();
+      });
+
+      it('returns null AND logs at error level for unexpected (non-JOSE) failures (#1109)', async () => {
+        // Force getVerifyKey to throw a non-JOSE error: switch to RS256 with
+        // a non-existent public-key file. readFileSync will throw ENOENT, a
+        // Node SystemError that is NOT a JOSEError — exactly the failure
+        // mode #1109 surfaces in operator logs.
+        const cryptoLog = __cryptoLoggerHandle.current;
+        if (!cryptoLog) {
+          throw new Error('crypto child logger was not captured by the logger mock — setup bug');
+        }
+        cryptoLog.error.mockClear();
+
+        _resetKeyCache();
+        setConfigForTest({
+          JWT_ALGORITHM: 'RS256',
+          JWT_PUBLIC_KEY_PATH: '/nonexistent/path/to/public-key.pem',
+        });
+
+        let threw = false;
+        let result: unknown = 'not-set';
+        try {
+          result = await verifyJwt('any-token');
+        } catch {
+          threw = true;
+        }
+
+        expect(threw).toBe(false);
+        expect(result).toBeNull();
+        expect(cryptoLog.error).toHaveBeenCalledTimes(1);
+        const [logObj, msg] = cryptoLog.error.mock.calls[0] as [{ err: unknown }, string];
+        expect(logObj).toHaveProperty('err');
+        expect(logObj.err).toBeInstanceOf(Error);
+        expect((logObj.err as NodeJS.ErrnoException).code).toBe('ENOENT');
+        expect(msg).toMatch(/unexpected/i);
+      });
+
+      it('does NOT log at error level for expected jose errors (#1109)', async () => {
+        // Routine failures (tampered, expired, wrong-alg, missing-claim,
+        // malformed) all produce JOSEError subclasses. These must remain
+        // silent — no log spam on every failed login attempt.
+        const cryptoLog = __cryptoLoggerHandle.current;
+        if (!cryptoLog) {
+          throw new Error('crypto child logger was not captured by the logger mock — setup bug');
+        }
+        cryptoLog.error.mockClear();
+
+        // Tampered signature → JWSSignatureVerificationFailed
+        const validToken = await signJwt({ sub: 'u', username: 'a', sessionId: 's' });
+        await verifyJwt(validToken.slice(0, -5) + 'XXXXX');
+
+        // Wrong algorithm → JOSEAlgNotAllowed
+        const key = new TextEncoder().encode(JWT_SECRET);
+        const wrongAlgToken = await new SignJWT({ sub: 'u', username: 'a', sessionId: 's' })
+          .setProtectedHeader({ alg: 'HS512' })
+          .setIssuedAt()
+          .setExpirationTime('60m')
+          .sign(key);
+        await verifyJwt(wrongAlgToken);
+
+        // Malformed → JWSInvalid / JWTInvalid
+        await verifyJwt('not.a.valid.jwt');
+
+        expect(cryptoLog.error).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/core/src/utils/crypto.ts
+++ b/packages/core/src/utils/crypto.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
-import { SignJWT, jwtVerify, importPKCS8, importSPKI, type CryptoKey } from 'jose';
+import { SignJWT, jwtVerify, importPKCS8, importSPKI, errors, type CryptoKey } from 'jose';
 import bcrypt from 'bcrypt';
 import { getConfig } from '../config/index.js';
+import { createChildLogger } from './logger.js';
+
+const log = createChildLogger('crypto');
 
 /**
  * JWT Signing Algorithm Decision (Issue #312)
@@ -89,10 +92,25 @@ export async function signJwt(payload: {
 
 export async function verifyJwt(token: string) {
   try {
+    const { JWT_ALGORITHM } = getConfig();
     const key = await getVerifyKey();
-    const { payload } = await jwtVerify(token, key);
+    const { payload } = await jwtVerify(token, key, {
+      algorithms: [JWT_ALGORITHM],
+      requiredClaims: ['sub', 'exp', 'iat'],
+    });
     return payload as { sub: string; username: string; sessionId: string; role?: string; exp: number; iat: number };
-  } catch {
+  } catch (err) {
+    // jose-specific errors represent the normal "invalid token" failure mode
+    // (expired, bad signature, wrong algorithm, missing claim, malformed JWT).
+    // We return null silently — these are routine and should not produce log spam
+    // on every failed auth attempt.
+    if (err instanceof errors.JOSEError) {
+      return null;
+    }
+    // Anything else is unexpected: a key-import failure, missing key file, an
+    // invariant violation in our own code, etc. These indicate operational or
+    // configuration issues that operators must see in logs.
+    log.error({ err }, 'JWT verification failed with unexpected error');
     return null;
   }
 }


### PR DESCRIPTION
## Summary

Two related JWT verification security fixes bundled in a single small PR:

- **#1109** — `verifyJwt`'s bare `catch {}` swallowed every error silently. It now discriminates jose-class errors (the routine "invalid token" failure mode) from unexpected errors (key-import failure, missing PEM file, etc.). The latter are logged at `error` level via `createChildLogger('crypto')`, so operators can see them; the former remain silent so failed-login attempts don't spam logs.
- **#1120** — `jwtVerify` was called without explicit `algorithms` and `requiredClaims`. Adds defense-in-depth: `algorithms: [JWT_ALGORITHM]` defends against algorithm-confusion attacks (e.g. an HS512 token being accepted under HS256 verification), and `requiredClaims: ['sub', 'exp', 'iat']` rejects payloads missing standard claims.

#1109 fixes the silent-swallow bug. #1120 is defense-in-depth.

## Changes

- `packages/core/src/utils/crypto.ts` — added jose `errors` import, `createChildLogger('crypto')`, and the discriminated `catch (err)` block; added `algorithms` + `requiredClaims` options to `jwtVerify`.
- `backend/src/routes/security-regression.test.ts` — 5 new black-box regression tests anchoring the security contract for both issues. Crypto mock changed to passthrough (`await importOriginal()`) so real `verifyJwt` is exercised. Auth-sweep tests still naturally fail auth because they send no JWT.
- `packages/core/src/utils/crypto.test.ts` — 7 new unit tests, including the load-bearing `log.error called once` assertion for the unexpected-error path. Uses an in-package `vi.mock('./logger.js', …)` that reliably intercepts `createChildLogger('crypto')` from the source module (workspace-level mocks in security-regression.test.ts cannot reach the relative import inside `crypto.ts`).

## Test plan

- [x] `npm run lint` (root) — passes
- [x] `npm run typecheck` (root) — passes
- [x] `cd backend && npx vitest run src/routes/security-regression.test.ts` — 91/91 passing (86 pre-existing + 5 new)
- [x] `cd packages/core && npx vitest run src/utils/crypto.test.ts` — 31/31 passing (24 pre-existing + 7 new)
- [x] `cd packages/core && npx vitest run` — 533/533 non-integration tests passing (2 PostgreSQL integration tests fail on baseline `dev` too — unrelated)
- [x] `cd backend && npx vitest run` — 298/298 backend tests passing
- [ ] CI green on `dev` integration

Closes #1109
Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)