### PR TITLE
security: bind frontend port to localhost only

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -62,6 +62,7 @@
     "tsx": "^4.19.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.2",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "yaml": "^2.8.4"
   }
 }

--- a/backend/src/docker-security.test.ts
+++ b/backend/src/docker-security.test.ts
@@ -1,11 +1,20 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 
 const ROOT = resolve(__dirname, '../..');
 
 function readFile(relativePath: string): string {
   return readFileSync(resolve(ROOT, relativePath), 'utf-8');
+}
+
+function readCompose(): {
+  services: Record<string, { ports?: string[] | undefined }>;
+} {
+  return parseYaml(readFile('docker/docker-compose.yml')) as {
+    services: Record<string, { ports?: string[] | undefined }>;
+  };
 }
 
 function readLines(relativePath: string): string[] {
@@ -333,5 +342,28 @@ describe('docker/docker-compose.yml capability hardening', () => {
       // change tracked outside this PR.
       expect(getServiceListField(block, 'cap_add')).toEqual(['NET_RAW', 'NET_ADMIN']);
     });
+  });
+});
+
+describe('docker/docker-compose.yml port bindings (#1113)', () => {
+  // Production compose must publish ports to localhost only — direct external
+  // exposure is gated by a host-level reverse proxy (Traefik/nginx). LAN-direct
+  // deployments can override via docker-compose.override.yml.
+  const compose = readCompose();
+
+  it('frontend service binds port 8080 to 127.0.0.1 only', () => {
+    const ports = compose.services.frontend?.ports ?? [];
+    expect(ports).toHaveLength(1);
+    expect(ports[0]).toBe('127.0.0.1:8080:8080');
+    // Defence-in-depth: explicitly reject the two unsafe forms.
+    expect(ports[0]).not.toBe('8080:8080');
+    expect(ports[0]).not.toMatch(/^0\.0\.0\.0:/);
+  });
+
+  it('backend service binds port 3051 to 127.0.0.1 only (regression guard)', () => {
+    const ports = compose.services.backend?.ports ?? [];
+    expect(ports).toHaveLength(1);
+    expect(ports[0]).toBe('127.0.0.1:3051:3051');
+    expect(ports[0]).not.toMatch(/^0\.0\.0\.0:/);
   });
 });

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -122,7 +122,10 @@ services:
       context: ..
       dockerfile: frontend/Dockerfile
     ports:
-      - "8080:8080"
+      # Localhost-only: external clients should reach the dashboard via a
+      # host-level reverse proxy (Traefik/nginx). LAN-direct deployments
+      # without a fronting proxy can override via docker-compose.override.yml.
+      - "127.0.0.1:8080:8080"
     # Hardening (#1118): nginx runs as the DHI nonroot user on port 8080 (>1024).
     # No bind to privileged ports → no caps required. If a future nginx config
     # change demands setuid (e.g. binding 80/443 directly), revisit by adding

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,8 @@
         "tsx": "^4.19.2",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
-        "vitest": "^4.0.18"
+        "vitest": "^4.0.18",
+        "yaml": "^2.8.4"
       }
     },
     "backend/node_modules/@boundaries/elements": {


### PR DESCRIPTION
Closes #1113

## Summary

The frontend service published port 8080 on 0.0.0.0, exposing nginx
directly on every interface. The deployment is intended to be
Traefik-fronted (the host-level reverse proxy), so direct external
port access is not the access path. The backend already binds its
port to 127.0.0.1 for the same reason; this brings the frontend in line.

LAN-direct deployments without a fronting proxy can override via
``docker-compose.override.yml``.

## Change

`docker/docker-compose.yml` — frontend ``ports:``:

```diff
-      - "8080:8080"
+      # Localhost-only: external clients should reach the dashboard via a
+      # host-level reverse proxy (Traefik/nginx). LAN-direct deployments
+      # without a fronting proxy can override via docker-compose.override.yml.
+      - "127.0.0.1:8080:8080"
```

## Tests

Adds a new ``describe`` block to ``backend/src/docker-security.test.ts`` that
parses the production compose with the ``yaml`` package and asserts:

- frontend ``ports[0] === "127.0.0.1:8080:8080"`` (the fix)
- backend  ``ports[0] === "127.0.0.1:3051:3051"`` (regression guard — already true, locked in)

Both also reject ``0.0.0.0:`` prefixes as a defence-in-depth check.

## Rebase note

PR #1174 (``feature/1100-1104-1118-cap-hardening``) is queued for the same test
file. If #1174 lands first, this PR's new ``describe`` block at the bottom of
the file rebases trivially (no overlap with #1174's compose-level capability assertions).

## Verification

- `docker compose -f docker/docker-compose.yml config -q` → exits 0; resolved frontend ``host_ip: 127.0.0.1``
- `npm run lint` → clean (zero warnings)
- `cd backend && npx vitest run src/docker-security.test.ts` → 30 passed (28 existing + 2 new)

## Rollback

Revert this commit. Single-line yaml change; no data migration; no runtime
code changes; no env-var schema changes.