### PR TITLE
test(llm-assistant): cover clear-history modal and chat send/receive flow

### DIFF
--- a/frontend/src/features/ai-intelligence/pages/llm-assistant.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-assistant.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -736,5 +736,237 @@ describe('Connection status indicator', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Dismiss context banner' }));
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1050 — clear-history modal flow + chat send/receive coverage.
+//
+// Depends on #1019 (CLOSED): `window.confirm()` was replaced with the
+// `ConfirmDialog` Radix modal, so we exercise it via accessible role/name
+// queries instead of stubbing `window.confirm`. The LLM transport is mocked
+// at the `useLlmChat` hook boundary (matches the pattern used above and
+// project CLAUDE.md guidance to "keep mocks close to the boundary").
+// ---------------------------------------------------------------------------
+
+describe('Clear history flow (#1050)', () => {
+  const sampleMessages = [
+    { id: 'u1', role: 'user' as const, content: 'Hello', timestamp: new Date().toISOString() },
+    { id: 'a1', role: 'assistant' as const, content: 'Hi there!', timestamp: new Date().toISOString() },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLlmSocket.connected = true;
+    vi.mocked(useLlmModels).mockReturnValue({
+      data: { models: [{ name: 'llama3.2' }], default: 'llama3.2' },
+    } as any);
+  });
+
+  it('opens the confirm dialog when Clear History button is clicked', () => {
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: sampleMessages,
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    renderPage();
+
+    // No dialog before clicking.
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear History/i }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText('Clear Chat History')).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(/Clear all chat history\? This action cannot be undone\./i),
+    ).toBeInTheDocument();
+  });
+
+  it('calls clearHistory and closes the dialog when confirming', () => {
+    const clearHistory = vi.fn();
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: sampleMessages,
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory,
+    } as any);
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Clear History/i }));
+
+    const dialog = screen.getByRole('dialog');
+    // The dialog has its own "Clear History" confirm button — scope to the dialog
+    // so we don't accidentally re-click the header trigger.
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Clear History' }));
+
+    expect(clearHistory).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('preserves messages and does not call clearHistory when Cancel is clicked', () => {
+    const clearHistory = vi.fn();
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: sampleMessages,
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory,
+    } as any);
+
+    renderPage();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Hi there!')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear History/i }));
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(clearHistory).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).toBeNull();
+    // Messages still rendered after cancel.
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Hi there!')).toBeInTheDocument();
+  });
+});
+
+describe('Chat send/receive flow (#1050)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLlmSocket.connected = true;
+    vi.mocked(useLlmModels).mockReturnValue({
+      data: { models: [{ name: 'llama3.2' }], default: 'llama3.2' },
+    } as any);
+  });
+
+  it('sends the typed message to the LLM transport on submit', () => {
+    const sendMessage = vi.fn();
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage,
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    renderPage();
+
+    const input = screen.getByPlaceholderText('Ask about your infrastructure...') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'How many containers are running?' } });
+    expect(input.value).toBe('How many containers are running?');
+
+    fireEvent.click(screen.getByRole('button', { name: /Send/i }));
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      'How many containers are running?',
+      undefined,
+      'llama3.2',
+    );
+    // Input is cleared after submit.
+    expect(input.value).toBe('');
+  });
+
+  it('renders an assistant response returned by the LLM transport', () => {
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [
+        { id: 'u1', role: 'user', content: 'Status?', timestamp: new Date().toISOString() },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: 'All containers healthy.',
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    renderPage();
+
+    expect(screen.getByText('Status?')).toBeInTheDocument();
+    expect(screen.getByText('All containers healthy.')).toBeInTheDocument();
+  });
+
+  it('shows the loading indicator after submit while waiting for the response', () => {
+    const sendMessage = vi.fn();
+    vi.mocked(useLlmChat).mockReturnValue({
+      // `isSending` is local to the page and toggles on submit. The
+      // ThinkingIndicator renders while isSending && !isStreaming.
+      messages: [],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: 'Loading model llama3.2...',
+      sendMessage,
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    renderPage();
+
+    // No indicator before submit.
+    expect(screen.queryByTestId('thinking-indicator')).toBeNull();
+
+    const input = screen.getByPlaceholderText('Ask about your infrastructure...');
+    fireEvent.change(input, { target: { value: 'ping' } });
+    fireEvent.click(screen.getByRole('button', { name: /Send/i }));
+
+    // Indicator appears between submit and response receipt.
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('thinking-indicator')).toBeInTheDocument();
+  });
+
+  it('renders a system error message when the LLM transport surfaces an error', () => {
+    // The page renders messages with role === 'system' as a destructive
+    // alert bubble inside the chat (see MessageBubble). The hook is the
+    // boundary that emits these on transport errors, so we mock that state.
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [
+        { id: 'u1', role: 'user', content: 'List anomalies', timestamp: new Date().toISOString() },
+        {
+          id: 'sys-err',
+          role: 'system',
+          content: 'Error: failed to reach the AI service. Please try again.',
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    renderPage();
+
+    expect(
+      screen.getByText('Error: failed to reach the AI service. Please try again.'),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #1050

## Summary

Adds 7 frontend tests against `frontend/src/features/ai-intelligence/pages/llm-assistant.tsx` covering the gaps called out in #1050. The LLM transport is mocked at the `useLlmChat` hook boundary (matches the pre-existing pattern in the file and the project's CLAUDE.md guidance to *keep mocks close to the boundary*). The clear-history modal is exercised via accessible role/name queries against the `ConfirmDialog` Radix modal — `window.confirm` is **not** stubbed, since #1019 (CLOSED) replaced the native confirm with the modal dialog.

## Test cases added

**`Clear history flow (#1050)`**
1. Opens the confirm dialog when *Clear History* button is clicked
2. Calls `clearHistory` and closes the dialog when confirming
3. Preserves messages and does not call `clearHistory` when *Cancel* is clicked

**`Chat send/receive flow (#1050)`**
4. Sends the typed message to the LLM transport on submit (`sendMessage` invoked with `(text, undefined, selectedModel)`, input cleared)
5. Renders an assistant response returned by the LLM transport
6. Shows the loading indicator (`data-testid="thinking-indicator"`) after submit while waiting for the response
7. Renders a system error message when the LLM transport surfaces an error (`role: 'system'`)

## Originating closed issue

- **#1019** — `window.confirm()` → `ConfirmDialog` Radix modal replacement. Verified `CLOSED` before writing tests; tests target the modal, not the native confirm.

## Source modifications

**None.** `llm-assistant.tsx` was not modified. The test file was append-only (one cosmetic import-line edit to add `within` from `@testing-library/react`, plus two new top-level `describe` blocks).

## Verification

- `cd frontend && npm run lint` — clean (zero warnings, `--max-warnings=0`)
- `cd frontend && npm run typecheck` — clean
- `cd frontend && npx vitest run src/features/ai-intelligence/pages/llm-assistant.test.tsx` — **41/41 pass** (34 existing + 7 new)
- `cd frontend && npx vitest run` — **1618/1618 pass**, no regressions

## Test plan

- [x] Lint passes
- [x] Typecheck passes
- [x] Target test file passes (41 tests)
- [x] Full frontend suite passes (1618 tests)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)