### PR TITLE
perf: hourly session cleanup, network-tracker prune, ttl-cache docs

### DIFF
--- a/packages/core/src/portainer/portainer-cache.ts
+++ b/packages/core/src/portainer/portainer-cache.ts
@@ -67,7 +67,18 @@ class TtlCache {
     }
   }
 
-  /** Evict `count` entries with the earliest staleAt timestamps */
+  /**
+   * Evict `count` entries with the earliest `staleAt` timestamps.
+   *
+   * Complexity is O(n log n) due to the full sort on each overflow. This is
+   * acceptable while `maxSize` ≤ 5000 — at that scale the sort is sub-ms and
+   * only runs when the cache is over its cap. If `maxSize` is raised
+   * substantially (≥ ~50k) or eviction shows up in profiling, replace this
+   * with a proper LRU (doubly-linked list + Map for O(1) eviction). See
+   * issue #1116 for the cost/benefit analysis — at current scale the
+   * algorithmic upgrade adds bug surface to a security-critical cache for
+   * no measurable performance gain.
+   */
   private evictOldest(count: number): void {
     const entries = [...this.store.entries()]
       .sort((a, b) => a[1].staleAt - b[1].staleAt);

--- a/packages/observability/src/__tests__/network-rate-tracker.test.ts
+++ b/packages/observability/src/__tests__/network-rate-tracker.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   recordNetworkSample,
   getRatesForEndpoint,
   getAllRates,
+  pruneStaleEntries,
   _resetTracker,
 } from '../services/network-rate-tracker.js';
 
@@ -110,5 +111,91 @@ describe('network-rate-tracker', () => {
 
   it('getAllRates returns empty object when no samples recorded', () => {
     expect(getAllRates()).toEqual({});
+  });
+
+  describe('pruneStaleEntries (issue #1111)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('removes all entries when staleMs is 0', () => {
+      for (let i = 0; i < 10; i++) {
+        recordNetworkSample(1, `c${i}`, 0, 0);
+      }
+      expect(Object.keys(getAllRates())).toHaveLength(10);
+
+      const removed = pruneStaleEntries(0);
+
+      expect(removed).toBe(10);
+      expect(getAllRates()).toEqual({});
+    });
+
+    it('returns 0 when no entries are stale', () => {
+      recordNetworkSample(1, 'fresh', 0, 0);
+      const removed = pruneStaleEntries(120_000);
+      expect(removed).toBe(0);
+      expect(getAllRates()).toHaveProperty('fresh');
+    });
+
+    it('returns the correct count of removed entries', () => {
+      for (let i = 0; i < 7; i++) {
+        recordNetworkSample(1, `c${i}`, 0, 0);
+      }
+      const removed = pruneStaleEntries(0);
+      expect(removed).toBe(7);
+    });
+
+    it('removes only entries older than staleMs (default 120s)', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+
+      // 100 stale entries recorded at t=0
+      for (let i = 0; i < 100; i++) {
+        recordNetworkSample(1, `c${i}`, 0, 0);
+      }
+      expect(Object.keys(getAllRates())).toHaveLength(100);
+
+      // Advance virtual clock 200s so existing entries are now stale
+      vi.setSystemTime(200_000);
+
+      // One fresh entry
+      recordNetworkSample(1, 'fresh', 0, 0);
+
+      const removed = pruneStaleEntries(120_000);
+
+      expect(removed).toBe(100);
+      expect(Object.keys(getAllRates())).toEqual(['fresh']);
+    });
+
+    it('drops empty endpoint maps so re-recording on the same endpoint is clean', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      recordNetworkSample(42, 'gone', 0, 0);
+
+      vi.setSystemTime(300_000);
+      const removed = pruneStaleEntries(120_000);
+      expect(removed).toBe(1);
+
+      // Re-record on endpoint 42 — its map was deleted, must be rebuilt cleanly
+      recordNetworkSample(42, 'new', 0, 0);
+      expect(getAllRates()).toHaveProperty('new');
+      expect(getAllRates()).not.toHaveProperty('gone');
+    });
+
+    it('preserves entries across multiple endpoints when only one has stale data', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      recordNetworkSample(1, 'old-1', 0, 0);
+      recordNetworkSample(2, 'old-2', 0, 0);
+
+      vi.setSystemTime(200_000);
+      // Refresh only endpoint 1
+      recordNetworkSample(1, 'old-1', 100, 100);
+
+      const removed = pruneStaleEntries(120_000);
+      expect(removed).toBe(1);
+      expect(getRatesForEndpoint(1)).toHaveProperty('old-1');
+      expect(getRatesForEndpoint(2)).toEqual({});
+    });
   });
 });

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -51,6 +51,7 @@ export {
   recordNetworkSample,
   getRatesForEndpoint,
   getAllRates,
+  pruneStaleEntries,
   _resetTracker,
 } from './services/network-rate-tracker.js';
 

