### PR TITLE
ci: re-enable E2E job with production compose path and label gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,99 +263,126 @@ jobs:
       - name: Build
         run: npm run build
 
-  # e2e:
-  #   name: E2E Smoke Tests
-  #   runs-on: ubuntu-latest
-  #   if: >-
-  #     github.actor != 'dependabot[bot]' && (
-  #     github.event_name == 'schedule' ||
-  #     github.event_name == 'workflow_dispatch' ||
-  #     (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'dev')) ||
-  #     contains(github.event.pull_request.labels.*.name, 'e2e')
-  #     )
-  #   needs: [build]
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
+  e2e:
+    name: E2E Smoke Tests
+    runs-on: ubuntu-latest
+    # Gated: never run on Dependabot PRs. Otherwise only run on schedule,
+    # manual dispatch, or when a PR carries the `e2e` label. PRs to main/dev
+    # do NOT auto-run E2E — reviewers add the `e2e` label to opt in.
+    if: >-
+      github.actor != 'dependabot[bot]' && (
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'e2e')
+      )
+    needs: [build]
+    # Test credentials only — never used outside the disposable CI runner.
+    # JWT_SECRET is 48 chars to satisfy the production 32+ char guard in env.schema.ts.
+    env:
+      DASHBOARD_USERNAME: admin
+      DASHBOARD_PASSWORD: changeme12345
+      JWT_SECRET: test-secret-ci-e2e-do-not-use-in-prod-0123456789ab
+      POSTGRES_APP_PASSWORD: changeme-postgres-app
+      TIMESCALE_PASSWORD: changeme-timescale
+      REDIS_PASSWORD: changeme-redis
+      DASHBOARD_DOMAIN: localhost
+      PORTAINER_API_URL: http://127.0.0.1:9999
+      PORTAINER_API_KEY: e2e-dummy-key
+      OLLAMA_BASE_URL: http://127.0.0.1:11434
+      LOG_LEVEL: info
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
-  #     - name: Setup Node.js
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: '22'
-  #         cache: 'npm'
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
 
-  #     - name: Install dependencies
-  #       run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-  #     - name: Log in to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ vars.DOCKER_USER }}
-  #         password: ${{ secrets.DOCKER_PAT }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
 
