### PR TITLE
fix(test): repair llm-chat.test.ts reference to removed chatThrottleMap

### DIFF
--- a/packages/ai-intelligence/src/__tests__/llm-chat.test.ts
+++ b/packages/ai-intelligence/src/__tests__/llm-chat.test.ts
@@ -767,7 +767,10 @@ describe('setupLlmNamespace — per-user chat throttle', () => {
 describe('setupLlmNamespace — canary lifecycle (#1119)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    chatThrottleMap.clear();
+    // PR #1186 replaced the in-file `chatThrottleMap` with the shared
+    // `socket-throttle` utility. Clear the test-user's bucket the same way
+    // the throttling describe (line ~707) does so canary tests start fresh.
+    chatThrottle.clearByUserId('test-user');
     clearCanary('test-socket-id');
     mockCollectAllTools.mockReturnValue([]);
     mockRouteToolCalls.mockResolvedValue([]);


### PR DESCRIPTION
## Summary

PR #1186 (socket-security) refactored `llm-chat.ts` to use the shared `socket-throttle` utility, deleting the in-file `chatThrottleMap`. PR #1180 (LLM canary) merged AFTER #1186 had landed, but its added canary lifecycle describe still referenced `chatThrottleMap.clear()` in its `beforeEach`.

The compile passes but vitest throws `ReferenceError: chatThrottleMap is not defined` when the canary describe runs — failing `Package Tests` CI on every PR opened against `dev`.

## Fix

Replace `chatThrottleMap.clear()` with `chatThrottle.clearByUserId('test-user')`, mirroring the existing throttling describe at `llm-chat.test.ts:707`.

## Verification

`npx vitest run src/__tests__/llm-chat.test.ts` is currently blocked locally by the pre-existing `password authentication failed for user app_user` env issue (documented across multiple prior agent sessions). The syntactic fix is straightforward and CI's test PG resolves the env problem.

## Why a separate PR

This is a 4-line test fix that unblocks `Package Tests` for every other open PR (#1189, #1190 currently affected). Fast-tracking lets those PRs go green before merging.