### PR TITLE
security: remove duplicate Referrer-Policy and disable deprecated X-XSS-Protection

### DIFF
--- a/backend/src/routes/security-regression.test.ts
+++ b/backend/src/routes/security-regression.test.ts
@@ -1657,6 +1657,37 @@ describe('Nginx Security Header Consistency', () => {
     expect(content).toContain('Content-Security-Policy');
   });
 
+  it('should set X-XSS-Protection to "0" per OWASP guidance (issue #1105)', () => {
+    // The deprecated XSS auditor in older browsers can be tricked into
+    // removing legitimate script content. Explicitly disable it; CSP
+    // script-src 'self' provides superior protection.
+    const file = path.resolve(process.cwd(), '..', 'frontend', 'nginx-security-headers.conf');
+    const content = readFileSync(file, 'utf8');
+
+    expect(content).toMatch(/add_header\s+X-XSS-Protection\s+"0"\s+always/);
+    expect(content).not.toMatch(/add_header\s+X-XSS-Protection\s+"1/);
+  });
+
+  it('should NOT set Referrer-Policy from the backend — nginx is the owner (issue #1101)', async () => {
+    // Backend duplicating browser-facing headers can produce duplicate /
+    // conflicting values. nginx emits Referrer-Policy: strict-origin-when-cross-origin.
+    const Fastify = (await import('fastify')).default;
+    const securityHeadersPlugin = (await import('@dashboard/core/plugins/security-headers.js'))
+      .default;
+
+    const app = Fastify();
+    await app.register(securityHeadersPlugin);
+    app.get('/ping', async () => ({ ok: true }));
+    await app.ready();
+
+    const response = await app.inject({ method: 'GET', url: '/ping' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['referrer-policy']).toBeUndefined();
+
+    await app.close();
+  });
+
   it('should use a map to restrict WebSocket upgrade values against H2C smuggling', () => {
     const file = path.resolve(process.cwd(), '..', 'frontend', 'nginx.conf');
     const content = readFileSync(file, 'utf8');

--- a/docs/ai-instructions/security-checklist.md
+++ b/docs/ai-instructions/security-checklist.md
@@ -44,7 +44,7 @@ Configurable: `LLM_PROMPT_GUARD_STRICT` env var.
 - External API calls respect `PORTAINER_VERIFY_SSL` setting
 - WebSocket connections authenticated via same JWT mechanism as REST
 - CORS via `@fastify/cors` — no wildcard origins in production
-- **Security header ownership**: nginx is the single source of truth for browser-facing headers (`CSP`, `X-Frame-Options`, `X-XSS-Protection`). The backend sets API-level headers only (`X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security`)
+- **Security header ownership**: nginx is the single source of truth for browser-facing headers (`CSP`, `X-Frame-Options`, `X-XSS-Protection: 0` per OWASP, `Referrer-Policy`). The backend sets API-level headers only (`X-Content-Type-Options`, `Permissions-Policy`, `Strict-Transport-Security`). Issue #1101 removed the duplicate `Referrer-Policy` from the backend; issue #1105 changed `X-XSS-Protection` from the deprecated `1; mode=block` to `0`.
 - **WebSocket protocol**: CSP currently allows both `ws:` and `wss:` to support deployments without TLS. For production with TLS, edit `frontend/nginx.conf` and remove `ws:` from `connect-src`
 
 ## Security Regression Tests

--- a/frontend/nginx-security-headers.conf
+++ b/frontend/nginx-security-headers.conf
@@ -4,7 +4,13 @@
 # clears ALL server-level add_header directives.
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
-add_header X-XSS-Protection "1; mode=block" always;
+# X-XSS-Protection is deprecated by all modern browsers (Chrome removed the
+# XSS Auditor in 2019). Per OWASP, explicitly set to "0" to disable the
+# legacy auditor in older browsers — its false-positive behaviour can be
+# tricked into removing legitimate script content, creating new attack
+# vectors. CSP `script-src 'self'` (below) provides superior protection.
+# See issue #1105.
+add_header X-XSS-Protection "0" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 # CSP: style-src 'unsafe-inline' required by Tailwind/Framer Motion runtime styles.
 # connect-src allows both ws: and wss: — for TLS-only deployments, remove ws: and keep wss: only.

--- a/packages/core/src/plugins/security-headers.test.ts
+++ b/packages/core/src/plugins/security-headers.test.ts
@@ -19,7 +19,9 @@ describe('security headers plugin', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['x-content-type-options']).toBe('nosniff');
-    expect(response.headers['referrer-policy']).toBe('no-referrer');
+    // Referrer-Policy is owned by nginx (issue #1101) — backend must NOT set it
+    // to avoid duplicate / conflicting values reaching the browser.
+    expect(response.headers['referrer-policy']).toBeUndefined();
     expect(response.headers['permissions-policy']).toContain('geolocation=()');
     // X-Frame-Options and CSP are handled by nginx, not the backend
     expect(response.headers['x-frame-options']).toBeUndefined();

--- a/packages/core/src/plugins/security-headers.ts
+++ b/packages/core/src/plugins/security-headers.ts
@@ -4,7 +4,11 @@ import fp from 'fastify-plugin';
 async function securityHeadersPlugin(fastify: FastifyInstance) {
   fastify.addHook('onSend', async (request, reply, payload) => {
     reply.header('X-Content-Type-Options', 'nosniff');
-    reply.header('Referrer-Policy', 'no-referrer');
+    // Referrer-Policy is intentionally NOT set here. nginx is the canonical
+    // owner of browser-facing headers (per docs/ai-instructions/security-checklist.md)
+    // and emits `Referrer-Policy: strict-origin-when-cross-origin` (OWASP-recommended).
+    // Setting it here would conflict with the nginx value (only the first survives some
+    // proxy configurations). See issue #1101.
     reply.header('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
 
     const forwardedProto = request.headers['x-forwarded-proto'];


### PR DESCRIPTION
## Summary

Two header-policy fixes:

- **#1101 — Referrer-Policy duplication.** Backend was emitting `Referrer-Policy: no-referrer` while nginx emits `Referrer-Policy: strict-origin-when-cross-origin`. The project security checklist designates nginx as the single source of truth for browser-facing headers. Browser behaviour with duplicate / conflicting values is undefined. **Removed the backend assignment.** nginx value stays unchanged.

- **#1105 — Deprecated X-XSS-Protection.** All modern browsers ignore `X-XSS-Protection` (Chrome removed the XSS Auditor in 2019). On older browsers the auditor can be tricked into removing legitimate script content, creating new attack vectors. Per OWASP, set to `"0"` to explicitly disable. CSP `script-src 'self'` (already in the same nginx snippet) provides superior protection.

## Files

- `packages/core/src/plugins/security-headers.ts` — delete the `Referrer-Policy` line, replace with explanatory comment.
- `frontend/nginx-security-headers.conf` — `X-XSS-Protection "1; mode=block"` → `X-XSS-Protection "0"` with OWASP rationale comment.
- `packages/core/src/plugins/security-headers.test.ts` — existing assertion flipped from `'no-referrer'` to `toBeUndefined()`.
- `backend/src/routes/security-regression.test.ts` — 2 new regression tests (nginx config has `"0"` and not `"1`; backend response has no `Referrer-Policy`).
- `docs/ai-instructions/security-checklist.md` — header-ownership note updated.

## Verification

| Gate | Result |
|------|--------|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npx vitest run backend/src/routes/security-regression.test.ts` | 88/88 pass (2 new) |
| `npx vitest run packages/core/src/plugins/security-headers.test.ts` | 2/2 pass |

## Notes

- This PR is the recovery of a stalled agent run (Lane 1 PR6). The single source code change (`security-headers.ts`) was already in place from the stalled session; this commit adds the matching nginx change, test updates, and doc update.
- Will need trivial rebase against unmerged Lane 1 PRs that touch `security-regression.test.ts` (PR#1169, PR#1173, PR#1179, PR#1182, PR#1183) — all use the append-at-bottom pattern.

Closes #1101
Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)