### PR TITLE
security: assemble DB URLs from components, migrate timescale-backup to secrets (#1187)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,11 @@ Branch: `dev` → `feature/<issue#>-<desc>`. PRs: `feature/* → dev` (CI runs).
 
 ## Environment
 
-Copy `.env.example` to `.env`. Key vars: `PORTAINER_API_URL`, `PORTAINER_API_KEY`, `DASHBOARD_USERNAME`, `DASHBOARD_PASSWORD`, `OLLAMA_BASE_URL` (default `http://host.docker.internal:11434`), `OLLAMA_MODEL` (default `llama3.2`), `REDIS_URL`, `JWT_SECRET` (32+ chars), `POSTGRES_APP_PASSWORD`, `TIMESCALE_PASSWORD`. Harbor (optional): `HARBOR_API_URL`, `HARBOR_ROBOT_NAME`, `HARBOR_ROBOT_SECRET`, `HARBOR_VERIFY_SSL` (default `true`), `HARBOR_SYNC_ENABLED` (default `false`), `HARBOR_SYNC_INTERVAL_MINUTES` (default `30`), `HARBOR_CONCURRENCY` (default `5`). Harbor can also be configured via Settings UI (stored in PostgreSQL, takes precedence over env vars). See `.env.example` for full list.
+Copy `.env.example` to `.env`. Key vars: `PORTAINER_API_URL`, `PORTAINER_API_KEY`, `DASHBOARD_USERNAME`, `DASHBOARD_PASSWORD`, `OLLAMA_BASE_URL` (default `http://host.docker.internal:11434`), `OLLAMA_MODEL` (default `llama3.2`), `REDIS_URL`, `JWT_SECRET` (32+ chars), `POSTGRES_APP_PASSWORD`, `TIMESCALE_PASSWORD`. Harbor (optional): `HARBOR_API_URL`, `HARBOR_ROBOT_NAME`, `HARBOR_ROBOT_SECRET`, `HARBOR_VERIFY_SSL` (default `true`), `HARBOR_SYNC_ENABLED` (default `false`), `HARBOR_SYNC_INTERVAL_MINUTES` (default `30`), `HARBOR_CONCURRENCY` (default `5`). Harbor can also be configured via Settings UI (stored in PostgreSQL, takes precedence over env vars).
+
+Component-based DB URLs (#1187): `POSTGRES_APP_HOST`/`PORT`/`USER`/`DATABASE`, `TIMESCALE_HOST`/`PORT`/`USER`/`DATABASE`, `REDIS_HOST`/`PORT` are optional. When set, the backend assembles the connection URL from these + the password resolved via `readSecret()` (Docker Secrets file > env), instead of relying on env-var interpolation in compose. Backwards compatible: existing `*_URL` env vars still work when components are not set.
+
+See `.env.example` for full list.
 
 ## Issue Templates
 

--- a/backend/src/docker-security.test.ts
+++ b/backend/src/docker-security.test.ts
@@ -443,3 +443,104 @@ describe('Docker Secrets migration (#1121)', () => {
     expect(block).toMatch(/JWT_SECRET=\$\{JWT_SECRET:-\}/);
   });
 });
