### PR TITLE
feat(health-monitoring): UX overhaul + 502 on Portainer auth failure

### DIFF
--- a/frontend/src/features/ai-intelligence/components/fleet-health-summary.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/fleet-health-summary.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Container } from '@/features/containers/hooks/use-containers';
-import { calculateHealthStats } from './fleet-health-summary';
+import { calculateHealthScore, calculateHealthStats } from './fleet-health-summary';
 
 function makeContainer(overrides: Partial<Container> = {}): Container {
   return {
@@ -31,6 +31,7 @@ describe('calculateHealthStats', () => {
       unhealthy: 0,
       healthy: 0,
       unknown: 0,
+      noHealthcheck: 0,
     });
   });
 
@@ -203,14 +204,14 @@ describe('calculateHealthStats', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Percentage calculation — acceptance criterion: verify percentage math
-  // for a mixed fleet. The component computes:
-  //   healthPercentage = stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0
-  // Tests pin the expected health percentage so that future refactors of
-  // either the stats logic or the percentage formula stay in sync.
+  // Health-score formula — score = healthy / (healthy + unhealthy). Containers
+  // without an explicit health signal are excluded so the operator's choice
+  // not to configure a Docker healthcheck cannot drag the score down.
   // -------------------------------------------------------------------------
 
-  it('mixed fleet: derives a 50% health percentage from 2 healthy out of 4 total', () => {
+  it('score: 2 healthy + 1 unhealthy + 1 stopped-no-check yields ~66.7% (stopped excluded)', () => {
+    // Pre-fix used (healthy / total) * 100 = 50%. Post-fix excludes the
+    // exited-no-healthcheck container from the denominator.
     const containers = [
       makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
       makeContainer({ id: '2', state: 'running', healthStatus: 'healthy' }),
@@ -219,14 +220,16 @@ describe('calculateHealthStats', () => {
     ];
 
     const stats = calculateHealthStats(containers);
-    const healthPercentage = stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0;
+    const score = calculateHealthScore(stats);
 
     expect(stats.total).toBe(4);
     expect(stats.healthy).toBe(2);
-    expect(healthPercentage).toBe(50);
+    expect(score).toBeCloseTo(66.666, 2);
   });
 
-  it('mixed fleet: derives ~33.3% health percentage from 1 healthy out of 3 total', () => {
+  it('score: 1 healthy + 1 unhealthy + 1 running-no-check yields 50% (no-check excluded)', () => {
+    // Pre-fix returned ~33.3% by dividing by total. The fix excludes the
+    // no-healthcheck container from both numerator and denominator.
     const containers = [
       makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
       makeContainer({ id: '2', state: 'running', healthStatus: 'unhealthy' }),
@@ -234,20 +237,108 @@ describe('calculateHealthStats', () => {
     ];
 
     const stats = calculateHealthStats(containers);
-    const healthPercentage = stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0;
+    const score = calculateHealthScore(stats);
 
     expect(stats.healthy).toBe(1);
     expect(stats.unhealthy).toBe(1);
-    expect(stats.unknown).toBe(1);
-    expect(healthPercentage).toBeCloseTo(33.333, 2);
+    expect(stats.noHealthcheck).toBe(1);
+    expect(score).toBe(50);
   });
 
-  it('empty fleet: percentage formula evaluates to 0 (no division-by-zero)', () => {
-    const stats = calculateHealthStats([]);
-    const healthPercentage = stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0;
+  it('score: returns null when no container reports a health signal', () => {
+    // 47 of 55 containers without healthchecks used to produce a misleading
+    // ~13% score. Now we surface "N/A" instead so operators are not misled.
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: undefined }),
+      makeContainer({ id: '2', state: 'running', healthStatus: undefined }),
+    ];
 
-    expect(stats.total).toBe(0);
-    expect(healthPercentage).toBe(0);
+    const stats = calculateHealthStats(containers);
+    const score = calculateHealthScore(stats);
+
+    expect(stats.healthy).toBe(0);
+    expect(stats.unhealthy).toBe(0);
+    expect(stats.noHealthcheck).toBe(2);
+    expect(score).toBeNull();
+  });
+
+  it('score: empty fleet returns null (no division-by-zero)', () => {
+    const stats = calculateHealthStats([]);
+    const score = calculateHealthScore(stats);
+
+    expect(score).toBeNull();
+  });
+
+  it('score: all healthy yields 100%', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
+      makeContainer({ id: '2', state: 'running', healthStatus: 'healthy' }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+    const score = calculateHealthScore(stats);
+
+    expect(score).toBe(100);
+  });
+
+  it('score: all unhealthy yields 0%', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: 'unhealthy' }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+    const score = calculateHealthScore(stats);
+
+    expect(score).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // noHealthcheck field — counts running containers that report no explicit
+  // health signal. Used to render "N without healthcheck (excluded)" copy.
+  // -------------------------------------------------------------------------
+
+  it('noHealthcheck: counts running containers without healthStatus', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: undefined }),
+      makeContainer({ id: '2', state: 'running' }),
+      makeContainer({ id: '3', state: 'running', healthStatus: 'healthy' }),
+      makeContainer({ id: '4', state: 'running', healthStatus: 'unhealthy' }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+
+    expect(stats.noHealthcheck).toBe(2);
+  });
+
+  it('noHealthcheck: does NOT count exited or paused containers (only running)', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'exited', healthStatus: undefined }),
+      makeContainer({ id: '2', state: 'paused', healthStatus: undefined }),
+      makeContainer({ id: '3', state: 'running', healthStatus: undefined }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+
+    // Stopped/paused are tracked separately; only running-no-check rolls into
+    // noHealthcheck. All three still flow into the broader `unknown` bucket.
+    expect(stats.noHealthcheck).toBe(1);
+    expect(stats.unknown).toBe(3);
+  });
+
+  it('noHealthcheck: ignores intermediate health values like "starting" or "none"', () => {
+    const containers = [
+      makeContainer({ id: '1', state: 'running', healthStatus: 'starting' }),
+      makeContainer({ id: '2', state: 'running', healthStatus: 'none' }),
+    ];
+
+    const stats = calculateHealthStats(containers);
+
+    // These intermediate values still don't qualify as "reporting health" —
+    // they go through the same else-branch as `undefined`, so they count
+    // toward noHealthcheck for running containers.
+    expect(stats.noHealthcheck).toBe(2);
+    expect(stats.healthy).toBe(0);
+    expect(stats.unhealthy).toBe(0);
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
+++ b/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
@@ -1,4 +1,4 @@
-import { Activity, AlertCircle, AlertTriangle, CheckCircle2, Pause, XCircle } from 'lucide-react';
+import { Activity, AlertCircle, AlertTriangle, CheckCircle2, HelpCircle, XCircle } from 'lucide-react';
 import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
 import type { Container } from '@/features/containers/hooks/use-containers';
 
@@ -10,6 +10,13 @@ export interface HealthStats {
   unhealthy: number;
   healthy: number;
   unknown: number;
+  /**
+   * Running containers without a Docker healthcheck configured. These are
+   * excluded from the health-score denominator (score = healthy / (healthy +
+   * unhealthy)) so the operator's choice not to configure a healthcheck
+   * doesn't artificially deflate the fleet health number.
+   */
+  noHealthcheck: number;
 }
 
 export function calculateHealthStats(containers: Container[]): HealthStats {
@@ -21,6 +28,7 @@ export function calculateHealthStats(containers: Container[]): HealthStats {
     unhealthy: 0,
     healthy: 0,
     unknown: 0,
+    noHealthcheck: 0,
   };
 
   containers.forEach((container) => {
@@ -30,14 +38,32 @@ export function calculateHealthStats(containers: Container[]): HealthStats {
 
     if (container.healthStatus === 'unhealthy') stats.unhealthy++;
     else if (container.healthStatus === 'healthy') stats.healthy++;
-    else if (container.state === 'running') stats.unknown++;
-    else stats.unknown++;
+    else {
+      stats.unknown++;
+      if (container.state === 'running') stats.noHealthcheck++;
+    }
   });
 
   return stats;
 }
 
-function HealthStatCard({
+/**
+ * Score = healthy / (healthy + unhealthy). Containers without a healthcheck
+ * are excluded so the operator's choice not to configure one doesn't drag
+ * the score down. Returns null when no container reports a health signal.
+ */
+export function calculateHealthScore(stats: HealthStats): number | null {
+  const reporting = stats.healthy + stats.unhealthy;
+  if (reporting === 0) return null;
+  return (stats.healthy / reporting) * 100;
+}
+
+/**
+ * Compact horizontal stat tile used in the Fleet Vitals strip. Replaces the
+ * earlier 4-card grid of large boxed stats — keeps all four numbers visible
+ * but in roughly half the vertical mass so the hero score still dominates.
+ */
+function HealthStatTile({
   icon: Icon,
   label,
   value,
@@ -50,112 +76,122 @@ function HealthStatCard({
   percentage?: number;
   variant?: 'default' | 'success' | 'warning' | 'danger';
 }) {
-  const variantClasses = {
-    default: 'bg-card border-border',
-    success: 'bg-emerald-50 border-emerald-200 dark:bg-emerald-900/20 dark:border-emerald-900/30',
-    warning: 'bg-amber-50 border-amber-200 dark:bg-amber-900/20 dark:border-amber-900/30',
-    danger: 'bg-red-50 border-red-200 dark:bg-red-900/20 dark:border-red-900/30',
-  };
-
   const iconVariantClasses = {
-    default: 'text-primary',
+    default: 'text-muted-foreground',
     success: 'text-emerald-600 dark:text-emerald-400',
     warning: 'text-amber-600 dark:text-amber-400',
     danger: 'text-red-600 dark:text-red-400',
   };
 
   return (
-    <div className={`rounded-lg border p-4 shadow-sm ${variantClasses[variant]}`}>
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <p className="text-sm text-muted-foreground mb-1">{label}</p>
-          <p className="text-3xl font-bold">{value}</p>
-          {percentage !== undefined && (
-            <p className="text-xs text-muted-foreground mt-1">{percentage.toFixed(1)}%</p>
+    <div className="flex items-center gap-3 rounded-md bg-card/60 px-3 py-2">
+      <div className={`flex h-8 w-8 items-center justify-center rounded-md bg-background ${iconVariantClasses[variant]}`}>
+        <Icon className="h-4 w-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2">
+          <span className="text-xl font-bold tabular-nums leading-none">{value}</span>
+          {percentage !== undefined && value > 0 && (
+            <span className="text-xs text-muted-foreground tabular-nums">{percentage.toFixed(0)}%</span>
           )}
         </div>
-        <div className={`rounded-lg p-2 ${iconVariantClasses[variant]}`}>
-          <Icon className="h-6 w-6" />
-        </div>
+        <p className="text-xs text-muted-foreground mt-0.5 truncate">{label}</p>
       </div>
     </div>
   );
 }
 
-export function FleetHealthSummary({ stats, healthPercentage, isLoading }: {
+export function FleetHealthSummary({ stats, isLoading }: {
   stats: HealthStats | null;
-  healthPercentage: number;
   isLoading: boolean;
 }) {
   if (isLoading || !stats) {
-    return (
-      <>
-        <SkeletonCard className="h-36" />
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-          <SkeletonCard className="h-24" />
-          <SkeletonCard className="h-24" />
-          <SkeletonCard className="h-24" />
-          <SkeletonCard className="h-24" />
-        </div>
-      </>
-    );
+    return <SkeletonCard className="h-44" />;
   }
 
+  const healthScore = calculateHealthScore(stats);
+  const reporting = stats.healthy + stats.unhealthy;
+  const issueCount = stats.unhealthy + stats.stopped;
+
   return (
-    <>
-      {/* Overall Health Score */}
-      <div className="rounded-lg border bg-gradient-to-br from-primary/5 to-primary/10 p-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm font-medium text-muted-foreground mb-2">Overall Health Score</p>
-            <p className="text-5xl font-bold">{healthPercentage.toFixed(1)}%</p>
-            <p className="text-sm text-muted-foreground mt-2">
-              {stats.healthy} of {stats.total} containers healthy
-            </p>
-          </div>
-          <div className="flex h-32 w-32 items-center justify-center rounded-full border-8 border-primary/20">
-            {healthPercentage >= 80 ? (
-              <CheckCircle2 className="h-16 w-16 text-emerald-500" />
-            ) : healthPercentage >= 50 ? (
-              <AlertCircle className="h-16 w-16 text-amber-500" />
+    <div className="rounded-lg border bg-gradient-to-br from-primary/5 to-primary/10 p-6" data-testid="fleet-health-hero">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        {/* Hero — score + issue count */}
+        <div className="flex items-center gap-5 min-w-0">
+          <div className="flex h-24 w-24 flex-shrink-0 items-center justify-center rounded-full border-8 border-primary/20 bg-card/40">
+            {healthScore === null ? (
+              <HelpCircle className="h-12 w-12 text-muted-foreground" />
+            ) : healthScore >= 80 ? (
+              <CheckCircle2 className="h-12 w-12 text-emerald-500" />
+            ) : healthScore >= 50 ? (
+              <AlertCircle className="h-12 w-12 text-amber-500" />
             ) : (
-              <XCircle className="h-16 w-16 text-red-500" />
+              <XCircle className="h-12 w-12 text-red-500" />
+            )}
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-muted-foreground">Overall Health Score</p>
+            {healthScore === null ? (
+              <>
+                <p className="text-2xl font-semibold text-muted-foreground" data-testid="health-score-na">
+                  No healthchecks configured
+                </p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {stats.total} containers tracked. Configure Docker healthchecks to enable scoring.
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="text-4xl font-bold tabular-nums leading-none mt-1" data-testid="health-score">
+                  {healthScore.toFixed(1)}%
+                </p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {stats.healthy} of {reporting} reporting healthy
+                  {stats.noHealthcheck > 0 && ` · ${stats.noHealthcheck} without healthcheck`}
+                </p>
+              </>
+            )}
+            {issueCount > 0 && (
+              <p className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium text-red-700 dark:text-red-400">
+                <AlertTriangle className="h-4 w-4" />
+                {issueCount} container{issueCount === 1 ? '' : 's'} need{issueCount === 1 ? 's' : ''} attention
+              </p>
             )}
           </div>
         </div>
-      </div>
 
-      {/* Health Statistics Grid */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <HealthStatCard
-          icon={Activity}
-          label="Running"
-          value={stats.running}
-          percentage={stats.total > 0 ? (stats.running / stats.total) * 100 : 0}
-          variant="success"
-        />
-        <HealthStatCard
-          icon={CheckCircle2}
-          label="Healthy"
-          value={stats.healthy}
-          percentage={stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0}
-          variant="success"
-        />
-        <HealthStatCard
-          icon={AlertTriangle}
-          label="Unhealthy"
-          value={stats.unhealthy}
-          percentage={stats.total > 0 ? (stats.unhealthy / stats.total) * 100 : 0}
-          variant="danger"
-        />
-        <HealthStatCard
-          icon={Pause}
-          label="Stopped"
-          value={stats.stopped}
-          percentage={stats.total > 0 ? (stats.stopped / stats.total) * 100 : 0}
-          variant="warning"
-        />
+        {/* Compact status strip — 4 stats inline instead of separate large cards */}
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:w-auto">
+          <HealthStatTile
+            icon={Activity}
+            label="Running"
+            value={stats.running}
+            percentage={stats.total > 0 ? (stats.running / stats.total) * 100 : 0}
+            variant="success"
+          />
+          <HealthStatTile
+            icon={CheckCircle2}
+            label="Healthy"
+            value={stats.healthy}
+            percentage={stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0}
+            variant="success"
+          />
+          <HealthStatTile
+            icon={AlertTriangle}
+            label="Unhealthy"
+            value={stats.unhealthy}
+            percentage={stats.total > 0 ? (stats.unhealthy / stats.total) * 100 : 0}
+            variant="danger"
+          />
+          <HealthStatTile
+            icon={HelpCircle}
+            label="No Healthcheck"
+            value={stats.noHealthcheck}
+            percentage={stats.total > 0 ? (stats.noHealthcheck / stats.total) * 100 : 0}
+            variant={stats.noHealthcheck > 0 ? 'warning' : 'default'}
+          />
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
@@ -193,7 +193,9 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
-    expect(screen.getByText('Anomalies & Health Issues')).toBeTruthy();
+    // Section was renamed from "Anomalies & Health Issues" to clearer twin
+    // sections: "ML-Detected Anomalies" + "Container Health".
+    expect(screen.getByText('ML-Detected Anomalies')).toBeTruthy();
     expect(screen.getByText('web-server')).toBeTruthy();
     expect(screen.getByText('Resource Exhaustion')).toBeTruthy();
     expect(screen.getByText('4.08')).toBeTruthy();
@@ -209,10 +211,13 @@ describe('AiMonitorPage', () => {
     } as ReturnType<typeof useCorrelatedAnomalies>);
 
     renderPage();
-    expect(screen.queryByText('Anomalies & Health Issues')).toBeNull();
+    expect(screen.queryByText('ML-Detected Anomalies')).toBeNull();
   });
 
   it('renders IncidentCard with colored correlation type badge', () => {
+    // Use a recent timestamp so the default 24h time-range filter doesn't
+    // exclude this fixture from the visible incidents list.
+    const recentTimestamp = new Date().toISOString();
     vi.mocked(useIncidents).mockReturnValue({
       data: {
         incidents: [
@@ -222,16 +227,16 @@ describe('AiMonitorPage', () => {
             severity: 'critical' as const,
             status: 'active' as const,
             root_cause_insight_id: null,
-            related_insight_ids: '[]',
-            affected_containers: '["nginx","redis"]',
+            related_insight_ids: [],
+            affected_containers: ['nginx', 'redis'],
             endpoint_id: 1,
             endpoint_name: 'prod',
             correlation_type: 'temporal',
             correlation_confidence: 'high' as const,
             insight_count: 3,
             summary: 'Correlated CPU anomalies',
-            created_at: '2025-01-15T10:00:00Z',
-            updated_at: '2025-01-15T10:00:00Z',
+            created_at: recentTimestamp,
+            updated_at: recentTimestamp,
             resolved_at: null,
           },
         ],
@@ -243,7 +248,8 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
-    // Should show "Temporal" badge text, not "temporal correlation" plain text
+    // Correlation type badge moved to a muted metadata line under the title
+    // (item 5: reduce visual noise). The label text is still rendered.
     expect(screen.getByText('Temporal')).toBeTruthy();
     expect(screen.queryByText('temporal correlation')).toBeNull();
   });
@@ -413,13 +419,19 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
+    // New score formula: healthy / (healthy + unhealthy). 1 healthy + 1
+    // unhealthy = 50.0%. The db (no healthcheck) and cache (exited) are
+    // excluded from the denominator so the operator's healthcheck coverage
+    // gap doesn't penalise the score.
     expect(screen.getByText('Overall Health Score')).toBeTruthy();
-    // 1 healthy (web) out of 4 = 25.0% — db has no healthcheck so counts as unknown, not healthy
-    expect(screen.getAllByText('25.0%').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('50.0%').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Running')).toBeTruthy();
     expect(screen.getByText('Healthy')).toBeTruthy();
     expect(screen.getAllByText('Unhealthy').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('Stopped').length).toBeGreaterThanOrEqual(1);
+    // The "Stopped" stat card was replaced by "No Healthcheck" — surfacing
+    // the cohort that's actually excluded from scoring is more useful than
+    // counting exited containers (already shown elsewhere as health issues).
+    expect(screen.getByText('No Healthcheck')).toBeTruthy();
   });
 
   it('shows skeleton loading state for health section', () => {
@@ -450,10 +462,13 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
-    // Health score and all stat card percentages should be "0.0%", never NaN
-    const allPcts = screen.getAllByText('0.0%');
-    expect(allPcts.length).toBeGreaterThanOrEqual(1);
-    allPcts.forEach((el) => expect(el.textContent).not.toContain('NaN'));
+    // Empty fleet now shows "No healthchecks configured" instead of an
+    // arbitrary 0.0% — the new score formula returns null when no container
+    // reports a health signal and we surface that as N/A so operators are
+    // not misled by a bogus zero.
+    expect(screen.getByTestId('health-score-na')).toBeTruthy();
+    // No NaN should ever leak into the rendered DOM.
+    expect(document.body.textContent ?? '').not.toContain('NaN');
   });
 
   it('surfaces unhealthy and stopped containers in the Anomalies & Health Issues section', () => {
@@ -476,7 +491,10 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
-    expect(screen.getByText('Anomalies & Health Issues')).toBeTruthy();
+    // The mixed list was split into "ML-Detected Anomalies" + "Container
+    // Health". State-based issues (unhealthy/stopped) live under "Container
+    // Health" now.
+    expect(screen.getByText('Container Health')).toBeTruthy();
     // Both problematic containers appear; healthy one does not
     expect(screen.getByText('sick-api')).toBeTruthy();
     expect(screen.getByText('crashed-worker')).toBeTruthy();

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
@@ -47,7 +47,10 @@ vi.mock('@/features/ai-intelligence/hooks/use-investigations', () => ({
 
 vi.mock('@/features/ai-intelligence/hooks/use-incidents', () => ({
   useIncidents: vi.fn().mockReturnValue({ data: null }),
-  useResolveIncident: vi.fn().mockReturnValue({ mutate: vi.fn() }),
+  useResolveIncident: vi.fn().mockReturnValue({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+  }),
 }));
 
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
@@ -80,7 +83,7 @@ vi.mock('@/shared/hooks/use-force-refresh', () => ({
 }));
 
 import { useMonitoring } from '@/features/ai-intelligence/hooks/use-monitoring';
-import { useIncidents } from '@/features/ai-intelligence/hooks/use-incidents';
+import { useIncidents, useResolveIncident } from '@/features/ai-intelligence/hooks/use-incidents';
 import { useCorrelatedAnomalies } from '@/features/observability/hooks/use-correlated-anomalies';
 import { useContainers } from '@/features/containers/hooks/use-containers';
 import AiMonitorPage from './ai-monitor';
@@ -523,5 +526,368 @@ describe('AiMonitorPage', () => {
     fireEvent.click(screen.getByText('CPU trend spike'));
 
     expect(screen.getByText('Failed to acknowledge insight')).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// New UX features (PR review feedback): cover the AC that previously had no
+// behavioural tests — search, time-range filter, sort, bulk-resolve, and
+// bell-icon subscription independence.
+// =============================================================================
+
+import { act, waitFor } from '@testing-library/react';
+
+function nowIso(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function fakeIncident(overrides: Partial<{
+  id: string;
+  title: string;
+  severity: 'critical' | 'warning' | 'info';
+  status: 'active' | 'resolved';
+  affected_containers: string[];
+  endpoint_name: string | null;
+  correlation_type: string;
+  created_at: string;
+  insight_count: number;
+}> = {}) {
+  return {
+    id: overrides.id ?? 'inc-x',
+    title: overrides.title ?? 'Test incident',
+    severity: overrides.severity ?? 'warning',
+    status: overrides.status ?? 'active',
+    root_cause_insight_id: null,
+    related_insight_ids: [],
+    affected_containers: overrides.affected_containers ?? [],
+    endpoint_id: 1,
+    endpoint_name: overrides.endpoint_name ?? 'prod',
+    correlation_type: overrides.correlation_type ?? 'temporal',
+    correlation_confidence: 'high' as const,
+    insight_count: overrides.insight_count ?? 1,
+    summary: 'Summary',
+    created_at: overrides.created_at ?? nowIso(),
+    updated_at: overrides.created_at ?? nowIso(),
+    resolved_at: null,
+  };
+}
+
+describe('AiMonitorPage — search, sort, time range', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('search box filters insights and persists to URL after debounce', async () => {
+    vi.mocked(useMonitoring).mockReturnValue({
+      insights: [
+        { id: 'i1', endpoint_id: 1, endpoint_name: 'local', container_id: 'c1', container_name: 'matching-redis', severity: 'warning', category: 'anomaly', title: 'Redis spike', description: '', suggested_action: null, is_acknowledged: 0, created_at: nowIso() },
+        { id: 'i2', endpoint_id: 1, endpoint_name: 'local', container_id: 'c2', container_name: 'unrelated-pg', severity: 'warning', category: 'anomaly', title: 'PG normal', description: '', suggested_action: null, is_acknowledged: 0, created_at: nowIso() },
+      ],
+      isLoading: false,
+      error: null,
+      subscribedSeverities: new Set(['critical', 'warning', 'info']),
+      subscribeSeverity: vi.fn(),
+      unsubscribeSeverity: vi.fn(),
+      acknowledgeInsight: vi.fn(),
+      acknowledgeError: null,
+      isAcknowledging: false,
+      acknowledgingInsightId: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMonitoring>);
+
+    renderPage();
+
+    // Both rows visible at first
+    expect(screen.getByText('Redis spike')).toBeTruthy();
+    expect(screen.getByText('PG normal')).toBeTruthy();
+
+    const searchBox = screen.getByPlaceholderText(/Search by container/i);
+    fireEvent.change(searchBox, { target: { value: 'redis' } });
+
+    // Debounce window — advance fake timers past the 150ms threshold
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.getByText('Redis spike')).toBeTruthy();
+    expect(screen.queryByText('PG normal')).toBeNull();
+  });
+
+  it('clearing the search box restores all rows', async () => {
+    vi.mocked(useMonitoring).mockReturnValue({
+      insights: [
+        { id: 'i1', endpoint_id: 1, endpoint_name: 'local', container_id: 'c1', container_name: 'redis-1', severity: 'warning', category: 'anomaly', title: 'Match A', description: '', suggested_action: null, is_acknowledged: 0, created_at: nowIso() },
+        { id: 'i2', endpoint_id: 1, endpoint_name: 'local', container_id: 'c2', container_name: 'pg-1', severity: 'warning', category: 'anomaly', title: 'Match B', description: '', suggested_action: null, is_acknowledged: 0, created_at: nowIso() },
+      ],
+      isLoading: false, error: null,
+      subscribedSeverities: new Set(['critical', 'warning', 'info']),
+      subscribeSeverity: vi.fn(), unsubscribeSeverity: vi.fn(),
+      acknowledgeInsight: vi.fn(), acknowledgeError: null,
+      isAcknowledging: false, acknowledgingInsightId: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMonitoring>);
+
+    renderPage();
+    const searchBox = screen.getByPlaceholderText(/Search by container/i);
+    fireEvent.change(searchBox, { target: { value: 'redis' } });
+    await act(async () => { vi.advanceTimersByTime(200); });
+    expect(screen.queryByText('Match B')).toBeNull();
+
+    fireEvent.change(searchBox, { target: { value: '' } });
+    await act(async () => { vi.advanceTimersByTime(200); });
+    expect(screen.getByText('Match A')).toBeTruthy();
+    expect(screen.getByText('Match B')).toBeTruthy();
+  });
+
+  it('time-range filter (1H) excludes incidents older than the window', async () => {
+    vi.mocked(useIncidents).mockReturnValue({
+      data: {
+        incidents: [
+          fakeIncident({ id: 'fresh', title: 'Recent incident', created_at: nowIso(-10 * 60_000) }), // 10 min ago
+          fakeIncident({ id: 'stale', title: 'Old incident', created_at: nowIso(-3 * 60 * 60_000) }), // 3h ago
+        ],
+        counts: { active: 2, resolved: 0, total: 2 },
+        limit: 50, offset: 0,
+      },
+    } as ReturnType<typeof useIncidents>);
+
+    renderPage();
+
+    // Default range is 24H — both visible
+    expect(screen.getByText('Recent incident')).toBeTruthy();
+    expect(screen.getByText('Old incident')).toBeTruthy();
+
+    // Switch to 1H — only fresh remains
+    fireEvent.click(screen.getByRole('tab', { name: '1H' }));
+    expect(screen.getByText('Recent incident')).toBeTruthy();
+    expect(screen.queryByText('Old incident')).toBeNull();
+  });
+
+  it('sort: severity (default) puts critical above warning', () => {
+    vi.mocked(useIncidents).mockReturnValue({
+      data: {
+        incidents: [
+          // Warning is FIRST in source order but should render second after sort.
+          fakeIncident({ id: 'w', title: 'Warning Z', severity: 'warning', created_at: nowIso(-5 * 60_000) }),
+          fakeIncident({ id: 'c', title: 'Critical A', severity: 'critical', created_at: nowIso(-10 * 60_000) }),
+        ],
+        counts: { active: 2, resolved: 0, total: 2 },
+        limit: 50, offset: 0,
+      },
+    } as ReturnType<typeof useIncidents>);
+
+    renderPage();
+
+    const titles = screen.getAllByRole('heading', { level: 3 }).map((el) => el.textContent ?? '');
+    const ci = titles.indexOf('Critical A');
+    const wi = titles.indexOf('Warning Z');
+    expect(ci).toBeGreaterThanOrEqual(0);
+    expect(wi).toBeGreaterThan(ci);
+  });
+
+  it('sort: switching to Recent reorders by timestamp regardless of severity', () => {
+    vi.mocked(useIncidents).mockReturnValue({
+      data: {
+        incidents: [
+          // Critical 30 min ago, Warning 5 min ago. Severity sort would put
+          // Critical first; Recent sort flips that.
+          fakeIncident({ id: 'c', title: 'Critical Old', severity: 'critical', created_at: nowIso(-30 * 60_000) }),
+          fakeIncident({ id: 'w', title: 'Warning New', severity: 'warning', created_at: nowIso(-5 * 60_000) }),
+        ],
+        counts: { active: 2, resolved: 0, total: 2 },
+        limit: 50, offset: 0,
+      },
+    } as ReturnType<typeof useIncidents>);
+
+    renderPage();
+    fireEvent.click(screen.getByRole('tab', { name: /Recent/i }));
+
+    const titles = screen.getAllByRole('heading', { level: 3 }).map((el) => el.textContent ?? '');
+    const ci = titles.indexOf('Critical Old');
+    const wi = titles.indexOf('Warning New');
+    expect(wi).toBeGreaterThanOrEqual(0);
+    expect(ci).toBeGreaterThan(wi);
+  });
+});
+
+describe('AiMonitorPage — bulk resolve', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('action bar appears when an incident is selected, and resolves call mutateAsync per id', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(useResolveIncident).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync,
+    } as unknown as ReturnType<typeof useResolveIncident>);
+
+    vi.mocked(useIncidents).mockReturnValue({
+      data: {
+        incidents: [
+          fakeIncident({ id: 'inc-a', title: 'Inc A', severity: 'critical' }),
+          fakeIncident({ id: 'inc-b', title: 'Inc B', severity: 'warning' }),
+        ],
+        counts: { active: 2, resolved: 0, total: 2 },
+        limit: 50, offset: 0,
+      },
+    } as ReturnType<typeof useIncidents>);
+
+    renderPage();
+
+    // Select two incidents
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+
+    // Action bar visible with selection count
+    const bar = screen.getByTestId('bulk-action-bar');
+    expect(bar.textContent).toContain('2 selected');
+
+    // Resolve both
+    fireEvent.click(screen.getByRole('button', { name: /Resolve 2/i }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledTimes(2);
+    });
+    expect(mutateAsync).toHaveBeenCalledWith('inc-a');
+    expect(mutateAsync).toHaveBeenCalledWith('inc-b');
+  });
+
+  it('partial failure: keeps failed ids selected and surfaces an inline error', async () => {
+    const mutateAsync = vi
+      .fn()
+      .mockImplementation((id: string) =>
+        id === 'inc-fail' ? Promise.reject(new Error('boom')) : Promise.resolve(),
+      );
+    vi.mocked(useResolveIncident).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync,
+    } as unknown as ReturnType<typeof useResolveIncident>);
+
+    vi.mocked(useIncidents).mockReturnValue({
+      data: {
+        incidents: [
+          fakeIncident({ id: 'inc-ok', title: 'OK', severity: 'warning' }),
+          fakeIncident({ id: 'inc-fail', title: 'Fail', severity: 'warning' }),
+        ],
+        counts: { active: 2, resolved: 0, total: 2 },
+        limit: 50, offset: 0,
+      },
+    } as ReturnType<typeof useIncidents>);
+
+    renderPage();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(screen.getByRole('button', { name: /Resolve 2/i }));
+
+    // Error message should surface with the failure count
+    await waitFor(() => {
+      expect(screen.getByTestId('bulk-resolve-error')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('bulk-resolve-error').textContent).toContain('Failed to resolve 1 of 2');
+    // The action bar still shows 1 selected (only the failed id remains)
+    expect(screen.getByTestId('bulk-action-bar').textContent).toContain('1 selected');
+  });
+});
+
+describe('AiMonitorPage — container chip linking', () => {
+  it('renders a container link to /containers/:endpointId/:containerId on insights with ids', () => {
+    vi.mocked(useMonitoring).mockReturnValue({
+      insights: [
+        {
+          id: 'i-link',
+          endpoint_id: 7,
+          endpoint_name: 'prod',
+          container_id: 'c-abc',
+          container_name: 'linkable-container',
+          severity: 'warning',
+          category: 'anomaly',
+          title: 'Linkable',
+          description: '',
+          suggested_action: null,
+          is_acknowledged: 0,
+          created_at: nowIso(),
+        },
+      ],
+      isLoading: false, error: null,
+      subscribedSeverities: new Set(['critical', 'warning', 'info']),
+      subscribeSeverity: vi.fn(), unsubscribeSeverity: vi.fn(),
+      acknowledgeInsight: vi.fn(), acknowledgeError: null,
+      isAcknowledging: false, acknowledgingInsightId: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMonitoring>);
+
+    renderPage();
+
+    // The accessible name for a link comes from its text content. The chip
+    // wraps a Box icon + the container name. The chip lives inside a
+    // `hidden sm:flex` wrapper which jsdom treats as inaccessible by default,
+    // so opt into hidden lookups for the query.
+    const link = screen.getByRole('link', { name: /linkable-container/i, hidden: true });
+    expect(link.getAttribute('href')).toBe('/containers/7/c-abc');
+  });
+
+  it('renders a plain (non-link) chip for incident affected_containers because ids are unknown', () => {
+    vi.mocked(useIncidents).mockReturnValue({
+      data: {
+        incidents: [
+          fakeIncident({ id: 'inc-x', title: 'Has affected containers', affected_containers: ['nginx-1'] }),
+        ],
+        counts: { active: 1, resolved: 0, total: 1 },
+        limit: 50, offset: 0,
+      },
+    } as ReturnType<typeof useIncidents>);
+
+    renderPage();
+
+    // Expand the incident card so the affected-containers list renders
+    fireEvent.click(screen.getByText('Has affected containers'));
+
+    // The text appears, but it's NOT inside an anchor — incidents store
+    // affected_containers as names only, not as ids.
+    const nginxChip = screen.getByText('nginx-1');
+    expect(nginxChip.closest('a')).toBeNull();
+  });
+});
+
+describe('AiMonitorPage — stat card filter vs subscription independence', () => {
+  it('clicking the bell icon toggles subscription without changing the severity filter', async () => {
+    const subscribe = vi.fn();
+    const unsubscribe = vi.fn();
+    vi.mocked(useMonitoring).mockReturnValue({
+      insights: [],
+      isLoading: false, error: null,
+      subscribedSeverities: new Set(['critical', 'warning', 'info']),
+      subscribeSeverity: subscribe,
+      unsubscribeSeverity: unsubscribe,
+      acknowledgeInsight: vi.fn(),
+      acknowledgeError: null,
+      isAcknowledging: false,
+      acknowledgingInsightId: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMonitoring>);
+
+    renderPage();
+
+    // Bell button has accessible name "Pause live critical alerts"
+    const pauseCritical = screen.getByRole('button', { name: /Pause live critical alerts/i });
+    fireEvent.click(pauseCritical);
+
+    expect(unsubscribe).toHaveBeenCalledWith('critical');
+    // Should NOT have triggered a severity-filter change — the All filter
+    // tab remains the active tab (aria-pressed=true on Total Insights btn).
+    const totalCard = screen.getByRole('button', { name: /Total Insights/i });
+    expect(totalCard.getAttribute('aria-pressed')).toBe('true');
   });
 });

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -983,6 +983,22 @@ export default function AiMonitorPage() {
   const { data: containers, isLoading: containersLoading, refetch: containerRefetch, isFetching: containersFetching } = useContainers();
   const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', containerRefetch);
 
+  // Wire the auto-refresh dropdown to actual refetches. The hook only owns
+  // the interval state; without this effect, switching the dropdown to "30s"
+  // would advertise a behaviour that never happens. We refetch the page's
+  // two operator-controlled queries (insights + containers); incidents and
+  // correlated anomalies have their own internal refetch cadences set in
+  // their respective hooks.
+  useEffect(() => {
+    if (interval <= 0) return;
+    const tick = () => {
+      refetch();
+      containerRefetch();
+    };
+    const id = window.setInterval(tick, interval * 1000);
+    return () => window.clearInterval(id);
+  }, [interval, refetch, containerRefetch]);
+
   const healthStats = useMemo(() => {
     if (!containers) return null;
     return calculateHealthStats(containers);
@@ -1079,20 +1095,28 @@ export default function AiMonitorPage() {
     const ids = Array.from(selectedIncidentIds);
     const failedIds: string[] = [];
 
-    // Concurrency cap of 5 keeps the UI responsive without flooding the
-    // backend. Per-id success/failure is tracked here rather than via the
-    // mutation hook because mutation.error/data only ever reflects the most
-    // recent call when many run in parallel.
-    const concurrency = 5;
-    for (let i = 0; i < ids.length; i += concurrency) {
-      const batch = ids.slice(i, i + concurrency);
-      const results = await Promise.allSettled(
-        batch.map((id) => resolveIncidentMutation.mutateAsync(id)),
-      );
-      results.forEach((r, idx) => {
-        if (r.status === 'rejected') failedIds.push(batch[idx]);
-      });
-    }
+    // Streaming worker pool — N workers each pull the next id from a shared
+    // queue. A slow request blocks only its own worker, not the whole batch
+    // (the previous batched-wave loop made all 5 workers wait for the
+    // slowest in each wave before starting the next 5). Per-id success and
+    // failure is tracked here rather than via the mutation hook because
+    // `mutation.error` only ever reflects the most recent call when many
+    // run in parallel.
+    const POOL_SIZE = 5;
+    const queue = [...ids];
+    const worker = async () => {
+      while (queue.length > 0) {
+        const id = queue.shift();
+        if (id === undefined) break;
+        try {
+          await resolveIncidentMutation.mutateAsync(id);
+        } catch {
+          failedIds.push(id);
+        }
+      }
+    };
+    const workerCount = Math.min(POOL_SIZE, ids.length);
+    await Promise.all(Array.from({ length: workerCount }, worker));
 
     // Keep only failed ids selected so the user can retry without
     // re-checking each row, and surface the failure count inline.
@@ -1235,7 +1259,7 @@ export default function AiMonitorPage() {
                 title={isFiltered ? 'Click to clear filter' : `Filter list to ${card.label.toLowerCase()}`}
                 className="block w-full text-left"
               >
-                <div className="flex items-center justify-between pr-7">
+                <div className="flex items-center justify-between pr-9">
                   <p className={cn('text-xs font-medium uppercase tracking-wide', card.text)}>{card.label}</p>
                   <Icon className={cn('h-4 w-4', card.iconColor)} />
                 </div>
@@ -1243,23 +1267,24 @@ export default function AiMonitorPage() {
                   {card.count}
                 </p>
               </button>
-              {/* Live-alert subscription toggle — separate target so it doesn't filter */}
+              {/* Live-alert subscription toggle — separate sibling target.
+                  No stopPropagation needed because this button is a sibling
+                  of the card-body button (not nested inside it). 32×32 hit
+                  area: above WCAG 2.5.5 AA (24×24) and well above the
+                  practical comfort zone for pointer + touch input. */}
               <button
                 type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleSubscriptionToggle(card.severity);
-                }}
+                onClick={() => handleSubscriptionToggle(card.severity)}
                 aria-pressed={isSubscribed}
                 title={isSubscribed ? `Pause live ${card.label.toLowerCase()} alerts` : `Resume live ${card.label.toLowerCase()} alerts`}
                 className={cn(
-                  'absolute right-2.5 top-2.5 inline-flex h-6 w-6 items-center justify-center rounded-full transition-colors',
+                  'absolute right-1.5 top-1.5 inline-flex h-8 w-8 items-center justify-center rounded-full transition-colors',
                   isSubscribed
                     ? 'bg-card text-muted-foreground hover:bg-muted'
                     : 'bg-muted text-muted-foreground/60 hover:bg-muted/80',
                 )}
               >
-                {isSubscribed ? <Bell className="h-3 w-3" /> : <BellOff className="h-3 w-3" />}
+                {isSubscribed ? <Bell className="h-3.5 w-3.5" /> : <BellOff className="h-3.5 w-3.5" />}
                 <span className="sr-only">
                   {isSubscribed ? 'Pause' : 'Resume'} live {card.label.toLowerCase()} alerts
                 </span>

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useMonitoring } from '@/features/ai-intelligence/hooks/use-monitoring';
 import { useInvestigations, safeParseJson } from '@/features/ai-intelligence/hooks/use-investigations';
 import type { Investigation, RecommendedAction } from '@/features/ai-intelligence/hooks/use-investigations';
@@ -34,7 +34,10 @@ import {
   Zap,
   TrendingUp,
   FileText,
+  Bell,
+  BellOff,
 } from 'lucide-react';
+import { Link, useSearchParams } from 'react-router-dom';
 import { getModelUseCase } from '@/features/core/components/settings/model-use-cases';
 
 type Severity = 'critical' | 'warning' | 'info';
@@ -58,6 +61,48 @@ interface InsightCardProps {
   onAcknowledge: (insightId: string) => void;
   isAcknowledging: boolean;
   acknowledgeErrorMessage?: string;
+}
+
+/**
+ * Renders a container name in a chip. Links to the container detail page
+ * when both endpointId and containerId are known; otherwise renders as plain
+ * text. `stopPropagation` keeps the parent row's expand-on-click behaviour
+ * intact when the chip lives inside an expandable card.
+ */
+function ContainerChip({
+  name,
+  endpointId,
+  containerId,
+  className,
+}: {
+  name: string;
+  endpointId?: number | null;
+  containerId?: string | null;
+  className?: string;
+}) {
+  const baseClasses = cn(
+    'inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-xs font-mono',
+    className,
+  );
+  if (endpointId != null && containerId) {
+    return (
+      <Link
+        to={`/containers/${endpointId}/${containerId}`}
+        onClick={(e) => e.stopPropagation()}
+        className={cn(baseClasses, 'hover:bg-muted/70 hover:text-foreground transition-colors')}
+        title={`Open ${name}`}
+      >
+        <Box className="h-3 w-3 text-muted-foreground" />
+        {name}
+      </Link>
+    );
+  }
+  return (
+    <span className={baseClasses}>
+      <Box className="h-3 w-3 text-muted-foreground" />
+      {name}
+    </span>
+  );
 }
 
 function SeverityBadge({ severity }: { severity: Severity }) {
@@ -293,7 +338,7 @@ function CorrelatedAnomalyCard({ anomaly }: { anomaly: CorrelatedAnomaly }) {
   );
 }
 
-function HealthIssueCard({ container }: { container: { name: string; image: string; state: string; healthStatus?: string } }) {
+function HealthIssueCard({ container }: { container: { id: string; name: string; image: string; state: string; healthStatus?: string; endpointId: number } }) {
   const isUnhealthy = container.healthStatus === 'unhealthy';
   return (
     <div
@@ -306,10 +351,14 @@ function HealthIssueCard({ container }: { container: { name: string; image: stri
       data-testid="health-issue-card"
     >
       <div className="flex items-start justify-between gap-3 mb-3">
-        <div className="flex items-center gap-2 min-w-0">
+        <Link
+          to={`/containers/${container.endpointId}/${container.id}`}
+          className="flex items-center gap-2 min-w-0 hover:text-foreground transition-colors"
+          title={`Open ${container.name}`}
+        >
           <Box className="h-4 w-4 text-muted-foreground flex-shrink-0" />
           <span className="font-mono text-sm font-medium truncate">{container.name}</span>
-        </div>
+        </Link>
         {isUnhealthy ? (
           <XCircle className="h-5 w-5 text-red-500 flex-shrink-0" />
         ) : (
@@ -491,10 +540,29 @@ function InvestigationSection({ investigation }: { investigation: Investigation 
   );
 }
 
-function IncidentCard({ incident, onResolve }: { incident: Incident; onResolve: (id: string) => void }) {
+function IncidentCard({
+  incident,
+  onResolve,
+  isSelected,
+  onToggleSelect,
+}: {
+  incident: Incident;
+  onResolve: (id: string) => void;
+  isSelected: boolean;
+  onToggleSelect: (id: string) => void;
+}) {
   const [expanded, setExpanded] = useState(false);
   const containers: string[] = incident.affected_containers || [];
   const isActive = incident.status === 'active';
+
+  // Tint the leading icon by severity instead of always purple. Pulls the
+  // viewer's eye to the row's actual urgency rather than the generic
+  // "incident" shape.
+  const severityIconClasses = {
+    critical: 'bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400',
+    warning: 'bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400',
+    info: 'bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400',
+  }[incident.severity];
 
   return (
     <div className={cn(
@@ -512,35 +580,44 @@ function IncidentCard({ incident, onResolve }: { incident: Incident; onResolve: 
       >
         <div className="flex items-start justify-between gap-4">
           <div className="flex items-start gap-3 flex-1 min-w-0">
-            <div className="mt-0.5 rounded-full bg-purple-100 dark:bg-purple-900/30 p-2">
-              <Layers className="h-4 w-4 text-purple-600 dark:text-purple-400" />
+            {isActive && (
+              <input
+                type="checkbox"
+                checked={isSelected}
+                onChange={() => onToggleSelect(incident.id)}
+                onClick={(e) => e.stopPropagation()}
+                aria-label={`Select incident: ${incident.title}`}
+                className="mt-1.5 h-4 w-4 cursor-pointer rounded border-input accent-primary"
+              />
+            )}
+            <div className={cn('mt-0.5 rounded-full p-2', severityIconClasses)}>
+              <Layers className="h-4 w-4" />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1 flex-wrap">
+              <div className="flex items-center gap-2 mb-1">
                 <SeverityBadge severity={incident.severity} />
-                <span className={cn(
-                  'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium',
-                  isActive
-                    ? 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
-                    : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-                )}>
-                  {isActive ? 'Active Incident' : 'Resolved'}
-                </span>
-                <CorrelationTypeBadge type={incident.correlation_type} />
-                <span className="text-xs text-muted-foreground">
-                  {formatDate(incident.created_at)}
-                </span>
+                {!isActive && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                    Resolved
+                  </span>
+                )}
               </div>
               <h3 className="font-semibold text-base leading-snug mb-1">{incident.title}</h3>
               {!expanded && incident.summary && (
                 <p className="text-sm text-muted-foreground line-clamp-2">{incident.summary}</p>
               )}
+              {/* Demoted metadata — correlation type + timestamp on a muted line.
+                  Removes 2 of the 5 same-weight chips that crowded the header. */}
+              <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                <CorrelationTypeBadge type={incident.correlation_type} />
+                <span>·</span>
+                <span>{formatDate(incident.created_at)}</span>
+                <span>·</span>
+                <span>{incident.insight_count} alert{incident.insight_count === 1 ? '' : 's'}</span>
+              </div>
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <span className="inline-flex items-center rounded-md bg-muted px-2 py-1 text-xs font-medium">
-              {incident.insight_count} alerts
-            </span>
             {expanded ? (
               <ChevronDown className="h-5 w-5 text-muted-foreground flex-shrink-0" />
             ) : (
@@ -564,10 +641,10 @@ function IncidentCard({ incident, onResolve }: { incident: Incident; onResolve: 
               <h4 className="text-sm font-medium mb-1.5">Affected Containers</h4>
               <div className="flex flex-wrap gap-1.5">
                 {containers.map((name) => (
-                  <span key={name} className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs font-mono">
-                    <Box className="h-3 w-3 text-muted-foreground" />
-                    {name}
-                  </span>
+                  // Incidents store affected containers by name only; without
+                  // ids we render plain chips. ContainerChip degrades to a
+                  // span when the ids aren't provided.
+                  <ContainerChip key={name} name={name} />
                 ))}
               </div>
             </div>
@@ -664,9 +741,12 @@ function InsightCard({
               <Loader2 className="h-4 w-4 animate-spin text-purple-500" />
             )}
             {insight.container_name && (
-              <div className="hidden sm:flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-xs">
-                <Box className="h-3 w-3 text-muted-foreground" />
-                <span className="font-mono">{insight.container_name}</span>
+              <div className="hidden sm:flex">
+                <ContainerChip
+                  name={insight.container_name}
+                  endpointId={insight.endpoint_id}
+                  containerId={insight.container_id}
+                />
               </div>
             )}
             {expanded ? (
@@ -796,10 +876,75 @@ function InsightCard({
   );
 }
 
+type TimeRange = '1h' | '24h' | '7d' | 'all';
+type IncidentSort = 'severity' | 'time';
+
+const TIME_RANGE_MS: Record<Exclude<TimeRange, 'all'>, number> = {
+  '1h': 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+};
+
+// Severity weight for default sort: critical > warning > info. Higher = more
+// urgent and floats to the top.
+const SEVERITY_WEIGHT: Record<Severity, number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+};
+
 export default function AiMonitorPage() {
   const [severityFilter, setSeverityFilter] = useState<'all' | Severity>('all');
   const [acknowledgementFilter, setAcknowledgementFilter] = useState<'all' | 'unacknowledged'>('all');
   const { interval, setInterval } = useAutoRefresh(30);
+
+  // URL-synced controls so reloads, deep links, and back-navigation preserve
+  // the operator's filter context. Trade-off: each control change invalidates
+  // a render but the page already re-renders on every refetch so this isn't
+  // load-bearing.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchInput, setSearchInput] = useState(searchParams.get('q') ?? '');
+  const [searchQuery, setSearchQuery] = useState(searchParams.get('q') ?? '');
+  const timeRange = (searchParams.get('range') as TimeRange) || '24h';
+  const incidentSort = (searchParams.get('sort') as IncidentSort) || 'severity';
+
+  // Debounce search input → query (~150ms) so each keystroke doesn't refilter
+  // the full list. URL-sync happens on the debounced value.
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearchQuery(searchInput);
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (searchInput) next.set('q', searchInput);
+        else next.delete('q');
+        return next;
+      }, { replace: true });
+    }, 150);
+    return () => window.clearTimeout(timer);
+  }, [searchInput, setSearchParams]);
+
+  const setUrlParam = (key: string, value: string | null) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value === null) next.delete(key);
+      else next.set(key, value);
+      return next;
+    }, { replace: true });
+  };
+
+  // Bulk-resolve selection state — keyed by incident id. Cleared whenever the
+  // resolve mutation completes so stale ids don't linger.
+  const [selectedIncidentIds, setSelectedIncidentIds] = useState<Set<string>>(new Set());
+  const [isBulkResolving, setIsBulkResolving] = useState(false);
+  const toggleIncidentSelected = (id: string) => {
+    setSelectedIncidentIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+  const clearSelection = () => setSelectedIncidentIds(new Set());
 
   const {
     insights,
@@ -828,11 +973,6 @@ export default function AiMonitorPage() {
     return calculateHealthStats(containers);
   }, [containers]);
 
-  const healthPercentage = useMemo(() => {
-    if (!healthStats || healthStats.total === 0) return 0;
-    return (healthStats.healthy / healthStats.total) * 100;
-  }, [healthStats]);
-
   // Containers with a simple health issue (unhealthy or stopped) — surfaced in Correlated Anomalies (AC-4)
   const healthIssues = useMemo(() => {
     if (!containers) return [];
@@ -841,18 +981,107 @@ export default function AiMonitorPage() {
     );
   }, [containers]);
 
-  // Filter insights by severity
+  // Lowercased query for case-insensitive substring matching.
+  const searchLower = searchQuery.trim().toLowerCase();
+  const matchesSearch = (haystack: Array<string | null | undefined>) =>
+    !searchLower ||
+    haystack.some((s) => typeof s === 'string' && s.toLowerCase().includes(searchLower));
+
+  // Filter insights by severity, acknowledgement, and search query.
   const filteredInsights = useMemo(() => {
     const bySeverity = severityFilter === 'all'
       ? insights
       : insights.filter((i) => i.severity === severityFilter);
 
+    const bySearch = !searchLower
+      ? bySeverity
+      : bySeverity.filter((i) =>
+          matchesSearch([i.title, i.description, i.container_name, i.endpoint_name, i.category]),
+        );
+
     if (acknowledgementFilter === 'unacknowledged') {
-      return bySeverity.filter((i) => !i.is_acknowledged);
+      return bySearch.filter((i) => !i.is_acknowledged);
     }
 
-    return bySeverity;
-  }, [acknowledgementFilter, insights, severityFilter]);
+    return bySearch;
+    // matchesSearch is a stable closure over searchLower; depending on it
+    // explicitly avoids a stale-closure subtle bug.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [acknowledgementFilter, insights, severityFilter, searchLower]);
+
+  // Filter, sort, and bound incidents for the visible list.
+  const visibleIncidents = useMemo(() => {
+    if (!incidentsData) return [];
+    const cutoff = timeRange === 'all' ? null : Date.now() - TIME_RANGE_MS[timeRange];
+
+    let result = incidentsData.incidents.filter((incident) => {
+      if (cutoff !== null) {
+        const created = Date.parse(incident.created_at);
+        if (Number.isFinite(created) && created < cutoff) return false;
+      }
+      if (searchLower) {
+        const haystack = [
+          incident.title,
+          incident.summary,
+          incident.endpoint_name,
+          incident.correlation_type,
+          ...(incident.affected_containers ?? []),
+        ];
+        if (!matchesSearch(haystack)) return false;
+      }
+      return true;
+    });
+
+    if (incidentSort === 'severity') {
+      result = [...result].sort((a, b) => {
+        const weightDiff = SEVERITY_WEIGHT[b.severity] - SEVERITY_WEIGHT[a.severity];
+        if (weightDiff !== 0) return weightDiff;
+        return Date.parse(b.created_at) - Date.parse(a.created_at);
+      });
+    } else {
+      result = [...result].sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+    }
+
+    return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [incidentsData, timeRange, incidentSort, searchLower]);
+
+  // Apply search to anomalies + health issues so the search box covers every
+  // list on the page consistently.
+  const filteredCorrelatedAnomalies = useMemo(() => {
+    if (!correlatedAnomalies) return correlatedAnomalies;
+    if (!searchLower) return correlatedAnomalies;
+    return correlatedAnomalies.filter((a) =>
+      matchesSearch([a.containerName, a.pattern, ...a.metrics.map((m) => m.type)]),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [correlatedAnomalies, searchLower]);
+
+  const filteredHealthIssues = useMemo(() => {
+    if (!searchLower) return healthIssues;
+    return healthIssues.filter((c) => matchesSearch([c.name, c.image, c.healthStatus]));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [healthIssues, searchLower]);
+
+  const handleBulkResolve = async () => {
+    if (selectedIncidentIds.size === 0 || isBulkResolving) return;
+    setIsBulkResolving(true);
+    const ids = Array.from(selectedIncidentIds);
+    try {
+      // Concurrency cap of 5 keeps the UI responsive without flooding the
+      // backend; mutateAsync rejects on individual failures but Promise.all
+      // here would short-circuit, so use allSettled and surface failures via
+      // the existing react-query error pipeline.
+      const concurrency = 5;
+      for (let i = 0; i < ids.length; i += concurrency) {
+        const batch = ids.slice(i, i + concurrency);
+        await Promise.allSettled(batch.map((id) => resolveIncidentMutation.mutateAsync(id)));
+      }
+    } finally {
+      clearSelection();
+      setIsBulkResolving(false);
+    }
+  };
 
   // Stats
   const stats = useMemo(() => {
@@ -866,13 +1095,15 @@ export default function AiMonitorPage() {
     return result;
   }, [insights]);
 
-  const handleSeverityToggle = (severity: Severity) => {
+  const handleSeverityFilter = (severity: Severity) => {
+    // Stat-card body click filters the list (or clears filter if already
+    // active). Live-alert subscription is a separate control on each card.
+    setSeverityFilter((current) => (current === severity ? 'all' : severity));
+  };
+
+  const handleSubscriptionToggle = (severity: Severity) => {
     if (subscribedSeverities.has(severity)) {
       unsubscribeSeverity(severity);
-      // If we're filtering by this severity and we unsubscribe, reset to 'all'
-      if (severityFilter === severity) {
-        setSeverityFilter('all');
-      }
     } else {
       subscribeSeverity(severity);
     }
@@ -928,61 +1159,89 @@ export default function AiMonitorPage() {
       {/* Fleet Health Summary */}
       <FleetHealthSummary
         stats={healthStats}
-        healthPercentage={healthPercentage}
         isLoading={containersLoading}
       />
 
-      {/* Stats Cards — click to toggle real-time alerts */}
-      <div className="grid gap-4 md:grid-cols-4">
-        <div className="rounded-lg border bg-card p-4">
+      {/* Insights Filter Cards — click body to filter, bell icon toggles live alerts.
+          Slimmer than before so the page hero (Fleet Vitals) keeps dominance. */}
+      <div className="grid gap-3 md:grid-cols-4">
+        <button
+          type="button"
+          onClick={() => setSeverityFilter('all')}
+          aria-pressed={severityFilter === 'all'}
+          className={cn(
+            'rounded-lg border bg-card px-4 py-3 text-left transition-all',
+            severityFilter === 'all' ? 'ring-2 ring-primary/40' : 'hover:bg-muted/30',
+          )}
+        >
           <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-muted-foreground">Total Insights</p>
-            <Activity className="h-5 w-5 text-primary" />
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Total Insights</p>
+            <Activity className="h-4 w-4 text-primary" />
           </div>
-          <p className="mt-2 text-3xl font-bold">{stats.total}</p>
-        </div>
+          <p className="mt-1 text-2xl font-bold tabular-nums">{stats.total}</p>
+        </button>
         {([
           { severity: 'critical' as const, label: 'Critical', icon: AlertTriangle, count: stats.critical,
-            active: 'bg-red-50 dark:bg-red-900/20 ring-2 ring-red-500/20',
+            tint: 'bg-red-50 dark:bg-red-900/20',
             text: 'text-red-800 dark:text-red-200', iconColor: 'text-red-600 dark:text-red-400',
-            countColor: 'text-red-900 dark:text-red-100', dotColor: 'bg-red-500' },
+            countColor: 'text-red-900 dark:text-red-100', ring: 'ring-red-500/40' },
           { severity: 'warning' as const, label: 'Warnings', icon: AlertCircle, count: stats.warning,
-            active: 'bg-amber-50 dark:bg-amber-900/20 ring-2 ring-amber-500/20',
+            tint: 'bg-amber-50 dark:bg-amber-900/20',
             text: 'text-amber-800 dark:text-amber-200', iconColor: 'text-amber-600 dark:text-amber-400',
-            countColor: 'text-amber-900 dark:text-amber-100', dotColor: 'bg-amber-500' },
+            countColor: 'text-amber-900 dark:text-amber-100', ring: 'ring-amber-500/40' },
           { severity: 'info' as const, label: 'Info', icon: Info, count: stats.info,
-            active: 'bg-blue-50 dark:bg-blue-900/20 ring-2 ring-blue-500/20',
+            tint: 'bg-blue-50 dark:bg-blue-900/20',
             text: 'text-blue-800 dark:text-blue-200', iconColor: 'text-blue-600 dark:text-blue-400',
-            countColor: 'text-blue-900 dark:text-blue-100', dotColor: 'bg-blue-500' },
+            countColor: 'text-blue-900 dark:text-blue-100', ring: 'ring-blue-500/40' },
         ]).map((card) => {
           const isSubscribed = subscribedSeverities.has(card.severity);
+          const isFiltered = severityFilter === card.severity;
           const Icon = card.icon;
           return (
             <div
               key={card.severity}
               className={cn(
-                'rounded-lg border p-4 cursor-pointer transition-all',
-                isSubscribed ? card.active : 'bg-card opacity-60'
+                'relative rounded-lg border px-4 py-3 transition-all',
+                card.tint,
+                isFiltered && `ring-2 ${card.ring}`,
               )}
-              onClick={() => handleSeverityToggle(card.severity)}
-              title={isSubscribed ? `Click to pause ${card.label.toLowerCase()} live alerts` : `Click to enable ${card.label.toLowerCase()} live alerts`}
             >
-              <div className="flex items-center justify-between">
-                <p className={cn('text-sm font-medium', card.text)}>{card.label}</p>
-                <Icon className={cn('h-5 w-5', card.iconColor)} />
-              </div>
-              <p className={cn('mt-2 text-3xl font-bold', card.countColor)}>
-                {card.count}
-              </p>
-              <div className="mt-2 flex items-center gap-1.5">
-                <span className={cn(
-                  'h-2 w-2 rounded-full',
-                  isSubscribed ? card.dotColor + ' animate-pulse' : 'bg-muted-foreground/40'
-                )} />
-                <span className="text-xs text-muted-foreground">
-                  {isSubscribed ? 'Live alerts' : 'Paused'}
+              <button
+                type="button"
+                onClick={() => handleSeverityFilter(card.severity)}
+                aria-pressed={isFiltered}
+                title={isFiltered ? 'Click to clear filter' : `Filter list to ${card.label.toLowerCase()}`}
+                className="block w-full text-left"
+              >
+                <div className="flex items-center justify-between pr-7">
+                  <p className={cn('text-xs font-medium uppercase tracking-wide', card.text)}>{card.label}</p>
+                  <Icon className={cn('h-4 w-4', card.iconColor)} />
+                </div>
+                <p className={cn('mt-1 text-2xl font-bold tabular-nums', card.countColor)}>
+                  {card.count}
+                </p>
+              </button>
+              {/* Live-alert subscription toggle — separate target so it doesn't filter */}
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleSubscriptionToggle(card.severity);
+                }}
+                aria-pressed={isSubscribed}
+                title={isSubscribed ? `Pause live ${card.label.toLowerCase()} alerts` : `Resume live ${card.label.toLowerCase()} alerts`}
+                className={cn(
+                  'absolute right-2.5 top-2.5 inline-flex h-6 w-6 items-center justify-center rounded-full transition-colors',
+                  isSubscribed
+                    ? 'bg-card text-muted-foreground hover:bg-muted'
+                    : 'bg-muted text-muted-foreground/60 hover:bg-muted/80',
+                )}
+              >
+                {isSubscribed ? <Bell className="h-3 w-3" /> : <BellOff className="h-3 w-3" />}
+                <span className="sr-only">
+                  {isSubscribed ? 'Pause' : 'Resume'} live {card.label.toLowerCase()} alerts
                 </span>
-              </div>
+              </button>
             </div>
           );
         })}
@@ -1072,16 +1331,39 @@ export default function AiMonitorPage() {
         </button>
       </div>
 
-      {/* Correlated Anomalies + Health Issues (AC-4) */}
-      {(correlatedLoading || (correlatedAnomalies && correlatedAnomalies.length > 0) || healthIssues.length > 0) && (
+      {/* Search box — covers incidents, anomalies, health issues, insights */}
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
+        <input
+          type="search"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Search by container, image, title, or endpoint…"
+          aria-label="Search incidents and insights"
+          className="h-10 w-full rounded-md border border-input bg-background pl-10 pr-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        />
+        {searchInput && (
+          <button
+            type="button"
+            onClick={() => setSearchInput('')}
+            aria-label="Clear search"
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:bg-muted"
+          >
+            <XCircle className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {/* ML-Detected Anomalies */}
+      {(correlatedLoading || (filteredCorrelatedAnomalies && filteredCorrelatedAnomalies.length > 0)) && (
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <Activity className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+            <Brain className="h-5 w-5 text-purple-600 dark:text-purple-400" />
             <h2 className="text-lg font-semibold">
-              Anomalies &amp; Health Issues
+              ML-Detected Anomalies
               {!correlatedLoading && (
                 <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  ({(correlatedAnomalies?.length ?? 0) + healthIssues.length})
+                  ({filteredCorrelatedAnomalies?.length ?? 0})
                 </span>
               )}
             </h2>
@@ -1093,36 +1375,150 @@ export default function AiMonitorPage() {
             </div>
           ) : (
             <div className="grid gap-4 md:grid-cols-2">
-              {(correlatedAnomalies ?? []).map((anomaly) => (
+              {(filteredCorrelatedAnomalies ?? []).map((anomaly) => (
                 <CorrelatedAnomalyCard key={anomaly.containerId} anomaly={anomaly} />
-              ))}
-              {healthIssues.map((container) => (
-                <HealthIssueCard key={container.name} container={container} />
               ))}
             </div>
           )}
         </div>
       )}
 
-      {/* Active Incidents */}
-      {incidentsData && incidentsData.incidents.length > 0 && (
+      {/* Container Health (state-based: unhealthy / stopped) */}
+      {filteredHealthIssues.length > 0 && (
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <Layers className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+            <Activity className="h-5 w-5 text-orange-600 dark:text-orange-400" />
             <h2 className="text-lg font-semibold">
-              Active Incidents
+              Container Health
               <span className="ml-2 text-sm font-normal text-muted-foreground">
-                ({incidentsData.counts.active} active)
+                ({filteredHealthIssues.length})
               </span>
             </h2>
           </div>
-          {incidentsData.incidents.map((incident) => (
-            <IncidentCard
-              key={incident.id}
-              incident={incident}
-              onResolve={(id) => resolveIncidentMutation.mutate(id)}
-            />
-          ))}
+          <div className="grid gap-4 md:grid-cols-2">
+            {filteredHealthIssues.map((container) => (
+              <HealthIssueCard key={container.id} container={container} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Active Incidents */}
+      {incidentsData && incidentsData.incidents.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Layers className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+              <h2 className="text-lg font-semibold">
+                Active Incidents
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  ({visibleIncidents.length} of {incidentsData.counts.active})
+                </span>
+              </h2>
+            </div>
+
+            {/* Time-range + sort controls */}
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="inline-flex items-center gap-0.5 rounded-md border bg-card p-0.5" role="tablist" aria-label="Time range">
+                {(['1h', '24h', '7d', 'all'] as const).map((range) => (
+                  <button
+                    key={range}
+                    type="button"
+                    role="tab"
+                    aria-selected={timeRange === range}
+                    onClick={() => setUrlParam('range', range)}
+                    className={cn(
+                      'rounded px-2.5 py-1 text-xs font-medium transition-colors',
+                      timeRange === range
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                    )}
+                  >
+                    {range === 'all' ? 'All' : range.toUpperCase()}
+                  </button>
+                ))}
+              </div>
+              <div className="inline-flex items-center gap-0.5 rounded-md border bg-card p-0.5" role="tablist" aria-label="Sort">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={incidentSort === 'severity'}
+                  onClick={() => setUrlParam('sort', 'severity')}
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded px-2.5 py-1 text-xs font-medium transition-colors',
+                    incidentSort === 'severity'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                  )}
+                >
+                  <AlertTriangle className="h-3 w-3" /> Severity
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={incidentSort === 'time'}
+                  onClick={() => setUrlParam('sort', 'time')}
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded px-2.5 py-1 text-xs font-medium transition-colors',
+                    incidentSort === 'time'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                  )}
+                >
+                  <Clock className="h-3 w-3" /> Recent
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Bulk-action bar — only renders when something is selected so it
+              doesn't take vertical space at rest. */}
+          {selectedIncidentIds.size > 0 && (
+            <div className="flex items-center justify-between rounded-md border border-primary/40 bg-primary/5 px-4 py-2">
+              <p className="text-sm font-medium">
+                {selectedIncidentIds.size} selected
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={clearSelection}
+                  disabled={isBulkResolving}
+                  className="rounded-md border border-input bg-background px-3 py-1 text-xs font-medium hover:bg-accent disabled:opacity-50"
+                >
+                  Clear
+                </button>
+                <button
+                  type="button"
+                  onClick={handleBulkResolve}
+                  disabled={isBulkResolving}
+                  className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                >
+                  {isBulkResolving ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <CheckCircle2 className="h-3 w-3" />
+                  )}
+                  Resolve {selectedIncidentIds.size}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {visibleIncidents.length === 0 ? (
+            <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+              No incidents match the current filters.
+            </div>
+          ) : (
+            visibleIncidents.map((incident) => (
+              <IncidentCard
+                key={incident.id}
+                incident={incident}
+                onResolve={(id) => resolveIncidentMutation.mutate(id)}
+                isSelected={selectedIncidentIds.has(incident.id)}
+                onToggleSelect={toggleIncidentSelected}
+              />
+            ))
+          )}
         </div>
       )}
 

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -923,6 +923,16 @@ export default function AiMonitorPage() {
     return () => window.clearTimeout(timer);
   }, [searchInput, setSearchParams]);
 
+  // Sync local input state from URL when the URL changes from outside this
+  // component (browser back/forward, deep link). Without this, navigating
+  // back to a state with `?q=foo` leaves the input field empty even though
+  // the filter is active.
+  const urlQuery = searchParams.get('q') ?? '';
+  useEffect(() => {
+    setSearchInput((current) => (current === urlQuery ? current : urlQuery));
+    setSearchQuery((current) => (current === urlQuery ? current : urlQuery));
+  }, [urlQuery]);
+
   const setUrlParam = (key: string, value: string | null) => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
@@ -932,10 +942,11 @@ export default function AiMonitorPage() {
     }, { replace: true });
   };
 
-  // Bulk-resolve selection state — keyed by incident id. Cleared whenever the
-  // resolve mutation completes so stale ids don't linger.
+  // Bulk-resolve selection state — keyed by incident id. Failed ids stay in
+  // the set on completion so the user can retry; succeeded ids are removed.
   const [selectedIncidentIds, setSelectedIncidentIds] = useState<Set<string>>(new Set());
   const [isBulkResolving, setIsBulkResolving] = useState(false);
+  const [bulkResolveError, setBulkResolveError] = useState<string | null>(null);
   const toggleIncidentSelected = (id: string) => {
     setSelectedIncidentIds((prev) => {
       const next = new Set(prev);
@@ -943,8 +954,12 @@ export default function AiMonitorPage() {
       else next.add(id);
       return next;
     });
+    setBulkResolveError(null);
   };
-  const clearSelection = () => setSelectedIncidentIds(new Set());
+  const clearSelection = () => {
+    setSelectedIncidentIds(new Set());
+    setBulkResolveError(null);
+  };
 
   const {
     insights,
@@ -1004,9 +1019,6 @@ export default function AiMonitorPage() {
     }
 
     return bySearch;
-    // matchesSearch is a stable closure over searchLower; depending on it
-    // explicitly avoids a stale-closure subtle bug.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [acknowledgementFilter, insights, severityFilter, searchLower]);
 
   // Filter, sort, and bound incidents for the visible list.
@@ -1043,7 +1055,6 @@ export default function AiMonitorPage() {
     }
 
     return result;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [incidentsData, timeRange, incidentSort, searchLower]);
 
   // Apply search to anomalies + health issues so the search box covers every
@@ -1054,33 +1065,44 @@ export default function AiMonitorPage() {
     return correlatedAnomalies.filter((a) =>
       matchesSearch([a.containerName, a.pattern, ...a.metrics.map((m) => m.type)]),
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [correlatedAnomalies, searchLower]);
 
   const filteredHealthIssues = useMemo(() => {
     if (!searchLower) return healthIssues;
     return healthIssues.filter((c) => matchesSearch([c.name, c.image, c.healthStatus]));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [healthIssues, searchLower]);
 
   const handleBulkResolve = async () => {
     if (selectedIncidentIds.size === 0 || isBulkResolving) return;
     setIsBulkResolving(true);
+    setBulkResolveError(null);
     const ids = Array.from(selectedIncidentIds);
-    try {
-      // Concurrency cap of 5 keeps the UI responsive without flooding the
-      // backend; mutateAsync rejects on individual failures but Promise.all
-      // here would short-circuit, so use allSettled and surface failures via
-      // the existing react-query error pipeline.
-      const concurrency = 5;
-      for (let i = 0; i < ids.length; i += concurrency) {
-        const batch = ids.slice(i, i + concurrency);
-        await Promise.allSettled(batch.map((id) => resolveIncidentMutation.mutateAsync(id)));
-      }
-    } finally {
-      clearSelection();
-      setIsBulkResolving(false);
+    const failedIds: string[] = [];
+
+    // Concurrency cap of 5 keeps the UI responsive without flooding the
+    // backend. Per-id success/failure is tracked here rather than via the
+    // mutation hook because mutation.error/data only ever reflects the most
+    // recent call when many run in parallel.
+    const concurrency = 5;
+    for (let i = 0; i < ids.length; i += concurrency) {
+      const batch = ids.slice(i, i + concurrency);
+      const results = await Promise.allSettled(
+        batch.map((id) => resolveIncidentMutation.mutateAsync(id)),
+      );
+      results.forEach((r, idx) => {
+        if (r.status === 'rejected') failedIds.push(batch[idx]);
+      });
     }
+
+    // Keep only failed ids selected so the user can retry without
+    // re-checking each row, and surface the failure count inline.
+    setSelectedIncidentIds(new Set(failedIds));
+    if (failedIds.length > 0) {
+      setBulkResolveError(
+        `Failed to resolve ${failedIds.length} of ${ids.length} incident${ids.length === 1 ? '' : 's'}. Retry from the action bar.`,
+      );
+    }
+    setIsBulkResolving(false);
   };
 
   // Stats
@@ -1472,35 +1494,59 @@ export default function AiMonitorPage() {
           </div>
 
           {/* Bulk-action bar — only renders when something is selected so it
-              doesn't take vertical space at rest. */}
-          {selectedIncidentIds.size > 0 && (
-            <div className="flex items-center justify-between rounded-md border border-primary/40 bg-primary/5 px-4 py-2">
-              <p className="text-sm font-medium">
-                {selectedIncidentIds.size} selected
-              </p>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={clearSelection}
-                  disabled={isBulkResolving}
-                  className="rounded-md border border-input bg-background px-3 py-1 text-xs font-medium hover:bg-accent disabled:opacity-50"
-                >
-                  Clear
-                </button>
-                <button
-                  type="button"
-                  onClick={handleBulkResolve}
-                  disabled={isBulkResolving}
-                  className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
-                >
-                  {isBulkResolving ? (
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                  ) : (
-                    <CheckCircle2 className="h-3 w-3" />
-                  )}
-                  Resolve {selectedIncidentIds.size}
-                </button>
+              doesn't take vertical space at rest. Surfaces partial-failure
+              count inline so the operator knows which retries are pending. */}
+          {(selectedIncidentIds.size > 0 || bulkResolveError) && (
+            <div
+              data-testid="bulk-action-bar"
+              className={cn(
+                'rounded-md border px-4 py-2',
+                bulkResolveError
+                  ? 'border-red-500/40 bg-red-50/30 dark:bg-red-900/10'
+                  : 'border-primary/40 bg-primary/5',
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">
+                  {selectedIncidentIds.size > 0
+                    ? `${selectedIncidentIds.size} selected`
+                    : 'No incidents selected'}
+                </p>
+                {selectedIncidentIds.size > 0 && (
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={clearSelection}
+                      disabled={isBulkResolving}
+                      className="rounded-md border border-input bg-background px-3 py-1 text-xs font-medium hover:bg-accent disabled:opacity-50"
+                    >
+                      Clear
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleBulkResolve}
+                      disabled={isBulkResolving}
+                      className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                    >
+                      {isBulkResolving ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <CheckCircle2 className="h-3 w-3" />
+                      )}
+                      Resolve {selectedIncidentIds.size}
+                    </button>
+                  </div>
+                )}
               </div>
+              {bulkResolveError && (
+                <p
+                  role="alert"
+                  data-testid="bulk-resolve-error"
+                  className="mt-2 text-xs text-red-700 dark:text-red-400"
+                >
+                  {bulkResolveError}
+                </p>
+              )}
             </div>
           )}
 

--- a/frontend/src/features/observability/pages/metrics-dashboard.test.tsx
+++ b/frontend/src/features/observability/pages/metrics-dashboard.test.tsx
@@ -145,6 +145,13 @@ vi.mock('@/features/ai-intelligence/components/metrics/correlation-insights-pane
   CorrelationInsightsPanel: () => <div data-testid="correlation-insights-panel" />,
 }));
 
+// Stub AutoRefreshToggle: its real implementation now renders a native <select>
+// which would appear before the page's own endpoint/stack/container selects in
+// the combobox role-list and shift these tests' index-based selectors.
+vi.mock('@/shared/components/ui/auto-refresh-toggle', () => ({
+  AutoRefreshToggle: () => <div data-testid="mock-auto-refresh" />,
+}));
+
 import MetricsDashboardPage from './metrics-dashboard';
 
 function renderPage() {

--- a/frontend/src/shared/components/ui/auto-refresh-toggle.test.tsx
+++ b/frontend/src/shared/components/ui/auto-refresh-toggle.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AutoRefreshToggle } from './auto-refresh-toggle';
+
+describe('AutoRefreshToggle', () => {
+  it('renders the current interval label when off', () => {
+    render(<AutoRefreshToggle interval={0} onIntervalChange={vi.fn()} />);
+    expect(screen.getByText(/Auto-refresh: Off/i)).toBeTruthy();
+  });
+
+  it('renders the current interval label when active', () => {
+    render(<AutoRefreshToggle interval={30} onIntervalChange={vi.fn()} />);
+    // The label appears once in the visible <span> and again in the <option>
+    // shadow rendered by the native <select>. Both appearances are correct;
+    // assert at least one and inspect the label specifically.
+    expect(screen.getAllByText(/Every 30s/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('calls onIntervalChange with the chosen interval value', () => {
+    const onChange = vi.fn();
+    render(<AutoRefreshToggle interval={0} onIntervalChange={onChange} />);
+
+    const select = screen.getByLabelText('Auto-refresh interval') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '60' } });
+
+    expect(onChange).toHaveBeenCalledWith(60);
+  });
+
+  it('exposes all six interval options as <option> elements', () => {
+    render(<AutoRefreshToggle interval={30} onIntervalChange={vi.fn()} />);
+    const select = screen.getByLabelText('Auto-refresh interval') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    // Off / 15s / 30s / 1m / 2m / 5m
+    expect(optionValues).toEqual(['0', '15', '30', '60', '120', '300']);
+  });
+
+  it('coerces the select value to a number before invoking the callback', () => {
+    const onChange = vi.fn();
+    render(<AutoRefreshToggle interval={0} onIntervalChange={onChange} />);
+    const select = screen.getByLabelText('Auto-refresh interval') as HTMLSelectElement;
+
+    fireEvent.change(select, { target: { value: '300' } });
+
+    // The onChange must receive a number, not the string '300', so the
+    // RefreshInterval discriminated union stays well-typed at the boundary.
+    const arg = onChange.mock.calls[0][0];
+    expect(typeof arg).toBe('number');
+    expect(arg).toBe(300);
+  });
+});

--- a/frontend/src/shared/components/ui/auto-refresh-toggle.tsx
+++ b/frontend/src/shared/components/ui/auto-refresh-toggle.tsx
@@ -1,4 +1,4 @@
-import { Timer, TimerOff } from 'lucide-react';
+import { ChevronDown, Timer, TimerOff } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { type RefreshInterval } from '@/shared/hooks/use-auto-refresh';
 
@@ -17,42 +17,52 @@ interface AutoRefreshToggleProps {
   className?: string;
 }
 
+/**
+ * Compact auto-refresh selector. Replaced the inline pill-row of 6 buttons
+ * (~280px) with a single dropdown to free up header real estate while keeping
+ * the same set of intervals. Native `<select>` for built-in keyboard support
+ * and screen-reader semantics.
+ */
 export function AutoRefreshToggle({ interval, onIntervalChange, className }: AutoRefreshToggleProps) {
   const isActive = interval > 0;
+  const selected = INTERVALS.find((opt) => opt.value === interval) ?? INTERVALS[0];
 
   return (
-    <div className={cn('inline-flex h-10 items-center gap-1 rounded-full border border-input bg-background p-1', className)}>
-      {INTERVALS.map((opt) => {
-        const isSelected = interval === opt.value;
-        const isOff = opt.value === 0;
-        return (
-          <button
-            key={opt.value}
-            onClick={() => onIntervalChange(opt.value)}
-            className={cn(
-              'inline-flex h-8 items-center gap-1.5 rounded-full px-3 text-sm font-medium transition-colors',
-              isSelected
-                ? isOff
-                  ? 'bg-muted text-foreground'
-                  : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-                : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-            )}
-          >
-            {isOff && (
-              isSelected
-                ? <TimerOff className="h-3.5 w-3.5" />
-                : <TimerOff className="h-3.5 w-3.5" />
-            )}
-            {!isOff && isSelected && (
-              <Timer className="h-3.5 w-3.5" />
-            )}
-            {opt.label}
-          </button>
-        );
-      })}
-      {isActive && (
-        <span className="ml-1 mr-1.5 h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
+    <label
+      className={cn(
+        'relative inline-flex h-10 items-center gap-2 rounded-full border border-input bg-background pl-3 pr-8 text-sm font-medium cursor-pointer transition-colors hover:bg-muted/30',
+        className,
       )}
-    </div>
+    >
+      {isActive ? (
+        <Timer className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+      ) : (
+        <TimerOff className="h-4 w-4 text-muted-foreground" />
+      )}
+      <span
+        className={cn(
+          'tabular-nums',
+          isActive ? 'text-foreground' : 'text-muted-foreground',
+        )}
+      >
+        {selected.label === 'Off' ? 'Auto-refresh: Off' : `Every ${selected.label}`}
+      </span>
+      {isActive && (
+        <span className="h-2 w-2 rounded-full bg-emerald-500 animate-pulse" aria-hidden />
+      )}
+      <ChevronDown className="absolute right-2.5 h-4 w-4 text-muted-foreground" aria-hidden />
+      <select
+        value={interval}
+        onChange={(e) => onIntervalChange(Number(e.target.value) as RefreshInterval)}
+        aria-label="Auto-refresh interval"
+        className="absolute inset-0 cursor-pointer rounded-full opacity-0"
+      >
+        {INTERVALS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label === 'Off' ? 'Off' : `Every ${opt.label}`}
+          </option>
+        ))}
+      </select>
+    </label>
   );
 }

--- a/packages/foundation/src/__tests__/endpoints-route.test.ts
+++ b/packages/foundation/src/__tests__/endpoints-route.test.ts
@@ -87,6 +87,43 @@ describe('Endpoints Routes', () => {
       expect(body).toEqual([]);
     });
 
+    it('returns 502 (not 401) when upstream Portainer returns 401', async () => {
+      // Regression: an upstream Portainer auth failure must NOT surface as 401.
+      // The frontend api client treats 401 as "session expired" and clears the
+      // user's token, which would bounce a logged-in user back to /login
+      // whenever PORTAINER_API_KEY is missing or invalid.
+      const portainerAuthError = Object.assign(new Error('Auth failed: 401'), {
+        name: 'PortainerError',
+        kind: 'auth',
+        status: 401,
+      });
+      vi.spyOn(portainerClient, 'getEndpoints').mockRejectedValue(portainerAuthError);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/endpoints',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(502);
+      const body = JSON.parse(response.body);
+      expect(body.error).toMatch(/Portainer/i);
+    });
+
+    it('returns 502 when upstream Portainer is unreachable', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockRejectedValue(
+        new Error('ECONNREFUSED'),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/endpoints',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(502);
+    });
+
     it('requires authentication', async () => {
       const unauthApp = Fastify({ logger: false });
       unauthApp.setValidatorCompiler(validatorCompiler);
@@ -126,9 +163,13 @@ describe('Endpoints Routes', () => {
       expect(body.name).toBe('prod');
     });
 
-    it('propagates errors from portainer client', async () => {
+    it('returns 502 when upstream Portainer fails', async () => {
       vi.spyOn(portainerClient, 'getEndpoint').mockRejectedValue(
-        Object.assign(new Error('Not Found'), { statusCode: 404 }),
+        Object.assign(new Error('Auth failed: 401'), {
+          name: 'PortainerError',
+          kind: 'auth',
+          status: 401,
+        }),
       );
 
       const response = await app.inject({
@@ -137,8 +178,7 @@ describe('Endpoints Routes', () => {
         headers: { authorization: 'Bearer test' },
       });
 
-      // Fastify propagates the error; exact status depends on error type
-      expect(response.statusCode).toBeGreaterThanOrEqual(400);
+      expect(response.statusCode).toBe(502);
     });
   });
 

--- a/packages/foundation/src/routes/endpoints.ts
+++ b/packages/foundation/src/routes/endpoints.ts
@@ -3,6 +3,9 @@ import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { normalizeEndpoint } from '@dashboard/core/portainer/portainer-normalizers.js';
 import { EndpointIdParamsSchema } from '@dashboard/core/models/api-schemas.js';
+import { createChildLogger } from '@dashboard/core/utils/logger.js';
+
+const log = createChildLogger('route:endpoints');
 
 export async function endpointsRoutes(fastify: FastifyInstance) {
   fastify.get('/api/endpoints', {
@@ -12,13 +15,24 @@ export async function endpointsRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
     },
     preHandler: [fastify.authenticate],
-  }, async () => {
-    const endpoints = await cachedFetch(
-      getCacheKey('endpoints'),
-      TTL.ENDPOINTS,
-      () => portainer.getEndpoints(),
-    );
-    return endpoints.map(normalizeEndpoint);
+  }, async (_request, reply) => {
+    // Upstream Portainer failures (including 401 from Portainer itself) must
+    // surface as 502 Bad Gateway, not 401. The frontend treats 401 as
+    // "session expired" and clears the user's auth, which would otherwise
+    // bounce a logged-in user back to /login on every page load when the
+    // dashboard's PORTAINER_API_KEY is missing or invalid.
+    try {
+      const endpoints = await cachedFetch(
+        getCacheKey('endpoints'),
+        TTL.ENDPOINTS,
+        () => portainer.getEndpoints(),
+      );
+      return endpoints.map(normalizeEndpoint);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err }, 'Failed to fetch endpoints from Portainer');
+      return reply.code(502).send({ error: 'Unable to connect to Portainer', details: msg });
+    }
   });
 
   // Diagnostic endpoint: shows raw Portainer data for Edge endpoints
@@ -29,8 +43,15 @@ export async function endpointsRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
     },
     preHandler: [fastify.authenticate],
-  }, async () => {
-    const endpoints = await portainer.getEndpoints();
+  }, async (_request, reply) => {
+    let endpoints;
+    try {
+      endpoints = await portainer.getEndpoints();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err }, 'Failed to fetch endpoints from Portainer (edge-status)');
+      return reply.code(502).send({ error: 'Unable to connect to Portainer', details: msg });
+    }
     return endpoints.map((ep) => {
       const normalized = normalizeEndpoint(ep);
       return {
@@ -62,13 +83,19 @@ export async function endpointsRoutes(fastify: FastifyInstance) {
       params: EndpointIdParamsSchema,
     },
     preHandler: [fastify.authenticate],
-  }, async (request) => {
+  }, async (request, reply) => {
     const { id } = request.params as { id: number };
-    const endpoint = await cachedFetch(
-      getCacheKey('endpoint', id),
-      TTL.ENDPOINTS,
-      () => portainer.getEndpoint(id),
-    );
-    return normalizeEndpoint(endpoint);
+    try {
+      const endpoint = await cachedFetch(
+        getCacheKey('endpoint', id),
+        TTL.ENDPOINTS,
+        () => portainer.getEndpoint(id),
+      );
+      return normalizeEndpoint(endpoint);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err, id }, 'Failed to fetch endpoint from Portainer');
+      return reply.code(502).send({ error: 'Unable to connect to Portainer', details: msg });
+    }
   });
 }


### PR DESCRIPTION
## Summary

Two related changes on the Health & Monitoring page and the upstream-error path that bounces users out of it.

### 1. Backend: `/api/endpoints` no longer leaks Portainer 401 to clients
Upstream Portainer auth failures (e.g. missing/invalid `PORTAINER_API_KEY`) used to surface as a 401 to the browser. The frontend api client treats any 401 as "session expired" and clears the user's token — bouncing logged-in users back to `/login` on every page load. The route now wraps each handler in try/catch and replies **502 Bad Gateway** on `PortainerError`, matching the pattern already used in `stacks.ts` / `containers.ts`.

### 2. Frontend: Health & Monitoring page UX overhaul
The page audit surfaced nine issues; this PR addresses every one.

**Hero / score**
- Health Score formula changed from `healthy / total` (which dragged 87% fleets down to "12.7%" because containers without healthchecks were in the denominator) to `healthy / (healthy + unhealthy)`. Returns `null` when no container reports a health signal — UI shows "No healthchecks configured" instead of a misleading zero.
- New `noHealthcheck` cohort surfaced explicitly as a 4th stat tile.
- Hero + two 4-card grids (9 above-the-fold KPIs) collapsed into one Fleet Vitals bento + a slim insight filter row (5 KPIs).

**Triage**
- Stat-card click filters the list (the natural expectation). Live-alert subscription moved to a per-card bell-icon button.
- Time-range filter on incidents (1H / 24H / 7D / All, default 24H), URL-synced via `?range=`.
- Sort by Severity (default) or Recent, URL-synced via `?sort=`.
- Per-row checkbox + bulk-resolve with a concurrency cap of 5.
- Search box (debounced ~150 ms, URL-synced via `?q=`) filters incidents, ML anomalies, container health, and insights uniformly.
- Section split: "Anomalies & Health Issues" → "ML-Detected Anomalies" + "Container Health" with type-appropriate icons.

**Polish**
- Auto-refresh: 6-button pill row (~280 px) → single `Every 30s` dropdown.
- Container chips link to `/containers/:endpointId/:containerId` via a shared `ContainerChip`.
- Incident cards: severity-tinted leading icon (was always purple); correlation type, timestamp, and alert count demoted to one muted metadata line.

## Behavior changes worth flagging

- The Health Score number will change for everyone. Operators who memorised the old "low" score will see a much higher one. The new formula is correct.
- Stat cards now filter on click; live-alert subscription moved to the bell icon. Anyone relying on the old click-to-subscribe behaviour will need to use the bell.
- Default time range on incidents is now 24h. Users will see "(N of M)" with M being the total active count, and can switch to "All" for the old behaviour.

## Test plan

- [x] `npm run test -w frontend` — 1759/1759 passing
- [x] Visual smoke in browser at http://localhost:8080/health (logged in as admin)
- [x] Verified bulk-resolve checkbox surfaces the action bar
- [x] Verified search filters all four list types
- [x] Verified time-range and sort tabs persist via URL
- [x] Verified `/api/endpoints` returns 502 (not 401) when Portainer auth fails — login no longer loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)