-  #     - name: Log in to DHI registry
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: dhi.io
-  #         username: ${{ vars.DOCKER_USER }}
-  #         password: ${{ secrets.DOCKER_PAT }}
+      - name: Log in to DHI registry
+        uses: docker/login-action@v4
+        with:
+          registry: dhi.io
+          username: ${{ vars.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
 
-  #     - name: Install Playwright browsers
-  #       run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
-  #     - name: Start application
-  #       run: |
-  #         # Phase 1: Start database services only
-  #         docker compose -f docker/docker-compose.dev.yml up -d redis postgres-app timescaledb
+      - name: Build application images
+        run: docker compose -f docker/docker-compose.yml build backend frontend
 
-  #         # Phase 2: Wait for databases to accept connections
-  #         echo "Waiting for PostgreSQL..."
-  #         timeout 60 bash -c 'until docker compose -f docker/docker-compose.dev.yml exec -T postgres-app pg_isready -U app_user -d portainer_dashboard > /dev/null 2>&1; do sleep 3; done'
-  #         echo "Waiting for TimescaleDB..."
-  #         timeout 90 bash -c 'until docker compose -f docker/docker-compose.dev.yml exec -T timescaledb pg_isready -U metrics_user -d metrics > /dev/null 2>&1; do sleep 3; done'
-  #         echo "Databases ready"
+      - name: Start databases (phase 1)
+        run: |
+          docker compose -f docker/docker-compose.yml up -d postgres-app timescaledb
 
-  #         # Phase 3: Start application services now that databases are ready
-  #         docker compose -f docker/docker-compose.dev.yml up -d
+          echo "Waiting for postgres-app..."
+          timeout 90 bash -c 'until docker compose -f docker/docker-compose.yml exec -T postgres-app pg_isready -U app_user -d portainer_dashboard > /dev/null 2>&1; do sleep 3; done'
+          echo "Waiting for timescaledb..."
+          timeout 120 bash -c 'until docker compose -f docker/docker-compose.yml exec -T timescaledb pg_isready -U metrics_user -d metrics > /dev/null 2>&1; do sleep 3; done'
+          echo "Databases ready"
 
-  #         # Phase 4: Wait for application endpoints
-  #         echo "Waiting for backend health endpoint..."
-  #         timeout 120 bash -c 'until curl -sf http://localhost:3051/health > /dev/null 2>&1; do sleep 3; done'
-  #         echo "Waiting for frontend..."
-  #         timeout 60 bash -c 'until curl -sf http://localhost:5273 > /dev/null 2>&1; do sleep 3; done'
-  #         echo "All services ready"
-  #       env:
-  #         DASHBOARD_USERNAME: admin
-  #         DASHBOARD_PASSWORD: changeme12345
-  #         PORTAINER_API_KEY: e2e-dummy-key
+      - name: Start application (phase 2)
+        run: |
+          # Compose `depends_on: condition: service_healthy` blocks `up` until
+          # redis + DBs are healthy and the backend healthcheck passes.
+          docker compose -f docker/docker-compose.yml up -d redis backend frontend
 
-  #     - name: Dump service logs on failure
-  #       if: failure()
-  #       run: |
-  #         echo "=== Backend logs ==="
-  #         docker compose -f docker/docker-compose.dev.yml logs backend --tail 100
-  #         echo "=== Frontend logs ==="
-  #         docker compose -f docker/docker-compose.dev.yml logs frontend --tail 50
-  #         echo "=== TimescaleDB logs ==="
-  #         docker compose -f docker/docker-compose.dev.yml logs timescaledb --tail 50
+          echo "Waiting for backend /health..."
+          timeout 180 bash -c 'until curl -sf http://localhost:3051/health > /dev/null 2>&1; do sleep 3; done'
+          echo "Waiting for frontend..."
+          timeout 90 bash -c 'until curl -sf http://localhost:8080/ > /dev/null 2>&1; do sleep 3; done'
+          echo "All services ready"
 
-  #     - name: Run E2E tests
-  #       run: npm run test:e2e
-  #       env:
-  #         E2E_BASE_URL: http://localhost:5273
-  #         E2E_USERNAME: admin
-  #         E2E_PASSWORD: changeme12345
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          E2E_BASE_URL: http://localhost:8080
+          E2E_USERNAME: admin
+          E2E_PASSWORD: changeme12345
 
-  #     - name: Upload test results
-  #       uses: actions/upload-artifact@v4
-  #       if: always()
-  #       with:
-  #         name: playwright-report
-  #         path: playwright-report/
-  #         retention-days: 7
+      - name: Dump service logs on failure
+        if: failure()
+        run: |
+          mkdir -p e2e-logs
+          {
+            echo "=== docker compose ps ==="
+            docker compose -f docker/docker-compose.yml ps
+            for svc in backend frontend redis postgres-app timescaledb; do
+              echo
+              echo "=== ${svc} logs ==="
+              docker compose -f docker/docker-compose.yml logs --tail 200 "${svc}" || true
+            done
+          } > e2e-logs/compose.log 2>&1
 
-  #     - name: Stop application
-  #       if: always()
-  #       run: docker compose -f docker/docker-compose.dev.yml down
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload compose logs
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: e2e-compose-logs
+          path: e2e-logs/
+          retention-days: 7
+
+      - name: Stop application
+        if: always()
+        run: docker compose -f docker/docker-compose.yml down -v


### PR DESCRIPTION
Closes #1007

## Summary

The E2E test job has been commented out in `.github/workflows/ci.yml` (lines 266–361 on `dev`), leaving zero E2E coverage on PRs. This PR re-enables the job and migrates it to the production Docker compose stack.

## Gating (opt-in only)

The job runs **only** when:
- `github.event_name == 'schedule'` (nightly cron) **or**
- `github.event_name == 'workflow_dispatch'` (manual trigger) **or**
- The PR carries the `e2e` label

…and **never** when `github.actor == 'dependabot[bot]'`.

PRs to `main`/`dev` no longer auto-trigger the job — reviewers add the `e2e` label to opt in. This keeps PR feedback fast while still giving us nightly + on-demand coverage.

## Compose path migration (project memory)

**Every** reference to `docker/docker-compose.dev.yml` in the e2e job is replaced with `docker/docker-compose.yml` (8 occurrences). This honors the project policy that the dev compose is unmaintained and slated for deletion.

`grep -n docker-compose .github/workflows/ci.yml` after the change shows only `docker/docker-compose.yml` paths in the e2e job.

## Wiring differences vs. the old (commented) job

| Concern | Before (dev compose) | After (prod compose) |
|---|---|---|
| Frontend port | `:5273` (Vite dev server) | `:8080` (nginx in prod image) |
| `E2E_BASE_URL` | `http://localhost:5273` | `http://localhost:8080` |
| Backend port | `:3051` | `:3051` (unchanged, `127.0.0.1` bind) |
| Required env | `DASHBOARD_USERNAME`, `DASHBOARD_PASSWORD`, `PORTAINER_API_KEY` | + `JWT_SECRET` (48 chars, satisfies 32+ prod guard), `POSTGRES_APP_PASSWORD`, `TIMESCALE_PASSWORD`, `REDIS_PASSWORD`, `DASHBOARD_DOMAIN` (Traefik label interpolation) |
| Image build | implicit | explicit `docker compose build backend frontend` step |

## Step ordering

1. Checkout (with schedule-time `dev` ref pin)
2. setup-node@v6 (Node 22)
3. `npm ci`
4. Docker Hub + DHI registry login (DHI required for `dhi.io/redis:8.0-debian13`)
5. `npx playwright install --with-deps chromium`
6. `docker compose build backend frontend`
7. **Phase 1**: start `postgres-app` + `timescaledb`, poll `pg_isready` per DB
8. **Phase 2**: start `redis` + `backend` + `frontend` — compose `depends_on: condition: service_healthy` blocks until backend healthcheck passes; HTTP-poll backend `/health` and frontend `/` afterwards
9. `npm run test:e2e` (Playwright with cached storage state via `e2e/global-setup.ts`)
10. **On failure**: dump `docker compose ps` + per-service logs to `e2e-logs/compose.log`
11. **Always**: upload `playwright-report/`
12. **On failure**: upload `e2e-compose-logs/`
13. **Always**: `docker compose down -v` teardown

Bounded `timeout` is used everywhere (90s/120s/180s) — no unbounded loops or `sleep 30`.

## Local validation performed

- `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"` — file parses cleanly, all 10 jobs intact, all `needs:` references resolve.
- `grep -n docker-compose` confirms zero `docker-compose.dev.yml` references in the e2e job.
- `docker compose -f docker/docker-compose.yml config --quiet` with the full set of CI env vars (`DASHBOARD_USERNAME`, `DASHBOARD_PASSWORD`, `JWT_SECRET`, `POSTGRES_APP_PASSWORD`, `TIMESCALE_PASSWORD`, `REDIS_PASSWORD`, `DASHBOARD_DOMAIN`) exits 0 — every required interpolation variable is present.
- `npm run typecheck` and `npm run test -w frontend` (1611 tests) pass via the pre-push hook.
- A Playwright-against-running-stack run is **not** executed locally because the prod compose pulls images from the DHI registry which requires repo-secret auth. CI is the canonical place to validate; see Test plan below.

## Test plan

- [ ] Reviewer adds the `e2e` label to this PR — confirms label gating works and the job runs once against the production compose stack.
- [ ] Inspect the `playwright-report/` artifact on the resulting run.
- [ ] Verify Dependabot PRs do **not** trigger the job (next Dependabot PR).
- [ ] Verify scheduled nightly run picks up the `dev` ref correctly.
- [ ] Confirm `docker compose down -v` cleans the runner (volumes wiped).

## Risks & rollback

Single-file change. Rollback = `git revert` of this commit (re-comments the job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)