+
+// Issue #1187 — Follow-up to #1121. Two remaining gaps closed:
+//  (1) timescale-backup sidecar reads its password from
+//      /run/secrets/timescale_password via POSTGRES_PASSWORD_FILE (native
+//      support in prodrigestivill/postgres-backup-local).
+//  (2) Backend's POSTGRES_APP_URL / TIMESCALE_URL / REDIS_URL are no longer
+//      reconstructed via env-var interpolation in compose. Components
+//      (HOST/PORT/USER/DATABASE) come from env, password from the secret
+//      file, and the URL is assembled inside the backend's config layer.
+describe('Docker Secrets follow-up (#1187)', () => {
+  const compose = readFile('docker/docker-compose.yml');
+
+  function getServiceBlock(name: string): string {
+    const lines = compose.split('\n');
+    const startIdx = lines.findIndex((l) => l === `  ${name}:`);
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    const endIdx = lines.findIndex(
+      (l, i) => i > startIdx && /^(\S| {2}\S)/.test(l) && !/^ {2}\s/.test(l),
+    );
+    return lines.slice(startIdx, endIdx === -1 ? undefined : endIdx).join('\n');
+  }
+
+  describe('timescale-backup secrets migration', () => {
+    const block = getServiceBlock('timescale-backup');
+
+    it('uses POSTGRES_PASSWORD_FILE pointing at the timescale_password secret', () => {
+      expect(block).toMatch(/POSTGRES_PASSWORD_FILE:\s+\/run\/secrets\/timescale_password/);
+    });
+
+    it('no longer interpolates TIMESCALE_PASSWORD as a plaintext env var', () => {
+      // Before #1187: `POSTGRES_PASSWORD: ${TIMESCALE_PASSWORD:?...}` — the
+      // compose interpolation would reconstruct the password into the env.
+      expect(block).not.toMatch(/POSTGRES_PASSWORD:\s+\$\{TIMESCALE_PASSWORD/);
+    });
+
+    it('mounts the timescale_password secret', () => {
+      expect(block).toMatch(/^ {4}secrets:\s*$/m);
+      expect(block).toMatch(/^\s+- timescale_password$/m);
+    });
+
+    it('preserves the no-new-privileges hardening from the B1 audit', () => {
+      // Regression guard for the #1121 B1 audit — this PR must NOT regress
+      // the security_opt setting on the backup sidecar.
+      expect(block).toMatch(/^ {4}security_opt:\s*$/m);
+      expect(block).toMatch(/no-new-privileges:true/);
+    });
+  });
+
+  describe('backend URL components (no password in compose interpolation)', () => {
+    const block = getServiceBlock('backend');
+
+    it('does not embed POSTGRES_APP_PASSWORD inside POSTGRES_APP_URL', () => {
+      // Before #1187:
+      //   POSTGRES_APP_URL=postgresql://app_user:${POSTGRES_APP_PASSWORD:?...}@postgres-app:5432/...
+      // After: the URL is empty and assembled inside the backend.
+      expect(block).not.toMatch(/POSTGRES_APP_URL=postgresql:\/\/[^$]*\$\{POSTGRES_APP_PASSWORD/);
+    });
+
+    it('does not embed TIMESCALE_PASSWORD inside TIMESCALE_URL', () => {
+      expect(block).not.toMatch(/TIMESCALE_URL=postgresql:\/\/[^$]*\$\{TIMESCALE_PASSWORD/);
+    });
+
+    it('exposes POSTGRES_APP_HOST/PORT/USER/DATABASE as discrete env vars', () => {
+      expect(block).toMatch(/POSTGRES_APP_HOST=\$\{POSTGRES_APP_HOST:-postgres-app\}/);
+      expect(block).toMatch(/POSTGRES_APP_PORT=\$\{POSTGRES_APP_PORT:-5432\}/);
+      expect(block).toMatch(/POSTGRES_APP_USER=\$\{POSTGRES_APP_USER:-app_user\}/);
+      expect(block).toMatch(/POSTGRES_APP_DATABASE=\$\{POSTGRES_APP_DATABASE:-portainer_dashboard\}/);
+    });
+
+    it('exposes TIMESCALE_HOST/PORT/USER/DATABASE as discrete env vars', () => {
+      expect(block).toMatch(/TIMESCALE_HOST=\$\{TIMESCALE_HOST:-timescaledb\}/);
+      expect(block).toMatch(/TIMESCALE_PORT=\$\{TIMESCALE_PORT:-5432\}/);
+      expect(block).toMatch(/TIMESCALE_USER=\$\{TIMESCALE_USER:-metrics_user\}/);
+      expect(block).toMatch(/TIMESCALE_DATABASE=\$\{TIMESCALE_DATABASE:-metrics\}/);
+    });
+
+    it('exposes REDIS_HOST/PORT as discrete env vars', () => {
+      expect(block).toMatch(/REDIS_HOST=\$\{REDIS_HOST:-redis\}/);
+      expect(block).toMatch(/REDIS_PORT=\$\{REDIS_PORT:-6379\}/);
+    });
+
+    it('keeps POSTGRES_APP_PASSWORD/TIMESCALE_PASSWORD passthroughs as soft-default (file > env)', () => {
+      // Backend reads via readSecret() — file at /run/secrets/* takes
+      // precedence. The env-var passthrough must NOT be hard-failing
+      // (`:?`) because Docker Secrets users do not set the env var.
+      expect(block).toMatch(/POSTGRES_APP_PASSWORD=\$\{POSTGRES_APP_PASSWORD:-\}/);
+      expect(block).toMatch(/TIMESCALE_PASSWORD=\$\{TIMESCALE_PASSWORD:-\}/);
+      expect(block).not.toMatch(/POSTGRES_APP_PASSWORD=\$\{POSTGRES_APP_PASSWORD:\?/);
+      expect(block).not.toMatch(/TIMESCALE_PASSWORD=\$\{TIMESCALE_PASSWORD:\?/);
+    });
+
+    it('keeps POSTGRES_APP_URL / TIMESCALE_URL / REDIS_URL as overridable empty defaults', () => {
+      // Components take precedence inside the backend, but the dev/legacy
+      // single-string path still works when an operator sets the URL env
+      // var explicitly. The default must be empty — never embed a password.
+      expect(block).toMatch(/POSTGRES_APP_URL=\$\{POSTGRES_APP_URL:-\}/);
+      expect(block).toMatch(/TIMESCALE_URL=\$\{TIMESCALE_URL:-\}/);
+      expect(block).toMatch(/REDIS_URL=\$\{REDIS_URL:-\}/);
+    });
+  });
+});

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -208,7 +208,16 @@ INVESTIGATION_METRICS_WINDOW_MINUTES=60
 # Cache
 CACHE_ENABLED=true
 CACHE_TTL_SECONDS=900
-REDIS_URL=redis://redis:6379
+# REDIS_URL is the dev/legacy single-string fallback. For Docker Secrets
+# deploys (#1187), leave it empty and use REDIS_HOST/REDIS_PORT below;
+# the backend assembles the URL from those + the resolved REDIS_PASSWORD
+# (sourced from /run/secrets/redis_password).
+# REDIS_URL=redis://redis:6379
+# REDIS_HOST/REDIS_PORT (#1187): components used to assemble REDIS_URL when
+# REDIS_HOST is set. Production deploys should use these instead of REDIS_URL
+# so REDIS_PASSWORD never appears in compose-time env-var interpolation.
+# REDIS_HOST=redis
+# REDIS_PORT=6379
 # REDIS_PASSWORD: see Secrets management section at the top. Leave commented
 # to source from docker/secrets/redis_password.txt (Docker Secrets path).
 # Uncomment for env-var fallback only.
@@ -228,11 +237,22 @@ RABBITMQ_DEFAULT_PASS=CHANGE_ME_BEFORE_PRODUCTION
 
 # App PostgreSQL (app data: users, sessions, settings, audit logs, insights, etc.)
 # Separate from TimescaleDB (metrics). Both run PostgreSQL 17.
-# POSTGRES_APP_PASSWORD: the postgres image reads
-# /run/secrets/postgres_app_password (POSTGRES_PASSWORD_FILE). The env var is
-# still consumed by docker-compose to assemble POSTGRES_APP_URL for the
-# backend connection — see Secrets management section at the top.
+#
+# After #1187, the backend's connection URL is assembled from components
+# (POSTGRES_APP_HOST/PORT/USER/DATABASE) plus the password resolved from
+# /run/secrets/postgres_app_password — the password is no longer reconstructed
+# via env-var interpolation in compose. POSTGRES_APP_PASSWORD is still
+# consumed by docker/init-pg-databases.sh on first init for one-shot DB
+# provisioning, so it must still be set during Compose bootstrap. Use the
+# same value you wrote to docker/secrets/postgres_app_password.txt.
 POSTGRES_APP_PASSWORD=CHANGE_ME_BEFORE_PRODUCTION
+# POSTGRES_APP_HOST=postgres-app          # Default for the Compose stack
+# POSTGRES_APP_PORT=5432                  # Standard postgres port
+# POSTGRES_APP_USER=app_user
+# POSTGRES_APP_DATABASE=portainer_dashboard
+# POSTGRES_APP_URL: dev/legacy single-string fallback. Leave empty when
+# using component-based assembly (#1187).
+# POSTGRES_APP_URL=postgresql://app_user:CHANGE_ME@postgres-app:5432/portainer_dashboard
 # POSTGRES_APP_MAX_CONNECTIONS=20
 
 # PostgreSQL Test Database (for backend tests)
@@ -248,12 +268,21 @@ POSTGRES_APP_PASSWORD=CHANGE_ME_BEFORE_PRODUCTION
 
 # TimescaleDB (metrics + KPI time-series storage)
 # TimescaleDB runs as a Docker Compose sidecar for high-performance metrics queries.
-# TIMESCALE_PASSWORD is used by docker-compose.yml to assemble the backend's
-# TIMESCALE_URL. The TimescaleDB container itself reads its password from
-# /run/secrets/timescale_password (POSTGRES_PASSWORD_FILE). Change this
-# before production. See Secrets management section at the top.
-TIMESCALE_PASSWORD=CHANGE_ME_BEFORE_PRODUCTION
-TIMESCALE_URL=postgresql://metrics_user:CHANGE_ME_BEFORE_PRODUCTION@timescaledb:5432/metrics
+#
+# After #1187: same component pattern as POSTGRES_APP_*. The backend
+# assembles TIMESCALE_URL from TIMESCALE_HOST/PORT/USER/DATABASE plus the
+# password from /run/secrets/timescale_password. The timescale-backup
+# sidecar also reads from this secret file via POSTGRES_PASSWORD_FILE.
+# Setting TIMESCALE_PASSWORD here is only needed when you cannot use
+# Docker Secrets (env-var fallback path).
+# TIMESCALE_PASSWORD=CHANGE_ME_BEFORE_PRODUCTION
+# TIMESCALE_HOST=timescaledb              # Default for the Compose stack
+# TIMESCALE_PORT=5432
+# TIMESCALE_USER=metrics_user
+# TIMESCALE_DATABASE=metrics
+# TIMESCALE_URL: dev/legacy single-string fallback. Leave empty when using
+# component-based assembly (#1187).
+# TIMESCALE_URL=postgresql://metrics_user:CHANGE_ME_BEFORE_PRODUCTION@timescaledb:5432/metrics
 # TIMESCALE_MAX_CONNECTIONS=50
 # TIMESCALE_REPORTS_MAX_CONNECTIONS=5
 # METRICS_RAW_RETENTION_DAYS=7        # Raw 60s-interval data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,13 @@ services:
       - ANOMALY_MIN_SAMPLES=${ANOMALY_MIN_SAMPLES:-10}
       - CACHE_ENABLED=${CACHE_ENABLED:-true}
       - CACHE_TTL_SECONDS=${CACHE_TTL_SECONDS:-900}
-      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      # REDIS_URL: dev/legacy fallback. When REDIS_HOST (below) is set, the
+      # backend assembles the URL from components + the resolved REDIS_PASSWORD
+      # (Docker Secrets file > env var) — see #1187. The component path keeps
+      # the password out of compose-time env-var interpolation entirely.
+      - REDIS_URL=${REDIS_URL:-}
+      - REDIS_HOST=${REDIS_HOST:-redis}
+      - REDIS_PORT=${REDIS_PORT:-6379}
       # REDIS_PASSWORD: same resolution order as JWT_SECRET — file > env. Schema
       # treats it as optional so the secret-file path works standalone.
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
@@ -68,18 +74,32 @@ services:
       - TRACES_INGESTION_ENABLED=${TRACES_INGESTION_ENABLED:-false}
       - TRACES_INGESTION_API_KEY=${TRACES_INGESTION_API_KEY:-}
       # App PostgreSQL (replaces SQLite for app data)
-      # NOTE: The connection URL still embeds POSTGRES_APP_PASSWORD via env-var
-      # interpolation. Docker Secrets feed the postgres-app container's own
-      # POSTGRES_PASSWORD_FILE for storage, but the backend's URL must still
-      # resolve to a string at compose time. Operators using full Docker Secrets
-      # MUST also export POSTGRES_APP_PASSWORD in their orchestrator env (e.g.
-      # via Swarm `secrets:` projected to env, or the .env file). A follow-up
-      # PR can move URL assembly into the backend so the password is read from
-      # /run/secrets at runtime.
-      - POSTGRES_APP_URL=postgresql://app_user:${POSTGRES_APP_PASSWORD:?POSTGRES_APP_PASSWORD is required}@postgres-app:5432/portainer_dashboard
+      # #1187: the connection URL is assembled INSIDE the backend from the
+      # component env vars below + the password resolved from
+      # /run/secrets/postgres_app_password (or POSTGRES_APP_PASSWORD env-var
+      # fallback). The password is no longer reconstructed by compose-time
+      # interpolation, so `docker inspect` and `/proc/<pid>/environ` no
+      # longer expose it via the URL. POSTGRES_APP_URL is kept as an empty
+      # default so the dev/legacy single-string path still works when the
+      # operator sets it explicitly.
+      - POSTGRES_APP_URL=${POSTGRES_APP_URL:-}
+      - POSTGRES_APP_HOST=${POSTGRES_APP_HOST:-postgres-app}
+      - POSTGRES_APP_PORT=${POSTGRES_APP_PORT:-5432}
+      - POSTGRES_APP_USER=${POSTGRES_APP_USER:-app_user}
+      - POSTGRES_APP_DATABASE=${POSTGRES_APP_DATABASE:-portainer_dashboard}
+      # POSTGRES_APP_PASSWORD: file > env, same resolution order as JWT_SECRET.
+      # Operators should leave this empty in compose and rely on the secret
+      # file at /run/secrets/postgres_app_password.
+      - POSTGRES_APP_PASSWORD=${POSTGRES_APP_PASSWORD:-}
       - POSTGRES_APP_MAX_CONNECTIONS=${POSTGRES_APP_MAX_CONNECTIONS:-20}
-      # TimescaleDB Metrics Storage — same caveat as POSTGRES_APP_URL above.
-      - TIMESCALE_URL=postgresql://metrics_user:${TIMESCALE_PASSWORD:?TIMESCALE_PASSWORD is required}@timescaledb:5432/metrics
+      # TimescaleDB Metrics Storage — same component pattern as POSTGRES_APP_*
+      # above. Password resolved from /run/secrets/timescale_password.
+      - TIMESCALE_URL=${TIMESCALE_URL:-}
+      - TIMESCALE_HOST=${TIMESCALE_HOST:-timescaledb}
+      - TIMESCALE_PORT=${TIMESCALE_PORT:-5432}
+      - TIMESCALE_USER=${TIMESCALE_USER:-metrics_user}
+      - TIMESCALE_DATABASE=${TIMESCALE_DATABASE:-metrics}
+      - TIMESCALE_PASSWORD=${TIMESCALE_PASSWORD:-}
       - TIMESCALE_MAX_CONNECTIONS=${TIMESCALE_MAX_CONNECTIONS:-20}
       - METRICS_RAW_RETENTION_DAYS=${METRICS_RAW_RETENTION_DAYS:-7}
       - METRICS_ROLLUP_5MIN_RETENTION_DAYS=${METRICS_ROLLUP_5MIN_RETENTION_DAYS:-30}
@@ -328,7 +348,12 @@ services:
       POSTGRES_PORT: "5432"
       POSTGRES_DB: metrics
       POSTGRES_USER: metrics_user
-      POSTGRES_PASSWORD: ${TIMESCALE_PASSWORD:?TIMESCALE_PASSWORD is required}
+      # #1187: prodrigestivill/postgres-backup-local natively reads
+      # POSTGRES_PASSWORD_FILE — the env.sh entrypoint copies the trimmed
+      # file contents into PGPASSWORD before invoking pg_dump. Mounting the
+      # same secret file the timescaledb service uses keeps the backup
+      # password in lockstep with the source DB password.
+      POSTGRES_PASSWORD_FILE: /run/secrets/timescale_password
       POSTGRES_EXTRA_OPTS: ${TIMESCALE_BACKUP_EXTRA_OPTS:--Z6 --no-comments}
       SCHEDULE: ${TIMESCALE_BACKUP_SCHEDULE:-0 3 * * *}
       BACKUP_KEEP_DAYS: ${TIMESCALE_BACKUP_KEEP_DAYS:-7}
@@ -348,6 +373,8 @@ services:
         condition: service_healthy
     networks:
       - dashboard-net
+    secrets:
+      - timescale_password
     deploy:
       resources:
         limits:

--- a/docs/ai-instructions/security-checklist.md
+++ b/docs/ai-instructions/security-checklist.md
@@ -68,11 +68,46 @@ chmod 600 secrets/*.txt
 - **postgres-app / timescaledb**: the official `postgres` image natively
   honours `POSTGRES_PASSWORD_FILE`. Compose sets it to
   `/run/secrets/postgres_app_password` (or `timescale_password`).
+- **timescale-backup** (#1187): `prodrigestivill/postgres-backup-local`
+  natively honours `POSTGRES_PASSWORD_FILE` — its `env.sh` reads the file
+  and copies the value into `PGPASSWORD` for `pg_dump`. Compose mounts the
+  same `timescale_password` secret used by the source DB so passwords stay
+  in lockstep.
 - **redis**: the official Redis image does NOT honour `REDIS_PASSWORD_FILE`.
   Compose uses a shell wrapper (`sh -c "REDIS_PASS=$(cat /run/secrets/redis_password); exec redis-server --requirepass \"$REDIS_PASS\""`) so the password never appears in argv-visible form.
 - **backend (Fastify)**: `readSecret()` is called inside the env-schema
-  preprocessor for `JWT_SECRET` and `REDIS_PASSWORD` before Zod validation.
-  The min-length / weak-default guards still fire on the resolved value.
+  preprocessor for `JWT_SECRET`, `REDIS_PASSWORD`, `POSTGRES_APP_PASSWORD`,
+  and `TIMESCALE_PASSWORD` before Zod validation. The min-length /
+  weak-default guards still fire on the resolved value.
+
+### URL assembly from components (#1187)
+
+Before #1187, the backend's `POSTGRES_APP_URL` and `TIMESCALE_URL` were
+constructed at compose-time via env-var interpolation:
+```yaml
+POSTGRES_APP_URL=postgresql://app_user:${POSTGRES_APP_PASSWORD:?...}@postgres-app:5432/...
+```
+That defeats the Docker Secrets benefit — the password is reconstructed in
+the container env (visible via `docker inspect` and `/proc/<pid>/environ`).
+
+After #1187, compose exposes the URL components as discrete env vars and
+the backend assembles the URL at runtime, reading the password via
+`readSecret()`:
+
+| Var | Source | Default in compose |
+|-----|--------|---------------------|
+| `POSTGRES_APP_HOST` | env | `postgres-app` |
+| `POSTGRES_APP_PORT` | env | `5432` |
+| `POSTGRES_APP_USER` | env | `app_user` |
+| `POSTGRES_APP_DATABASE` | env | `portainer_dashboard` |
+| `POSTGRES_APP_PASSWORD` | `/run/secrets/postgres_app_password` (file) > env | empty |
+| `POSTGRES_APP_URL` | env (override only — empty when components used) | empty |
+
+Identical pattern for `TIMESCALE_*` and `REDIS_*` (Redis components do not
+require USER/DATABASE — the protocol does not mandate either).
+
+**Backwards compatibility**: when `*_HOST` is unset the existing single
+`*_URL` env var is consumed unchanged, so the dev workflow (`postgresql://user:pass@host/db` straight in `.env`) keeps working.
 
 **Validation invariants**:
 - `JWT_SECRET` must be ≥ 32 characters after resolution. Production

--- a/packages/core/src/config/env.schema.ts
+++ b/packages/core/src/config/env.schema.ts
@@ -185,20 +185,56 @@ export const envSchema = z.object({
   // Cache
   CACHE_ENABLED: z.coerce.boolean().default(true),
   CACHE_TTL_SECONDS: z.coerce.number().int().min(10).default(900),
+  // REDIS_URL is the dev/legacy single-string fallback. When the component
+  // env vars below (REDIS_HOST/REDIS_PORT/...) are set, the config layer
+  // assembles the URL from those components + the resolved REDIS_PASSWORD
+  // (which may come from /run/secrets/redis_password). See #1187.
   REDIS_URL: z.string().url().optional(),
   // REDIS_PASSWORD: prefers /run/secrets/redis_password (Docker Secrets),
   // falls back to the REDIS_PASSWORD env var. Optional — only required when
   // the Redis server is configured with --requirepass (production default).
   REDIS_PASSWORD: z.preprocess(preprocessSecret('redis_password'), z.string().optional()),
   REDIS_KEY_PREFIX: z.string().default('aidash:cache:'),
+  // Redis URL components (#1187) — when set, the config layer builds REDIS_URL
+  // from these + the resolved REDIS_PASSWORD instead of relying on env-var
+  // interpolation in compose. All optional for backwards compatibility.
+  REDIS_HOST: z.string().optional(),
+  REDIS_PORT: z.coerce.number().int().min(1).max(65535).optional(),
+  REDIS_USER: z.string().optional(),
+  REDIS_DATABASE: z.string().optional(),
 
   // App PostgreSQL
+  // POSTGRES_APP_URL is the dev/legacy single-string fallback. When the
+  // component env vars below are set, the config layer assembles the URL
+  // from those components + the resolved POSTGRES_APP_PASSWORD (which may
+  // come from /run/secrets/postgres_app_password). See #1187.
   POSTGRES_APP_URL: z.string().default('postgresql://app_user:changeme@localhost:5433/portainer_dashboard'),
   POSTGRES_APP_MAX_CONNECTIONS: z.coerce.number().int().min(1).max(200).default(20),
+  // App PostgreSQL URL components (#1187) — see POSTGRES_APP_URL note above.
+  POSTGRES_APP_HOST: z.string().optional(),
+  POSTGRES_APP_PORT: z.coerce.number().int().min(1).max(65535).optional(),
+  POSTGRES_APP_USER: z.string().optional(),
+  POSTGRES_APP_DATABASE: z.string().optional(),
+  // POSTGRES_APP_PASSWORD: prefers /run/secrets/postgres_app_password,
+  // falls back to env. Only consumed when the URL is assembled from
+  // components above; otherwise the password lives inside POSTGRES_APP_URL.
+  POSTGRES_APP_PASSWORD: z.preprocess(preprocessSecret('postgres_app_password'), z.string().optional()),
 
   // TimescaleDB (metrics + KPI storage)
+  // TIMESCALE_URL is the dev/legacy single-string fallback. When the
+  // component env vars below are set, the config layer assembles the URL
+  // from those components + the resolved TIMESCALE_PASSWORD. See #1187.
   TIMESCALE_URL: z.string().default('postgresql://metrics_user:changeme@localhost:5432/metrics'),
   TIMESCALE_MAX_CONNECTIONS: z.coerce.number().int().min(1).max(200).default(50),
+  // TimescaleDB URL components (#1187) — see TIMESCALE_URL note above.
+  TIMESCALE_HOST: z.string().optional(),
+  TIMESCALE_PORT: z.coerce.number().int().min(1).max(65535).optional(),
+  TIMESCALE_USER: z.string().optional(),
+  TIMESCALE_DATABASE: z.string().optional(),
+  // TIMESCALE_PASSWORD: prefers /run/secrets/timescale_password, falls back
+  // to env. Only consumed when the URL is assembled from components above;
+  // otherwise the password lives inside TIMESCALE_URL.
+  TIMESCALE_PASSWORD: z.preprocess(preprocessSecret('timescale_password'), z.string().optional()),
   TIMESCALE_REPORTS_MAX_CONNECTIONS: z.coerce.number().int().min(1).max(50).default(5),
   METRICS_RAW_RETENTION_DAYS: z.coerce.number().int().min(1).default(7),
   METRICS_ROLLUP_5MIN_RETENTION_DAYS: z.coerce.number().int().min(1).default(30),

--- a/packages/core/src/config/index.test.ts
+++ b/packages/core/src/config/index.test.ts
@@ -485,6 +485,195 @@ describe('config validation', () => {
     });
   });
 
+  // Issue #1187 — URL-from-components assembly. When component env vars are
+  // set (HOST/PORT/USER/DATABASE), the config layer assembles *_URL from
+  // those + the resolved password (Docker Secrets file > env var). When
+  // components are absent, the existing single-string *_URL env var is used
+  // unchanged — backwards compatible with dev workflows.
+  describe('URL-from-components assembly (#1187)', () => {
+    describe('POSTGRES_APP_URL', () => {
+      it('falls back to POSTGRES_APP_URL when no components are set', async () => {
+        delete process.env.POSTGRES_APP_HOST;
+        delete process.env.POSTGRES_APP_PORT;
+        delete process.env.POSTGRES_APP_USER;
+        delete process.env.POSTGRES_APP_DATABASE;
+        delete process.env.POSTGRES_APP_PASSWORD;
+        process.env.POSTGRES_APP_URL =
+          'postgresql://app_user:str0ng-pg-pass@postgres-app:5432/app';
+
+        const { getConfig } = await import('./index.js');
+        const config = getConfig();
+        expect(config.POSTGRES_APP_URL).toBe(
+          'postgresql://app_user:str0ng-pg-pass@postgres-app:5432/app',
+        );
+      });
+
+      it('assembles URL from components when POSTGRES_APP_HOST is set', async () => {
+        process.env.POSTGRES_APP_HOST = 'postgres-app';
+        process.env.POSTGRES_APP_PORT = '5432';
+        process.env.POSTGRES_APP_USER = 'app_user';
+        process.env.POSTGRES_APP_DATABASE = 'portainer_dashboard';
+        process.env.POSTGRES_APP_PASSWORD = 'secret-pg-pass';
+        // Even if POSTGRES_APP_URL is set, components take precedence.
+        process.env.POSTGRES_APP_URL = 'postgresql://stale:stale@stale:5432/stale';
+
+        const { getConfig } = await import('./index.js');
+        const config = getConfig();
+        // Round-trip via URL parser to assert structure regardless of
+        // percent-encoding edge cases.
+        const url = new URL(config.POSTGRES_APP_URL);
+        expect(url.protocol).toBe('postgresql:');
+        expect(url.hostname).toBe('postgres-app');
+        expect(url.port).toBe('5432');
+        expect(url.username).toBe('app_user');
+        expect(decodeURIComponent(url.password)).toBe('secret-pg-pass');
+        expect(url.pathname).toBe('/portainer_dashboard');
+      });
+
+      it('rejects component config missing USER', async () => {
+        process.env.POSTGRES_APP_HOST = 'postgres-app';
+        process.env.POSTGRES_APP_DATABASE = 'portainer_dashboard';
+        delete process.env.POSTGRES_APP_USER;
+
+        const { getConfig } = await import('./index.js');
+        expect(() => getConfig()).toThrowError(
+          /POSTGRES_APP_USER and POSTGRES_APP_DATABASE are required/i,
+        );
+      });
+
+      it('rejects component config missing DATABASE', async () => {
+        process.env.POSTGRES_APP_HOST = 'postgres-app';
+        process.env.POSTGRES_APP_USER = 'app_user';
+        delete process.env.POSTGRES_APP_DATABASE;
+
+        const { getConfig } = await import('./index.js');
+        expect(() => getConfig()).toThrowError(
+          /POSTGRES_APP_USER and POSTGRES_APP_DATABASE are required/i,
+        );
+      });
+
+      it('defaults POSTGRES_APP_PORT to 5432 when only HOST/USER/DATABASE set', async () => {
+        process.env.POSTGRES_APP_HOST = 'postgres-app';
+        process.env.POSTGRES_APP_USER = 'app_user';
+        process.env.POSTGRES_APP_DATABASE = 'portainer_dashboard';
+        process.env.POSTGRES_APP_PASSWORD = 'secret';
+        delete process.env.POSTGRES_APP_PORT;
+
+        const { getConfig } = await import('./index.js');
+        const config = getConfig();
+        expect(new URL(config.POSTGRES_APP_URL).port).toBe('5432');
+      });
+
+      it('percent-encodes password reserved characters', async () => {
+        process.env.POSTGRES_APP_HOST = 'postgres-app';
+        process.env.POSTGRES_APP_USER = 'app_user';
+        process.env.POSTGRES_APP_DATABASE = 'portainer_dashboard';
+        // `@`, `:`, `/`, `#` are URL-significant and must be encoded.
+        process.env.POSTGRES_APP_PASSWORD = 'p@ss:w/ord#';
+
+        const { getConfig } = await import('./index.js');
+        const config = getConfig();
+        const url = new URL(config.POSTGRES_APP_URL);
+        expect(decodeURIComponent(url.password)).toBe('p@ss:w/ord#');
+        // The raw encoded URL must not contain literal `@` inside the password.
+        expect(config.POSTGRES_APP_URL).not.toContain('@ss');
+      });
+    });
+
+    describe('TIMESCALE_URL', () => {
+      it('falls back to TIMESCALE_URL when no components are set', async () => {
+        delete process.env.TIMESCALE_HOST;
+        delete process.env.TIMESCALE_PASSWORD;
+        process.env.TIMESCALE_URL =
+          'postgresql://metrics_user:str0ng-ts-p4ss@timescaledb:5432/metrics';
+
+        const { getConfig } = await import('./index.js');
+        const config = getConfig();
+        expect(config.TIMESCALE_URL).toBe(
+          'postgresql://metrics_user:str0ng-ts-p4ss@timescaledb:5432/metrics',
+        );
+      });
+
+      it('assembles URL from components when TIMESCALE_HOST is set', async () => {
+        process.env.TIMESCALE_HOST = 'timescaledb';
+        process.env.TIMESCALE_PORT = '5432';
+        process.env.TIMESCALE_USER = 'metrics_user';
+        process.env.TIMESCALE_DATABASE = 'metrics';
+        process.env.TIMESCALE_PASSWORD = 'secret-ts-pass';
+        process.env.TIMESCALE_URL = 'postgresql://stale:stale@stale:5432/stale';
+
+        const { getConfig } = await import('./index.js');
+        const config = getConfig();
+        const url = new URL(config.TIMESCALE_URL);
+        expect(url.hostname).toBe('timescaledb');
+        expect(url.username).toBe('metrics_user');
+        expect(decodeURIComponent(url.password)).toBe('secret-ts-pass');
+        expect(url.pathname).toBe('/metrics');
+      });
+
+      it('weak-password guard runs against the assembled URL in production', async () => {
+        process.env.NODE_ENV = 'production';
+        process.env.TIMESCALE_HOST = 'timescaledb';
+        process.env.TIMESCALE_USER = 'metrics_user';
+        process.env.TIMESCALE_DATABASE = 'metrics';
+        process.env.TIMESCALE_PASSWORD = 'changeme-timescale';
+        process.env.DASHBOARD_PASSWORD = 'xK9#mP2$vL7@nQ4!';
+
+        const { getConfig } = await import('./index.js');
+        expect(() => getConfig()).toThrowError(/weak TimescaleDB password/i);
+      });
+    });
+
+    describe('REDIS_URL', () => {
+      it('falls back to REDIS_URL when no components are set', async () => {
+        delete process.env.REDIS_HOST;
+        process.env.REDIS_URL = 'redis://redis:6379';
+
+        const { getConfig } = await import('./index.js');
+        const config = getConfig();
+        expect(config.REDIS_URL).toBe('redis://redis:6379');
+      });
+
+      it('assembles redis:// URL from components', async () => {
+        process.env.REDIS_HOST = 'redis';
+        process.env.REDIS_PORT = '6379';
+        process.env.REDIS_PASSWORD = 'secret-redis-pass';
+        delete process.env.REDIS_URL;
+
+        const { getConfig } = await import('./index.js');
+        const config = getConfig();
+        expect(config.REDIS_URL).toBeDefined();
+        const url = new URL(config.REDIS_URL!);
+        expect(url.protocol).toBe('redis:');
+        expect(url.hostname).toBe('redis');
+        expect(url.port).toBe('6379');
+        expect(decodeURIComponent(url.password)).toBe('secret-redis-pass');
+      });
+
+      it('omits password when REDIS_PASSWORD is empty', async () => {
+        process.env.REDIS_HOST = 'redis';
+        process.env.REDIS_PORT = '6379';
+        delete process.env.REDIS_PASSWORD;
+        delete process.env.REDIS_URL;
+
+        const { getConfig } = await import('./index.js');
+        const config = getConfig();
+        const url = new URL(config.REDIS_URL!);
+        expect(url.password).toBe('');
+      });
+
+      it('REDIS components do not require USER/DATABASE (unlike postgres)', async () => {
+        process.env.REDIS_HOST = 'redis';
+        delete process.env.REDIS_USER;
+        delete process.env.REDIS_DATABASE;
+
+        const { getConfig } = await import('./index.js');
+        // Should NOT throw — Redis ACL is opt-in, no USER/DATABASE mandate.
+        expect(() => getConfig()).not.toThrow();
+      });
+    });
+  });
+
   // Issue #1121 — Docker Secrets integration. The env-schema preprocessor
   // resolves /run/secrets/<name> first, then falls back to the named env var.
   // The min-length / production-guard rules must still fire on the resolved

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -132,6 +132,9 @@ function validateServicePasswords(data: EnvConfig): void {
   }
 
   // Extract password from TIMESCALE_URL (format: postgresql://user:password@host:port/db)
+  // After #1187 the URL may have been re-assembled from components; the password
+  // check below catches both the legacy URL-with-password path AND the newer
+  // component-based path (the assembled URL still embeds the resolved password).
   try {
     const url = new URL(data.TIMESCALE_URL);
     const tsPassword = decodeURIComponent(url.password);
@@ -143,6 +146,112 @@ function validateServicePasswords(data: EnvConfig): void {
   } catch (e) {
     if (e instanceof Error && e.message.includes('TIMESCALE_URL')) throw e;
     // URL parsing failed — non-standard format, skip password check
+  }
+}
+
+/**
+ * Assemble a postgres-style connection URL from individual components.
+ *
+ * Reserved characters in `password` (e.g. `@`, `:`, `/`, `#`, `?`) are
+ * percent-encoded automatically by the WHATWG URL setter. We deliberately do
+ * NOT pre-encode the password — pre-encoding would either be a no-op for
+ * already-safe chars OR cause double-encoding for values containing literal
+ * `%`. The downstream consumers (`pg` library + `backup-service.ts`'s
+ * `decodeURIComponent(url.password)` round-trip) expect the standard libpq
+ * convention of single-encoded passwords inside the URL.
+ *
+ * `user` is config-controlled (not a secret) and assumed to use the safe
+ * subset; the URL setter still escapes any unexpected reserved chars.
+ */
+function assembleConnectionUrl(
+  scheme: 'postgresql' | 'redis',
+  host: string,
+  port: number,
+  user: string | undefined,
+  password: string | undefined,
+  database: string | undefined,
+): string {
+  const url = new URL(`${scheme}://${host}:${port}`);
+  if (user) url.username = user;
+  if (password !== undefined && password !== '') url.password = password;
+  // URL semantics: pathname always begins with '/'; for postgres URLs the
+  // database name is the path *without* a leading slash. `url.pathname = ''`
+  // collapses to `/`, which `pg` handles fine (no database selected).
+  if (database) url.pathname = `/${database}`;
+  return url.toString();
+}
+
+/**
+ * Issue #1187 — assemble service URLs from components when those components
+ * are set. This lets operators avoid embedding secrets in compose-time env-var
+ * interpolations: instead, host/port/user/database come from env, while the
+ * password is resolved via `readSecret()` (Docker Secrets file > env var).
+ *
+ * Behaviour:
+ *   - If HOST is set for a service, the URL is rebuilt from components +
+ *     resolved password. PORT defaults to the service's standard port; USER
+ *     and DATABASE are required when components are used (validated below).
+ *   - If HOST is unset, the existing *_URL value (env or schema default) is
+ *     left in place — full backwards compatibility for dev workflows.
+ *
+ * The assembled URL takes precedence over any *_URL env var when components
+ * are present. This is the documented behaviour: components are opt-in for
+ * production deployments using Docker Secrets.
+ */
+function assembleUrlsFromComponents(data: EnvConfig): void {
+  // Postgres app DB
+  if (data.POSTGRES_APP_HOST) {
+    const port = data.POSTGRES_APP_PORT ?? 5432;
+    const user = data.POSTGRES_APP_USER;
+    const database = data.POSTGRES_APP_DATABASE;
+    if (!user || !database) {
+      throw new Error(
+        'Invalid environment configuration:\n  POSTGRES_APP_USER and POSTGRES_APP_DATABASE are required when POSTGRES_APP_HOST is set (component-based URL assembly, #1187)'
+      );
+    }
+    data.POSTGRES_APP_URL = assembleConnectionUrl(
+      'postgresql',
+      data.POSTGRES_APP_HOST,
+      port,
+      user,
+      data.POSTGRES_APP_PASSWORD,
+      database,
+    );
+  }
+
+  // TimescaleDB
+  if (data.TIMESCALE_HOST) {
+    const port = data.TIMESCALE_PORT ?? 5432;
+    const user = data.TIMESCALE_USER;
+    const database = data.TIMESCALE_DATABASE;
+    if (!user || !database) {
+      throw new Error(
+        'Invalid environment configuration:\n  TIMESCALE_USER and TIMESCALE_DATABASE are required when TIMESCALE_HOST is set (component-based URL assembly, #1187)'
+      );
+    }
+    data.TIMESCALE_URL = assembleConnectionUrl(
+      'postgresql',
+      data.TIMESCALE_HOST,
+      port,
+      user,
+      data.TIMESCALE_PASSWORD,
+      database,
+    );
+  }
+
+  // Redis. Database is optional (redis databases are numeric and 0 is the
+  // implicit default). User is also optional (redis ACLs are opt-in via
+  // requirepass + ACL, not username/password by default).
+  if (data.REDIS_HOST) {
+    const port = data.REDIS_PORT ?? 6379;
+    data.REDIS_URL = assembleConnectionUrl(
+      'redis',
+      data.REDIS_HOST,
+      port,
+      data.REDIS_USER,
+      data.REDIS_PASSWORD,
+      data.REDIS_DATABASE,
+    );
   }
 }
 
@@ -239,6 +348,9 @@ export function getConfig(): EnvConfig {
     validateJwtSecret(result.data.JWT_SECRET);
     validateJwtAlgorithm(result.data);
     validateDashboardCredentials(result.data.DASHBOARD_USERNAME, result.data.DASHBOARD_PASSWORD);
+    // #1187: assemble *_URL from components BEFORE password validation so the
+    // weak-password guard runs against the resolved (post-assembly) URL.
+    assembleUrlsFromComponents(result.data);
     validateServicePasswords(result.data);
     validatePrometheusToken(result.data);
     warnDeprecatedEnvVars();


### PR DESCRIPTION
## Summary

Closes #1187. Follow-up to #1121 (Docker Secrets migration) covering the
two known gaps that were intentionally scoped out:

- **`timescale-backup` sidecar** now reads `POSTGRES_PASSWORD_FILE` from
  `/run/secrets/timescale_password`. The
  `prodrigestivill/postgres-backup-local` image natively supports
  `POSTGRES_PASSWORD_FILE` via its `env.sh` entrypoint (verified via
  DeepWiki against the upstream repo) — it copies the trimmed file
  contents into `PGPASSWORD` for `pg_dump`. No shell wrapper needed.

- **Backend's connection URLs** (`POSTGRES_APP_URL`, `TIMESCALE_URL`,
  `REDIS_URL`) are now assembled from individual components
  (`*_HOST`/`*_PORT`/`*_USER`/`*_DATABASE`) plus the password resolved
  via the existing `readSecret()` helper from #1121
  (`/run/secrets/<name>` > env-var fallback). Compose-time env-var
  interpolation no longer reconstructs the password into a single string,
  so `docker inspect` and `/proc/<pid>/environ` no longer expose it via
  the URL.

**Backwards compatible**: when `*_HOST` is unset, the legacy single
`*_URL` env var is consumed unchanged. The dev workflow
(`POSTGRES_APP_URL=postgres://user:pass@host/db` straight in `.env`)
keeps working — zero breaking change.

## Compose diff (high level)

```diff
   timescale-backup:
     environment:
-      POSTGRES_PASSWORD: ${TIMESCALE_PASSWORD:?TIMESCALE_PASSWORD is required}
+      POSTGRES_PASSWORD_FILE: /run/secrets/timescale_password
+    secrets:
+      - timescale_password

   backend:
     environment:
-      - POSTGRES_APP_URL=postgresql://app_user:${POSTGRES_APP_PASSWORD:?...}@postgres-app:5432/portainer_dashboard
-      - TIMESCALE_URL=postgresql://metrics_user:${TIMESCALE_PASSWORD:?...}@timescaledb:5432/metrics
+      - POSTGRES_APP_URL=${POSTGRES_APP_URL:-}
+      - POSTGRES_APP_HOST=${POSTGRES_APP_HOST:-postgres-app}
+      - POSTGRES_APP_PORT=${POSTGRES_APP_PORT:-5432}
+      - POSTGRES_APP_USER=${POSTGRES_APP_USER:-app_user}
+      - POSTGRES_APP_DATABASE=${POSTGRES_APP_DATABASE:-portainer_dashboard}
+      - POSTGRES_APP_PASSWORD=${POSTGRES_APP_PASSWORD:-}
+      # ... same shape for TIMESCALE_* and REDIS_*
```

## URL-assembly logic

`packages/core/src/config/index.ts` adds `assembleUrlsFromComponents()`
that runs after Zod validation. For each service:

1. If `*_HOST` is set → assemble `scheme://USER:PASSWORD@HOST:PORT/DATABASE`
   from components, percent-encoding the password via the WHATWG URL
   setter (single-encoded — `pg` and `backup-service.ts`'s
   `decodeURIComponent(url.password)` round-trip cleanly).
2. If `*_HOST` is unset → leave `*_URL` untouched (env var or schema default).

Postgres services require `USER` + `DATABASE` when components are used
(throws if missing). Redis treats USER/DATABASE as optional (Redis ACL is
opt-in; database is numeric and 0 is implicit).

The existing weak-password guard (`validateServicePasswords`) runs
**after** assembly so the production-only check fires against the final
URL — both legacy and component paths.

## Tests added (24 total)

**`packages/core/src/config/index.test.ts` — 13 new tests**:
- Falls back to `POSTGRES_APP_URL` when no components set
- Assembles URL from components when `POSTGRES_APP_HOST` set (verifies
  precedence over stale `*_URL`)
- Rejects component config missing `USER` / `DATABASE`
- Defaults `*_PORT` to standard ports
- Percent-encodes password reserved characters (`@`, `:`, `/`, `#`)
- Same shape for `TIMESCALE_*`, weak-password guard runs against
  assembled URL
- `REDIS_URL` assembly + verifies USER/DATABASE optional for Redis

**`backend/src/docker-security.test.ts` — 11 new tests**:
- `timescale-backup` uses `POSTGRES_PASSWORD_FILE`
- `timescale-backup` no longer interpolates `${TIMESCALE_PASSWORD}`
- `timescale-backup` mounts the `timescale_password` secret
- `timescale-backup` retains `no-new-privileges:true` (B1 audit guard)
- Backend block does NOT embed password inside `POSTGRES_APP_URL` /
  `TIMESCALE_URL`
- Backend exposes component env vars with correct defaults
- Backend keeps `*_PASSWORD` passthroughs as soft-default (file > env)
- Backend keeps `*_URL` overridable empty defaults

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `cd packages/core && npx vitest run src/config/` — 90 tests pass
      (was 77, +13 new)
- [x] `cd backend && npx vitest run src/docker-security.test.ts` — 62
      tests pass (was 51, +11 new)
- [x] `cd backend && npx vitest run src/routes/security-regression.test.ts`
      — 129 tests pass + 11 pre-existing skips (no regressions)
- [x] `docker compose -f docker/docker-compose.yml config --quiet` —
      parses cleanly with placeholder env vars
- [x] Smoke-test legacy env-var path: `POSTGRES_APP_URL` set, components
      unset → URL preserved verbatim
- [x] Smoke-test components path: stale `POSTGRES_APP_URL` set,
      components also set → components win, URL re-assembled
- [ ] Reviewer: sanity-check that a Docker Secrets deploy with no
      `POSTGRES_APP_PASSWORD` env var (only the secret file) starts
      cleanly. Note: `init-pg-databases.sh` still requires the env var
      for one-shot DB provisioning at first init — that's a separate
      future improvement scoped outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)