--- a/packages/observability/src/services/network-rate-tracker.ts
+++ b/packages/observability/src/services/network-rate-tracker.ts
@@ -88,6 +88,42 @@ export function getAllRates(): Record<string, LiveNetworkRate> {
   return rates;
 }
 
+/**
+ * Drop entries whose latest sample is older than `staleMs`.
+ *
+ * Called periodically by the scheduler to prevent unbounded growth of the
+ * tracker map when containers are deleted/recreated with new IDs (issue #1111).
+ * Without pruning, the tracker would accumulate stale entries indefinitely.
+ *
+ * Empty endpoint maps are also removed so re-creating containers on a recycled
+ * endpoint starts from a clean slate.
+ *
+ * @param staleMs - entries with `current.timestamp` older than `Date.now() - staleMs`
+ *                  are dropped. Default 120_000 ms (2× the default 60 s metrics
+ *                  collection interval) — picks up samples that haven't been
+ *                  refreshed across two collection cycles.
+ * @returns number of entries removed (for logging).
+ */
+export function pruneStaleEntries(staleMs: number = 120_000): number {
+  const cutoff = Date.now() - staleMs;
+  let removed = 0;
+  for (const [endpointId, endpointMap] of store) {
+    for (const [containerId, entry] of endpointMap) {
+      if (entry.current.timestamp <= cutoff) {
+        endpointMap.delete(containerId);
+        removed++;
+      }
+    }
+    if (endpointMap.size === 0) {
+      store.delete(endpointId);
+    }
+  }
+  if (removed > 0) {
+    log.debug({ removed }, 'Pruned stale network rate entries');
+  }
+  return removed;
+}
+
 /** Clear all stored samples (for testing). */
 export function _resetTracker(): void {
   store.clear();

--- a/packages/server/src/__tests__/scheduler-session-cleanup.test.ts
+++ b/packages/server/src/__tests__/scheduler-session-cleanup.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Issue #1114 — hourly expired-session cleanup.
+ *
+ * Verifies that startScheduler() registers a 1-hour interval that calls
+ * cleanExpiredSessions, plus a startup-delay run. Kept separate from the
+ * main scheduler.test.ts because this suite uses fake timers across the
+ * whole test, which would interfere with the cache/Redis setup there.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import { setConfigForTest, resetConfig } from '@dashboard/core/config/index.js';
+
+// Capture the cleanExpiredSessions mock so we can assert against it.
+const cleanExpiredSessionsMock = vi.fn().mockResolvedValue(0);
+vi.mock('@dashboard/core/services/session-store.js', () => ({
+  cleanExpiredSessions: (...args: unknown[]) => cleanExpiredSessionsMock(...args),
+}));
+// The scheduler imports cleanExpiredSessions via the services barrel.
+vi.mock('@dashboard/core/services/index.js', async (importOriginal) => {
+  const orig = await importOriginal() as Record<string, unknown>;
+  return {
+    ...orig,
+    cleanExpiredSessions: (...args: unknown[]) => cleanExpiredSessionsMock(...args),
+    // Settings reads must return null so the Portainer-backup branch is skipped.
+    getSetting: vi.fn().mockResolvedValue(null),
+    // Monitoring/Harbor config: disabled so those intervals stay quiet.
+    getEffectiveMonitoringSchedulerConfig: vi.fn().mockResolvedValue({ enabled: false, intervalMinutes: 60 }),
+    getEffectiveHarborConfig: vi.fn().mockResolvedValue({ enabled: false, syncIntervalMinutes: 30 }),
+  };
+});
+
+// Domain mocks — keep the scheduler's other subsystems quiet.
+vi.mock('@dashboard/security', () => ({
+  runStalenessChecks: vi.fn().mockResolvedValue({ checked: 0, stale: 0 }),
+  cleanupOldCaptures: vi.fn(),
+  cleanupOrphanedSidecars: vi.fn().mockResolvedValue(0),
+  cleanupOldVulnerabilities: vi.fn().mockResolvedValue(0),
+  isHarborConfiguredAsync: vi.fn().mockResolvedValue(false),
+  isHarborSyncRunning: vi.fn().mockReturnValue(false),
+  runHarborSync: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@dashboard/observability', async (importOriginal) => {
+  const orig = await importOriginal() as Record<string, unknown>;
+  return {
+    ...orig,
+    collectMetrics: vi.fn().mockResolvedValue({ cpu: 0, memory: 0, memoryBytes: 0, networkRxBytes: 0, networkTxBytes: 0 }),
+    insertMetrics: vi.fn().mockResolvedValue(undefined),
+    cleanOldMetrics: vi.fn().mockResolvedValue(0),
+    insertKpiSnapshot: vi.fn(),
+    cleanOldKpiSnapshots: vi.fn().mockResolvedValue(0),
+    recordNetworkSample: vi.fn(),
+    pruneStaleEntries: vi.fn().mockReturnValue(0),
+  };
+});
+
+vi.mock('@dashboard/operations', () => ({
+  createPortainerBackup: vi.fn(),
+  cleanupOldPortainerBackups: vi.fn(),
+  startWebhookListener: vi.fn(),
+  stopWebhookListener: vi.fn(),
+  processRetries: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('@dashboard/ai', () => ({
+  startCooldownSweep: vi.fn(),
+  stopCooldownSweep: vi.fn(),
+  cleanupOldInsights: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('@dashboard/infrastructure', () => ({
+  startElasticsearchLogForwarder: vi.fn().mockResolvedValue(undefined),
+  stopElasticsearchLogForwarder: vi.fn(),
+}));
+
+// Run the trace-context callback for real so the interval body actually
+// invokes cleanExpiredSessions.
+vi.mock('@dashboard/core/tracing/index.js', () => ({
+  runWithTraceContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+
+// Bypass Portainer client — getEndpoints returns [] so waitForPortainer
+// succeeds on the first attempt.
+vi.mock('@dashboard/core/portainer/index.js', async (importOriginal) => {
+  const orig = await importOriginal() as Record<string, unknown>;
+  return {
+    ...orig,
+    getEndpoints: vi.fn().mockResolvedValue([]),
+    getContainers: vi.fn().mockResolvedValue([]),
+    getImages: vi.fn().mockResolvedValue([]),
+    isEndpointDegraded: vi.fn().mockReturnValue(false),
+    cachedFetch: vi.fn(async (_k: string, _t: number, fn: () => Promise<unknown>) => fn()),
+    cachedFetchSWR: vi.fn(async (_k: string, _t: number, fn: () => Promise<unknown>) => fn()),
+    getCacheKey: vi.fn((...args: (string | number)[]) => args.join(':')),
+    TTL: { ENDPOINTS: 900, CONTAINERS: 300, IMAGES: 600 },
+  };
+});
+
+import { startScheduler, stopScheduler } from '../scheduler.js';
+
+beforeAll(() => {
+  setConfigForTest({
+    CACHE_ENABLED: false,
+    METRICS_COLLECTION_ENABLED: false,
+    MONITORING_ENABLED: false,
+    WEBHOOKS_ENABLED: false,
+    IMAGE_STALENESS_CHECK_ENABLED: false,
+    METRICS_RETENTION_DAYS: 30,
+    METRICS_ENDPOINT_CONCURRENCY: 10,
+    METRICS_CONTAINER_CONCURRENCY: 20,
+    METRICS_COLLECTION_INTERVAL_SECONDS: 60,
+  });
+});
+
+afterAll(() => {
+  resetConfig();
+});
+
+beforeEach(() => {
+  cleanExpiredSessionsMock.mockClear();
+  cleanExpiredSessionsMock.mockResolvedValue(0);
+});
+
+afterEach(() => {
+  stopScheduler();
+  vi.useRealTimers();
+});
+
+describe('scheduler — hourly session cleanup (issue #1114)', () => {
+  it('runs cleanExpiredSessions ~30 s after startup', async () => {
+    vi.useFakeTimers();
+    const noopMonitoring = async () => {};
+    const startPromise = startScheduler(noopMonitoring);
+    // waitForPortainer + warmCache resolve via the mocked getEndpoints
+    await vi.advanceTimersByTimeAsync(0);
+    await startPromise;
+
+    // Startup delay is 30 s — advance just past it.
+    await vi.advanceTimersByTimeAsync(30_001);
+
+    expect(cleanExpiredSessionsMock).toHaveBeenCalled();
+  });
+
+  it('runs cleanExpiredSessions on every hour after the first hourly tick', async () => {
+    vi.useFakeTimers();
+    const noopMonitoring = async () => {};
+    const startPromise = startScheduler(noopMonitoring);
+    await vi.advanceTimersByTimeAsync(0);
+    await startPromise;
+
+    // Skip past the 30 s startup-delay run so we count only hourly ticks.
+    await vi.advanceTimersByTimeAsync(30_001);
+    cleanExpiredSessionsMock.mockClear();
+
+    // First hourly tick.
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(cleanExpiredSessionsMock).toHaveBeenCalledTimes(1);
+
+    // Second hourly tick.
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(cleanExpiredSessionsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not run hourly cleanup before the first hour elapses', async () => {
+    vi.useFakeTimers();
+    const noopMonitoring = async () => {};
+    const startPromise = startScheduler(noopMonitoring);
+    await vi.advanceTimersByTimeAsync(0);
+    await startPromise;
+
+    // Skip past startup-delay run.
+    await vi.advanceTimersByTimeAsync(30_001);
+    cleanExpiredSessionsMock.mockClear();
+
+    // Advance only 30 minutes — not enough for the hourly interval.
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(cleanExpiredSessionsMock).not.toHaveBeenCalled();
+  });
+
+  it('continues running even when cleanExpiredSessions throws', async () => {
+    vi.useFakeTimers();
+    cleanExpiredSessionsMock.mockRejectedValue(new Error('DB unavailable'));
+
+    const noopMonitoring = async () => {};
+    const startPromise = startScheduler(noopMonitoring);
+    await vi.advanceTimersByTimeAsync(0);
+    await startPromise;
+
+    // Startup-delay run swallows the error.
+    await vi.advanceTimersByTimeAsync(30_001);
+    expect(cleanExpiredSessionsMock).toHaveBeenCalled();
+    cleanExpiredSessionsMock.mockClear();
+
+    // Subsequent hourly tick still fires.
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(cleanExpiredSessionsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -8,7 +8,7 @@ import { normalizeEndpoint, type NormalizedEndpoint } from '@dashboard/core/port
 import { getSetting, getEffectiveHarborConfig, getEffectiveMonitoringSchedulerConfig, cleanExpiredSessions } from '@dashboard/core/services/index.js';
 import { runWithTraceContext } from '@dashboard/core/tracing/index.js';
 import { startCooldownSweep, stopCooldownSweep, cleanupOldInsights } from '@dashboard/ai';
-import { collectMetrics, insertMetrics, cleanOldMetrics, type MetricInsert, recordNetworkSample, insertKpiSnapshot, cleanOldKpiSnapshots } from '@dashboard/observability';
+import { collectMetrics, insertMetrics, cleanOldMetrics, type MetricInsert, recordNetworkSample, insertKpiSnapshot, cleanOldKpiSnapshots, pruneStaleEntries } from '@dashboard/observability';
 import { cleanupOldCaptures, cleanupOrphanedSidecars, runStalenessChecks, runHarborSync, isHarborSyncRunning, isHarborConfiguredAsync, cleanupOldVulnerabilities } from '@dashboard/security';
 import { createPortainerBackup, cleanupOldPortainerBackups, startWebhookListener, stopWebhookListener, processRetries } from '@dashboard/operations';
 import { startElasticsearchLogForwarder, stopElasticsearchLogForwarder } from '@dashboard/infrastructure';
@@ -380,6 +380,21 @@ export async function runCleanup(): Promise<void> {
   } catch (err) {
     log.error({ err }, 'Harbor vulnerability cleanup failed');
   }
+
+  // Prune stale entries from the in-memory network rate tracker (issue #1111).
+  // Containers that are deleted/recreated with new IDs leave entries in the
+  // tracker map indefinitely. Anything older than 2× the metrics collection
+  // interval is guaranteed to be stale (we'd have refreshed it otherwise).
+  try {
+    const config = getConfig();
+    const staleMs = config.METRICS_COLLECTION_INTERVAL_SECONDS * 1000 * 2;
+    const pruned = pruneStaleEntries(staleMs);
+    if (pruned > 0) {
+      log.info({ pruned }, 'Stale network rate tracker entries pruned');
+    }
+  } catch (err) {
+    log.error({ err }, 'Network rate tracker pruning failed');
+  }
 }
 
 async function waitForPortainer(): Promise<boolean> {
@@ -607,6 +622,41 @@ export async function startScheduler(runMonitoringCycle: () => Promise<void>): P
     24 * 60 * 60 * 1000,
   );
   intervals.push(cleanupInterval);
+
+  // Hourly expired-session cleanup (issue #1114). Sessions have a 1h TTL, so a
+  // 24h cleanup leaves expired rows in the table for up to 23h. Hourly matches
+  // the TTL exactly. The DELETE is idempotent, so the daily runCleanup above
+  // remains as a safety net (it'll just delete 0 rows when the hourly already
+  // cleared them). cleanExpiredSessions itself is unchanged — only the cadence.
+  const sessionCleanupInterval = setInterval(
+    () => runWithTraceContext({ source: 'scheduler' }, async () => {
+      try {
+        const deleted = await cleanExpiredSessions();
+        if (deleted > 0) {
+          log.info({ deleted }, 'Expired sessions cleaned up (hourly)');
+        }
+      } catch (err) {
+        log.error({ err }, 'Hourly session cleanup failed');
+      }
+    }),
+    60 * 60 * 1000,
+  );
+  sessionCleanupInterval.unref();
+  intervals.push(sessionCleanupInterval);
+  // Run once shortly after startup so a freshly-restarted server clears
+  // sessions left over from before the restart promptly.
+  setTimeout(() => {
+    runWithTraceContext({ source: 'scheduler' }, async () => {
+      try {
+        const deleted = await cleanExpiredSessions();
+        if (deleted > 0) {
+          log.info({ deleted }, 'Expired sessions cleaned up (startup)');
+        }
+      } catch (err) {
+        log.error({ err }, 'Startup session cleanup failed');
+      }
+    }).catch(() => {});
+  }, 30_000);
 
   // Periodic sweep of expired anomaly cooldowns (every 15 minutes)
   startCooldownSweep();


### PR DESCRIPTION
Closes #1111
Closes #1114
Closes #1116

Lane 2 PR3 from the 33-issue unified plan (`/tmp/issue-plans/UNIFIED-PLAN.md`, ship row 12, group D). Three small perf/quality fixes that share the scheduler file.

## Changes per issue

### #1111 — network rate tracker leak
- New `pruneStaleEntries(staleMs)` in `packages/observability/src/services/network-rate-tracker.ts` walks the outer `Map<endpointId, Map<containerId, …>>` and drops entries whose `current.timestamp` is at or below `Date.now() - staleMs`. Empty endpoint maps are removed too.
- Exported from the observability barrel (`packages/observability/src/index.ts`).
- Hooked into the existing daily `runCleanup()` in `packages/server/src/scheduler.ts` with `staleMs = METRICS_COLLECTION_INTERVAL_SECONDS × 2 × 1000` — anything older than two collection cycles is guaranteed stale (we'd have refreshed it otherwise).
- Tests: 6 new cases in `network-rate-tracker.test.ts` (zero-staleMs prune, no-op when fresh, count return, 120 s default boundary, empty-endpoint cleanup, multi-endpoint preservation).

### #1114 — hourly expired-session cleanup
- New 1 h `setInterval` next to the existing daily `cleanupInterval` in `packages/server/src/scheduler.ts`. Calls `cleanExpiredSessions()` (unchanged — only the cadence). `unref()` so it doesn't block shutdown; pushed into the same `intervals[]` array so `stopScheduler()` clears it.
- Startup-delay run (30 s after `startScheduler()`) so a freshly-restarted server clears sessions left over from before the restart promptly.
- The daily `runCleanup` still calls `cleanExpiredSessions` as an idempotent safety net.
- Tests: 4 new cases in `packages/server/src/__tests__/scheduler-session-cleanup.test.ts` using `vi.useFakeTimers()` — startup-delay run, hourly tick (×2), no-fire-before-30-min, error-resilience.

### #1116 — TtlCache.evictOldest documentation only
- Per the planning critic (issue priority 2.0/10), an LRU rewrite at `maxSize=5000` adds bug surface to a security-critical cache for no measurable gain (sub-ms sort on overflow). **No code change** to the eviction algorithm — only a JSDoc explaining the O(n log n) complexity, the cap at which it's acceptable, and the upgrade path if `maxSize` ever grows past ~50k.
- All 45 existing `portainer-cache.test.ts` cases still pass.

## Verification

- `npm run lint` — clean (root + backend + frontend).
- `npm run typecheck` — clean.
- `cd packages/observability && npx vitest run src/__tests__/network-rate-tracker.test.ts` — **14/14 passed**.
- `cd packages/server && npx vitest run` — **27/27 passed** (23 existing + 4 new hourly-cleanup cases).
- `cd packages/core && npx vitest run src/portainer/portainer-cache.test.ts` — **45/45 passed**.
- `npm run test -w backend` — **293/293 passed** (1 pre-existing skip).
- `npm run test -w frontend` — **1611/1611 passed**.

## Pre-existing failures (NOT caused by this PR)

Confirmed via `git stash` baseline test on clean `dev`:

- `packages/core/src/db/postgres.test.ts` — `error: password authentication failed for user "app_user"` (suite-level, all 13 tests skipped).
- `packages/core/src/services/session-store.integration.test.ts` — same PG-auth error (11 tests skipped).
- `packages/observability/src/__tests__/{prometheus-route,traces-route,traces-ingest-route}.test.ts` — same root cause (`getTestDb` → migrations → `pg-pool` connection error).

These are environmental — local PG on port 5433 is missing the `app_user` role/password. Lane 2 PR2 noted the same issue. Not addressed here.

## Rollback

Pure revert. The `pruneStaleEntries` export, the runCleanup hook, the hourly `setInterval`, and the JSDoc are independent additions that revert cleanly. Daily `runCleanup` and `cleanExpiredSessions` remain functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)