### PR TITLE
security: harden Linux capabilities on backend/frontend/postgres + fix timescaledb gosu conflict

### DIFF
--- a/backend/src/docker-security.test.ts
+++ b/backend/src/docker-security.test.ts
@@ -158,3 +158,180 @@ describe('.dockerignore security', () => {
     }
   });
 });
+
+/**
+ * Returns true if `line` is a top-level service key (exactly 2-space indent,
+ * a single identifier, then a colon, optional trailing whitespace, nothing else).
+ * Implemented with string ops rather than dynamic regex to avoid ReDoS surface.
+ */
+function isServiceKeyLine(line: string): boolean {
+  if (!line.startsWith('  ') || line.startsWith('   ')) return false;
+  const rest = line.slice(2);
+  const colonIdx = rest.indexOf(':');
+  if (colonIdx <= 0) return false;
+  const ident = rest.slice(0, colonIdx);
+  if (!/^[A-Za-z0-9_-]+$/.test(ident)) return false;
+  return rest.slice(colonIdx + 1).trim() === '';
+}
+
+/**
+ * Returns true if `line` is a service-body key (exactly 4-space indent,
+ * single identifier, colon, optional trailing whitespace).
+ */
+function isFieldKeyLine(line: string): boolean {
+  if (!line.startsWith('    ') || line.startsWith('     ')) return false;
+  const rest = line.slice(4);
+  const colonIdx = rest.indexOf(':');
+  if (colonIdx <= 0) return false;
+  const ident = rest.slice(0, colonIdx);
+  if (!/^[A-Za-z0-9_-]+$/.test(ident)) return false;
+  return rest.slice(colonIdx + 1).trim() === '';
+}
+
+/**
+ * Extracts the YAML block for a given top-level service from
+ * `docker/docker-compose.yml`. We rely on the indentation contract:
+ *   - service keys are indented by exactly 2 spaces
+ *   - their bodies are indented by 4+ spaces
+ * The block ends at the next 2-space-indented key or EOF.
+ */
+function getComposeServiceBlock(serviceName: string): string {
+  const content = readFile('docker/docker-compose.yml');
+  const lines = content.split('\n');
+  const header = `  ${serviceName}:`;
+  const start = lines.findIndex((l) => l === header || l === header + ' ');
+  if (start === -1) {
+    throw new Error(`Service "${serviceName}" not found in docker/docker-compose.yml`);
+  }
+  const after = lines.slice(start + 1);
+  const endRel = after.findIndex((l) => isServiceKeyLine(l));
+  const end = endRel === -1 ? lines.length : start + 1 + endRel;
+  return lines.slice(start, end).join('\n');
+}
+
+/**
+ * Within a single service block, returns the lines belonging to the named
+ * top-level key (e.g. "cap_drop", "cap_add", "security_opt") as a flat
+ * array of trimmed list-item values. The key is at 4-space indent inside
+ * the block; its list items are at 6-space indent with `- ` prefix.
+ * Returns `null` if the key is not present.
+ */
+function getServiceListField(block: string, fieldName: string): string[] | null {
+  const lines = block.split('\n');
+  const header = `    ${fieldName}:`;
+  const start = lines.findIndex((l) => l === header || l === header + ' ');
+  if (start === -1) return null;
+  const items: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith('      - ')) {
+      // Strip inline comments and trailing whitespace
+      items.push(line.slice(8).replace(/\s+#.*$/, '').trim());
+      continue;
+    }
+    if (isFieldKeyLine(line)) break;
+    if (line.trim() === '') continue;
+    // Any other content terminates the list (e.g. dedent to next service)
+    break;
+  }
+  return items;
+}
+
+describe('docker/docker-compose.yml capability hardening', () => {
+  // Services that SHOULD have cap_drop: [ALL]
+  const cappedServices = ['backend', 'frontend', 'postgres-app', 'timescaledb'];
+
+  for (const svc of cappedServices) {
+    describe(`${svc}`, () => {
+      const block = getComposeServiceBlock(svc);
+
+      it('drops ALL Linux capabilities', () => {
+        const capDrop = getServiceListField(block, 'cap_drop');
+        expect(capDrop).not.toBeNull();
+        expect(capDrop).toEqual(['ALL']);
+      });
+    });
+  }
+
+  describe('backend', () => {
+    const block = getComposeServiceBlock('backend');
+
+    it('does NOT request any cap_add (non-root, port >1024)', () => {
+      expect(getServiceListField(block, 'cap_add')).toBeNull();
+    });
+
+    it('sets no-new-privileges:true (no privilege transition needed)', () => {
+      expect(getServiceListField(block, 'security_opt')).toEqual(['no-new-privileges:true']);
+    });
+  });
+
+  describe('frontend', () => {
+    const block = getComposeServiceBlock('frontend');
+
+    it('does NOT request any cap_add (nginx as nonroot on port 8080)', () => {
+      expect(getServiceListField(block, 'cap_add')).toBeNull();
+    });
+
+    it('sets no-new-privileges:true (no privilege transition needed)', () => {
+      expect(getServiceListField(block, 'security_opt')).toEqual(['no-new-privileges:true']);
+    });
+  });
+
+  // postgres-app and timescaledb both run the postgres entrypoint that uses
+  // `gosu` to switch from root → postgres at startup. `no-new-privileges:true`
+  // would block that transition, so it MUST be omitted on these two services.
+  // They share the same minimal cap_add allowlist instead.
+  const postgresServices = ['postgres-app', 'timescaledb'] as const;
+  const postgresExpectedCapAdd = ['CHOWN', 'DAC_OVERRIDE', 'FOWNER', 'SETUID', 'SETGID'];
+
+  for (const svc of postgresServices) {
+    describe(`${svc}`, () => {
+      const block = getComposeServiceBlock(svc);
+
+      it('does NOT set no-new-privileges (gosu requires privilege transition)', () => {
+        const securityOpt = getServiceListField(block, 'security_opt');
+        // Either the field is absent entirely, or present without no-new-privileges.
+        if (securityOpt !== null) {
+          expect(securityOpt).not.toContain('no-new-privileges:true');
+        }
+      });
+
+      it('adds the minimal cap set for postgres entrypoint (gosu + chown init)', () => {
+        const capAdd = getServiceListField(block, 'cap_add');
+        expect(capAdd).not.toBeNull();
+        expect([...(capAdd ?? [])].sort()).toEqual([...postgresExpectedCapAdd].sort());
+      });
+    });
+  }
+
+  it('postgres-app and timescaledb share the same cap_add set', () => {
+    const a = getServiceListField(getComposeServiceBlock('postgres-app'), 'cap_add');
+    const b = getServiceListField(getComposeServiceBlock('timescaledb'), 'cap_add');
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect([...(a ?? [])].sort()).toEqual([...(b ?? [])].sort());
+  });
+
+  // Regression guard for the B1 audit (CRITIC-FINDINGS §A1).
+  // These two services were investigated and confirmed compatible with
+  // `no-new-privileges:true`. They MUST NOT be modified by this PR.
+  // See /tmp/issue-plans/B1-AUDIT.md for the full investigation.
+  describe('B1 audit regression guard (services intentionally NOT modified)', () => {
+    it('timescale-backup retains no-new-privileges:true (entrypoint runs as root, no gosu)', () => {
+      const block = getComposeServiceBlock('timescale-backup');
+      expect(getServiceListField(block, 'security_opt')).toEqual(['no-new-privileges:true']);
+      // Must NOT have inherited the timescaledb cap_drop+cap_add pattern.
+      expect(getServiceListField(block, 'cap_drop')).toBeNull();
+      expect(getServiceListField(block, 'cap_add')).toBeNull();
+    });
+
+    it('kali-mcp retains no-new-privileges:true (USER appuser at build time)', () => {
+      const block = getComposeServiceBlock('kali-mcp');
+      expect(getServiceListField(block, 'security_opt')).toEqual(['no-new-privileges:true']);
+      // Pre-existing cap_add (non-functional for non-root USER without setcap)
+      // is intentionally left untouched here; addressing it is a separate Dockerfile
+      // change tracked outside this PR.
+      expect(getServiceListField(block, 'cap_add')).toEqual(['NET_RAW', 'NET_ADMIN']);
+    });
+  });
+});

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,13 @@ services:
       - "127.0.0.1:3051:3051"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    # Hardening (#1118): backend runs as non-root `node` user on port 3051 (>1024)
