### PR TITLE
test(e2e): add specs for AI Monitor, Infrastructure Overview, and Metrics pages

### DIFF
--- a/e2e/ai-monitor.spec.ts
+++ b/e2e/ai-monitor.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect, type ConsoleMessage } from '@playwright/test';
+
+/**
+ * AI Monitor / Health & Monitoring E2E tests.
+ *
+ * The route `/ai-monitor` is a legacy alias that redirects to `/health`,
+ * which renders the AI Monitor page (`features/ai-intelligence/pages/ai-monitor.tsx`).
+ *
+ * These tests use the cached auth state from global-setup, so the browser
+ * is already authenticated when tests start.
+ *
+ * Assertions are intentionally tolerant: the page may render insights,
+ * anomalies, or empty states depending on the live state of the fleet
+ * and Ollama availability in CI. The goal is page render integrity, not
+ * exact data shape.
+ */
+test.describe('AI Monitor (Health & Monitoring)', () => {
+  test('legacy /ai-monitor route redirects to /health and renders the page', async ({
+    page,
+  }) => {
+    await page.goto('/ai-monitor');
+
+    // The router rewrites /ai-monitor -> /health
+    await expect(page).toHaveURL(/\/health/);
+
+    // Authenticated layout renders
+    await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
+    await expect(page.locator('[data-testid="header"]')).toBeVisible();
+
+    // Breadcrumb confirms we're on the Health & Monitoring page
+    const breadcrumb = page.locator(
+      '[data-testid="header"] nav[aria-label="Breadcrumb"]',
+    );
+    await expect(breadcrumb).toContainText('Health & Monitoring');
+
+    // The page-level heading renders even if no insights have been generated
+    await expect(
+      page.getByRole('heading', { name: /health & monitoring/i, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('renders insight stats cards or graceful empty state', async ({ page }) => {
+    await page.goto('/health');
+    await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
+
+    // The page renders four stat cards (Total / Critical / Warning / Info) once
+    // loading completes, or an empty-state copy if no insights exist.
+    const statsHeading = page.getByText(/total insights/i);
+    const emptyHeading = page.getByRole('heading', { name: /no insights/i });
+
+    await expect(statsHeading.or(emptyHeading)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('anomaly / health-issue section is present when there are issues', async ({
+    page,
+  }) => {
+    await page.goto('/health');
+    await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
+
+    // Wait for the page to fully render (heading is the most reliable anchor).
+    await expect(
+      page.getByRole('heading', { name: /health & monitoring/i, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The anomalies section only renders when there are correlated anomalies
+    // or unhealthy containers. Check that *if* it renders, it includes its
+    // section heading; if not, the page must still be operable (i.e. the
+    // heading-1 above is still visible). Either branch is acceptable.
+    const anomaliesHeading = page.getByRole('heading', {
+      name: /anomalies & health issues/i,
+    });
+    const healthIssueCard = page.locator('[data-testid="health-issue-card"]');
+    const zscoreBars = page.locator('[data-testid="zscore-bars"]');
+
+    if (await anomaliesHeading.isVisible().catch(() => false)) {
+      // If the section is rendered, at least one cue (card or z-score bars)
+      // should also be present.
+      await expect(
+        anomaliesHeading
+          .or(healthIssueCard.first())
+          .or(zscoreBars.first()),
+      ).toBeVisible();
+    }
+  });
+
+  test('does not throw uncaught JS errors when WebSocket connection fails', async ({
+    page,
+  }) => {
+    // Capture pageerror (uncaught JS exceptions) and console.error messages.
+    const pageErrors: string[] = [];
+    const consoleErrors: string[] = [];
+    page.on('pageerror', (err: Error) => {
+      pageErrors.push(err.message);
+    });
+    page.on('console', (msg: ConsoleMessage) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    // Force every WebSocket upgrade to fail before navigation. The page
+    // must still render and remain interactive.
+    await page.route('**/ws/**', (route) => route.abort());
+    await page.route('**/socket.io/**', (route) => route.abort());
+
+    await page.goto('/health');
+    await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /health & monitoring/i, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Allow the failed WS handshake to surface any unhandled rejection.
+    await page.waitForLoadState('networkidle').catch(() => {
+      /* networkidle is best-effort with long-poll fallbacks */
+    });
+
+    // No uncaught exceptions; console.error is allowed (the app may log
+    // about WS retries) but must not include an "Uncaught" prefix.
+    expect(pageErrors, pageErrors.join('\n')).toHaveLength(0);
+    const uncaught = consoleErrors.filter((msg) => /uncaught/i.test(msg));
+    expect(uncaught, uncaught.join('\n')).toHaveLength(0);
+  });
+});

--- a/e2e/infrastructure.spec.ts
+++ b/e2e/infrastructure.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Infrastructure Overview E2E tests.
+ *
+ * `/infrastructure` renders `features/containers/pages/fleet-overview.tsx`,
+ * which exposes three Radix tabs: Fleet Overview, Stack Overview, Kubernetes.
+ *
+ * These tests use cached auth state. They focus on page-render integrity
+ * (sidebar / header / breadcrumb / tabs) rather than exact endpoint data,
+ * so the suite stays green whether or not Portainer endpoints are present
+ * in the CI fixture.
+ */
+test.describe('Infrastructure Overview', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/infrastructure');
+    await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
+  });
+
+  test('renders the page header, breadcrumb, and tab list', async ({ page }) => {
+    // Page heading
+    await expect(
+      page.getByRole('heading', { name: /^infrastructure$/i, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Breadcrumb confirms route
+    const breadcrumb = page.locator(
+      '[data-testid="header"] nav[aria-label="Breadcrumb"]',
+    );
+    await expect(breadcrumb).toContainText('Infrastructure');
+
+    // The three Radix tabs render
+    await expect(page.locator('[data-testid="tab-fleet"]')).toBeVisible();
+    await expect(page.locator('[data-testid="tab-stacks"]')).toBeVisible();
+    await expect(page.locator('[data-testid="tab-kubernetes"]')).toBeVisible();
+  });
+
+  test('endpoint list renders or graceful empty state appears', async ({ page }) => {
+    // The Fleet tab is the default landing tab. The filtered count is always
+    // rendered once endpoints have loaded, even if the count is zero.
+    const filteredCount = page.locator('[data-testid="fleet-filtered-count"]');
+    const errorState = page.getByRole('heading', {
+      name: /failed to load infrastructure data/i,
+    });
+
+    // Either we get the count text (success path) or an explicit error card.
+    // We accept both — backend may be cold/unreachable in CI.
+    await expect(filteredCount.or(errorState)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('switching to the Stacks tab updates the active tab', async ({ page }) => {
+    const stacksTab = page.locator('[data-testid="tab-stacks"]');
+    await expect(stacksTab).toBeVisible();
+    await stacksTab.click();
+
+    // Radix exposes the active state via aria-selected or data-state="active"
+    await expect(stacksTab).toHaveAttribute('data-state', 'active');
+  });
+
+  test('endpoint status badges render up/down state when endpoints exist', async ({
+    page,
+  }) => {
+    // Endpoint cards include either a "Running"/"Up" or "Stopped"/"Down" label
+    // (case-insensitive). When no endpoints exist, the filtered count is "0".
+    const filteredCount = page.locator('[data-testid="fleet-filtered-count"]');
+    await expect(filteredCount).toBeVisible({ timeout: 15_000 });
+
+    const countText = (await filteredCount.textContent()) ?? '';
+    const hasEndpoints = !/^\s*0\s/.test(countText);
+
+    if (hasEndpoints) {
+      // At least one status keyword should appear somewhere on the page.
+      const statusKeywords = page.getByText(
+        /\b(running|up|stopped|down|unreachable|edge|active|inactive)\b/i,
+      );
+      await expect(statusKeywords.first()).toBeVisible({ timeout: 10_000 });
+    }
+  });
+});

--- a/e2e/infrastructure.spec.ts
+++ b/e2e/infrastructure.spec.ts
@@ -39,9 +39,9 @@ test.describe('Infrastructure Overview', () => {
     // The Fleet tab is the default landing tab. The filtered count is always
     // rendered once endpoints have loaded, even if the count is zero.
     const filteredCount = page.locator('[data-testid="fleet-filtered-count"]');
-    const errorState = page.getByRole('heading', {
-      name: /failed to load infrastructure data/i,
-    });
+    // The error message is rendered inside a <p> at fleet-overview.tsx:856,
+    // not a heading — match by visible text instead of role.
+    const errorState = page.getByText(/failed to load infrastructure data/i);
 
     // Either we get the count text (success path) or an explicit error card.
     // We accept both — backend may be cold/unreachable in CI.

--- a/e2e/metrics.spec.ts
+++ b/e2e/metrics.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Metrics Dashboard E2E tests.
+ *
+ * `/metrics` renders `features/observability/pages/metrics-dashboard.tsx`,
+ * which shows endpoint / container selectors, a time-range selector, and a
+ * chart container that lights up once a container is selected.
+ *
+ * These tests use cached auth state. The chart container only renders after
+ * an endpoint + container have been selected, so the assertions focus on the
+ * page chrome (selectors, time-range buttons) rather than chart contents,
+ * which is sufficient for E2E page-coverage smoke.
+ */
+test.describe('Metrics Dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/metrics');
+    await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
+  });
+
+  test('renders the page header and breadcrumb', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { name: /metrics dashboard/i, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const breadcrumb = page.locator(
+      '[data-testid="header"] nav[aria-label="Breadcrumb"]',
+    );
+    await expect(breadcrumb).toContainText('Metrics Dashboard');
+  });
+
+  test('renders endpoint, stack and container selectors', async ({ page }) => {
+    // The three ThemedSelects render as comboboxes. Wait until at least three
+    // are present (endpoint, stack, container).
+    await expect(
+      page.getByRole('heading', { name: /metrics dashboard/i, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const comboboxes = page.getByRole('combobox');
+    await expect(comboboxes.first()).toBeVisible({ timeout: 15_000 });
+
+    const count = await comboboxes.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+
+  test('renders the time-range selector with multiple options', async ({ page }) => {
+    // Time range buttons are simple <button> elements with labels like 1h, 6h, 24h.
+    // Look for at least two distinct range labels to confirm the strip rendered.
+    await expect(
+      page.getByRole('heading', { name: /metrics dashboard/i, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const ranges = page.getByRole('button', {
+      name: /^\s*\d+\s*(m|h|d)\s*$/i,
+    });
+    const rangeCount = await ranges.count();
+    expect(rangeCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test('zoom controls are present', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { name: /metrics dashboard/i, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The page renders zoom in / zoom out buttons (title attributes), and
+    // a percentage label in between (e.g. "100%"). Assert the percentage
+    // text is visible — it's stable regardless of selection state.
+    await expect(page.getByText(/^\d{2,3}%$/).first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});


### PR DESCRIPTION
Closes #1011

## Summary

Adds Playwright E2E specs for three previously-uncovered pages, completing the page-coverage gap called out in #1011. All three specs reuse the existing cached-auth pattern (chromium project with `storageState`) — no changes to `playwright.config.ts`, `global-setup.ts`, or any production code.

### New spec files

| File | Tests | Page route | Page component |
|------|-------|------------|----------------|
| `e2e/ai-monitor.spec.ts` | 4 | `/ai-monitor` → `/health` | `features/ai-intelligence/pages/ai-monitor.tsx` |
| `e2e/infrastructure.spec.ts` | 4 | `/infrastructure` | `features/containers/pages/fleet-overview.tsx` |
| `e2e/metrics.spec.ts` | 4 | `/metrics` | `features/observability/pages/metrics-dashboard.tsx` |

**Total: 12 new test cases.**

### Assertion targets

**AI Monitor** (`e2e/ai-monitor.spec.ts`)
- Legacy `/ai-monitor` route redirects to `/health` and renders the layout (`sidebar`, `header`, breadcrumb).
- Page-level heading "Health & Monitoring" renders.
- Insight stats cards OR graceful empty state appear ("Total Insights" / "No insights").
- Anomaly / health-issue section is consistent with its content (uses existing `health-issue-card` and `zscore-bars` testids).
- **Graceful WebSocket handling**: `page.route('**/ws/**' | '**/socket.io/**', r => r.abort())` before navigation, then asserts no `pageerror` events and no `Uncaught` console errors. Page must still render the heading after the failed WS handshake.

**Infrastructure Overview** (`e2e/infrastructure.spec.ts`)
- Page header, breadcrumb, and three Radix tabs render (`tab-fleet`, `tab-stacks`, `tab-kubernetes`).
- Endpoint list renders (via `fleet-filtered-count` testid) or an explicit error card appears.
- Switching to the Stacks tab updates `data-state="active"`.
- Status badge keywords (running/up/stopped/down/edge/active/inactive) appear when endpoints exist; tolerated when count is zero.

**Metrics Dashboard** (`e2e/metrics.spec.ts`)
- Page header and breadcrumb render.
- Three combobox selectors (endpoint, stack, container) are present.
- Time-range buttons (1h/6h/24h/...) are present (≥2 distinct labels).
- Zoom controls render with a percentage label (e.g. "100%").

### Constraints honoured

- Spec files only — **no production code changes**, no new `data-testid` attributes added.
- Specs rely entirely on existing testids (`sidebar`, `header`, `tab-fleet`, `tab-stacks`, `tab-kubernetes`, `fleet-filtered-count`, `health-issue-card`, `zscore-bars`) plus heading text + ARIA roles.
- `playwright.config.ts` untouched.
- Branched from `dev`. No `--no-verify`, no `--amend`.

### CI activation

These specs **will not run in CI** until **#1007** (Lane 3 PR7 — re-enable e2e job) lands. That is expected per the Group E plan; both PRs are designed to ship in parallel. Tag this PR with the `e2e` label once #1007 has merged so the workflow runs against it.

## Test plan

- [x] `npx playwright test --list e2e/ai-monitor.spec.ts e2e/infrastructure.spec.ts e2e/metrics.spec.ts` — 13 tests parsed (12 new + `setup` project).
- [x] `npm run lint` — clean (backend + frontend; `e2e/` is not under either workspace's lint scope, but the workspace lints still pass).
- [x] `npm run typecheck` — clean.
- [ ] Local stack-up validation skipped: no `.env` available in this worktree to bring `docker/docker-compose.yml` up. Per the unified plan, `playwright test --list` is an acceptable substitute when local stack cannot be started.
- [ ] After #1007 lands, re-tag with `e2e` and run via `workflow_dispatch` to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)