### PR TITLE
test: add unit tests for useStacks hook (#1051)

### DIFF
--- a/frontend/src/features/containers/hooks/use-stacks.test.ts
+++ b/frontend/src/features/containers/hooks/use-stacks.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+import { api } from '@/shared/lib/api';
+import { useStacks, type Stack } from './use-stacks';
+
+const mockApi = vi.mocked(api);
+
+function makeStack(overrides: Partial<Stack> = {}): Stack {
+  return {
+    id: 1,
+    name: 'web',
+    type: 2,
+    endpointId: 1,
+    status: 'active',
+    envCount: 0,
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('useStacks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches stacks from /api/stacks', async () => {
+    const stacks = [makeStack({ id: 1, name: 'web' }), makeStack({ id: 2, name: 'worker' })];
+    mockApi.get.mockResolvedValueOnce(stacks);
+
+    const { result } = renderHook(() => useStacks(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/stacks');
+    expect(result.current.data).toEqual(stacks);
+  });
+
+  it('returns empty array when no stacks exist', async () => {
+    mockApi.get.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useStacks(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('surfaces fetch errors', async () => {
+    mockApi.get.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(() => useStacks(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it('preserves stack source field for label-derived stacks', async () => {
+    const stacks = [
+      makeStack({ id: 1, source: 'portainer' }),
+      makeStack({ id: 2, source: 'compose-label' }),
+    ];
+    mockApi.get.mockResolvedValueOnce(stacks);
+
+    const { result } = renderHook(() => useStacks(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].source).toBe('portainer');
+    expect(result.current.data?.[1].source).toBe('compose-label');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `frontend/src/features/containers/hooks/use-stacks.test.ts` covering success, empty, error, and `source` field passthrough paths.
- Closes #1051.

## Notes on scope
The issue's hook list (`use-containers`, `use-stacks`, `use-endpoints`, `use-images`, `use-websocket`, `use-theme`, `use-sidebar`, `use-notifications`) was reviewed before writing — only `use-stacks` was actually missing tests:

| Hook | Status |
|---|---|
| `use-containers` | already covered (`use-containers.test.ts`) |
| `use-endpoints` | already covered (`use-endpoints.test.ts`) |
| `use-images` | already covered (`use-images.test.ts`) |
| `use-stacks` | **added in this PR** |
| `use-websocket` | not a hook — sockets live in `providers/socket-provider.test.tsx` |
| `use-theme` | implemented as `stores/theme-store.ts`, already covered (`theme-store.test.ts`) |
| `use-sidebar` | implemented as `features/core/components/layout/sidebar.tsx`, already covered (`sidebar.test.tsx`) |
| `use-notifications` | implemented as `stores/notification-store.ts`, already covered (`notification-store.test.ts`) |

## Test plan
- [x] `npx vitest run src/features/containers/hooks/use-stacks.test.ts` (4 tests pass)
- [x] full frontend suite still passes (1749 tests, 181 files)
- [x] `npm run typecheck -w frontend` clean
- [x] `npm run lint -w frontend` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)