+    # and never escalates privileges. All Linux capabilities are dropped, and
+    # no-new-privileges blocks any future setuid binary from gaining privs.
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     environment:
       - LOG_LEVEL=debug
       - NODE_ENV=production
@@ -116,6 +123,14 @@ services:
       dockerfile: frontend/Dockerfile
     ports:
       - "8080:8080"
+    # Hardening (#1118): nginx runs as the DHI nonroot user on port 8080 (>1024).
+    # No bind to privileged ports → no caps required. If a future nginx config
+    # change demands setuid (e.g. binding 80/443 directly), revisit by adding
+    # the conservative set [CHOWN, SETUID, SETGID].
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     healthcheck:
       test: ["CMD", "/usr/bin/wget", "--spider", "--quiet", "http://127.0.0.1:8080/"]
       interval: 30s
@@ -177,8 +192,18 @@ services:
   postgres-app:
     image: postgres:17-alpine
     restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
+    # Hardening (#1104): mirror the timescaledb pattern. The PostgreSQL entrypoint
+    # requires a root → postgres privilege transition via `gosu`, which is
+    # incompatible with `no-new-privileges:true`. Instead, drop ALL capabilities
+    # and add back only the minimum set needed for entrypoint init + runtime.
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN        # chown data directory to postgres
+      - DAC_OVERRIDE # access files during init regardless of perms
+      - FOWNER       # set ownership on data files
+      - SETUID       # gosu: switch from root to postgres
+      - SETGID       # gosu: switch group
     environment:
       POSTGRES_DB: portainer_dashboard
       POSTGRES_USER: app_user
