### PR TITLE
test: cover network-topology, auth-callback, edge-agent-logs, ui-store

### DIFF
--- a/frontend/src/features/containers/pages/network-topology.test.tsx
+++ b/frontend/src/features/containers/pages/network-topology.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import NetworkTopologyPage from './network-topology';
+import { useUiStore } from '@/stores/ui-store';
+
+// Mock data hooks at the boundary
+vi.mock('@/features/containers/hooks/use-containers', () => ({
+  useContainers: vi.fn(),
+}));
+
+vi.mock('@/features/containers/hooks/use-networks', () => ({
+  useNetworks: vi.fn(),
+}));
+
+vi.mock('@/features/containers/hooks/use-endpoints', () => ({
+  useEndpoints: vi.fn(),
+}));
+
+vi.mock('@/features/observability/hooks/use-metrics', () => ({
+  useNetworkRates: vi.fn(),
+}));
+
+vi.mock('@/shared/hooks/use-auto-refresh', () => ({
+  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn() }),
+}));
+
+// Stub TopologyGraph — it depends on @xyflow/react which is heavy in jsdom and
+// adds nothing to the page-level smoke test.
+vi.mock('@/features/containers/components/network/topology-graph', () => ({
+  TopologyGraph: ({
+    containers,
+    networks,
+  }: {
+    containers: Array<{ id: string; name: string }>;
+    networks: Array<{ id: string; name: string }>;
+  }) => (
+    <div data-testid="topology-graph">
+      <span data-testid="topology-container-count">{containers.length}</span>
+      <span data-testid="topology-network-count">{networks.length}</span>
+    </div>
+  ),
+}));
+
+import { useContainers } from '@/features/containers/hooks/use-containers';
+import { useNetworks } from '@/features/containers/hooks/use-networks';
+import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
+import { useNetworkRates } from '@/features/observability/hooks/use-metrics';
+
+const mockUseContainers = vi.mocked(useContainers);
+const mockUseNetworks = vi.mocked(useNetworks);
+const mockUseEndpoints = vi.mocked(useEndpoints);
+const mockUseNetworkRates = vi.mocked(useNetworkRates);
+
+function makeContainer(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'c1',
+    name: 'web',
+    image: 'nginx:latest',
+    state: 'running',
+    status: 'Up 2 minutes',
+    endpointId: 1,
+    endpointName: 'local',
+    ports: [],
+    created: 1700000000,
+    labels: {},
+    networks: ['bridge'],
+    networkIPs: { bridge: '172.17.0.2' },
+    ...overrides,
+  };
+}
+
+function makeNetwork(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'n1',
+    name: 'bridge',
+    driver: 'bridge',
+    scope: 'local',
+    subnet: '172.17.0.0/16',
+    gateway: '172.17.0.1',
+    endpointId: 1,
+    endpointName: 'local',
+    containers: ['c1'],
+    ...overrides,
+  };
+}
+
+function setHooks({
+  containers,
+  networks,
+  containersState = {},
+  networksState = {},
+}: {
+  containers?: ReturnType<typeof makeContainer>[];
+  networks?: ReturnType<typeof makeNetwork>[];
+  containersState?: Record<string, unknown>;
+  networksState?: Record<string, unknown>;
+}) {
+  mockUseContainers.mockReturnValue({
+    data: containers,
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    refetch: vi.fn(),
+    ...containersState,
+  } as any);
+
+  mockUseNetworks.mockReturnValue({
+    data: networks,
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    refetch: vi.fn(),
+    ...networksState,
+  } as any);
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <NetworkTopologyPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('NetworkTopologyPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({
+      sidebarCollapsed: false,
+      commandPaletteOpen: false,
+      potatoMode: false,
+      collapsedGroups: {},
+      pageViewModes: {},
+    });
+
+    mockUseEndpoints.mockReturnValue({
+      data: [
+        { id: 1, name: 'local' },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    mockUseNetworkRates.mockReturnValue({ data: { rates: {} } } as any);
+  });
+
+  it('renders the page heading and description', () => {
+    setHooks({ containers: [makeContainer()], networks: [makeNetwork()] });
+
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', { name: 'Network Topology' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Interactive network graph visualization'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the topology graph with container and network counts', () => {
+    setHooks({
+      containers: [
+        makeContainer({ id: 'c1', name: 'web' }),
+        makeContainer({ id: 'c2', name: 'api' }),
+      ],
+      networks: [makeNetwork({ id: 'n1', name: 'bridge' })],
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId('topology-graph')).toBeInTheDocument();
+    expect(screen.getByTestId('topology-container-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('topology-network-count')).toHaveTextContent('1');
+  });
+
+  it('shows the count summary text', () => {
+    setHooks({
+      containers: [makeContainer({ id: 'c1' }), makeContainer({ id: 'c2' })],
+      networks: [makeNetwork({ id: 'n1' }), makeNetwork({ id: 'n2' })],
+    });
+
+    renderPage();
+
+    expect(screen.getByText(/2 containers/)).toBeInTheDocument();
+    expect(screen.getByText(/2 networks/)).toBeInTheDocument();
+  });
+
+  it('shows the loading skeleton while data is loading', () => {
+    setHooks({
+      containers: undefined,
+      networks: undefined,
+      containersState: { isLoading: true, isPending: true },
+      networksState: { isLoading: true, isPending: true },
+    });
+
+    renderPage();
+
+    // Topology graph should not render in the loading state
+    expect(screen.queryByTestId('topology-graph')).not.toBeInTheDocument();
+    // SkeletonCard renders a status node with aria-label="Loading"
+    expect(
+      screen.getByRole('status', { name: 'Loading' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders an error state when containers fetch fails', () => {
+    setHooks({
+      containers: undefined,
+      networks: [makeNetwork()],
+      containersState: { isError: true },
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Error loading topology')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.queryByTestId('topology-graph')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty topology graph when containers and networks are empty arrays', () => {
+    setHooks({ containers: [], networks: [] });
+
+    renderPage();
+
+    // No error, no skeleton — just a graph with zero nodes
+    expect(screen.queryByText('Error loading topology')).not.toBeInTheDocument();
+    expect(screen.getByTestId('topology-graph')).toBeInTheDocument();
+    expect(screen.getByTestId('topology-container-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('topology-network-count')).toHaveTextContent('0');
+  });
+});

--- a/frontend/src/features/core/pages/auth-callback.test.tsx
+++ b/frontend/src/features/core/pages/auth-callback.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AuthCallbackPage from './auth-callback';
+
+const mockNavigate = vi.fn();
+const mockLoginWithToken = vi.fn();
+const mockApiPost = vi.fn();
+let currentSearch = '';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useSearchParams: () => [new URLSearchParams(currentSearch), vi.fn()],
+  };
+});
+
+vi.mock('@/features/core/hooks/use-auth', () => ({
+  useAuth: () => ({
+    loginWithToken: mockLoginWithToken,
+  }),
+}));
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    post: (...args: unknown[]) => mockApiPost(...args),
+  },
+}));
+
+function renderPage(search: string) {
+  currentSearch = search;
+  return render(
+    <MemoryRouter>
+      <AuthCallbackPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AuthCallbackPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockReset();
+    mockLoginWithToken.mockReset();
+    mockApiPost.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('successful OIDC callback', () => {
+    it('exchanges the code, calls loginWithToken and redirects to "/"', async () => {
+      mockApiPost.mockResolvedValue({
+        token: 'jwt.token.value',
+        username: 'alice',
+        expiresAt: '2099-01-01T00:00:00Z',
+      });
+
+      renderPage('?code=auth-code-123&state=state-xyz');
+
+      // Loading spinner shown initially
+      expect(screen.getByText(/Completing sign-in/i)).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(mockApiPost).toHaveBeenCalledWith(
+          '/api/auth/oidc/callback',
+          expect.objectContaining({ state: 'state-xyz' }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockLoginWithToken).toHaveBeenCalledWith('jwt.token.value', 'alice');
+      });
+      expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+    });
+
+    it('passes the current callback URL to the backend', async () => {
+      mockApiPost.mockResolvedValue({
+        token: 'tok',
+        username: 'bob',
+        expiresAt: '2099-01-01T00:00:00Z',
+      });
+
+      renderPage('?code=c&state=s');
+
+      await waitFor(() => {
+        expect(mockApiPost).toHaveBeenCalledWith(
+          '/api/auth/oidc/callback',
+          expect.objectContaining({
+            callbackUrl: window.location.href,
+            state: 's',
+          }),
+        );
+      });
+    });
+  });
+
+  describe('missing token / state path', () => {
+    it('renders an error and redirects to /login when code is missing', async () => {
+      vi.useFakeTimers();
+      renderPage('?state=only-state');
+
+      // Error message rendered immediately on the synchronous effect path
+      expect(
+        screen.getByText(/Missing authorization code or state/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Redirecting to login/i)).toBeInTheDocument();
+
+      // Backend never called
+      expect(mockApiPost).not.toHaveBeenCalled();
+
+      // Redirect happens after the 3s delay
+      vi.advanceTimersByTime(3000);
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
+    });
+
+    it('renders an error and redirects to /login when state is missing', async () => {
+      vi.useFakeTimers();
+      renderPage('?code=only-code');
+
+      expect(
+        screen.getByText(/Missing authorization code or state/i),
+      ).toBeInTheDocument();
+      expect(mockApiPost).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(3000);
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
+    });
+  });
+
+  describe('OIDC error in URL params', () => {
+    it('shows error_description and redirects to /login', async () => {
+      vi.useFakeTimers();
+      renderPage('?error=access_denied&error_description=User%20cancelled');
+
+      expect(screen.getByText('User cancelled')).toBeInTheDocument();
+
+      // Backend not called for upstream OIDC error
+      expect(mockApiPost).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(3000);
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
+    });
+
+    it('falls back to error code when error_description is absent', async () => {
+      renderPage('?error=access_denied');
+
+      expect(screen.getByText('access_denied')).toBeInTheDocument();
+      expect(mockApiPost).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backend exchange failure', () => {
+    it('renders the failure message and redirects to /login', async () => {
+      mockApiPost.mockRejectedValue(new Error('OIDC exchange failed'));
+
+      renderPage('?code=c&state=s');
+
+      // Wait for the rejected promise to settle and component to re-render
+      await waitFor(() => {
+        expect(screen.getByText('OIDC exchange failed')).toBeInTheDocument();
+      });
+
+      expect(mockLoginWithToken).not.toHaveBeenCalled();
+    });
+
+    it('shows a generic message when the rejection is not an Error instance', async () => {
+      mockApiPost.mockRejectedValue('not-an-error');
+
+      renderPage('?code=c&state=s');
+
+      await waitFor(() => {
+        expect(screen.getByText('Authentication failed')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/features/operations/pages/edge-agent-logs.test.tsx
+++ b/frontend/src/features/operations/pages/edge-agent-logs.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import EdgeAgentLogsPage from './edge-agent-logs';
+
+const mockApiGet = vi.fn();
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+  },
+}));
+
+vi.mock('@/shared/hooks/use-auto-refresh', () => ({
+  useAutoRefresh: () => ({ interval: 0, setInterval: vi.fn() }),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EdgeAgentLogsPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe('EdgeAgentLogsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('loading state', () => {
+    it('shows skeleton placeholders while the logs query is in flight', async () => {
+      // Long-pending promise — never resolves during the assertion window
+      let resolveQuery!: (v: unknown) => void;
+      mockApiGet.mockReturnValue(
+        new Promise((resolve) => {
+          resolveQuery = resolve;
+        }),
+      );
+
+      renderPage();
+
+      // Heading is always present
+      expect(
+        screen.getByRole('heading', { name: 'Edge Agent Logs' }),
+      ).toBeInTheDocument();
+
+      // SkeletonCard renders with role="status" + aria-label="Loading"
+      await waitFor(() => {
+        const loadingNodes = screen.getAllByRole('status', { name: 'Loading' });
+        // edge-agent-logs renders three SkeletonCards stacked while loading
+        expect(loadingNodes.length).toBeGreaterThan(0);
+      });
+
+      // Stats cards (which only render with logs > 0) should be absent
+      expect(screen.queryByText('Total Logs')).not.toBeInTheDocument();
+
+      // Cleanup pending promise so React Query doesn't warn
+      resolveQuery({ logs: [], total: 0 });
+    });
+  });
+
+  describe('not-configured state (503)', () => {
+    it('renders the configuration onboarding view when the API returns 503', async () => {
+      mockApiGet.mockRejectedValue(new Error('HTTP 503'));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Elasticsearch Not Configured'),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('link', { name: /Configure Elasticsearch/i }),
+      ).toBeInTheDocument();
+      // Generic error block must NOT render in this branch
+      expect(screen.queryByText('Failed to fetch logs')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('error state (non-503)', () => {
+    it('shows the failure card and a retry button', async () => {
+      mockApiGet.mockRejectedValue(new Error('HTTP 500: backend exploded'));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to fetch logs')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/HTTP 500/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    });
+  });
+
+  describe('data state', () => {
+    it('renders log rows, stats and the export button', async () => {
+      mockApiGet.mockResolvedValue({
+        logs: [
+          {
+            id: '1',
+            timestamp: '2026-05-05T10:00:00Z',
+            message: 'connection refused',
+            hostname: 'edge-01',
+            level: 'error',
+            source: { raw: 'log line' },
+          },
+          {
+            id: '2',
+            timestamp: '2026-05-05T10:01:00Z',
+            message: 'starting agent',
+            hostname: 'edge-02',
+            level: 'info',
+            source: { raw: 'log line 2' },
+          },
+        ],
+        total: 2,
+      });
+
+      renderPage();
+
+      // Wait for log row content
+      await waitFor(() => {
+        expect(screen.getByText('connection refused')).toBeInTheDocument();
+      });
+      expect(screen.getByText('starting agent')).toBeInTheDocument();
+
+      // Stats card visible (only renders when logs > 0)
+      expect(screen.getByText('Total Logs')).toBeInTheDocument();
+
+      // Results header reflects count
+      expect(screen.getByText(/Log Results/)).toBeInTheDocument();
+      expect(screen.getByText(/2 of 2/)).toBeInTheDocument();
+
+      // Export button appears once we have logs
+      expect(
+        screen.getByRole('button', { name: /Export/ }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the empty state when API returns no logs', async () => {
+      mockApiGet.mockResolvedValue({ logs: [], total: 0 });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('No logs found')).toBeInTheDocument();
+      });
+
+      // Without logs, neither the stats grid nor the export button render
+      expect(screen.queryByText('Total Logs')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /Export/ }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('expands a log row when the row is clicked', async () => {
+      mockApiGet.mockResolvedValue({
+        logs: [
+          {
+            id: 'log-1',
+            timestamp: '2026-05-05T10:00:00Z',
+            message: 'expandable message',
+            hostname: 'edge-01',
+            level: 'warn',
+            source: { detail: 'extended trace' },
+          },
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('expandable message')).toBeInTheDocument();
+      });
+
+      // Click the row to expand
+      fireEvent.click(screen.getByText('expandable message'));
+
+      // The expanded panel renders the JSON-stringified source
+      expect(screen.getByText('Full Log Entry')).toBeInTheDocument();
+      expect(screen.getByText(/extended trace/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/stores/ui-store.test.ts
+++ b/frontend/src/stores/ui-store.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act } from '@testing-library/react';
+import { useUiStore } from './ui-store';
+
+const STORAGE_KEY = 'ui-storage';
+
+describe('useUiStore', () => {
+  beforeEach(() => {
+    // Reset to initial state without touching persistence
+    useUiStore.setState({
+      sidebarCollapsed: false,
+      commandPaletteOpen: false,
+      potatoMode: false,
+      collapsedGroups: {},
+      pageViewModes: {},
+    });
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe('initial state', () => {
+    it('exposes the documented defaults', () => {
+      const state = useUiStore.getState();
+      expect(state.sidebarCollapsed).toBe(false);
+      expect(state.commandPaletteOpen).toBe(false);
+      expect(state.potatoMode).toBe(false);
+      expect(state.collapsedGroups).toEqual({});
+      expect(state.pageViewModes).toEqual({});
+    });
+  });
+
+  describe('toggleSidebar', () => {
+    it('flips sidebarCollapsed from false to true', () => {
+      act(() => {
+        useUiStore.getState().toggleSidebar();
+      });
+      expect(useUiStore.getState().sidebarCollapsed).toBe(true);
+    });
+
+    it('flips back to false on a second call', () => {
+      act(() => {
+        useUiStore.getState().toggleSidebar();
+        useUiStore.getState().toggleSidebar();
+      });
+      expect(useUiStore.getState().sidebarCollapsed).toBe(false);
+    });
+
+    it('does not mutate other state slices', () => {
+      act(() => {
+        useUiStore.getState().toggleSidebar();
+      });
+      const state = useUiStore.getState();
+      expect(state.potatoMode).toBe(false);
+      expect(state.commandPaletteOpen).toBe(false);
+      expect(state.pageViewModes).toEqual({});
+    });
+  });
+
+  describe('togglePotatoMode', () => {
+    it('flips potatoMode from false to true', () => {
+      act(() => {
+        useUiStore.getState().togglePotatoMode();
+      });
+      expect(useUiStore.getState().potatoMode).toBe(true);
+    });
+
+    it('flips back to false on a second call', () => {
+      act(() => {
+        useUiStore.getState().togglePotatoMode();
+        useUiStore.getState().togglePotatoMode();
+      });
+      expect(useUiStore.getState().potatoMode).toBe(false);
+    });
+
+    it('respects setPotatoMode for explicit values', () => {
+      act(() => {
+        useUiStore.getState().setPotatoMode(true);
+      });
+      expect(useUiStore.getState().potatoMode).toBe(true);
+
+      act(() => {
+        useUiStore.getState().setPotatoMode(false);
+      });
+      expect(useUiStore.getState().potatoMode).toBe(false);
+    });
+  });
+
+  describe('setPageViewMode', () => {
+    it('records a per-page view mode', () => {
+      act(() => {
+        useUiStore.getState().setPageViewMode('fleet', 'table');
+      });
+      expect(useUiStore.getState().pageViewModes).toEqual({ fleet: 'table' });
+    });
+
+    it('overwrites existing mode for the same page', () => {
+      act(() => {
+        useUiStore.getState().setPageViewMode('fleet', 'table');
+        useUiStore.getState().setPageViewMode('fleet', 'grid');
+      });
+      expect(useUiStore.getState().pageViewModes).toEqual({ fleet: 'grid' });
+    });
+
+    it('keeps modes for other pages independent', () => {
+      act(() => {
+        useUiStore.getState().setPageViewMode('fleet', 'table');
+        useUiStore.getState().setPageViewMode('stacks', 'grid');
+      });
+      expect(useUiStore.getState().pageViewModes).toEqual({
+        fleet: 'table',
+        stacks: 'grid',
+      });
+    });
+  });
+
+  describe('persistence (zustand persist middleware)', () => {
+    it('writes persisted slices to localStorage under "ui-storage"', () => {
+      act(() => {
+        useUiStore.getState().toggleSidebar();
+        useUiStore.getState().togglePotatoMode();
+        useUiStore.getState().setPageViewMode('fleet', 'table');
+        useUiStore.getState().toggleGroup('Operations');
+      });
+
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw as string);
+      // zustand persist wraps state under .state
+      expect(parsed.state.sidebarCollapsed).toBe(true);
+      expect(parsed.state.potatoMode).toBe(true);
+      expect(parsed.state.pageViewModes).toEqual({ fleet: 'table' });
+      expect(parsed.state.collapsedGroups).toEqual({ Operations: true });
+    });
+
+    it('does not persist commandPaletteOpen (excluded by partialize)', () => {
+      act(() => {
+        useUiStore.getState().setCommandPaletteOpen(true);
+      });
+
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw as string);
+      expect(parsed.state.commandPaletteOpen).toBeUndefined();
+    });
+
+    it('rehydrates persisted values when persist.rehydrate() is called', async () => {
+      // NOTE: setState() on the store triggers persist to write to localStorage,
+      // which would clobber a seed written before setState. Ordering matters:
+      // (1) reset in-memory state, (2) seed localStorage, (3) rehydrate.
+      useUiStore.setState({
+        sidebarCollapsed: false,
+        potatoMode: false,
+        collapsedGroups: {},
+        pageViewModes: {},
+      });
+
+      const seeded = {
+        state: {
+          sidebarCollapsed: true,
+          potatoMode: true,
+          collapsedGroups: { Inventory: true },
+          pageViewModes: { workloads: 'grid' },
+        },
+        version: 0,
+      };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(seeded));
+
+      // Trigger rehydration from the persist API
+      await useUiStore.persist.rehydrate();
+
+      const state = useUiStore.getState();
+      expect(state.sidebarCollapsed).toBe(true);
+      expect(state.potatoMode).toBe(true);
+      expect(state.collapsedGroups).toEqual({ Inventory: true });
+      expect(state.pageViewModes).toEqual({ workloads: 'grid' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Vitest coverage for three previously untested frontend pages plus the persisted UI store from the #1022 acceptance criteria.

- `frontend/src/features/containers/pages/network-topology.test.tsx` — page heading, container/network counts, loading skeleton, error state, empty state. Mocks data hooks (`useContainers`, `useNetworks`, `useEndpoints`, `useNetworkRates`) and stubs the heavy `TopologyGraph` component (which depends on `@xyflow/react`) at the import boundary.
- `frontend/src/features/core/pages/auth-callback.test.tsx` — OIDC callback flow: successful code+state exchange triggers `loginWithToken` and redirect to `/`, missing `code`/`state` shows error and redirects to `/login` after 3 s, OIDC provider error in URL params, and backend exchange failures (Error vs. non-Error rejections). Mocks `useNavigate`, `useSearchParams`, `useAuth`, and `api.post`.
- `frontend/src/features/operations/pages/edge-agent-logs.test.tsx` — loading, not-configured (HTTP 503), generic error, populated data, empty data, and row-expansion states. Mocks `api.get` only; everything else is real.
- `frontend/src/stores/ui-store.test.ts` — `toggleSidebar`, `togglePotatoMode`, `setPageViewMode`, plus zustand-persist behaviour: writes to `localStorage` under `"ui-storage"`, excludes `commandPaletteOpen` (per `partialize`), and rehydrates persisted values via `useUiStore.persist.rehydrate()`.

Total: **33 new tests across 4 files**.

## Issue scope notes

`Refs #1022` — partial. Pages and the UI store land here; the hook tests listed in the issue body are tracked separately under #1051 (awaiting maintainer rescope per the audit on that issue).

`container-health.tsx` from the issue body **does not exist** in the codebase. The closest match is `fleet-health-summary.tsx`, which lives under `features/ai-intelligence/components/` (not `containers/pages/`) and was already covered by PR #1165. It is intentionally excluded from this PR.

## Test plan

- [x] `cd frontend && npm run lint` — passes
- [x] `cd frontend && npm run typecheck` — passes
- [x] `cd frontend && npx vitest run <4 new files>` — 33/33 passing
- [x] `cd frontend && npx vitest run` — 1644/1644 passing (no regressions)
- [x] Pre-push hook full suite — 1644/1644 passing

## Constraints honoured

- Frontend-only change.
- No production sources modified.
- Mocks at the API/hook boundary only; pure logic and the real Zustand store run.
- Branched from `dev`; no `--no-verify`, no `--amend`.