### PR TITLE
test: add unit tests for 7 untested frontend hooks (#1022)

### DIFF
--- a/frontend/src/features/ai-intelligence/hooks/use-investigations.test.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-investigations.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+const mockMonitoringSocket = {
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+};
+
+let monitoringSocketRef: typeof mockMonitoringSocket | null = mockMonitoringSocket;
+
+vi.mock('@/providers/socket-provider', () => ({
+  useSockets: () => ({ monitoringSocket: monitoringSocketRef }),
+}));
+
+import { api } from '@/shared/lib/api';
+import {
+  useInvestigations,
+  useInvestigationDetail,
+  useInvestigationByInsightId,
+  safeParseJson,
+  type Investigation,
+} from './use-investigations';
+
+const mockApi = vi.mocked(api);
+
+function makeInvestigation(overrides: Partial<Investigation> = {}): Investigation {
+  return {
+    id: 'inv-1',
+    insight_id: 'insight-1',
+    endpoint_id: 1,
+    container_id: 'c1',
+    container_name: 'web',
+    status: 'complete',
+    evidence_summary: null,
+    root_cause: null,
+    contributing_factors: null,
+    severity_assessment: null,
+    recommended_actions: null,
+    confidence_score: null,
+    analysis_duration_ms: null,
+    llm_model: null,
+    ai_summary: null,
+    error_message: null,
+    created_at: new Date().toISOString(),
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function getHandler(eventName: string) {
+  const call = mockMonitoringSocket.on.mock.calls.find((c: unknown[]) => c[0] === eventName);
+  return call ? (call[1] as (...args: unknown[]) => void) : undefined;
+}
+
+describe('safeParseJson', () => {
+  it('parses valid JSON', () => {
+    expect(safeParseJson<{ a: number }>('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('returns null for null/undefined/empty input', () => {
+    expect(safeParseJson(null)).toBeNull();
+    expect(safeParseJson(undefined)).toBeNull();
+    expect(safeParseJson('')).toBeNull();
+  });
+
+  it('returns null for malformed JSON instead of throwing', () => {
+    expect(safeParseJson('{not json')).toBeNull();
+  });
+});
+
+describe('useInvestigations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    monitoringSocketRef = mockMonitoringSocket;
+  });
+
+  it('hydrates investigations from the initial fetch', async () => {
+    const initial = [makeInvestigation({ id: 'a' }), makeInvestigation({ id: 'b' })];
+    mockApi.get.mockResolvedValueOnce({ investigations: initial });
+
+    const { result } = renderHook(() => useInvestigations(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.investigations).toHaveLength(2));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/investigations');
+  });
+
+  it('subscribes and cleans up monitoring socket events', async () => {
+    mockApi.get.mockResolvedValueOnce({ investigations: [] });
+
+    const { unmount } = renderHook(() => useInvestigations(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(mockMonitoringSocket.on).toHaveBeenCalledWith(
+        'investigation:complete',
+        expect.any(Function),
+      );
+      expect(mockMonitoringSocket.on).toHaveBeenCalledWith(
+        'investigation:update',
+        expect.any(Function),
+      );
+    });
+
+    unmount();
+    expect(mockMonitoringSocket.off).toHaveBeenCalledWith(
+      'investigation:complete',
+      expect.any(Function),
+    );
+    expect(mockMonitoringSocket.off).toHaveBeenCalledWith(
+      'investigation:update',
+      expect.any(Function),
+    );
+  });
+
+  it('inserts a new investigation when investigation:complete fires for an unknown id', async () => {
+    mockApi.get.mockResolvedValueOnce({ investigations: [] });
+
+    const { result } = renderHook(() => useInvestigations(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const handler = getHandler('investigation:complete');
+    expect(handler).toBeDefined();
+
+    act(() => handler!(makeInvestigation({ id: 'new' })));
+    expect(result.current.investigations.map((i) => i.id)).toContain('new');
+  });
+
+  it('replaces an existing investigation when investigation:complete fires for a known id', async () => {
+    const existing = makeInvestigation({ id: 'inv-1', status: 'pending' });
+    mockApi.get.mockResolvedValueOnce({ investigations: [existing] });
+
+    const { result } = renderHook(() => useInvestigations(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.investigations).toHaveLength(1));
+
+    const handler = getHandler('investigation:complete');
+    act(() => handler!(makeInvestigation({ id: 'inv-1', status: 'complete' })));
+
+    expect(result.current.investigations).toHaveLength(1);
+    expect(result.current.investigations[0].status).toBe('complete');
+  });
+
+  it('updates only the matching investigation status on investigation:update', async () => {
+    const existing = makeInvestigation({ id: 'inv-1', status: 'pending' });
+    mockApi.get.mockResolvedValueOnce({ investigations: [existing] });
+
+    const { result } = renderHook(() => useInvestigations(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.investigations).toHaveLength(1));
+
+    const handler = getHandler('investigation:update');
+    act(() => handler!({ id: 'inv-1', status: 'analyzing' }));
+
+    expect(result.current.investigations[0].status).toBe('analyzing');
+  });
+
+  it('getInvestigationForInsight finds by insight_id', async () => {
+    const investigation = makeInvestigation({ insight_id: 'insight-42' });
+    mockApi.get.mockResolvedValueOnce({ investigations: [investigation] });
+
+    const { result } = renderHook(() => useInvestigations(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.investigations).toHaveLength(1));
+
+    expect(result.current.getInvestigationForInsight('insight-42')?.id).toBe(investigation.id);
+    expect(result.current.getInvestigationForInsight('missing')).toBeUndefined();
+  });
+
+  it('does not subscribe when monitoringSocket is null', async () => {
+    monitoringSocketRef = null;
+    mockApi.get.mockResolvedValueOnce({ investigations: [] });
+
+    renderHook(() => useInvestigations(), { wrapper: createWrapper() });
+    // No subscriptions should be attempted on the null socket — assertion via mock not being called
+    expect(mockMonitoringSocket.on).not.toHaveBeenCalled();
+  });
+});
+
+describe('useInvestigationDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    monitoringSocketRef = mockMonitoringSocket;
+  });
+
+  it('fetches detail when id is provided', async () => {
+    const inv = makeInvestigation({ id: 'inv-9' });
+    mockApi.get.mockResolvedValueOnce(inv);
+
+    const { result } = renderHook(() => useInvestigationDetail('inv-9'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/investigations/inv-9');
+    expect(result.current.data).toEqual(inv);
+  });
+
+  it('does not fetch when id is undefined', () => {
+    const { result } = renderHook(() => useInvestigationDetail(undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockApi.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useInvestigationByInsightId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    monitoringSocketRef = mockMonitoringSocket;
+  });
+
+  it('fetches investigation by insight id when provided', async () => {
+    const inv = makeInvestigation({ insight_id: 'insight-7' });
+    mockApi.get.mockResolvedValueOnce(inv);
+
+    const { result } = renderHook(() => useInvestigationByInsightId('insight-7'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/investigations/by-insight/insight-7');
+  });
+
+  it('does not fetch when insightId is undefined', () => {
+    const { result } = renderHook(() => useInvestigationByInsightId(undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockApi.get).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/containers/hooks/use-container-detail.test.ts
+++ b/frontend/src/features/containers/hooks/use-container-detail.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+import { api } from '@/shared/lib/api';
+import { useContainerDetail } from './use-container-detail';
+import type { Container } from './use-containers';
+
+const mockApi = vi.mocked(api);
+
+function makeContainer(overrides: Partial<Container> = {}): Container {
+  return {
+    id: 'fullsha1234567890abcdef',
+    name: 'web',
+    image: 'nginx:latest',
+    state: 'running',
+    status: 'Up 2 days',
+    endpointId: 1,
+    endpointName: 'prod',
+    ports: [],
+    created: 0,
+    labels: {},
+    networks: [],
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useContainerDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the container matching the full id', async () => {
+    const target = makeContainer({ id: 'aaaaaaaaaaaaaaaa', name: 'target' });
+    mockApi.get.mockResolvedValueOnce([target, makeContainer({ id: 'bbbbbbbbbbbbbbbb' })]);
+
+    const { result } = renderHook(() => useContainerDetail(1, 'aaaaaaaaaaaaaaaa'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(target);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('matches a container by id prefix (short id)', async () => {
+    const full = makeContainer({ id: 'abcd1234efgh5678', name: 'prefixed' });
+    mockApi.get.mockResolvedValueOnce([full]);
+
+    const { result } = renderHook(() => useContainerDetail(1, 'abcd1234'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data?.name).toBe('prefixed');
+  });
+
+  it('flags isError=true when no container matches and loading completes', async () => {
+    mockApi.get.mockResolvedValueOnce([makeContainer({ id: 'aaaaaaaa' })]);
+
+    const { result } = renderHook(() => useContainerDetail(1, 'doesnotexist'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isError).toBe(true);
+  });
+
+  it('passes endpointId through to the underlying useContainers query', async () => {
+    mockApi.get.mockResolvedValueOnce([]);
+
+    renderHook(() => useContainerDetail(42, 'whatever'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(mockApi.get).toHaveBeenCalled());
+    expect(mockApi.get).toHaveBeenCalledWith('/api/containers?endpointId=42');
+  });
+
+  it('propagates fetch errors', async () => {
+    mockApi.get.mockRejectedValueOnce(new Error('network'));
+
+    const { result } = renderHook(() => useContainerDetail(1, 'x'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/frontend/src/features/containers/hooks/use-networks.test.ts
+++ b/frontend/src/features/containers/hooks/use-networks.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+import { api } from '@/shared/lib/api';
+import { useNetworks, type Network } from './use-networks';
+
+const mockApi = vi.mocked(api);
+
+function makeNetwork(overrides: Partial<Network> = {}): Network {
+  return {
+    id: 'net-1',
+    name: 'bridge',
+    endpointId: 1,
+    endpointName: 'prod',
+    containers: [],
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useNetworks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches all networks when no endpointId is supplied', async () => {
+    const networks = [makeNetwork(), makeNetwork({ id: 'net-2', name: 'host' })];
+    mockApi.get.mockResolvedValueOnce(networks);
+
+    const { result } = renderHook(() => useNetworks(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/networks');
+    expect(result.current.data).toEqual(networks);
+  });
+
+  it('passes endpointId in the query string when provided', async () => {
+    mockApi.get.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useNetworks(7), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/networks?endpointId=7');
+  });
+
+  it('returns empty array when no networks exist', async () => {
+    mockApi.get.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useNetworks(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('surfaces fetch errors', async () => {
+    mockApi.get.mockRejectedValueOnce(new Error('network unreachable'));
+
+    const { result } = renderHook(() => useNetworks(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/frontend/src/features/core/hooks/use-auth.test.ts
+++ b/frontend/src/features/core/hooks/use-auth.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { useAuth as featureUseAuth } from './use-auth';
+import { useAuth as providerUseAuth } from '@/providers/auth-provider';
+
+describe('useAuth (feature re-export)', () => {
+  it('re-exports the same hook from auth-provider', () => {
+    // The feature-level hook is documented as a duplicate of the provider hook;
+    // assert it is a literal re-export so behaviour cannot drift.
+    expect(featureUseAuth).toBe(providerUseAuth);
+  });
+
+  it('throws when used outside AuthProvider', () => {
+    // The provider hook throws if no AuthContext is available; calling the
+    // re-exported hook outside React renders surfaces that contract directly.
+    expect(() => featureUseAuth()).toThrow();
+  });
+});

--- a/frontend/src/features/observability/hooks/use-traces.test.ts
+++ b/frontend/src/features/observability/hooks/use-traces.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+import { api } from '@/shared/lib/api';
+import {
+  useTraces,
+  useTrace,
+  useServiceMap,
+  useTraceSummary,
+  type TracesOptions,
+} from './use-traces';
+
+const mockApi = vi.mocked(api);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useTraces', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches traces with no params when none supplied', async () => {
+    mockApi.get.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useTraces(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/traces', { params: undefined });
+  });
+
+  it('passes filter options through to the api layer', async () => {
+    mockApi.get.mockResolvedValueOnce([]);
+
+    const options: TracesOptions = {
+      serviceName: 'web',
+      status: 'error',
+      limit: 50,
+      minDuration: 100,
+    };
+
+    const { result } = renderHook(() => useTraces(options), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/traces', { params: options });
+  });
+
+  it('returns the array data on success', async () => {
+    const traces = [
+      {
+        traceId: 't1',
+        spans: [],
+        rootSpan: {
+          traceId: 't1',
+          spanId: 's1',
+          operationName: 'GET /',
+          serviceName: 'web',
+          startTime: '0',
+          duration: 10,
+          status: 'ok',
+        },
+        duration: 10,
+        services: ['web'],
+        startTime: '0',
+        status: 'ok',
+      },
+    ];
+    mockApi.get.mockResolvedValueOnce(traces);
+
+    const { result } = renderHook(() => useTraces(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(traces);
+  });
+
+  it('surfaces fetch errors', async () => {
+    mockApi.get.mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderHook(() => useTraces(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useTrace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches a single trace when traceId is provided', async () => {
+    mockApi.get.mockResolvedValueOnce({
+      traceId: 't1',
+      spans: [],
+      rootSpan: {
+        traceId: 't1',
+        spanId: 's1',
+        operationName: 'op',
+        serviceName: 'svc',
+        startTime: '0',
+        duration: 1,
+        status: 'ok',
+      },
+      duration: 1,
+      services: [],
+      startTime: '0',
+      status: 'ok',
+    });
+
+    const { result } = renderHook(() => useTrace('t1'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/traces/t1');
+  });
+
+  it('does not fetch when traceId is undefined', () => {
+    const { result } = renderHook(() => useTrace(undefined), { wrapper: createWrapper() });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockApi.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useServiceMap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches service map with options as params', async () => {
+    mockApi.get.mockResolvedValueOnce({ nodes: [], edges: [] });
+
+    const options: TracesOptions = { serviceName: 'web' };
+    const { result } = renderHook(() => useServiceMap(options), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/traces/service-map', { params: options });
+  });
+});
+
+describe('useTraceSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches trace summary', async () => {
+    mockApi.get.mockResolvedValueOnce({
+      totalTraces: 10,
+      avgDuration: 100,
+      errorRate: 0.1,
+      services: 2,
+    });
+
+    const { result } = renderHook(() => useTraceSummary(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/traces/summary', { params: undefined });
+    expect(result.current.data?.totalTraces).toBe(10);
+  });
+
+  it('passes filter options through to the api layer', async () => {
+    mockApi.get.mockResolvedValueOnce({
+      totalTraces: 0,
+      avgDuration: 0,
+      errorRate: 0,
+      services: 0,
+    });
+
+    const options = { serviceName: 'web' };
+    const { result } = renderHook(() => useTraceSummary(options), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/traces/summary', { params: options });
+  });
+});

--- a/frontend/src/features/security/hooks/use-harbor-vulnerabilities.test.ts
+++ b/frontend/src/features/security/hooks/use-harbor-vulnerabilities.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { api } from '@/shared/lib/api';
+import {
+  useHarborStatus,
+  useHarborEnabled,
+  useHarborVulnerabilities,
+  useHarborVulnerabilitySummary,
+  useHarborExceptions,
+  useTriggerHarborSync,
+  useCreateException,
+  useDeactivateException,
+} from './use-harbor-vulnerabilities';
+
+const mockApi = vi.mocked(api);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+}
+
+describe('useHarborStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches Harbor status', async () => {
+    const status = { configured: true, connected: true, lastSync: null };
+    mockApi.get.mockResolvedValueOnce(status);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useHarborStatus(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/harbor/status');
+    expect(result.current.data).toEqual(status);
+  });
+});
+
+describe('useHarborEnabled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches the lightweight enabled flag', async () => {
+    mockApi.get.mockResolvedValueOnce({ enabled: false });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useHarborEnabled(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/harbor/enabled');
+    expect(result.current.data).toEqual({ enabled: false });
+  });
+});
+
+describe('useHarborVulnerabilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches without query string when no filters supplied', async () => {
+    mockApi.get.mockResolvedValueOnce({
+      vulnerabilities: [],
+      summary: {
+        total: 0,
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        in_use_total: 0,
+        in_use_critical: 0,
+        fixable: 0,
+        excepted: 0,
+      },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useHarborVulnerabilities(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/harbor/vulnerabilities');
+  });
+
+  it('serialises filter params and pagination into the URL', async () => {
+    mockApi.get.mockResolvedValueOnce({
+      vulnerabilities: [],
+      summary: {
+        total: 0,
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        in_use_total: 0,
+        in_use_critical: 0,
+        fixable: 0,
+        excepted: 0,
+      },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(
+      () =>
+        useHarborVulnerabilities({
+          severity: 'High',
+          inUse: true,
+          cveId: 'CVE-2024-1',
+          repositoryName: 'library/nginx',
+          limit: 50,
+          offset: 25,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const calledUrl = mockApi.get.mock.calls[0][0];
+    expect(calledUrl).toContain('/api/harbor/vulnerabilities?');
+    expect(calledUrl).toContain('severity=High');
+    expect(calledUrl).toContain('inUse=true');
+    expect(calledUrl).toContain('cveId=CVE-2024-1');
+    expect(calledUrl).toContain('repositoryName=library%2Fnginx');
+    expect(calledUrl).toContain('limit=50');
+    expect(calledUrl).toContain('offset=25');
+  });
+
+  it('serialises inUse=false explicitly', async () => {
+    mockApi.get.mockResolvedValueOnce({
+      vulnerabilities: [],
+      summary: {
+        total: 0,
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        in_use_total: 0,
+        in_use_critical: 0,
+        fixable: 0,
+        excepted: 0,
+      },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useHarborVulnerabilities({ inUse: false }), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get.mock.calls[0][0]).toContain('inUse=false');
+  });
+});
+
+describe('useHarborVulnerabilitySummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches the summary endpoint', async () => {
+    const summary = {
+      total: 5,
+      critical: 1,
+      high: 2,
+      medium: 1,
+      low: 1,
+      in_use_total: 3,
+      in_use_critical: 1,
+      fixable: 4,
+      excepted: 0,
+    };
+    mockApi.get.mockResolvedValueOnce(summary);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useHarborVulnerabilitySummary(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/harbor/vulnerabilities/summary');
+    expect(result.current.data).toEqual(summary);
+  });
+});
+
+describe('useHarborExceptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to activeOnly=true', async () => {
+    mockApi.get.mockResolvedValueOnce([]);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useHarborExceptions(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/harbor/exceptions?activeOnly=true');
+  });
+
+  it('passes activeOnly=false when requested', async () => {
+    mockApi.get.mockResolvedValueOnce([]);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useHarborExceptions(false), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/harbor/exceptions?activeOnly=false');
+  });
+});
+
+describe('useTriggerHarborSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('POSTs sync trigger and invalidates status immediately, vulnerabilities after delay', async () => {
+    mockApi.post.mockResolvedValueOnce({ ok: true });
+
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTriggerHarborSync(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(mockApi.post).toHaveBeenCalledWith('/api/harbor/sync', {});
+    // Status invalidates immediately
+    expect(invalidateSpy.mock.calls.map((c) => c[0]?.queryKey)).toEqual(
+      expect.arrayContaining([['harbor-status']]),
+    );
+
+    // Vulnerabilities + summary invalidate after the 5s delay
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    const allKeys = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(allKeys).toEqual(
+      expect.arrayContaining([
+        ['harbor-vulnerabilities'],
+        ['harbor-vulnerability-summary'],
+      ]),
+    );
+  });
+});
+
+describe('useCreateException', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs payload and invalidates exceptions + vulnerabilities', async () => {
+    mockApi.post.mockResolvedValueOnce({ id: 1 });
+
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateException(), { wrapper: Wrapper });
+
+    const payload = {
+      cve_id: 'CVE-2024-1',
+      scope: 'image',
+      justification: 'False positive',
+    };
+    await result.current.mutateAsync(payload);
+
+    expect(mockApi.post).toHaveBeenCalledWith('/api/harbor/exceptions', payload);
+    expect(invalidateSpy.mock.calls.map((c) => c[0]?.queryKey)).toEqual(
+      expect.arrayContaining([['harbor-exceptions'], ['harbor-vulnerabilities']]),
+    );
+  });
+});
+
+describe('useDeactivateException', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('DELETEs the given id and invalidates exceptions cache', async () => {
+    mockApi.delete.mockResolvedValueOnce({ ok: true });
+
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeactivateException(), { wrapper: Wrapper });
+
+    await result.current.mutateAsync(42);
+
+    expect(mockApi.delete).toHaveBeenCalledWith('/api/harbor/exceptions/42');
+    expect(invalidateSpy.mock.calls.map((c) => c[0]?.queryKey)).toEqual(
+      expect.arrayContaining([['harbor-exceptions']]),
+    );
+  });
+});

--- a/frontend/src/features/security/hooks/use-security-audit.test.ts
+++ b/frontend/src/features/security/hooks/use-security-audit.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+import { api } from '@/shared/lib/api';
+import {
+  useSecurityAudit,
+  useSecurityIgnoreList,
+  useUpdateSecurityIgnoreList,
+} from './use-security-audit';
+
+const mockApi = vi.mocked(api);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+}
+
+describe('useSecurityAudit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches global audit when no endpointId is provided', async () => {
+    mockApi.get.mockResolvedValueOnce({ entries: [] });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSecurityAudit(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/security/audit');
+    expect(result.current.data).toEqual({ entries: [] });
+  });
+
+  it('fetches per-endpoint audit when endpointId is provided', async () => {
+    const entries = [
+      {
+        containerId: 'c1',
+        containerName: 'web',
+        stackName: null,
+        endpointId: 7,
+        endpointName: 'prod',
+        state: 'running',
+        status: 'Up 2 days',
+        image: 'nginx:latest',
+        posture: { capAdd: [], privileged: false, networkMode: null, pidMode: null },
+        findings: [],
+        severity: 'none' as const,
+        ignored: false,
+      },
+    ];
+    mockApi.get.mockResolvedValueOnce({ entries });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSecurityAudit(7), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/security/audit/7');
+    expect(result.current.data?.entries).toHaveLength(1);
+  });
+
+  it('treats endpointId=0 as no filter (falsy guard)', async () => {
+    mockApi.get.mockResolvedValueOnce({ entries: [] });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSecurityAudit(0), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // The hook treats falsy endpointId as global — documents current behaviour.
+    expect(mockApi.get).toHaveBeenCalledWith('/api/security/audit');
+  });
+
+  it('surfaces fetch errors', async () => {
+    mockApi.get.mockRejectedValueOnce(new Error('boom'));
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSecurityAudit(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useSecurityIgnoreList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches the ignore list', async () => {
+    const ignoreList = {
+      key: 'security.audit.ignore',
+      category: 'security',
+      defaults: ['internal-tool'],
+      patterns: ['^test-'],
+    };
+    mockApi.get.mockResolvedValueOnce(ignoreList);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSecurityIgnoreList(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.get).toHaveBeenCalledWith('/api/security/ignore-list');
+    expect(result.current.data).toEqual(ignoreList);
+  });
+});
+
+describe('useUpdateSecurityIgnoreList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('PUTs new patterns and invalidates related caches on success', async () => {
+    mockApi.put.mockResolvedValueOnce({ ok: true });
+
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateSecurityIgnoreList(), { wrapper: Wrapper });
+
+    await result.current.mutateAsync(['^test-', '^staging-']);
+
+    expect(mockApi.put).toHaveBeenCalledWith('/api/security/ignore-list', {
+      patterns: ['^test-', '^staging-'],
+    });
+    const invalidatedKeys = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidatedKeys).toEqual(
+      expect.arrayContaining([
+        ['security-ignore-list'],
+        ['security-audit'],
+        ['dashboard', 'summary'],
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for the 7 frontend hooks listed in #1022 that lacked coverage. Closes #1022.

| File added | What it covers |
|---|---|
| `features/core/hooks/use-auth.test.ts` | Re-export identity + outside-provider error contract |
| `features/security/hooks/use-security-audit.test.ts` | Global vs per-endpoint URL, falsy-id behaviour, ignore list fetch, ignore-list mutation cache invalidation |
| `features/security/hooks/use-harbor-vulnerabilities.test.ts` | Status, enabled flag, vulnerability filter/pagination URL serialisation incl. `inUse=false`, summary, exceptions `activeOnly` default, sync trigger fake-timer flow, create/deactivate exception mutations |
| `features/containers/hooks/use-container-detail.test.ts` | Full id match, prefix match, missing-container error state, endpointId pass-through, fetch-error propagation |
| `features/containers/hooks/use-networks.test.ts` | Global vs scoped fetch, empty list, fetch error |
| `features/ai-intelligence/hooks/use-investigations.test.ts` | Initial hydration, monitoring socket subscribe/unsubscribe, complete-event insert vs replace, update-event status patch, `getInvestigationForInsight`, null-socket safety, plus `useInvestigationDetail` / `useInvestigationByInsightId` enabled/disabled states, plus `safeParseJson` |
| `features/observability/hooks/use-traces.test.ts` | `useTraces`, `useTrace` (incl. disabled when traceId undefined), `useServiceMap`, `useTraceSummary` |

## Notes on scope vs the issue checklist
- **Pages**: `network-topology.test.tsx`, `auth-callback.test.tsx`, and `edge-agent-logs.test.tsx` already exist on `dev`; `container-health.tsx` no longer exists in the codebase. No page work was needed.
- **Stores**: `ui-store.test.ts` already exists.
- The remaining 7 hooks from the issue list were the actual gap; all are now covered.

## Conventions
- Mocks `@/shared/lib/api` via `vi.mock` (matches existing hook tests).
- Mocks `@/providers/socket-provider` only where required (use-investigations).
- Uses real `QueryClient` + `QueryClientProvider` per project mocking guidance ("Keep mocks close to the boundary").

## Test plan
- [x] every new file run individually with `npx vitest run`
- [x] full frontend suite passes (1749 tests, 181 files)
- [x] `npm run typecheck -w frontend` clean
- [x] `npm run lint -w frontend` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)