@@ -205,11 +230,11 @@ services:
     # Pinned version — avoid :latest for reproducible builds (see #554)
     image: timescale/timescaledb:2.25.0-pg17
     restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
-    # PostgreSQL entrypoint requires root → postgres privilege transition (gosu)
-    # so no-new-privileges is NOT compatible. Instead, drop all caps and add
-    # back only the minimum set needed for entrypoint init + runtime.
+    # Hardening (#1100): the PostgreSQL entrypoint requires a root → postgres
+    # privilege transition via `gosu`, which is BLOCKED by `no-new-privileges:true`.
+    # Setting both directives is contradictory and would prevent the container
+    # from starting. We intentionally OMIT no-new-privileges here and instead
+    # rely on the strict cap_drop/cap_add allowlist below to bound privileges.
     cap_drop:
       - ALL
     cap_add:


### PR DESCRIPTION
Closes #1100
Closes #1104
Closes #1118

## Summary

Tightens Linux capability posture on four production services in `docker/docker-compose.yml`, and fixes a contradictory directive on `timescaledb` that would have blocked startup if the kernel ever enforced it.

| Service | Before | After |
|---|---|---|
| `backend` | no `cap_drop`, no `security_opt` | `cap_drop: [ALL]` + `no-new-privileges:true` |
| `frontend` | no `cap_drop`, no `security_opt` | `cap_drop: [ALL]` + `no-new-privileges:true` |
| `postgres-app` | no `cap_drop`, `no-new-privileges:true` | `cap_drop: [ALL]` + `cap_add: [CHOWN, DAC_OVERRIDE, FOWNER, SETUID, SETGID]` (no-new-privileges removed — gosu) |
| `timescaledb` | both `no-new-privileges:true` AND `cap_add: [SETUID, SETGID]` | `cap_drop: [ALL]` + minimal `cap_add` only (no-new-privileges removed — gosu) |

## Why

