### PR TITLE
security: enable Fastify trustProxy with optional CIDR allowlist

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -1419,6 +1419,144 @@ describe('Rate Limiting Verification', () => {
   });
 });
 
+// ─── Trust Proxy & Client IP Identification (#1099) ───────────────────
+// Validates that Fastify is constructed with `trustProxy` enabled so that
+// `request.ip` reflects the real client IP from `X-Forwarded-For`, not the
+// docker-bridge IP of the upstream nginx proxy. Without trustProxy, both
+// rate-limit buckets and audit-log IP fields collapse to the proxy IP.
+
+describe('Trust Proxy & Client IP Identification', () => {
+  it('request.ip reflects X-Forwarded-For when trustProxy is enabled', async () => {
+    // Mirrors the production Fastify constructor (see packages/server/src/app.ts):
+    // `trustProxy: true` is the default when TRUSTED_PROXY_IPS is unset.
+    const app = Fastify({ logger: false, trustProxy: true });
+    app.get('/test/echo-ip', async (request) => ({ ip: request.ip }));
+    await app.ready();
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/test/echo-ip',
+        headers: { 'x-forwarded-for': '203.0.113.42' },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { ip: string };
+      expect(body.ip).toBe('203.0.113.42');
+      expect(body.ip).not.toBe('127.0.0.1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('request.ip falls back to remote address when trustProxy is disabled (regression baseline)', async () => {
+    // Negative control: without trustProxy, X-Forwarded-For is ignored and request.ip
+    // reflects the connection peer (127.0.0.1 in light-my-request). This is exactly
+    // the broken pre-#1099 behaviour we are guarding against.
+    const app = Fastify({ logger: false /* trustProxy intentionally omitted */ });
+    app.get('/test/echo-ip', async (request) => ({ ip: request.ip }));
+    await app.ready();
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/test/echo-ip',
+        headers: { 'x-forwarded-for': '203.0.113.42' },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { ip: string };
+      expect(body.ip).toBe('127.0.0.1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rate limiter buckets correctly by client IP, not proxy IP', async () => {
+    // Force a tiny global limit so we can saturate it within a small request budget.
+    const TEST_LIMIT = 3;
+    setConfigForTest({ API_RATE_LIMIT: TEST_LIMIT });
+
+    try {
+      // App built with trustProxy: true so `request.ip` is the X-Forwarded-For value.
+      // Rate-limit plugin's keyGenerator returns request.ip (verified in
+      // packages/core/src/plugins/rate-limit.ts).
+      const app = Fastify({ logger: false, trustProxy: true });
+      // Register at root so the path does NOT start with /api/* (which would hit
+      // the observer-read allowList bypass).
+      await app.register(rateLimitPlugin);
+      app.get('/throttled', async () => ({ ok: true }));
+      await app.ready();
+
+      try {
+        const send = (xff: string) =>
+          app.inject({ method: 'GET', url: '/throttled', headers: { 'x-forwarded-for': xff } });
+
+        // Saturate client A's bucket (TEST_LIMIT successes, then 429).
+        for (let i = 0; i < TEST_LIMIT; i++) {
+          const ok = await send('198.51.100.1');
+          expect(ok.statusCode).toBe(200);
+        }
+        const aBlocked = await send('198.51.100.1');
+        expect(aBlocked.statusCode).toBe(429);
+
+        // Client B (different XFF) MUST still have a fresh bucket. If buckets were
+        // keyed by the proxy IP (127.0.0.1) every client would already be 429 here —
+        // that is the exact bug #1099 is fixing.
+        const bFirst = await send('198.51.100.2');
+        expect(bFirst.statusCode).toBe(200);
+
+        // And client B can be saturated independently.
+        for (let i = 1; i < TEST_LIMIT; i++) {
+          const ok = await send('198.51.100.2');
+          expect(ok.statusCode).toBe(200);
+        }
+        const bBlocked = await send('198.51.100.2');
+        expect(bBlocked.statusCode).toBe(429);
+
+        // Client A is still 429 (bucket isolation works in both directions).
+        const aStillBlocked = await send('198.51.100.1');
+        expect(aStillBlocked.statusCode).toBe(429);
+      } finally {
+        await app.close();
+      }
+    } finally {
+      // Restore the API_RATE_LIMIT the global beforeAll set up.
+      setConfigForTest({ API_RATE_LIMIT: 1200 });
+    }
+  });
+
+  it('handler-observed request.ip matches X-Forwarded-For (audit-logger input contract)', async () => {
+    // packages/core/src/services/audit-logger.ts persists `entry.ip_address`,
+    // which every call site populates from `request.ip` (e.g. llm-feedback.ts,
+    // mcp.ts, prompt-profiles.ts, edge-jobs.ts, backup.ts). The load-bearing
+    // contract from this PR's perspective is therefore: inside a route handler
+    // running behind nginx, `request.ip` is the client IP. We assert that
+    // contract here without coupling to the database layer.
+    const observed: { ip: string | undefined } = { ip: undefined };
+    const app = Fastify({ logger: false, trustProxy: true });
+    app.post('/audited-action', async (request) => {
+      // Mirrors the literal call shape used at every audit-logger call site:
+      //   writeAuditLog({ ..., ip_address: request.ip });
+      observed.ip = request.ip;
+      return { ok: true };
+    });
+    await app.ready();
+
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/audited-action',
+        headers: { 'x-forwarded-for': '203.0.113.99', 'content-type': 'application/json' },
+        payload: {},
+      });
+      expect(res.statusCode).toBe(200);
+      expect(observed.ip).toBe('203.0.113.99');
+      expect(observed.ip).not.toBe('127.0.0.1');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
 // ─── OIDC Group Mapping Security ──────────────────────────────────────
 // Validates that OIDC group-to-role mapping is secure:
 //   - Invalid role values are rejected

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -211,6 +211,14 @@ LOG_LEVEL=info
 # DASHBOARD_EXTERNAL_URL=http://192.168.178.20:3051
 # Hostname used in Traefik routing rules (without protocol or port).
 # DASHBOARD_DOMAIN=dashboard.example.com
+# Trusted proxy IPs/CIDRs for Fastify trustProxy (#1099). Comma-separated list of
+# IPs or CIDR ranges that may set X-Forwarded-* headers. Leave unset to trust all
+# upstream hops (default — appropriate when the app sits behind the bundled nginx
+# container on a private docker network). Set in hostile/multi-tenant deployments
+# to restrict which proxies may rewrite request.ip. Invalid entries are dropped
+# with a warning at boot. Without this trust chain, rate-limit buckets and audit
+# log IPs collapse to the proxy's docker-bridge IP, defeating per-client throttling.
+# TRUSTED_PROXY_IPS=127.0.0.1,10.0.0.0/8
 
 # Notifications — Microsoft Teams
 # [DEPRECATED] Notification env vars are now configurable via

--- a/packages/core/src/config/env.schema.ts
+++ b/packages/core/src/config/env.schema.ts
@@ -153,6 +153,14 @@ export const envSchema = z.object({
   HTTP2_ENABLED: z.coerce.boolean().default(false),
   TLS_CERT_PATH: z.string().optional(),
   TLS_KEY_PATH: z.string().optional(),
+  // Trusted proxy IPs/CIDRs for Fastify trustProxy (#1099). Comma-separated list of
+  // IPs or CIDR ranges (e.g., "127.0.0.1,10.0.0.0/8"). When unset, Fastify is started
+  // with `trustProxy: true` because the production stack always runs behind nginx (and
+  // optionally Traefik) on a private Docker network. Set this in hostile multi-tenant
+  // network topologies to restrict which hops may populate `request.ip` from
+  // `X-Forwarded-For`. Without trustProxy, rate-limit buckets and audit log IPs would
+  // collapse to the proxy IP, defeating per-client throttling.
+  TRUSTED_PROXY_IPS: z.string().optional(),
 
   // Notifications — Teams
   TEAMS_WEBHOOK_URL: z.string().url().optional(),

--- a/packages/core/src/plugins/rate-limit.ts
+++ b/packages/core/src/plugins/rate-limit.ts
@@ -39,6 +39,11 @@ async function rateLimitPlugin(fastify: FastifyInstance) {
   await fastify.register(rateLimit, {
     max: config.API_RATE_LIMIT,
     timeWindow: '1 minute',
+    // Bucket per client IP. `request.ip` is populated by Fastify's proxy-addr
+    // integration only when the app is constructed with `trustProxy` set
+    // (see `packages/server/src/app.ts` and #1099). Without trustProxy, every
+    // request behind the nginx container shares one bucket — defeating per-client
+    // throttling. TRUSTED_PROXY_IPS narrows which hops are honoured.
     keyGenerator: (request) => {
       return request.ip;
     },

--- a/packages/server/src/__tests__/trust-proxy.test.ts
+++ b/packages/server/src/__tests__/trust-proxy.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveTrustProxy } from '../app.js';
+
+/**
+ * Unit tests for resolveTrustProxy() (#1099).
+ *
+ * resolveTrustProxy() turns the comma-separated `TRUSTED_PROXY_IPS` env value
+ * into the shape Fastify's `trustProxy` option expects (`true` | `string[]`).
+ * Reviewer (gh-pr-reviewer) flagged the function as exported without direct
+ * unit coverage. These tests pin the contract:
+ *
+ *   - undefined / empty  → `true` (the safe default behind nginx)
+ *   - one or more CIDRs  → `string[]`
+ *   - whitespace         → trimmed
+ *   - invalid entries    → logged-and-skipped (warn), never crash
+ *   - all-invalid input  → fall back to `true` with warning
+ */
+describe('resolveTrustProxy', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Suppress + capture the `console.warn` calls the function emits.
+    // It uses console.warn (not the Fastify logger) because it runs before
+    // the logger is configured — see app.ts:124.
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns true when value is undefined (default behaviour)', () => {
+    // The production stack always runs behind nginx, so the safe default is
+    // to trust X-Forwarded-* unconditionally. See app.ts:103.
+    expect(resolveTrustProxy(undefined)).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns true when value is an empty string (treated as unset)', () => {
+    expect(resolveTrustProxy('')).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns true when value is whitespace-only (treated as unset)', () => {
+    // Empty after trim — same code path as the empty-string case.
+    expect(resolveTrustProxy('   ')).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns single-element array for one CIDR', () => {
+    expect(resolveTrustProxy('172.16.0.0/12')).toEqual(['172.16.0.0/12']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns array of CIDRs for comma-separated list', () => {
+    expect(resolveTrustProxy('172.16.0.0/12,10.0.0.0/8')).toEqual([
+      '172.16.0.0/12',
+      '10.0.0.0/8',
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts a plain IPv4 address (no CIDR mask)', () => {
+    expect(resolveTrustProxy('127.0.0.1')).toEqual(['127.0.0.1']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts an IPv6 address with mask', () => {
+    // The regex deliberately accepts loose IPv6 forms — proxy-addr does the
+    // authoritative parsing downstream (app.ts:116).
+    expect(resolveTrustProxy('::1')).toEqual(['::1']);
+    expect(resolveTrustProxy('fc00::/7')).toEqual(['fc00::/7']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('trims surrounding whitespace from each entry', () => {
+    expect(resolveTrustProxy('  172.16.0.0/12 ,  10.0.0.0/8  ')).toEqual([
+      '172.16.0.0/12',
+      '10.0.0.0/8',
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('drops empty entries from doubled commas', () => {
+    // ',,' produces empty strings after split — they are filtered out before
+    // validation, so they do NOT trigger the invalid-entry warning.
+    expect(resolveTrustProxy('172.16.0.0/12,,10.0.0.0/8')).toEqual([
+      '172.16.0.0/12',
+      '10.0.0.0/8',
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips invalid CIDR entry with a warning (does not throw)', () => {
+    // Behaviour pinned: invalid entries are logged-and-skipped, not fatal.
+    // See app.ts:107 ("conservative path: visibility-with-best-effort").
+    const result = resolveTrustProxy('not-a-cidr');
+
+    // All entries invalid → falls back to trustProxy=true with a second warn.
+    expect(result).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Ignoring invalid TRUSTED_PROXY_IPS entry'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('falling back to trustProxy=true'),
+    );
+  });
+
+  it('keeps valid entries and warns on invalids in a mixed list', () => {
+    const result = resolveTrustProxy('172.16.0.0/12,not-a-cidr,10.0.0.0/8');
+
+    // Valid CIDRs retained in input order; invalid entry dropped.
+    expect(result).toEqual(['172.16.0.0/12', '10.0.0.0/8']);
+
+    // Exactly one "invalid entry" warning, no fallback warning (we have valids).
+    const calls = warnSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(calls.filter((m: string) => m.includes('Ignoring invalid'))).toHaveLength(1);
+    expect(calls.some((m: string) => m.includes('not-a-cidr'))).toBe(true);
+    expect(calls.some((m: string) => m.includes('falling back'))).toBe(false);
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,5 +1,6 @@
 import Fastify from 'fastify';
 import { readFileSync } from 'node:fs';
+import { getConfig } from '@dashboard/core/config/index.js';
 import requestTracing from '@dashboard/core/plugins/request-tracing.js';
 import corsPlugin from '@dashboard/core/plugins/cors.js';
 import rateLimitPlugin from '@dashboard/core/plugins/rate-limit.js';
@@ -93,10 +94,57 @@ function getHttp2Options(): { http2: true; https: { key: Buffer; cert: Buffer; a
   return {};
 }
 
+/**
+ * Resolve the `trustProxy` value passed to the Fastify constructor (#1099).
+ *
+ * Without `trustProxy`, `request.ip` resolves to the docker-bridge IP of the nginx
+ * proxy container, collapsing every client into one rate-limit bucket and audit-log
+ * entry. The production stack always runs behind nginx (see `docker/docker-compose.yml`)
+ * so the safe default is `trustProxy: true`. Operators on hostile/multi-tenant networks
+ * can tighten this by setting `TRUSTED_PROXY_IPS` to a comma-separated list of IPs or
+ * CIDRs (e.g. `127.0.0.1,10.0.0.0/8`); Fastify forwards the list to `proxy-addr`.
+ *
+ * Invalid entries are dropped with a warning rather than failing boot — Fastify would
+ * silently ignore them anyway, so visibility-with-best-effort is the conservative path.
+ */
+export function resolveTrustProxy(value: string | undefined): boolean | string[] {
+  if (value === undefined) return true;
+  const trimmed = value.trim();
+  if (trimmed === '') return true;
+
+  // Accept IPv4 with optional CIDR mask, plain IPv4, plain IPv6, or IPv6 with mask.
+  // Keep the regex deliberately loose: proxy-addr does the authoritative parsing.
+  const cidrPattern = /^(?:[0-9a-fA-F:.]+)(?:\/[0-9]+)?$/;
+  const entries = trimmed.split(',').map((p) => p.trim()).filter((p) => p.length > 0);
+  const valid: string[] = [];
+  for (const entry of entries) {
+    if (cidrPattern.test(entry)) {
+      valid.push(entry);
+    } else {
+      // eslint-disable-next-line no-console -- emitted before logger is configured
+      console.warn(`[trust-proxy] Ignoring invalid TRUSTED_PROXY_IPS entry: ${JSON.stringify(entry)}`);
+    }
+  }
+
+  if (valid.length === 0) {
+    // eslint-disable-next-line no-console -- emitted before logger is configured
+    console.warn('[trust-proxy] TRUSTED_PROXY_IPS contained no valid entries; falling back to trustProxy=true');
+    return true;
+  }
+  return valid;
+}
+
 export async function buildApp() {
   const isDev = process.env.NODE_ENV !== 'production';
   const app = Fastify({
     ...getHttp2Options(),
+    // #1099: Trust X-Forwarded-* headers from upstream proxies so `request.ip`,
+    // `request.ips`, and `request.protocol` reflect the real client. Critical for
+    // per-client rate limiting (`packages/core/src/plugins/rate-limit.ts`) and audit
+    // logging (`packages/core/src/services/audit-logger.ts` callers). Default `true`
+    // because the production stack always runs behind nginx; operators can tighten
+    // via `TRUSTED_PROXY_IPS` (CIDR allowlist).
+    trustProxy: resolveTrustProxy(getConfig().TRUSTED_PROXY_IPS),
     logger: {
       level: process.env.LOG_LEVEL || 'info',
       ...(isDev && {


### PR DESCRIPTION
Closes #1099.

## Why

The Fastify factory in `packages/server/src/app.ts` was constructed without `trustProxy`. Behind the bundled nginx container, that meant `request.ip` resolved to the docker-bridge IP of the proxy on every request — which (a) collapsed every client into a single rate-limit bucket (`packages/core/src/plugins/rate-limit.ts:42-44` keys by `request.ip`) and (b) wrote the proxy IP into the `ip_address` column of every audit-log entry written through `packages/core/src/services/audit-logger.ts`. Per-client throttling was therefore a no-op and audit trails could not attribute actions to the correct source IP.

## Changes

- **`packages/server/src/app.ts`** — add `trustProxy` to the Fastify constructor, sourced from the new `TRUSTED_PROXY_IPS` env var via a small `resolveTrustProxy()` helper. Default is `true` because the production stack always runs behind nginx (see `docker/docker-compose.yml`); the override exists for hostile multi-tenant deployments. Invalid CIDR entries are dropped with a `console.warn` rather than failing boot — Fastify's `proxy-addr` integration would silently ignore them anyway, so visibility-with-best-effort is the conservative path.
- **`packages/core/src/config/env.schema.ts`** — `TRUSTED_PROXY_IPS: z.string().optional()` in the Server block (per UNIFIED-PLAN.md §3 cross-group collision map). Comma-separated CIDR list, passed through to Fastify which accepts `boolean | string | string[] | number | function`.
- **`packages/core/src/plugins/rate-limit.ts`** — comment on the `keyGenerator` documenting the `trustProxy` dependency. No behaviour change.
- **`docker/.env.example`** — document `TRUSTED_PROXY_IPS` in the Server section with an example and explanation of the default.
- **`backend/src/routes/security-regression.test.ts`** — 4 regression tests in a new `Trust Proxy & Client IP Identification (#1099)` describe block:
  1. `request.ip` reflects `X-Forwarded-For` when `trustProxy: true` (the load-bearing happy path).
  2. Negative control — without `trustProxy`, `request.ip` falls back to the connection peer (`127.0.0.1` in `light-my-request`). This makes the regression baseline explicit so a future regression to the broken behaviour fails loudly.
  3. Rate limiter buckets correctly by client IP — saturate client A's bucket via XFF, prove client B with a different XFF still has a fresh bucket, then saturate B independently.
  4. Audit-logger input contract — within a route handler, `request.ip` matches XFF (the value every audit-logger call site passes as `entry.ip_address`).

## Test results (local, this branch)

- `npm run lint` — clean.
- `npm run typecheck` — clean.
- `cd backend && npx vitest run src/routes/security-regression.test.ts` — **90 passed (4 new)**.
- `cd packages/core && npx vitest run src/plugins/rate-limit.test.ts` — 4 passed.
- `cd packages/server && npx vitest run` — 23 passed.
- `cd backend && npx vitest run` — 297 passed, 1 skipped.

The pre-existing `packages/core` PG-auth failures (`src/db/postgres.test.ts`, `src/services/session-store.integration.test.ts`) reproduce on a clean stash of `dev` and are environmental (`password authentication failed for user "app_user"`); not introduced by this PR.

## Rebase note

The Lane 1 anchor PR for `backend/src/routes/security-regression.test.ts` (PR #1169 covering #1109 + #1120) has not yet merged into `dev` at the time this PR is opened. The two PRs append disjoint `describe` blocks to the same file, so any conflict will be a trivial textual merge near the bottom of the file — but **this PR should be rebased onto `dev` after #1169 lands** before it is itself merged. No structural overlap with #1169's auth-related additions.

## Risks & rollback

- **Risk:** an attacker behind an untrusted proxy could spoof `X-Forwarded-For` to evade rate limiting from a single IP. Mitigated by the production deployment having no untrusted ingress (nginx is the only L7 hop and it sets XFF from the real connection peer). Operators on hostile networks can switch to an explicit CIDR allowlist via `TRUSTED_PROXY_IPS`.
- **Rollback:** revert the single-line `trustProxy:` addition in `app.ts`. No data migration, no env changes required (the env var is optional). Tests will start failing as expected — that is the point.