- **#1100**: `timescaledb` previously set `no-new-privileges:true` AND `cap_add: [SETUID, SETGID]`. The directives are contradictory — the postgres entrypoint runs as root and uses `gosu` to drop to the `postgres` user, which is exactly the privilege transition that `no-new-privileges` blocks. The cap-add was the right move; the security_opt line was the bug. Remove it. The comment is updated to record why it's intentionally absent.
- **#1104**: `postgres-app` was missing `cap_drop: ALL` entirely. Apply the same post-#1100 pattern. Same `gosu` constraint applies, so no-new-privileges is also omitted here.
- **#1118**: `backend` (Node on 3051) and `frontend` (nginx on 8080) both run as non-root on unprivileged ports, never escalate, and need no caps. Drop everything and set `no-new-privileges:true`.

## Audit notes — services intentionally NOT modified

Per [`/tmp/issue-plans/B1-AUDIT.md`](https://github.com/kenhaesler/ai-portainer-dashboard) (CRITIC-FINDINGS §A1), two co-resident services in this compose file carry `no-new-privileges:true` and were investigated as part of pre-flight for this PR:

1. **`timescale-backup`** (`prodrigestivill/postgres-backup-local:17`): the actual entrypoint is `/init.sh` → `go-cron` → `/backup.sh`, all running as root with no `gosu`/`su-exec` calls. Live test against a `postgres:17-alpine` peer confirmed `SQL backup created successfully` under `--security-opt no-new-privileges:true`. **Keep as-is.** Reviewers: do NOT apply the timescaledb `cap_drop: [ALL] + cap_add: […]` pattern here by analogy — it would be unnecessary and would weaken the existing posture.
2. **`kali-mcp`** (built locally from `tools/kali-mcp/Dockerfile`): drops to `appuser` at build time via `USER appuser`, then runs `tini` + a Python MCP server with no setuid transitions. The default `ALLOWED_COMMANDS` need no capabilities. **Keep as-is.**
   - **Follow-up issue suggested (out of scope here)**: kali-mcp's existing `cap_add: [NET_RAW, NET_ADMIN]` is **non-functional for the non-root USER** — Docker doesn't grant ambient/effective caps to non-root UIDs without explicit `setcap` on binaries. If operators ever expand `ALLOWED_COMMANDS` to raw-socket tools (`nmap -sS`, `tcpdump`, etc.), the proper fix is a Dockerfile change adding `setcap cap_net_raw,cap_net_admin+eip` to those binaries. Removing `no-new-privileges` would NOT enable the caps — they'd still be zero in the effective set. Tracking this as a separate concern is appropriate.

The new test suite includes a **regression guard** that asserts both services still carry `no-new-privileges:true` and have not had the timescaledb cap pattern applied to them, so any future drive-by edit will fail CI.

## Validation

**Static**:
- `docker compose -f docker/docker-compose.yml config` — parses cleanly.
- `npm run lint` — passes (root + backend + frontend workspaces).
- `npm run typecheck` — passes (backend strict TS).

**Tests**:
- `cd backend && npx vitest run src/docker-security.test.ts` — **43/43 passing** (28 pre-existing + 15 new compose assertions).
- New assertions cover: `cap_drop: [ALL]` on all four hardened services, `cap_add` allowlist match for the two postgres services, no-new-privileges presence for backend/frontend, no-new-privileges absence for the two postgres services (gosu requirement), shared cap_add between postgres-app and timescaledb, and regression guards on timescale-backup + kali-mcp.

**Live runtime** (highest-risk: gosu interaction):
- Brought up `postgres-app` and `timescaledb` in an isolated compose project with the new caps applied. Both reached `healthy` status within 30s. Logs show normal postgres init + gosu drop with no capability-related errors. Tear-down clean.

## Test plan

- [x] `docker compose config` parses cleanly
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `backend/src/docker-security.test.ts` — all 43 tests pass
- [x] Manual stack-up of postgres-app + timescaledb under the new caps reaches healthy
- [ ] Reviewer to confirm full-stack `docker compose up -d` on a clean environment reaches healthy across all default-profile services

🤖 Generated with [Claude Code](https://claude.com/claude-code)