### PR TITLE
feat(health): two-level rollup for Active Incidents

### DIFF
--- a/docs/superpowers/plans/2026-05-06-active-incidents-rollup.md
+++ b/docs/superpowers/plans/2026-05-06-active-incidents-rollup.md
@@ -822,7 +822,14 @@ detection_method: 'threshold',
 
 - [ ] **Step 5: Add structured fields to anomaly-context-only emission**
 
-Locate the third anomaly emission near line 458 (search for the third `category: 'anomaly'`). Determine which metric/method it represents from surrounding context; add the appropriate `metric_type` / `detection_method`. (If unclear, default to `metric_type: 'cpu'` and `detection_method: 'threshold'` and leave a TODO comment with `signature.test.ts` reference; the drift CSV will catch any miss.)
+Locate the third anomaly emission near line 458 (search for the third `category: 'anomaly'`). Read the 30 lines above to identify what the emission represents — typically a `metric_type` variable already exists in the surrounding scope (e.g., the loop variable `metricType`) and the detection mode is implied by the function context (z-score → `'ml-anomaly'`, threshold compare → `'threshold'`, prediction series → `'prediction'`). Add the matching pair to the literal:
+
+```ts
+metric_type: metricType,           // existing loop variable
+detection_method: '<mode>',         // 'ml-anomaly' | 'threshold' | 'prediction' per surrounding logic
+```
+
+Verify the choice by adding a corresponding row to the historical-titles CSV (Task 5 fixture) using a real title from this emission and confirming `signature.test.ts` still passes the equivalence assertion. If the equivalence fails, the chosen `detection_method` is wrong — re-read the surrounding code.
 
 - [ ] **Step 6: Add structured fields to prediction emission**
 

--- a/docs/superpowers/plans/2026-05-06-active-incidents-rollup.md
+++ b/docs/superpowers/plans/2026-05-06-active-incidents-rollup.md
@@ -1,0 +1,3267 @@
+# Active Incidents — Two-Level Rollup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the flat 455-row Active Incidents list on `/health` with a two-level rollup (signature group → top-10 containers + Show all) that scales to thousands of incidents and gives a 5-second overview.
+
+**Architecture:** Backend adds a `signature` column on `incidents`, populated at insert time from the source insight's structured fields. A new SQL aggregate endpoint `GET /api/incidents/groups` returns one row per signature with counts, top-10 containers, and the full container-name list for client-side search. A new `POST /api/incidents/resolve` batch endpoint lets the UI resolve a group atomically per-id. Frontend renders a new `IncidentGroupsView` with summary strip, endpoint chips, expandable groups, and the existing search/sort/time-range controls preserved.
+
+**Tech Stack:** PostgreSQL (real DB tests via `test-db-helper`), Fastify 5, TypeScript, Zod, npm workspaces (`packages/core`, `packages/ai-intelligence`), Vitest, React 19 + Vite + TanStack Query, Radix UI, jsdom + `@testing-library/react`.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-active-incidents-rollup-design.md`
+
+**Reference dependency:** Cache utilities (`cachedFetchSWR`, `getCacheKey`, `TTL`, `cache.invalidateTag`) are already in `@dashboard/core/portainer/portainer-cache.js` and importable from `packages/ai-intelligence`. No promotion task needed.
+
+---
+
+## Conventions for this plan
+
+- **Working dir:** repo root unless noted. Commands are zsh.
+- **Backend tests:** `cd packages/ai-intelligence && npx vitest run src/__tests__/<file>.test.ts`. DB-backed tests need `POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test` (see `CLAUDE.md`).
+- **Frontend tests:** `cd frontend && npx vitest run src/features/ai-intelligence/<path>` (must run from `frontend/`).
+- **Commit style:** match existing repo style. Each task ends in one commit per `docs/superpowers/specs/...`. Branch: continue on `feature/health-monitoring-ux-overhaul`.
+- **TDD:** every task writes the failing test first, runs it to confirm failure, implements, runs again to confirm pass, commits.
+- **Do not skip hooks** (`--no-verify` is forbidden by `CLAUDE.md`).
+
+---
+
+### Task 1: Phase A migration — add `signature` column
+
+**Files:**
+- Create: `packages/core/src/db/postgres-migrations/029_add_incident_signature.sql`
+
+**Why:** Non-blocking column add (Postgres metadata-only). Phase B index creation lives in Task 2 because `CREATE INDEX CONCURRENTLY` cannot run inside a transaction, but the migration runner wraps each migration in one.
+
+- [ ] **Step 1: Verify next migration number**
+
+```bash
+ls packages/core/src/db/postgres-migrations/ | tail -3
+```
+
+Expected: highest existing number is `028_*.sql`. Use `029` for the new file.
+
+- [ ] **Step 2: Create the migration file**
+
+Write `packages/core/src/db/postgres-migrations/029_add_incident_signature.sql`:
+
+```sql
+-- Migration 029: add `signature` column to incidents
+--
+-- Backs the two-level rollup on the Health & Monitoring page.
+-- Populated at insert time from the source insight's structured
+-- fields (`category`, `metric_type`, `detection_method`).
+--
+-- Phase A only — column add, no indexes here. The
+-- `CREATE INDEX CONCURRENTLY` step lives in
+-- packages/ai-intelligence/scripts/create-incident-signature-indexes.ts
+-- and is invoked outside any transaction at deploy time.
+
+ALTER TABLE incidents ADD COLUMN IF NOT EXISTS signature TEXT;
+```
+
+- [ ] **Step 3: Apply migration to dev DB**
+
+```bash
+docker compose -f docker/docker-compose.dev.yml up -d postgres-app postgres-test
+# The migration runs automatically on first getDb() call. Trigger it
+# by running the existing test suite once:
+cd packages/ai-intelligence && npx vitest run src/__tests__/incidents.test.ts -t "list incidents"
+```
+
+Expected: tests pass, no migration error in logs.
+
+- [ ] **Step 4: Verify column exists**
+
+```bash
+docker compose -f docker/docker-compose.dev.yml exec postgres-app \
+  psql -U app_user -d portainer_dashboard -c '\d incidents' | grep signature
+```
+
+Expected: `signature | text` line in output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/postgres-migrations/029_add_incident_signature.sql
+git commit -m "feat(incidents): add nullable signature column (Phase A migration)"
+```
+
+---
+
+### Task 2: Phase B index-creation script
+
+**Files:**
+- Create: `packages/ai-intelligence/scripts/create-incident-signature-indexes.ts`
+- Create: `packages/ai-intelligence/scripts/README.md` (only if absent — small index of scripts)
+- Modify: `packages/ai-intelligence/package.json` (add `scripts.indexes:incidents`)
+
+**Why:** `CREATE INDEX CONCURRENTLY` requires running outside any transaction. The auto-migration runner wraps migrations in one, so this lives as a deploy-time script.
+
+- [ ] **Step 1: Write the script**
+
+Write `packages/ai-intelligence/scripts/create-incident-signature-indexes.ts`:
+
+```ts
+#!/usr/bin/env tsx
+/**
+ * Phase B of the incident-signature rollup migration.
+ *
+ * Creates two indexes on the incidents table without holding a
+ * transaction lock — required by Postgres for CONCURRENTLY.
+ *
+ * Idempotent: IF NOT EXISTS guards re-runs.
+ *
+ * Usage (in a deploy step or one-off):
+ *   POSTGRES_APP_URL=postgresql://… npm run -w @dashboard/ai indexes:incidents
+ */
+import { Client } from 'pg';
+
+const APP_URL = process.env.POSTGRES_APP_URL ?? process.env.POSTGRES_URL;
+if (!APP_URL) {
+  console.error('POSTGRES_APP_URL (or POSTGRES_URL) must be set');
+  process.exit(1);
+}
+
+const STATEMENTS = [
+  `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_incidents_signature_status
+     ON incidents (signature, status)`,
+  `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_incidents_endpoint_status
+     ON incidents (endpoint_id, status)`,
+];
+
+async function main() {
+  const client = new Client({ connectionString: APP_URL });
+  await client.connect();
+  try {
+    for (const sql of STATEMENTS) {
+      const start = Date.now();
+      console.log(`> ${sql.split('\n')[0].trim()}`);
+      await client.query(sql);
+      console.log(`  ok (${Date.now() - start} ms)`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Index creation failed:', err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Add npm script entry**
+
+Edit `packages/ai-intelligence/package.json` — add this entry inside `"scripts"`:
+
+```json
+"indexes:incidents": "tsx scripts/create-incident-signature-indexes.ts"
+```
+
+- [ ] **Step 3: Run the script against dev DB**
+
+```bash
+POSTGRES_APP_URL=postgresql://app_user:changeme-postgres-app@localhost:5432/portainer_dashboard \
+  npm run -w @dashboard/ai indexes:incidents
+```
+
+Expected output:
+```
+> CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_incidents_signature_status
+  ok (... ms)
+> CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_incidents_endpoint_status
+  ok (... ms)
+```
+
+- [ ] **Step 4: Re-run to verify idempotency**
+
+Run the same command again. Expected: both statements succeed (no error from `IF NOT EXISTS`).
+
+- [ ] **Step 5: Verify indexes exist**
+
+```bash
+docker compose -f docker/docker-compose.dev.yml exec postgres-app \
+  psql -U app_user -d portainer_dashboard -c '\d incidents' | grep idx_incidents
+```
+
+Expected: two `btree` index lines, one for `(signature, status)`, one for `(endpoint_id, status)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ai-intelligence/scripts/create-incident-signature-indexes.ts \
+        packages/ai-intelligence/package.json
+git commit -m "feat(incidents): Phase B index-creation script (CONCURRENTLY, idempotent)"
+```
+
+---
+
+### Task 3: Add structured fields to the `Insight` model
+
+**Files:**
+- Modify: `packages/core/src/models/monitoring.ts` (Insight Zod schema)
+- Test: `packages/core/src/__tests__/monitoring-schema.test.ts` (create if absent — small)
+
+**Why:** `metric_type` and `detection_method` are the structured inputs to `deriveSignature` (Task 4). Adding them as **optional** fields keeps every existing call site backward-compatible.
+
+- [ ] **Step 1: Find the schema**
+
+```bash
+grep -n "InsightSchema\|insightSchema\|category: z\." packages/core/src/models/monitoring.ts
+```
+
+Expected: location of the `category: z.string()` line previously identified at line 10.
+
+- [ ] **Step 2: Write the failing test**
+
+Create or extend `packages/core/src/__tests__/monitoring-schema.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { InsightSchema } from '../models/monitoring.js';
+
+describe('Insight schema — structured signature inputs', () => {
+  it('accepts optional metric_type and detection_method', () => {
+    const parsed = InsightSchema.parse({
+      id: 'a',
+      endpoint_id: 1,
+      endpoint_name: 'e',
+      container_id: 'c',
+      container_name: 'cn',
+      severity: 'warning',
+      category: 'anomaly',
+      title: 't',
+      description: 'd',
+      suggested_action: null,
+      is_acknowledged: 0,
+      created_at: new Date().toISOString(),
+      metric_type: 'cpu',
+      detection_method: 'ml-anomaly',
+    });
+    expect(parsed.metric_type).toBe('cpu');
+    expect(parsed.detection_method).toBe('ml-anomaly');
+  });
+
+  it('still parses without the new optional fields', () => {
+    const parsed = InsightSchema.parse({
+      id: 'a',
+      endpoint_id: 1,
+      endpoint_name: 'e',
+      container_id: 'c',
+      container_name: 'cn',
+      severity: 'warning',
+      category: 'anomaly',
+      title: 't',
+      description: 'd',
+      suggested_action: null,
+      is_acknowledged: 0,
+      created_at: new Date().toISOString(),
+    });
+    expect(parsed.metric_type).toBeUndefined();
+    expect(parsed.detection_method).toBeUndefined();
+  });
+
+  it('rejects unknown metric_type values', () => {
+    expect(() =>
+      InsightSchema.parse({
+        id: 'a', endpoint_id: 1, endpoint_name: 'e', container_id: 'c',
+        container_name: 'cn', severity: 'warning', category: 'anomaly',
+        title: 't', description: 'd', suggested_action: null,
+        is_acknowledged: 0, created_at: new Date().toISOString(),
+        metric_type: 'bogus',
+      }),
+    ).toThrow();
+  });
+});
+```
+
+- [ ] **Step 3: Run the test, verify failure**
+
+```bash
+cd packages/core && npx vitest run src/__tests__/monitoring-schema.test.ts
+```
+
+Expected: failure (the schema rejects `metric_type` because it isn't declared yet, OR the import succeeds but the field is unknown).
+
+- [ ] **Step 4: Add the fields to the schema**
+
+In `packages/core/src/models/monitoring.ts`, locate the existing Insight definition and add:
+
+```ts
+metric_type: z.enum(['cpu', 'memory', 'disk', 'network', 'restart']).optional(),
+detection_method: z
+  .enum(['threshold', 'ml-anomaly', 'prediction', 'health-check', 'log-pattern', 'security-scan'])
+  .optional(),
+```
+
+(Add these fields immediately after `category` for grouping. If the file has both a Zod schema and a TS interface, mirror the change in the interface as `metric_type?: ...` / `detection_method?: ...`.)
+
+- [ ] **Step 5: Run the test, verify pass**
+
+```bash
+cd packages/core && npx vitest run src/__tests__/monitoring-schema.test.ts
+```
+
+Expected: 3 passing.
+
+- [ ] **Step 6: Run the full core test suite**
+
+```bash
+cd packages/core && npx vitest run
+```
+
+Expected: no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/models/monitoring.ts \
+        packages/core/src/__tests__/monitoring-schema.test.ts
+git commit -m "feat(monitoring): add optional metric_type and detection_method to Insight schema"
+```
+
+---
+
+### Task 4: `signature.ts` derivation module + tests
+
+**Files:**
+- Create: `packages/ai-intelligence/src/services/signature.ts`
+- Test: `packages/ai-intelligence/src/__tests__/signature.test.ts`
+
+**Why:** Single source of truth for signature derivation, used by both `buildIncident()` (Task 7) and the backfill (Task 8). Pure module — easy to test in isolation.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `packages/ai-intelligence/src/__tests__/signature.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  deriveSignature,
+  deriveSignatureFromTitle,
+  signatureLabel,
+  slugifyTitle,
+} from '../services/signature.js';
+
+describe('deriveSignature — structured-field path', () => {
+  it('uses metric_type + detection_method when both present', () => {
+    expect(
+      deriveSignature({
+        category: 'anomaly',
+        metric_type: 'cpu',
+        detection_method: 'ml-anomaly',
+        title: 'whatever',
+      }),
+    ).toBe('anomaly:ml-anomaly:cpu');
+  });
+
+  it('encodes prediction:memory correctly', () => {
+    expect(
+      deriveSignature({
+        category: 'predictive',
+        metric_type: 'memory',
+        detection_method: 'prediction',
+        title: 'Predicted memory exhaustion ~24h',
+      }),
+    ).toBe('predictive:prediction:memory');
+  });
+});
+
+describe('deriveSignature — category-only fallbacks', () => {
+  it('returns security:scan for security category', () => {
+    expect(
+      deriveSignature({ category: 'security', title: 'CVE-2024-1234 in container x' }),
+    ).toBe('security:scan');
+  });
+  it('returns log:pattern for log-analysis category', () => {
+    expect(deriveSignature({ category: 'log-analysis', title: 'OOM in logs' })).toBe('log:pattern');
+  });
+  it('returns ai:analysis for ai-analysis category', () => {
+    expect(deriveSignature({ category: 'ai-analysis', title: 'AI summary' })).toBe('ai:analysis');
+  });
+});
+
+describe('deriveSignatureFromTitle — title regex fallback', () => {
+  it('matches "Predicted X exhaustion"', () => {
+    expect(deriveSignatureFromTitle('Predicted memory exhaustion on "x" ~24h'))
+      .toBe('predictive:prediction:memory');
+    expect(deriveSignatureFromTitle('Predicted cpu exhaustion on "x" ~6h'))
+      .toBe('predictive:prediction:cpu');
+  });
+
+  it('matches "Anomalous X usage"', () => {
+    expect(deriveSignatureFromTitle('Anomalous cpu usage on "x" (ML-detected)'))
+      .toBe('anomaly:ml-anomaly:cpu');
+    expect(deriveSignatureFromTitle('Anomalous memory usage on "x"'))
+      .toBe('anomaly:threshold:memory');
+  });
+
+  it('matches "High X usage"', () => {
+    expect(deriveSignatureFromTitle('High cpu usage on "x"'))
+      .toBe('anomaly:threshold:cpu');
+  });
+
+  it('matches "no health check"', () => {
+    expect(deriveSignatureFromTitle('Container x has no health check configured'))
+      .toBe('config:health-check:missing');
+  });
+
+  it('matches "host network mode"', () => {
+    expect(deriveSignatureFromTitle('Container x using host network mode'))
+      .toBe('config:network:host-mode');
+  });
+
+  it('falls through to unknown:<slug> on no match', () => {
+    expect(deriveSignatureFromTitle('Some bizarre new thing happened'))
+      .toMatch(/^unknown:/);
+  });
+});
+
+describe('slugifyTitle', () => {
+  it('strips commas (signatures cannot contain commas — used as URL separator)', () => {
+    expect(slugifyTitle('a, b, c')).not.toContain(',');
+  });
+  it('lowercases and dashes', () => {
+    expect(slugifyTitle('Hello World')).toBe('hello-world');
+  });
+});
+
+describe('signatureLabel', () => {
+  it('returns curated label for known signature', () => {
+    expect(signatureLabel('predictive:prediction:memory')).toBe('Predicted memory exhaustion');
+  });
+  it('falls back to humanized form for unknown', () => {
+    expect(signatureLabel('anomaly:threshold:disk')).toBe('Anomaly · threshold · disk');
+  });
+});
+
+describe('equivalence — regex output equals structured-field output', () => {
+  // For each title pattern, the regex must produce the same signature
+  // the structured-field path would for the same problem class.
+  const cases = [
+    { title: 'Anomalous cpu usage on "x" (ML-detected)',
+      structured: { category: 'anomaly', metric_type: 'cpu' as const, detection_method: 'ml-anomaly' as const } },
+    { title: 'Anomalous memory usage on "x"',
+      structured: { category: 'anomaly', metric_type: 'memory' as const, detection_method: 'threshold' as const } },
+    { title: 'Predicted memory exhaustion on "x" ~24h',
+      structured: { category: 'predictive', metric_type: 'memory' as const, detection_method: 'prediction' as const } },
+    { title: 'Predicted cpu exhaustion on "x" ~6h',
+      structured: { category: 'predictive', metric_type: 'cpu' as const, detection_method: 'prediction' as const } },
+    { title: 'High cpu usage on "x"',
+      structured: { category: 'anomaly', metric_type: 'cpu' as const, detection_method: 'threshold' as const } },
+  ];
+
+  for (const c of cases) {
+    it(`"${c.title}" — regex matches structured`, () => {
+      const fromRegex = deriveSignatureFromTitle(c.title);
+      const fromStructured = deriveSignature({ ...c.structured, title: c.title });
+      expect(fromRegex).toBe(fromStructured);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd packages/ai-intelligence && npx vitest run src/__tests__/signature.test.ts
+```
+
+Expected: failure ("Cannot find module '../services/signature.js'" or similar).
+
+- [ ] **Step 3: Implement signature.ts**
+
+Create `packages/ai-intelligence/src/services/signature.ts`:
+
+```ts
+import type { Insight } from '@dashboard/core/models/monitoring.js';
+
+type DerivableInsight = Pick<Insight, 'category' | 'metric_type' | 'detection_method' | 'title'>;
+
+const SIGNATURE_LABELS: Record<string, string> = {
+  'anomaly:ml-anomaly:cpu': 'Anomalous CPU usage (ML)',
+  'anomaly:ml-anomaly:memory': 'Anomalous memory usage (ML)',
+  'anomaly:threshold:cpu': 'High CPU usage',
+  'anomaly:threshold:memory': 'High memory usage',
+  'predictive:prediction:cpu': 'Predicted CPU exhaustion',
+  'predictive:prediction:memory': 'Predicted memory exhaustion',
+  'predictive:prediction:disk': 'Predicted disk exhaustion',
+  'config:health-check:missing': 'Missing health check',
+  'config:network:host-mode': 'Host network mode',
+  'security:scan': 'Security scan finding',
+  'log:pattern': 'Log pattern detected',
+  'ai:analysis': 'AI analysis finding',
+};
+
+export function deriveSignature(input: DerivableInsight): string {
+  if (input.metric_type && input.detection_method) {
+    return `${input.category}:${input.detection_method}:${input.metric_type}`;
+  }
+  if (input.category === 'security') return 'security:scan';
+  if (input.category === 'log-analysis') return 'log:pattern';
+  if (input.category === 'ai-analysis') return 'ai:analysis';
+  return deriveSignatureFromTitle(input.title);
+}
+
+const TITLE_RULES: Array<{ rx: RegExp; signature: (m: RegExpExecArray) => string }> = [
+  // Predictions: "Predicted memory exhaustion …"
+  {
+    rx: /predicted\s+(cpu|memory|disk)\s+exhaustion/i,
+    signature: (m) => `predictive:prediction:${m[1].toLowerCase()}`,
+  },
+  // Anomalous via ML: "Anomalous cpu usage on "x" (ML-detected)"
+  {
+    rx: /anomalous\s+(cpu|memory|disk)\s+usage[^()]*\(ml-detected\)/i,
+    signature: (m) => `anomaly:ml-anomaly:${m[1].toLowerCase()}`,
+  },
+  // Anomalous threshold: "Anomalous cpu usage on "x"" (no ML qualifier)
+  {
+    rx: /anomalous\s+(cpu|memory|disk)\s+usage/i,
+    signature: (m) => `anomaly:threshold:${m[1].toLowerCase()}`,
+  },
+  // Threshold: "High cpu usage on "x""
+  {
+    rx: /high\s+(cpu|memory|disk)\s+usage/i,
+    signature: (m) => `anomaly:threshold:${m[1].toLowerCase()}`,
+  },
+  // Config: missing health check
+  {
+    rx: /no health check (configured|defined)|missing health check/i,
+    signature: () => 'config:health-check:missing',
+  },
+  // Config: host network mode
+  {
+    rx: /host network mode/i,
+    signature: () => 'config:network:host-mode',
+  },
+];
+
+export function deriveSignatureFromTitle(title: string): string {
+  for (const rule of TITLE_RULES) {
+    const m = rule.rx.exec(title);
+    if (m) return rule.signature(m);
+  }
+  return `unknown:${slugifyTitle(title)}`;
+}
+
+export function slugifyTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[",]/g, '')          // strip commas (URL separator) and quotes
+    .replace(/[^a-z0-9]+/g, '-')   // any non-alnum → dash
+    .replace(/^-+|-+$/g, '')       // trim dashes
+    .slice(0, 80);                  // bound length
+}
+
+export function signatureLabel(signature: string): string {
+  return SIGNATURE_LABELS[signature] ?? humanizeSignature(signature);
+}
+
+function humanizeSignature(signature: string): string {
+  return signature
+    .split(':')
+    .map((s) => s.replace(/-/g, ' '))
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(' · ');
+}
+
+export { SIGNATURE_LABELS };
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd packages/ai-intelligence && npx vitest run src/__tests__/signature.test.ts
+```
+
+Expected: all tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ai-intelligence/src/services/signature.ts \
+        packages/ai-intelligence/src/__tests__/signature.test.ts
+git commit -m "feat(incidents): signature derivation module + tests"
+```
+
+---
+
+### Task 5: Historical-titles dump + drift CSV + corpus assertions
+
+**Files:**
+- Create: `packages/ai-intelligence/scripts/dump-historical-titles.ts`
+- Create: `packages/ai-intelligence/src/__tests__/fixtures/historical-titles.csv`
+- Modify: `packages/ai-intelligence/src/__tests__/signature.test.ts` (add corpus block)
+
+**Why:** Drift verification (spec §3.4) — every legacy title must derive a signature that matches the structured-field path.
+
+- [ ] **Step 1: Write the dump script**
+
+Create `packages/ai-intelligence/scripts/dump-historical-titles.ts`:
+
+```ts
+#!/usr/bin/env tsx
+/**
+ * Exports a sample of historical incident titles (and their root insight
+ * structured fields, where available) to a CSV usable as a drift-test
+ * corpus.
+ *
+ * Usage:
+ *   POSTGRES_APP_URL=postgresql://… npm run -w @dashboard/ai dump:titles \
+ *     > packages/ai-intelligence/src/__tests__/fixtures/historical-titles.csv
+ */
+import { Client } from 'pg';
+
+const APP_URL = process.env.POSTGRES_APP_URL ?? process.env.POSTGRES_URL;
+if (!APP_URL) { console.error('POSTGRES_APP_URL must be set'); process.exit(1); }
+
+const SQL = `
+  SELECT DISTINCT
+    i.title AS incident_title,
+    ins.category,
+    ins.metric_type,
+    ins.detection_method
+  FROM incidents i
+  LEFT JOIN insights ins ON ins.id = i.root_cause_insight_id
+  ORDER BY i.title
+  LIMIT 500
+`;
+
+async function main() {
+  const client = new Client({ connectionString: APP_URL });
+  await client.connect();
+  try {
+    const r = await client.query(SQL);
+    console.log('title,category,metric_type,detection_method');
+    for (const row of r.rows) {
+      const csv = [row.incident_title, row.category, row.metric_type, row.detection_method]
+        .map((v) => v == null ? '' : `"${String(v).replace(/"/g, '""')}"`)
+        .join(',');
+      console.log(csv);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });
+```
+
+- [ ] **Step 2: Add the npm script**
+
+Edit `packages/ai-intelligence/package.json` — add inside `"scripts"`:
+
+```json
+"dump:titles": "tsx scripts/dump-historical-titles.ts"
+```
+
+- [ ] **Step 3: Seed the corpus CSV**
+
+Create `packages/ai-intelligence/src/__tests__/fixtures/historical-titles.csv` with a starter corpus (replace with real exported data when run against prod):
+
+```csv
+title,category,metric_type,detection_method
+"Anomalous cpu usage on ""docker-postgres-app-1"" (ML-detected)",anomaly,cpu,ml-anomaly
+"Anomalous memory usage on ""docker-postgres-app-1""",anomaly,memory,threshold
+"Predicted memory exhaustion on ""docker-postgres-app-1"" ~24h",predictive,memory,prediction
+"Predicted cpu exhaustion on ""docker-timescale-backup-1"" ~6h",predictive,cpu,prediction
+"High cpu usage on ""portainer-portainer-1""",anomaly,cpu,threshold
+"Container ""nginx"" has no health check configured",,,
+"Container ""custom"" using host network mode",,,
+```
+
+- [ ] **Step 4: Add the corpus assertion to the existing test file**
+
+Append to `packages/ai-intelligence/src/__tests__/signature.test.ts`:
+
+```ts
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('drift corpus — historical titles', () => {
+  const csvPath = path.join(__dirname, 'fixtures/historical-titles.csv');
+  const text = fs.readFileSync(csvPath, 'utf8').trim();
+  const [, ...rows] = text.split('\n');
+
+  const records = rows.map((r) => {
+    // Naive CSV parser sufficient for our quoted format.
+    const cells: string[] = [];
+    let cur = ''; let inQuote = false;
+    for (let i = 0; i < r.length; i++) {
+      const ch = r[i];
+      if (ch === '"') {
+        if (inQuote && r[i + 1] === '"') { cur += '"'; i++; }
+        else { inQuote = !inQuote; }
+      } else if (ch === ',' && !inQuote) { cells.push(cur); cur = ''; }
+      else { cur += ch; }
+    }
+    cells.push(cur);
+    const [title, category, metric_type, detection_method] = cells;
+    return { title, category, metric_type: metric_type || undefined, detection_method: detection_method || undefined };
+  });
+
+  it('every row derives a non-unknown signature', () => {
+    for (const r of records) {
+      const sig = deriveSignatureFromTitle(r.title);
+      expect(sig, `title="${r.title}"`).not.toMatch(/^unknown:/);
+    }
+  });
+
+  it('regex output equals structured-field output (when fields present)', () => {
+    for (const r of records) {
+      if (!r.category) continue;
+      const fromRegex = deriveSignatureFromTitle(r.title);
+      const fromStructured = deriveSignature({
+        category: r.category,
+        metric_type: r.metric_type as Insight['metric_type'],
+        detection_method: r.detection_method as Insight['detection_method'],
+        title: r.title,
+      });
+      expect(fromRegex, `title="${r.title}"`).toBe(fromStructured);
+    }
+  });
+});
+```
+
+Also add the import at the top of the test file:
+
+```ts
+import type { Insight } from '@dashboard/core/models/monitoring.js';
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd packages/ai-intelligence && npx vitest run src/__tests__/signature.test.ts
+```
+
+Expected: all tests passing including the corpus block.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ai-intelligence/scripts/dump-historical-titles.ts \
+        packages/ai-intelligence/src/__tests__/fixtures/historical-titles.csv \
+        packages/ai-intelligence/src/__tests__/signature.test.ts \
+        packages/ai-intelligence/package.json
+git commit -m "test(incidents): drift corpus + dump script for signature derivation"
+```
+
+---
+
+### Task 6: `monitoring-service` emits structured fields
+
+**Files:**
+- Modify: `packages/ai-intelligence/src/services/monitoring-service.ts`
+- Test: `packages/ai-intelligence/src/__tests__/monitoring-service-emission.test.ts` (create — small)
+
+**Why:** With the structured fields populated on emission, `deriveSignature` (Task 4) takes the preferred path instead of falling through to title regex.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/ai-intelligence/src/__tests__/monitoring-service-emission.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { InsightSchema } from '@dashboard/core/models/monitoring.js';
+
+// We assert at the schema layer rather than running the full service
+// (which depends on Portainer / DB / metrics). The principle: every
+// path in monitoring-service.ts that pushes an Insight literal MUST
+// include metric_type and detection_method when the category is
+// 'anomaly' or 'predictive'. If a future emission path forgets, this
+// test does not catch it — but the typecheck below will.
+describe('Insight emission — structured fields are typeable', () => {
+  it('an anomaly insight with structured fields parses', () => {
+    const insight = {
+      id: '1',
+      endpoint_id: 1,
+      endpoint_name: 'e',
+      container_id: 'c',
+      container_name: 'cn',
+      severity: 'warning' as const,
+      category: 'anomaly',
+      title: 'Anomalous cpu usage on "x"',
+      description: 'd',
+      suggested_action: null,
+      is_acknowledged: 0,
+      created_at: new Date().toISOString(),
+      metric_type: 'cpu' as const,
+      detection_method: 'ml-anomaly' as const,
+    };
+    expect(() => InsightSchema.parse(insight)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify it passes (it's an enabling test)**
+
+```bash
+cd packages/ai-intelligence && npx vitest run src/__tests__/monitoring-service-emission.test.ts
+```
+
+Expected: pass. (This test is the type-anchor: if Task 3's fields aren't on the schema, it fails.)
+
+- [ ] **Step 3: Add structured fields to ML-anomaly emission**
+
+In `packages/ai-intelligence/src/services/monitoring-service.ts`, locate the anomaly insight push around line 350–367 (search for `Anomalous ${item.metricType}`). Add to the object literal alongside `category: 'anomaly'`:
+
+```ts
+metric_type: item.metricType as 'cpu' | 'memory',
+detection_method: 'ml-anomaly',
+```
+
+- [ ] **Step 4: Add structured fields to threshold emission**
+
+In the same file, locate the high-threshold emission around line 397–417 (search for `High ${metricType}`). Add to the literal:
+
+```ts
+metric_type: metricType,
+detection_method: 'threshold',
+```
+
+- [ ] **Step 5: Add structured fields to anomaly-context-only emission**
+
+Locate the third anomaly emission near line 458 (search for the third `category: 'anomaly'`). Determine which metric/method it represents from surrounding context; add the appropriate `metric_type` / `detection_method`. (If unclear, default to `metric_type: 'cpu'` and `detection_method: 'threshold'` and leave a TODO comment with `signature.test.ts` reference; the drift CSV will catch any miss.)
+
+- [ ] **Step 6: Add structured fields to prediction emission**
+
+Locate `category: 'predictive'` (line 498). Add:
+
+```ts
+metric_type: predictedMetric, // 'cpu' | 'memory' from surrounding code
+detection_method: 'prediction',
+```
+
+- [ ] **Step 7: Add structured fields to log-analysis emission**
+
+Locate `category: 'log-analysis'` (line 564). Add:
+
+```ts
+detection_method: 'log-pattern',
+```
+
+(`metric_type` typically not applicable for log-pattern; leave it omitted — `deriveSignature` falls back to category-only `log:pattern`.)
+
+- [ ] **Step 8: Add structured fields to ai-analysis emission**
+
+Locate `category: 'ai-analysis'` (line 625). Leave both fields omitted — category-only fallback handles it.
+
+- [ ] **Step 9: Add structured fields to security emissions**
+
+In `packages/ai-intelligence/src/routes/monitoring.ts` lines 264 and 293 (the two `category: 'security'` literals), add:
+
+```ts
+detection_method: 'security-scan',
+```
+
+- [ ] **Step 10: Run the existing monitoring service tests**
+
+```bash
+cd packages/ai-intelligence && npx vitest run src/__tests__/
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add packages/ai-intelligence/src/services/monitoring-service.ts \
+        packages/ai-intelligence/src/routes/monitoring.ts \
+        packages/ai-intelligence/src/__tests__/monitoring-service-emission.test.ts
+git commit -m "feat(monitoring): emit structured metric_type and detection_method on insights"
+```
+
+---
+
+### Task 7: `incident-correlator` writes `signature` on insert
+
+**Files:**
+- Modify: `packages/ai-intelligence/src/services/incident-correlator.ts`
+- Modify: `packages/ai-intelligence/src/services/incident-store.ts`
+- Test: `packages/ai-intelligence/src/__tests__/incident-correlator.test.ts` (additions — likely an existing file)
+
+**Why:** Live writes start populating the `signature` column. From this point onward, every new incident has a signature.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/ai-intelligence/src/__tests__/incident-correlator.test.ts` (create file if absent — follow the `incidents.test.ts` style for DB setup):
+
+```ts
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+import { correlateInsights } from '../services/incident-correlator.js';
+import { insertInsights } from '../services/insights-store.js';
+import type { InsightInsert } from '../services/insights-store.js';
+
+describe('correlateInsights — writes signature', () => {
+  beforeEach(async () => {
+    await getTestDb();
+    await truncateTestTables(['incidents', 'insights']);
+  });
+  afterAll(async () => { await closeTestDb(); });
+
+  it('writes signature derived from structured fields', async () => {
+    const insights: InsightInsert[] = [
+      {
+        id: 'i1', endpoint_id: 1, endpoint_name: 'e', container_id: 'c1', container_name: 'cn1',
+        severity: 'warning', category: 'anomaly',
+        metric_type: 'cpu', detection_method: 'ml-anomaly',
+        title: 'Anomalous cpu usage on "cn1"', description: 'd', suggested_action: null,
+      },
+      {
+        id: 'i2', endpoint_id: 1, endpoint_name: 'e', container_id: 'c1', container_name: 'cn1',
+        severity: 'warning', category: 'anomaly',
+        metric_type: 'cpu', detection_method: 'ml-anomaly',
+        title: 'Anomalous cpu usage on "cn1"', description: 'd', suggested_action: null,
+      },
+    ];
+    await insertInsights(insights);
+    // Re-fetch with structured fields for correlator input
+    const fullInsights = insights.map((i) => ({ ...i, is_acknowledged: 0, created_at: new Date().toISOString() }));
+    await correlateInsights(fullInsights as never);
+
+    const db = await getTestDb();
+    const rows = await db.query<{ signature: string }>(
+      'SELECT signature FROM incidents',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].signature).toBe('anomaly:ml-anomaly:cpu');
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incident-correlator.test.ts
+```
+
+Expected: failure (signature column exists but value is NULL because correlator doesn't write it yet).
+
+- [ ] **Step 3: Update `IncidentInsert` interface**
+
+In `packages/ai-intelligence/src/services/incident-store.ts`, add to the `IncidentInsert` interface (search for `export interface IncidentInsert`):
+
+```ts
+signature: string;
+```
+
+- [ ] **Step 4: Update `insertIncident` SQL**
+
+In the same file, modify the INSERT statement in `insertIncident` to include `signature`:
+
+```ts
+await db.execute(`
+  INSERT INTO incidents (
+    id, title, severity, status, root_cause_insight_id,
+    related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+    correlation_type, correlation_confidence, insight_count, summary, signature,
+    created_at, updated_at
+  ) VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+`, [
+  incident.id,
+  incident.title,
+  incident.severity,
+  incident.root_cause_insight_id,
+  JSON.stringify(incident.related_insight_ids),
+  JSON.stringify(incident.affected_containers),
+  incident.endpoint_id,
+  incident.endpoint_name,
+  incident.correlation_type,
+  incident.correlation_confidence,
+  incident.insight_count,
+  incident.summary,
+  incident.signature,
+]);
+```
+
+- [ ] **Step 5: Update `buildIncident` to compute signature**
+
+In `packages/ai-intelligence/src/services/incident-correlator.ts`, add the import:
+
+```ts
+import { deriveSignature } from './signature.js';
+```
+
+In `buildIncident()` (search for `function buildIncident`), compute and include the signature:
+
+```ts
+const signature = deriveSignature({
+  category: rootCause.category,
+  metric_type: rootCause.metric_type,
+  detection_method: rootCause.detection_method,
+  title: rootCause.title,
+});
+
+return {
+  id: uuidv4(),
+  title,
+  severity,
+  root_cause_insight_id: rootCause.id,
+  related_insight_ids: relatedIds,
+  affected_containers: containers,
+  endpoint_id: rootCause.endpoint_id,
+  endpoint_name: rootCause.endpoint_name,
+  correlation_type: correlationType,
+  correlation_confidence: confidence,
+  insight_count: insights.length,
+  summary,
+  signature,
+};
+```
+
+- [ ] **Step 6: Run, verify pass**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incident-correlator.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Run all incident-related tests**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incidents.test.ts src/__tests__/incidents-jsonb.test.ts
+```
+
+Expected: pass (the existing tests don't assert on signature, but they shouldn't break).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ai-intelligence/src/services/incident-correlator.ts \
+        packages/ai-intelligence/src/services/incident-store.ts \
+        packages/ai-intelligence/src/__tests__/incident-correlator.test.ts
+git commit -m "feat(incidents): write signature on incident insert"
+```
+
+---
+
+### Task 8: Backfill script
+
+**Files:**
+- Create: `packages/ai-intelligence/scripts/backfill-incident-signatures.ts`
+- Test: `packages/ai-intelligence/src/__tests__/incidents-backfill.test.ts`
+- Modify: `packages/ai-intelligence/package.json` (npm script)
+
+**Why:** Existing legacy rows have `NULL` signatures. Backfill populates them with the same `deriveSignature` used by live writes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/ai-intelligence/src/__tests__/incidents-backfill.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+import { backfillSignatures } from '../scripts/backfill-incident-signatures.js';
+
+describe('backfillSignatures', () => {
+  beforeEach(async () => {
+    await getTestDb();
+    await truncateTestTables(['incidents', 'insights']);
+  });
+  afterAll(async () => { await closeTestDb(); });
+
+  it('populates NULL signatures using the root insight category/fields', async () => {
+    const db = await getTestDb();
+    await db.execute(`
+      INSERT INTO insights (id, endpoint_id, endpoint_name, container_id, container_name,
+                            severity, category, title, description, suggested_action,
+                            is_acknowledged, created_at, metric_type, detection_method)
+      VALUES ('ins1', 1, 'e', 'c', 'cn', 'warning', 'anomaly',
+              'Anomalous cpu usage on "cn"', 'd', NULL, false, NOW(), 'cpu', 'ml-anomaly')
+    `);
+    await db.execute(`
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES ('inc1', 'Anomalous cpu usage on "cn"', 'warning', 'active', 'ins1',
+              '[]'::jsonb, '["cn"]'::jsonb, 1, 'e', 'dedup', 'high', 1, NULL,
+              NULL, NOW(), NOW())
+    `);
+    const result = await backfillSignatures({ batchSize: 100, force: false });
+    expect(result.updated).toBe(1);
+
+    const after = await db.queryOne<{ signature: string }>('SELECT signature FROM incidents WHERE id = ?', ['inc1']);
+    expect(after?.signature).toBe('anomaly:ml-anomaly:cpu');
+  });
+
+  it('is idempotent — running again does nothing', async () => {
+    const db = await getTestDb();
+    await db.execute(`
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES ('inc1', 'High cpu usage on "cn"', 'warning', 'active', NULL,
+              '[]'::jsonb, '[]'::jsonb, NULL, NULL, 'temporal', 'medium', 1, NULL,
+              NULL, NOW(), NOW())
+    `);
+    const r1 = await backfillSignatures({ batchSize: 100, force: false });
+    expect(r1.updated).toBe(1);
+    const r2 = await backfillSignatures({ batchSize: 100, force: false });
+    expect(r2.updated).toBe(0);
+  });
+
+  it('handles missing root insight via title fallback', async () => {
+    const db = await getTestDb();
+    await db.execute(`
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES ('inc1', 'Predicted memory exhaustion on "cn" ~24h', 'warning', 'active', 'gone',
+              '[]'::jsonb, '["cn"]'::jsonb, 1, 'e', 'dedup', 'high', 1, NULL,
+              NULL, NOW(), NOW())
+    `);
+    const result = await backfillSignatures({ batchSize: 100, force: false });
+    expect(result.updated).toBe(1);
+
+    const after = await db.queryOne<{ signature: string }>('SELECT signature FROM incidents WHERE id = ?', ['inc1']);
+    expect(after?.signature).toBe('predictive:prediction:memory');
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incidents-backfill.test.ts
+```
+
+Expected: failure (`backfillSignatures` not exported).
+
+- [ ] **Step 3: Implement the backfill function**
+
+Create `packages/ai-intelligence/scripts/backfill-incident-signatures.ts`:
+
+```ts
+#!/usr/bin/env tsx
+/**
+ * Populates the `signature` column on incidents that don't yet have one.
+ *
+ * Idempotent: only updates rows where signature IS NULL by default.
+ * Use --force to re-derive every row.
+ *
+ * Usage:
+ *   POSTGRES_APP_URL=… npm run -w @dashboard/ai backfill:signatures
+ *   POSTGRES_APP_URL=… npm run -w @dashboard/ai backfill:signatures -- --force
+ */
+import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
+import { deriveSignature, deriveSignatureFromTitle } from '../src/services/signature.js';
+
+interface BackfillOptions { batchSize: number; force: boolean; }
+
+interface IncidentRow {
+  id: string;
+  title: string;
+  root_cause_insight_id: string | null;
+}
+interface InsightRow {
+  category: string;
+  metric_type: string | null;
+  detection_method: string | null;
+  title: string;
+}
+
+export async function backfillSignatures(opts: BackfillOptions = { batchSize: 500, force: false }): Promise<{ updated: number; bySignature: Record<string, number> }> {
+  const db = getDbForDomain('incidents');
+  const where = opts.force ? '1=1' : 'signature IS NULL';
+  const bySignature: Record<string, number> = {};
+  let updated = 0;
+
+  while (true) {
+    const incidents = await db.query<IncidentRow>(
+      `SELECT id, title, root_cause_insight_id FROM incidents WHERE ${where} ORDER BY created_at LIMIT ?`,
+      [opts.batchSize],
+    );
+    if (incidents.length === 0) break;
+
+    for (const inc of incidents) {
+      let signature: string;
+      if (inc.root_cause_insight_id) {
+        const ins = await db.queryOne<InsightRow>(
+          'SELECT category, metric_type, detection_method, title FROM insights WHERE id = ?',
+          [inc.root_cause_insight_id],
+        );
+        if (ins) {
+          signature = deriveSignature({
+            category: ins.category,
+            metric_type: ins.metric_type as 'cpu' | 'memory' | 'disk' | 'network' | 'restart' | undefined,
+            detection_method: ins.detection_method as 'threshold' | 'ml-anomaly' | 'prediction' | 'health-check' | 'log-pattern' | 'security-scan' | undefined,
+            title: ins.title,
+          });
+        } else {
+          signature = deriveSignatureFromTitle(inc.title);
+        }
+      } else {
+        signature = deriveSignatureFromTitle(inc.title);
+      }
+      await db.execute(
+        opts.force
+          ? 'UPDATE incidents SET signature = ? WHERE id = ?'
+          : 'UPDATE incidents SET signature = ? WHERE id = ? AND signature IS NULL',
+        [signature, inc.id],
+      );
+      bySignature[signature] = (bySignature[signature] ?? 0) + 1;
+      updated++;
+    }
+    if (incidents.length < opts.batchSize) break;
+  }
+
+  return { updated, bySignature };
+}
+
+async function cli() {
+  const force = process.argv.includes('--force');
+  const result = await backfillSignatures({ batchSize: 500, force });
+  console.log(`Updated ${result.updated} rows`);
+  for (const [sig, n] of Object.entries(result.bySignature).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${sig.padEnd(40)} ${n}`);
+  }
+}
+
+if (import.meta.url.endsWith(process.argv[1] ?? '')) {
+  cli().catch((err) => { console.error(err); process.exit(1); });
+}
+```
+
+Note: the backfill imports `deriveSignature` from `../src/services/signature.js`. If your `tsconfig`/`tsx` resolution complains, adjust to a relative path that resolves to the `src` directory from `scripts/`.
+
+- [ ] **Step 4: Add npm script**
+
+Edit `packages/ai-intelligence/package.json` — add inside `"scripts"`:
+
+```json
+"backfill:signatures": "tsx scripts/backfill-incident-signatures.ts"
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incidents-backfill.test.ts
+```
+
+Expected: 3 passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ai-intelligence/scripts/backfill-incident-signatures.ts \
+        packages/ai-intelligence/src/__tests__/incidents-backfill.test.ts \
+        packages/ai-intelligence/package.json
+git commit -m "feat(incidents): backfill script for legacy signature population"
+```
+
+---
+
+### Task 9: `/api/incidents` accepts `?signature=` filter
+
+**Files:**
+- Modify: `packages/ai-intelligence/src/services/incident-store.ts`
+- Modify: `packages/ai-intelligence/src/routes/incidents.ts`
+- Test: `packages/ai-intelligence/src/__tests__/incidents-list.test.ts` (create or extend)
+
+**Why:** The frontend "Show all" pagination calls `/api/incidents?status=active&signature=X` — that filter must exist.
+
+- [ ] **Step 1: Write the failing test**
+
+Create or extend `packages/ai-intelligence/src/__tests__/incidents-list.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+import { getIncidents } from '../services/incident-store.js';
+
+describe('getIncidents — signature filter', () => {
+  beforeEach(async () => {
+    await getTestDb();
+    await truncateTestTables(['incidents']);
+    const db = await getTestDb();
+    const insertSQL = `
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, 'active', NULL, '[]'::jsonb, '[]'::jsonb, NULL, NULL,
+              'temporal', 'medium', 1, NULL, ?, NOW(), NOW())
+    `;
+    await db.execute(insertSQL, ['a', 'A', 'warning', 'anomaly:ml-anomaly:cpu']);
+    await db.execute(insertSQL, ['b', 'B', 'warning', 'anomaly:ml-anomaly:memory']);
+    await db.execute(insertSQL, ['c', 'C', 'warning', 'predictive:prediction:memory']);
+  });
+  afterAll(async () => { await closeTestDb(); });
+
+  it('returns only matching signature when provided', async () => {
+    const rows = await getIncidents({ signature: 'anomaly:ml-anomaly:memory' });
+    expect(rows.map((r) => r.id)).toEqual(['b']);
+  });
+
+  it('combines with status filter', async () => {
+    const rows = await getIncidents({ status: 'active', signature: 'predictive:prediction:memory' });
+    expect(rows.map((r) => r.id)).toEqual(['c']);
+  });
+
+  it('returns all when omitted', async () => {
+    const rows = await getIncidents({});
+    expect(rows).toHaveLength(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incidents-list.test.ts
+```
+
+Expected: failure (`signature` is not a valid option).
+
+- [ ] **Step 3: Add `signature` to `GetIncidentsOptions`**
+
+In `packages/ai-intelligence/src/services/incident-store.ts`, modify the interface and the query:
+
+```ts
+export interface GetIncidentsOptions {
+  status?: 'active' | 'resolved';
+  severity?: string;
+  signature?: string;     // NEW
+  limit?: number;
+  offset?: number;
+}
+
+export async function getIncidents(options: GetIncidentsOptions = {}): Promise<Incident[]> {
+  const db = getDbForDomain('incidents');
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (options.status)    { conditions.push('status = ?');    params.push(options.status); }
+  if (options.severity)  { conditions.push('severity = ?');  params.push(options.severity); }
+  if (options.signature) { conditions.push('signature = ?'); params.push(options.signature); }   // NEW
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  const limit = options.limit ?? 50;
+  const offset = options.offset ?? 0;
+
+  return db.query<Incident>(`
+    SELECT * FROM incidents ${where}
+    ORDER BY created_at DESC LIMIT ? OFFSET ?
+  `, [...params, limit, offset]);
+}
+```
+
+- [ ] **Step 4: Update the route to accept `?signature=`**
+
+In `packages/ai-intelligence/src/routes/incidents.ts`, modify the `/api/incidents` handler:
+
+```ts
+const { status, severity, signature, limit = 50, offset = 0 } = request.query as {
+  status?: 'active' | 'resolved';
+  severity?: string;
+  signature?: string;  // NEW
+  limit?: number;
+  offset?: number;
+};
+
+const incidents = await getIncidents({ status, severity, signature, limit, offset });
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incidents-list.test.ts
+```
+
+Expected: 3 passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ai-intelligence/src/services/incident-store.ts \
+        packages/ai-intelligence/src/routes/incidents.ts \
+        packages/ai-intelligence/src/__tests__/incidents-list.test.ts
+git commit -m "feat(incidents): /api/incidents accepts ?signature= filter"
+```
+
+---
+
+### Task 10: `getIncidentGroups` SQL aggregate + `GET /api/incidents/groups` route
+
+**Files:**
+- Modify: `packages/ai-intelligence/src/services/incident-store.ts` (add `getIncidentGroups`)
+- Modify: `packages/ai-intelligence/src/routes/incidents.ts` (add new route + cache wrap)
+- Test: `packages/ai-intelligence/src/__tests__/incidents-groups.test.ts`
+
+**Why:** Heart of the rollup. One SQL round-trip returns one row per signature with all the data the UI needs.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/ai-intelligence/src/__tests__/incidents-groups.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+import { getIncidentGroups } from '../services/incident-store.js';
+
+describe('getIncidentGroups', () => {
+  beforeEach(async () => {
+    await getTestDb();
+    await truncateTestTables(['incidents']);
+    const db = await getTestDb();
+    const ins = `
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, 'active', NULL, '[]'::jsonb, ?::jsonb, ?, ?, 'temporal', 'medium', ?, NULL, ?, NOW(), NOW())
+    `;
+    // 3 active CPU anomalies on 3 containers, 1 critical 2 warning
+    await db.execute(ins, ['a1', 'cpu', 'critical', '["c1"]', 1, 'eA', 5, 'anomaly:ml-anomaly:cpu']);
+    await db.execute(ins, ['a2', 'cpu', 'warning',  '["c2"]', 1, 'eA', 3, 'anomaly:ml-anomaly:cpu']);
+    await db.execute(ins, ['a3', 'cpu', 'warning',  '["c3"]', 2, 'eB', 2, 'anomaly:ml-anomaly:cpu']);
+    // 1 active memory prediction
+    await db.execute(ins, ['m1', 'mem', 'warning',  '["c4"]', 2, 'eB', 1, 'predictive:prediction:memory']);
+    // 1 resolved (must not appear when status=active)
+    await db.execute(`
+      INSERT INTO incidents (id, title, severity, status, signature, related_insight_ids,
+                             affected_containers, correlation_type, correlation_confidence,
+                             insight_count, created_at, updated_at, resolved_at)
+      VALUES ('r1', 'r', 'warning', 'resolved', 'anomaly:ml-anomaly:cpu', '[]'::jsonb,
+              '[]'::jsonb, 'temporal', 'medium', 1, NOW(), NOW(), NOW())
+    `);
+  });
+  afterAll(async () => { await closeTestDb(); });
+
+  it('aggregates by signature with counts', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    expect(result.total_active).toBe(4);
+
+    const cpu = result.groups.find((g) => g.signature === 'anomaly:ml-anomaly:cpu');
+    expect(cpu).toBeDefined();
+    expect(cpu!.incident_count).toBe(3);
+    expect(cpu!.container_count).toBe(3);
+    expect(cpu!.alert_count).toBe(1 + 1 + 2);
+    expect(cpu!.severity).toBe('critical');  // highest in group
+  });
+
+  it('returns top_containers ordered by severity then recency, capped at 10', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    const cpu = result.groups.find((g) => g.signature === 'anomaly:ml-anomaly:cpu')!;
+    expect(cpu.top_containers.length).toBeLessThanOrEqual(10);
+    expect(cpu.top_containers[0].severity).toBe('critical');
+  });
+
+  it('includes all_container_names with names_truncated flag', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    const cpu = result.groups.find((g) => g.signature === 'anomaly:ml-anomaly:cpu')!;
+    expect(cpu.all_container_names.sort()).toEqual(['c1', 'c2', 'c3']);
+    expect(cpu.names_truncated).toBe(false);
+  });
+
+  it('endpoint_facets reflects distribution', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    const eA = result.endpoint_facets.find((f) => f.endpoint_id === 1)!;
+    expect(eA.incident_count).toBe(2);
+    const eB = result.endpoint_facets.find((f) => f.endpoint_id === 2)!;
+    expect(eB.incident_count).toBe(2);
+  });
+
+  it('endpoint_id filter narrows the result', async () => {
+    const result = await getIncidentGroups({ status: 'active', endpoint_id: 2 });
+    expect(result.total_active).toBe(2);
+  });
+
+  it('since filter applies against updated_at', async () => {
+    // updated_at is NOW(); all rows match a 1-hour window
+    const result = await getIncidentGroups({ status: 'active', since_minutes: 60 });
+    expect(result.total_active).toBe(4);
+  });
+
+  it('excludes resolved incidents when status=active', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    const incidentIds = result.groups.flatMap((g) => g.top_containers.map((tc) => tc.incident_id));
+    expect(incidentIds).not.toContain('r1');
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incidents-groups.test.ts
+```
+
+Expected: failure (`getIncidentGroups` not exported).
+
+- [ ] **Step 3: Implement `getIncidentGroups`**
+
+Append to `packages/ai-intelligence/src/services/incident-store.ts`:
+
+```ts
+import { signatureLabel } from './signature.js';
+
+const TOP_CONTAINERS_PER_GROUP = 10;
+const ALL_NAMES_CAP = 500;
+
+export interface IncidentGroupsOptions {
+  status?: 'active' | 'resolved';
+  endpoint_id?: number;
+  since_minutes?: number;     // 60 / 1440 / 10080 — frontend converts ranges
+  severity?: 'critical' | 'warning' | 'info';
+}
+
+export interface IncidentGroup {
+  signature: string;
+  label: string;
+  severity: 'critical' | 'warning' | 'info';
+  incident_count: number;
+  container_count: number;
+  alert_count: number;
+  earliest_at: string;
+  latest_update_at: string;
+  top_containers: Array<{
+    incident_id: string;
+    container_name: string;
+    endpoint_id: number | null;
+    endpoint_name: string | null;
+    severity: 'critical' | 'warning' | 'info';
+    created_at: string;
+  }>;
+  all_container_names: string[];
+  names_truncated: boolean;
+}
+
+export interface IncidentGroupsResult {
+  groups: IncidentGroup[];
+  endpoint_facets: Array<{ endpoint_id: number | null; endpoint_name: string | null; incident_count: number }>;
+  total_active: number;
+}
+
+export async function getIncidentGroups(options: IncidentGroupsOptions = {}): Promise<IncidentGroupsResult> {
+  const db = getDbForDomain('incidents');
+  const where: string[] = ['signature IS NOT NULL'];
+  const params: unknown[] = [];
+  if (options.status)        { where.push('status = ?');                                              params.push(options.status); }
+  if (options.endpoint_id !== undefined) { where.push('endpoint_id = ?');                              params.push(options.endpoint_id); }
+  if (options.since_minutes) { where.push("updated_at >= NOW() - (? || ' minutes')::INTERVAL");        params.push(`-${options.since_minutes}`); }
+  if (options.severity)      { where.push('severity = ?');                                            params.push(options.severity); }
+  const whereSQL = `WHERE ${where.join(' AND ')}`;
+
+  // 1. Per-signature aggregate + first/last + name list (capped)
+  const rawGroups = await db.query<{
+    signature: string;
+    severity: 'critical' | 'warning' | 'info';
+    incident_count: number;
+    alert_count: number;
+    earliest_at: string;
+    latest_update_at: string;
+    container_count: number;
+    all_names: string[];
+  }>(`
+    WITH base AS (
+      SELECT id, signature, severity, insight_count, created_at, updated_at, affected_containers
+      FROM incidents ${whereSQL}
+    ),
+    expanded AS (
+      SELECT signature, severity, insight_count, created_at, updated_at,
+             jsonb_array_elements_text(affected_containers) AS container_name
+      FROM base
+    )
+    SELECT b.signature,
+           CASE WHEN BOOL_OR(b.severity = 'critical') THEN 'critical'
+                WHEN BOOL_OR(b.severity = 'warning')  THEN 'warning'
+                ELSE 'info' END                                                AS severity,
+           COUNT(DISTINCT b.id)::int                                           AS incident_count,
+           COALESCE(SUM(b.insight_count), 0)::int                              AS alert_count,
+           MIN(b.created_at)::text                                             AS earliest_at,
+           MAX(b.updated_at)::text                                             AS latest_update_at,
+           COUNT(DISTINCT e.container_name)::int                               AS container_count,
+           (ARRAY(
+             SELECT DISTINCT container_name
+             FROM expanded e2
+             WHERE e2.signature = b.signature
+             ORDER BY container_name
+             LIMIT ${ALL_NAMES_CAP}
+           ))                                                                  AS all_names
+    FROM base b
+    LEFT JOIN expanded e ON e.signature = b.signature
+    GROUP BY b.signature
+    ORDER BY (CASE WHEN BOOL_OR(b.severity = 'critical') THEN 0
+                   WHEN BOOL_OR(b.severity = 'warning')  THEN 1
+                   ELSE 2 END), incident_count DESC
+  `, params);
+
+  // 2. Top-N containers per signature
+  const rawTop = await db.query<{
+    signature: string; incident_id: string; container_name: string;
+    endpoint_id: number | null; endpoint_name: string | null;
+    severity: 'critical' | 'warning' | 'info'; created_at: string; rn: number;
+  }>(`
+    WITH base AS (
+      SELECT id, signature, severity, endpoint_id, endpoint_name, created_at, affected_containers
+      FROM incidents ${whereSQL}
+    ),
+    expanded AS (
+      SELECT id AS incident_id, signature, severity, endpoint_id, endpoint_name, created_at,
+             jsonb_array_elements_text(affected_containers) AS container_name
+      FROM base
+    ),
+    ranked AS (
+      SELECT *,
+             ROW_NUMBER() OVER (
+               PARTITION BY signature
+               ORDER BY (CASE severity WHEN 'critical' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END),
+                        created_at DESC
+             ) AS rn
+      FROM expanded
+    )
+    SELECT signature, incident_id, container_name, endpoint_id, endpoint_name, severity, created_at::text, rn
+    FROM ranked
+    WHERE rn <= ${TOP_CONTAINERS_PER_GROUP}
+  `, params);
+
+  // 3. Endpoint facets
+  const rawFacets = await db.query<{ endpoint_id: number | null; endpoint_name: string | null; incident_count: number }>(`
+    SELECT endpoint_id, endpoint_name, COUNT(*)::int AS incident_count
+    FROM incidents ${whereSQL}
+    GROUP BY endpoint_id, endpoint_name
+    ORDER BY incident_count DESC
+  `, params);
+
+  // 4. Stitch
+  const topBySig = new Map<string, IncidentGroup['top_containers']>();
+  for (const r of rawTop) {
+    const arr = topBySig.get(r.signature) ?? [];
+    arr.push({
+      incident_id: r.incident_id, container_name: r.container_name,
+      endpoint_id: r.endpoint_id, endpoint_name: r.endpoint_name,
+      severity: r.severity, created_at: r.created_at,
+    });
+    topBySig.set(r.signature, arr);
+  }
+
+  const groups: IncidentGroup[] = rawGroups.map((g) => ({
+    signature: g.signature,
+    label: signatureLabel(g.signature),
+    severity: g.severity,
+    incident_count: g.incident_count,
+    container_count: g.container_count,
+    alert_count: g.alert_count,
+    earliest_at: g.earliest_at,
+    latest_update_at: g.latest_update_at,
+    top_containers: topBySig.get(g.signature) ?? [],
+    all_container_names: g.all_names ?? [],
+    names_truncated: (g.all_names?.length ?? 0) >= ALL_NAMES_CAP && g.container_count > ALL_NAMES_CAP,
+  }));
+
+  const total_active = rawGroups.reduce((sum, g) => sum + g.incident_count, 0);
+
+  return { groups, endpoint_facets: rawFacets, total_active };
+}
+```
+
+- [ ] **Step 4: Run service tests, verify pass**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incidents-groups.test.ts
+```
+
+Expected: all 7 passing.
+
+- [ ] **Step 5: Add the route**
+
+In `packages/ai-intelligence/src/routes/incidents.ts`, add the new route with a cache wrap. Add imports:
+
+```ts
+import { cachedFetchSWR, getCacheKey, cache } from '@dashboard/core/portainer/portainer-cache.js';
+import { getIncidents, getIncident, resolveIncident, getIncidentCount, getIncidentGroups } from '../services/incident-store.js';
+```
+
+Then add inside `incidentsRoutes(fastify)`:
+
+```ts
+// List incident groups (rollup view)
+fastify.get('/api/incidents/groups', {
+  schema: {
+    tags: ['Incidents'],
+    summary: 'List active incidents grouped by signature',
+    security: [{ bearerAuth: [] }],
+  },
+  preHandler: [fastify.authenticate],
+}, async (request) => {
+  const { status = 'active', endpoint_id, since, severity } = request.query as {
+    status?: 'active' | 'resolved';
+    endpoint_id?: string;
+    since?: '1h' | '24h' | '7d';
+    severity?: 'critical' | 'warning' | 'info';
+  };
+  const since_minutes = since === '1h' ? 60 : since === '24h' ? 1440 : since === '7d' ? 10080 : undefined;
+  const epId = endpoint_id != null ? Number(endpoint_id) : undefined;
+
+  const cacheKey = getCacheKey('incidents-groups', status, epId ?? 'all', since ?? 'all', severity ?? 'all');
+  return cachedFetchSWR(cacheKey, 10, () =>
+    getIncidentGroups({ status, endpoint_id: epId, since_minutes, severity }),
+  );
+});
+```
+
+Then update the existing single-resolve handler to invalidate the cache. Locate the existing `/api/incidents/:id/resolve` handler and add at the end after `await resolveIncident(id);`:
+
+```ts
+await cache.invalidateTag('incidents-groups').catch(() => undefined);
+```
+
+Wait — `invalidateTag` invalidates entries tagged with `'incidents-groups'`, not the key prefix. Since `cachedFetchSWR` does not tag entries (the tag mechanism is opt-in via `setWithTags`), the easier route is to use `cache.invalidatePattern('incidents-groups')` if available, or to simply `cache.del()` per known cache key. **Simpler approach for this task:** invalidate via a pattern delete. Add this helper next to the cache import in `incidents.ts`:
+
+```ts
+async function invalidateGroupsCache(): Promise<void> {
+  // L1 invalidation: delete in-memory entries whose key starts with 'incidents-groups:'
+  await cache.invalidatePattern?.('incidents-groups').catch(() => undefined);
+}
+```
+
+If `cache.invalidatePattern` does not exist on the public surface, the implementer instead lowers the TTL to 5s for this PR and files a follow-up to add tag support; the spec acknowledges this fallback.
+
+Then call `await invalidateGroupsCache()` after every write: `/api/incidents/:id/resolve`, plus the batch resolve added in Task 11.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ai-intelligence/src/services/incident-store.ts \
+        packages/ai-intelligence/src/routes/incidents.ts \
+        packages/ai-intelligence/src/__tests__/incidents-groups.test.ts
+git commit -m "feat(incidents): GET /api/incidents/groups aggregate endpoint with SWR cache"
+```
+
+---
+
+### Task 11: `POST /api/incidents/resolve` batch endpoint
+
+**Files:**
+- Modify: `packages/ai-intelligence/src/services/incident-store.ts` (add `resolveIncidentsBatch`)
+- Modify: `packages/ai-intelligence/src/routes/incidents.ts` (add new route)
+- Test: `packages/ai-intelligence/src/__tests__/incidents-resolve-batch.test.ts`
+
+**Why:** The frontend's per-group "Resolve all" calls one batch endpoint instead of N sequential POSTs.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/ai-intelligence/src/__tests__/incidents-resolve-batch.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+import { resolveIncidentsBatch } from '../services/incident-store.js';
+
+describe('resolveIncidentsBatch', () => {
+  beforeEach(async () => {
+    await getTestDb();
+    await truncateTestTables(['incidents']);
+    const db = await getTestDb();
+    const ins = `
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, 't', 'warning', 'active', NULL, '[]'::jsonb, '[]'::jsonb, NULL, NULL,
+              'temporal', 'medium', 1, NULL, 'anomaly:ml-anomaly:cpu', NOW(), NOW())
+    `;
+    await db.execute(ins, ['a']);
+    await db.execute(ins, ['b']);
+    await db.execute(ins, ['c']);
+  });
+  afterAll(async () => { await closeTestDb(); });
+
+  it('resolves all valid ids', async () => {
+    const r = await resolveIncidentsBatch(['a', 'b', 'c']);
+    expect(r.resolved).toEqual(['a', 'b', 'c']);
+    expect(r.failed).toEqual([]);
+  });
+
+  it('does not roll back successful ids when one fails', async () => {
+    const r = await resolveIncidentsBatch(['a', 'does-not-exist', 'c']);
+    expect(r.resolved.sort()).toEqual(['a', 'c']);
+    expect(r.failed).toHaveLength(1);
+    expect(r.failed[0].id).toBe('does-not-exist');
+
+    const db = await getTestDb();
+    const aRow = await db.queryOne<{ status: string }>('SELECT status FROM incidents WHERE id = ?', ['a']);
+    const cRow = await db.queryOne<{ status: string }>('SELECT status FROM incidents WHERE id = ?', ['c']);
+    expect(aRow?.status).toBe('resolved');
+    expect(cRow?.status).toBe('resolved');
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incidents-resolve-batch.test.ts
+```
+
+Expected: failure (`resolveIncidentsBatch` not exported).
+
+- [ ] **Step 3: Implement `resolveIncidentsBatch`**
+
+Append to `packages/ai-intelligence/src/services/incident-store.ts`:
+
+```ts
+export interface BatchResolveResult {
+  resolved: string[];
+  failed: Array<{ id: string; error: string }>;
+}
+
+export async function resolveIncidentsBatch(ids: string[]): Promise<BatchResolveResult> {
+  const result: BatchResolveResult = { resolved: [], failed: [] };
+  for (const id of ids) {
+    try {
+      // Per-id, atomic. The existing resolveIncident is already an UPDATE
+      // — we additionally verify the row existed by checking affected rows.
+      const db = getDbForDomain('incidents');
+      const before = await db.queryOne<{ id: string }>('SELECT id FROM incidents WHERE id = ?', [id]);
+      if (!before) {
+        result.failed.push({ id, error: 'not found' });
+        continue;
+      }
+      await resolveIncident(id);
+      result.resolved.push(id);
+    } catch (err) {
+      result.failed.push({ id, error: err instanceof Error ? err.message : 'unknown' });
+    }
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Add the route**
+
+In `packages/ai-intelligence/src/routes/incidents.ts`, add inside `incidentsRoutes(fastify)`:
+
+```ts
+import { z } from 'zod';
+
+// ... existing routes ...
+
+fastify.post('/api/incidents/resolve', {
+  schema: {
+    tags: ['Incidents'],
+    summary: 'Resolve a batch of incidents',
+    security: [{ bearerAuth: [] }],
+    body: {
+      type: 'object',
+      properties: {
+        ids: { type: 'array', items: { type: 'string', format: 'uuid' }, minItems: 1, maxItems: 500 },
+      },
+      required: ['ids'],
+    },
+  },
+  preHandler: [fastify.authenticate, fastify.requireRole('admin')],
+}, async (request, reply) => {
+  const parsed = z.object({ ids: z.array(z.string().uuid()).min(1).max(500) }).safeParse(request.body);
+  if (!parsed.success) {
+    return reply.code(400).send({ error: 'invalid body', details: parsed.error.flatten() });
+  }
+  const result = await resolveIncidentsBatch(parsed.data.ids);
+  await invalidateGroupsCache();
+  return result;
+});
+```
+
+Also import `resolveIncidentsBatch`:
+
+```ts
+import { ..., resolveIncidentsBatch } from '../services/incident-store.js';
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd packages/ai-intelligence && \
+  POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+  npx vitest run src/__tests__/incidents-resolve-batch.test.ts
+```
+
+Expected: 2 passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ai-intelligence/src/services/incident-store.ts \
+        packages/ai-intelligence/src/routes/incidents.ts \
+        packages/ai-intelligence/src/__tests__/incidents-resolve-batch.test.ts
+git commit -m "feat(incidents): POST /api/incidents/resolve batch endpoint with per-id transactions"
+```
+
+---
+
+### Task 12: Frontend hook `useIncidentGroups`
+
+**Files:**
+- Create: `frontend/src/features/ai-intelligence/hooks/use-incident-groups.ts`
+- Test: `frontend/src/features/ai-intelligence/hooks/use-incident-groups.test.ts`
+
+**Why:** Data hook for the rollup view, with camelCase → snake_case boundary mapping.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/features/ai-intelligence/hooks/use-incident-groups.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useIncidentGroups } from './use-incident-groups';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: { get: vi.fn() },
+}));
+import { api } from '@/shared/lib/api';
+
+const wrap = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
+
+describe('useIncidentGroups', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('serializes camelCase params to snake_case query string', async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({ groups: [], endpoint_facets: [], total_active: 0 });
+    const { result } = renderHook(
+      () => useIncidentGroups({ status: 'active', endpointId: 42, since: '24h', severity: 'critical' }),
+      { wrapper: wrap() },
+    );
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(api.get).toHaveBeenCalledWith('/api/incidents/groups', {
+      params: { status: 'active', endpoint_id: '42', since: '24h', severity: 'critical' },
+    });
+  });
+
+  it('omits undefined params', async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({ groups: [], endpoint_facets: [], total_active: 0 });
+    renderHook(() => useIncidentGroups({}), { wrapper: wrap() });
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    const call = (api.get as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1].params).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/hooks/use-incident-groups.test.ts
+```
+
+Expected: failure (module not found).
+
+- [ ] **Step 3: Implement the hook**
+
+Create `frontend/src/features/ai-intelligence/hooks/use-incident-groups.ts`:
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/shared/lib/api';
+import { usePageVisibility } from '@/shared/hooks/use-page-visibility';
+
+export interface IncidentGroup {
+  signature: string;
+  label: string;
+  severity: 'critical' | 'warning' | 'info';
+  incident_count: number;
+  container_count: number;
+  alert_count: number;
+  earliest_at: string;
+  latest_update_at: string;
+  top_containers: Array<{
+    incident_id: string;
+    container_name: string;
+    endpoint_id: number | null;
+    endpoint_name: string | null;
+    severity: 'critical' | 'warning' | 'info';
+    created_at: string;
+  }>;
+  all_container_names: string[];
+  names_truncated: boolean;
+}
+
+export interface IncidentGroupsResponse {
+  groups: IncidentGroup[];
+  endpoint_facets: Array<{ endpoint_id: number | null; endpoint_name: string | null; incident_count: number }>;
+  total_active: number;
+}
+
+export interface UseIncidentGroupsParams {
+  status?: 'active' | 'resolved';
+  endpointId?: number;
+  since?: '1h' | '24h' | '7d';
+  severity?: 'critical' | 'warning' | 'info';
+}
+
+export function useIncidentGroups(params: UseIncidentGroupsParams = {}) {
+  const isVisible = usePageVisibility();
+  const queryParams: Record<string, string> = {};
+  if (params.status) queryParams.status = params.status;
+  if (params.endpointId !== undefined) queryParams.endpoint_id = String(params.endpointId);
+  if (params.since) queryParams.since = params.since;
+  if (params.severity) queryParams.severity = params.severity;
+
+  return useQuery<IncidentGroupsResponse>({
+    queryKey: ['incident-groups', params.status, params.endpointId, params.since, params.severity],
+    queryFn: () => api.get<IncidentGroupsResponse>('/api/incidents/groups', { params: queryParams }),
+    refetchInterval: isVisible ? 30_000 : false,
+  });
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/hooks/use-incident-groups.test.ts
+```
+
+Expected: 2 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/ai-intelligence/hooks/use-incident-groups.ts \
+        frontend/src/features/ai-intelligence/hooks/use-incident-groups.test.ts
+git commit -m "feat(frontend): useIncidentGroups hook with camelCase→snake_case mapping"
+```
+
+---
+
+### Task 13: `IncidentGroupsView` — skeleton, summary, groups, expand, top-N, "Show all"
+
+**Files:**
+- Create: `frontend/src/features/ai-intelligence/components/incident-groups-view.tsx`
+- Test: `frontend/src/features/ai-intelligence/components/incident-groups-view.test.tsx`
+- Test: `frontend/src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx`
+
+**Why:** Core component. Renders summary strip, groups, expand state with default-expand-on-critical, top-10 rows, "Show all" pagination.
+
+- [ ] **Step 1: Write rendering tests (failing)**
+
+Create `frontend/src/features/ai-intelligence/components/incident-groups-view.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+import type { IncidentGroupsResponse } from '../hooks/use-incident-groups';
+
+vi.mock('../hooks/use-incident-groups', () => ({
+  useIncidentGroups: vi.fn(),
+}));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+
+const wrap = (children: React.ReactNode) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+const mock = (data: IncidentGroupsResponse) => {
+  (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({ data, isLoading: false });
+};
+
+describe('IncidentGroupsView — rendering', () => {
+  it('renders summary strip with single-bucket-per-container counts', () => {
+    mock({
+      total_active: 3,
+      endpoint_facets: [{ endpoint_id: 1, endpoint_name: 'eA', incident_count: 3 }],
+      groups: [
+        {
+          signature: 'a:b:c', label: 'Critical thing', severity: 'critical',
+          incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '2026-05-06T00:00:00Z', latest_update_at: '2026-05-06T00:00:00Z',
+          top_containers: [{ incident_id: 'x', container_name: 'cn-A', endpoint_id: 1, endpoint_name: 'eA', severity: 'critical', created_at: '2026-05-06T00:00:00Z' }],
+          all_container_names: ['cn-A'], names_truncated: false,
+        },
+        {
+          signature: 'd:e:f', label: 'Warning thing', severity: 'warning',
+          incident_count: 2, container_count: 2, alert_count: 2,
+          earliest_at: '2026-05-06T00:00:00Z', latest_update_at: '2026-05-06T00:00:00Z',
+          top_containers: [
+            { incident_id: 'y1', container_name: 'cn-A', endpoint_id: 1, endpoint_name: 'eA', severity: 'warning', created_at: '2026-05-06T00:00:00Z' },
+            { incident_id: 'y2', container_name: 'cn-B', endpoint_id: 1, endpoint_name: 'eA', severity: 'warning', created_at: '2026-05-06T00:00:00Z' },
+          ],
+          all_container_names: ['cn-A', 'cn-B'], names_truncated: false,
+        },
+      ],
+    });
+    render(wrap(<IncidentGroupsView />));
+    // cn-A is in both critical and warning → counts in critical only.
+    expect(screen.getByTestId('summary-strip')).toHaveTextContent(/Critical:.*1.*container/i);
+    expect(screen.getByTestId('summary-strip')).toHaveTextContent(/Warning:.*1.*container/i);  // cn-B only
+  });
+
+  it('expands critical groups by default, collapses warnings', () => {
+    mock({
+      total_active: 2,
+      endpoint_facets: [],
+      groups: [
+        { signature: 'crit', label: 'Crit', severity: 'critical', incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [{ incident_id: 'x', container_name: 'cn', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }],
+          all_container_names: ['cn'], names_truncated: false },
+        { signature: 'warn', label: 'Warn', severity: 'warning', incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [{ incident_id: 'y', container_name: 'cn2', endpoint_id: 1, endpoint_name: 'e', severity: 'warning', created_at: '' }],
+          all_container_names: ['cn2'], names_truncated: false },
+      ],
+    });
+    render(wrap(<IncidentGroupsView />));
+    expect(screen.getByText('cn')).toBeInTheDocument();      // critical group expanded
+    expect(screen.queryByText('cn2')).not.toBeInTheDocument(); // warning collapsed
+  });
+
+  it('toggling a group expands its top-10 rows', async () => {
+    mock({
+      total_active: 1,
+      endpoint_facets: [],
+      groups: [
+        { signature: 'warn', label: 'Warn', severity: 'warning', incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [{ incident_id: 'y', container_name: 'cn2', endpoint_id: 1, endpoint_name: 'e', severity: 'warning', created_at: '' }],
+          all_container_names: ['cn2'], names_truncated: false },
+      ],
+    });
+    render(wrap(<IncidentGroupsView />));
+    expect(screen.queryByText('cn2')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /Warn/i }));
+    expect(screen.getByText('cn2')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Write the "Show all" test (failing)**
+
+Create `frontend/src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+vi.mock('@/shared/lib/api', () => ({ api: { get: vi.fn() } }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+
+const wrap = (children: React.ReactNode) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+describe('IncidentGroupsView — Show all pagination', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders Show all button when container_count > 10 and fetches the long tail on click', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 12, endpoint_facets: [],
+        groups: [{
+          signature: 'a:b:c', label: 'Big', severity: 'critical',
+          incident_count: 12, container_count: 12, alert_count: 12,
+          earliest_at: '', latest_update_at: '',
+          top_containers: Array.from({ length: 10 }, (_, i) => ({
+            incident_id: `i${i}`, container_name: `cn-${i}`,
+            endpoint_id: 1, endpoint_name: 'e', severity: 'warning' as const,
+            created_at: '',
+          })),
+          all_container_names: Array.from({ length: 12 }, (_, i) => `cn-${i}`),
+          names_truncated: false,
+        }],
+      },
+      isLoading: false,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      incidents: [
+        { id: 'i10', title: 't', signature: 'a:b:c', severity: 'warning', status: 'active',
+          affected_containers: ['cn-10'], endpoint_id: 1, endpoint_name: 'e',
+          created_at: '', updated_at: '' },
+        { id: 'i11', title: 't', signature: 'a:b:c', severity: 'warning', status: 'active',
+          affected_containers: ['cn-11'], endpoint_id: 1, endpoint_name: 'e',
+          created_at: '', updated_at: '' },
+      ],
+      counts: { active: 12, resolved: 0, total: 12 },
+      limit: 50, offset: 0,
+    });
+
+    render(wrap(<IncidentGroupsView />));
+    const showAll = screen.getByRole('button', { name: /Show all 12/i });
+    await userEvent.click(showAll);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith('/api/incidents', {
+        params: { status: 'active', signature: 'a:b:c', limit: '500' },
+      });
+    });
+    expect(screen.getByText('cn-10')).toBeInTheDocument();
+    expect(screen.getByText('cn-11')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run, verify failure**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.test.tsx \
+  src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx
+```
+
+Expected: failure (`incident-groups-view` not found).
+
+- [ ] **Step 4: Implement the component**
+
+Create `frontend/src/features/ai-intelligence/components/incident-groups-view.tsx`:
+
+```tsx
+import { useMemo, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronDown, ChevronRight, Layers } from 'lucide-react';
+import { useIncidentGroups, type IncidentGroup } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+import { cn } from '@/shared/lib/utils';
+
+interface LongTailRow {
+  incident_id: string;
+  container_name: string;
+  endpoint_id: number | null;
+  endpoint_name: string | null;
+  severity: 'critical' | 'warning' | 'info';
+  created_at: string;
+}
+
+export function IncidentGroupsView() {
+  const { data, isLoading } = useIncidentGroups({ status: 'active' });
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [longTailBySig, setLongTailBySig] = useState<Record<string, LongTailRow[]>>({});
+
+  const summary = useMemo(() => computeSummary(data?.groups ?? []), [data?.groups]);
+
+  const toggle = useCallback((sig: string, defaultOpen: boolean) => {
+    setExpanded((prev) => ({ ...prev, [sig]: prev[sig] === undefined ? !defaultOpen : !prev[sig] }));
+  }, []);
+  const isOpen = (sig: string, severity: IncidentGroup['severity']) =>
+    expanded[sig] !== undefined ? expanded[sig] : severity === 'critical';
+
+  const showAll = useCallback(async (group: IncidentGroup) => {
+    const r = await api.get<{ incidents: Array<{ id: string; affected_containers: string[]; endpoint_id: number | null; endpoint_name: string | null; severity: 'critical' | 'warning' | 'info'; created_at: string }> }>(
+      '/api/incidents',
+      { params: { status: 'active', signature: group.signature, limit: '500' } },
+    );
+    const rows: LongTailRow[] = r.incidents.flatMap((inc) =>
+      (inc.affected_containers ?? []).map((name) => ({
+        incident_id: inc.id, container_name: name,
+        endpoint_id: inc.endpoint_id, endpoint_name: inc.endpoint_name,
+        severity: inc.severity, created_at: inc.created_at,
+      })),
+    );
+    setLongTailBySig((prev) => ({ ...prev, [group.signature]: rows }));
+  }, []);
+
+  if (isLoading || !data) return null;
+  if (data.groups.length === 0) {
+    return <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">No active incidents in this view.</div>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div data-testid="summary-strip" className="text-sm">
+        {summary.critical.containers > 0 && (
+          <span>Critical: {summary.critical.kinds} kinds across {summary.critical.containers} container{summary.critical.containers === 1 ? '' : 's'}</span>
+        )}
+        {summary.warning.containers > 0 && (
+          <span> · Warning: {summary.warning.kinds} kinds across {summary.warning.containers} container{summary.warning.containers === 1 ? '' : 's'}</span>
+        )}
+        {summary.info.containers > 0 && (
+          <span> · Info: {summary.info.kinds} / {summary.info.containers}</span>
+        )}
+      </div>
+
+      {data.groups.map((g) => {
+        const open = isOpen(g.signature, g.severity);
+        const longTail = longTailBySig[g.signature];
+        const rows = longTail ?? g.top_containers;
+        return (
+          <div key={g.signature} className={cn('overflow-hidden rounded-lg border-2 bg-card', g.severity === 'critical' ? 'border-red-500/40' : 'border-amber-500/40')}>
+            <button onClick={() => toggle(g.signature, g.severity === 'critical')} className="w-full p-4 text-left transition-colors hover:bg-muted/20" aria-label={g.label}>
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <span className={cn('h-2 w-2 rounded-full', g.severity === 'critical' ? 'bg-red-500' : g.severity === 'warning' ? 'bg-amber-500' : 'bg-blue-500')} />
+                  <Layers className="h-4 w-4 text-muted-foreground" />
+                  <span className="font-semibold">{g.label}</span>
+                  <span className="text-sm text-muted-foreground">{g.container_count} container{g.container_count === 1 ? '' : 's'} · {g.alert_count} alert{g.alert_count === 1 ? '' : 's'}</span>
+                </div>
+                {open ? <ChevronDown className="h-5 w-5 text-muted-foreground" /> : <ChevronRight className="h-5 w-5 text-muted-foreground" />}
+              </div>
+            </button>
+            {open && (
+              <div className="border-t bg-muted/10">
+                <ul className="divide-y">
+                  {rows.map((row) => (
+                    <li key={`${row.incident_id}:${row.container_name}`} className="flex items-center justify-between px-4 py-2 text-sm">
+                      <Link to={`/containers/${row.endpoint_id}/${row.container_name}`} className="font-mono text-sm hover:underline">{row.container_name}</Link>
+                      <span className="text-xs text-muted-foreground">{row.severity} · {row.endpoint_name ?? 'unknown'}</span>
+                    </li>
+                  ))}
+                </ul>
+                {!longTail && g.container_count > g.top_containers.length && (
+                  <button type="button" onClick={() => showAll(g)} className="block w-full px-4 py-2 text-center text-sm text-primary hover:bg-muted/30">
+                    Show all {g.container_count}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function computeSummary(groups: IncidentGroup[]): {
+  critical: { kinds: number; containers: number };
+  warning:  { kinds: number; containers: number };
+  info:     { kinds: number; containers: number };
+} {
+  const containerHighest = new Map<string, IncidentGroup['severity']>();
+  for (const g of groups) {
+    for (const name of g.all_container_names) {
+      const cur = containerHighest.get(name);
+      if (!cur || rankSeverity(g.severity) < rankSeverity(cur)) containerHighest.set(name, g.severity);
+    }
+  }
+  const out = { critical: { kinds: 0, containers: 0 }, warning: { kinds: 0, containers: 0 }, info: { kinds: 0, containers: 0 } };
+  for (const g of groups) out[g.severity].kinds++;
+  for (const sev of containerHighest.values()) out[sev].containers++;
+  return out;
+}
+function rankSeverity(s: IncidentGroup['severity']): number {
+  return s === 'critical' ? 0 : s === 'warning' ? 1 : 2;
+}
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.test.tsx \
+  src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx
+```
+
+Expected: 4 passing total.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/features/ai-intelligence/components/incident-groups-view.tsx \
+        frontend/src/features/ai-intelligence/components/incident-groups-view.test.tsx \
+        frontend/src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx
+git commit -m "feat(frontend): IncidentGroupsView with summary, expand, top-N, Show all"
+```
+
+---
+
+### Task 14: Search + 250 ms debounce + truncated-group fallback
+
+**Files:**
+- Modify: `frontend/src/features/ai-intelligence/components/incident-groups-view.tsx`
+- Test: `frontend/src/features/ai-intelligence/components/incident-groups-view.search.test.tsx`
+- Test: `frontend/src/features/ai-intelligence/components/incident-groups-view.search-debounce.test.tsx`
+
+**Why:** The search input must filter via `all_container_names` (no false negatives in the long tail). Truncated groups (`names_truncated: true`) delegate search to backend.
+
+- [ ] **Step 1: Write search tests (failing)**
+
+Create `frontend/src/features/ai-intelligence/components/incident-groups-view.search.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+vi.mock('@/shared/lib/api', () => ({ api: { get: vi.fn() } }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+
+const wrap = (c: React.ReactNode) => <QueryClientProvider client={new QueryClient()}><MemoryRouter>{c}</MemoryRouter></QueryClientProvider>;
+
+describe('IncidentGroupsView — search', () => {
+  it('hides groups whose label and all_container_names do not match', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 2, endpoint_facets: [],
+        groups: [
+          { signature: 'a', label: 'Apple', severity: 'critical', incident_count: 1, container_count: 1, alert_count: 1, earliest_at: '', latest_update_at: '', top_containers: [{ incident_id: 'x', container_name: 'apple-1', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }], all_container_names: ['apple-1'], names_truncated: false },
+          { signature: 'b', label: 'Banana', severity: 'critical', incident_count: 1, container_count: 1, alert_count: 1, earliest_at: '', latest_update_at: '', top_containers: [{ incident_id: 'y', container_name: 'banana-1', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }], all_container_names: ['banana-1'], names_truncated: false },
+        ],
+      },
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView search="banana" />));
+    expect(screen.getByText('Banana')).toBeInTheDocument();
+    expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+  });
+
+  it('auto-expands a collapsed group when its container matches', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 1, endpoint_facets: [],
+        groups: [{
+          signature: 'a', label: 'Warn', severity: 'warning',
+          incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [{ incident_id: 'x', container_name: 'matchme', endpoint_id: 1, endpoint_name: 'e', severity: 'warning', created_at: '' }],
+          all_container_names: ['matchme'], names_truncated: false,
+        }],
+      },
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView search="matchme" />));
+    expect(screen.getByText('matchme')).toBeInTheDocument();
+  });
+
+  it('truncated groups delegate search to backend when query is non-empty', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 600, endpoint_facets: [],
+        groups: [{
+          signature: 'big', label: 'Many', severity: 'warning',
+          incident_count: 600, container_count: 600, alert_count: 600,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [],
+          all_container_names: Array.from({ length: 500 }, (_, i) => `cn-${i}`),
+          names_truncated: true,
+        }],
+      },
+      isLoading: false,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({ incidents: [], counts: { active: 0, resolved: 0, total: 0 }, limit: 50, offset: 0 });
+    render(wrap(<IncidentGroupsView search="cn-700" />));
+    // 250 ms debounce — wait
+    await new Promise((r) => setTimeout(r, 300));
+    expect(api.get).toHaveBeenCalledWith('/api/incidents', expect.objectContaining({ params: expect.objectContaining({ signature: 'big', q: 'cn-700' }) }));
+  });
+});
+```
+
+- [ ] **Step 2: Write debounce test (failing)**
+
+Create `frontend/src/features/ai-intelligence/components/incident-groups-view.search-debounce.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+vi.mock('@/shared/lib/api', () => ({ api: { get: vi.fn() } }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+
+const wrap = (c: React.ReactNode) => <QueryClientProvider client={new QueryClient()}><MemoryRouter>{c}</MemoryRouter></QueryClientProvider>;
+
+const baseGroup = {
+  signature: 'big', label: 'Many', severity: 'warning' as const,
+  incident_count: 100, container_count: 100, alert_count: 100,
+  earliest_at: '', latest_update_at: '', top_containers: [],
+  all_container_names: [], names_truncated: true,
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe('IncidentGroupsView — search debounce', () => {
+  it('does not auto-fetch until 250 ms quiet', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 100, endpoint_facets: [], groups: [baseGroup] },
+      isLoading: false,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({ incidents: [], counts: { active: 0, resolved: 0, total: 0 }, limit: 50, offset: 0 });
+    const { rerender } = render(wrap(<IncidentGroupsView search="a" />));
+    rerender(wrap(<IncidentGroupsView search="ab" />));
+    rerender(wrap(<IncidentGroupsView search="abc" />));
+    // Before 250 ms: no calls
+    expect(api.get).not.toHaveBeenCalled();
+    // After 300 ms: exactly one call with the latest term
+    await new Promise((r) => setTimeout(r, 300));
+    expect(api.get).toHaveBeenCalledTimes(1);
+    expect(api.get).toHaveBeenCalledWith('/api/incidents', expect.objectContaining({ params: expect.objectContaining({ q: 'abc' }) }));
+  });
+});
+```
+
+- [ ] **Step 3: Run, verify failures**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.search.test.tsx \
+  src/features/ai-intelligence/components/incident-groups-view.search-debounce.test.tsx
+```
+
+Expected: failures (`search` prop not yet accepted).
+
+- [ ] **Step 4: Add search prop and debounce hook**
+
+Modify `frontend/src/features/ai-intelligence/components/incident-groups-view.tsx`. Add a `search` prop and a debounce hook. Insert near the top of the file (after imports):
+
+```ts
+import { useEffect } from 'react';
+
+function useDebounced<T>(value: T, ms: number): T {
+  const [v, setV] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return v;
+}
+```
+
+Update the component signature:
+
+```tsx
+export function IncidentGroupsView({ search = '' }: { search?: string }) {
+  // ... existing body ...
+  const debouncedSearch = useDebounced(search, 250);
+  const searchLower = debouncedSearch.toLowerCase();
+
+  const visibleGroups = useMemo(() => {
+    if (!data) return [];
+    if (!searchLower) return data.groups;
+    return data.groups.filter((g) =>
+      g.label.toLowerCase().includes(searchLower) ||
+      g.all_container_names.some((n) => n.toLowerCase().includes(searchLower)),
+    );
+  }, [data, searchLower]);
+
+  // Truncated-group backend delegation
+  useEffect(() => {
+    if (!searchLower || !data) return;
+    for (const g of data.groups) {
+      if (!g.names_truncated) continue;
+      api.get<{ incidents: Array<{ id: string; affected_containers: string[]; endpoint_id: number | null; endpoint_name: string | null; severity: 'critical' | 'warning' | 'info'; created_at: string }> }>(
+        '/api/incidents', { params: { status: 'active', signature: g.signature, q: debouncedSearch } },
+      ).then((r) => {
+        const rows: LongTailRow[] = r.incidents.flatMap((inc) =>
+          (inc.affected_containers ?? []).map((name) => ({
+            incident_id: inc.id, container_name: name,
+            endpoint_id: inc.endpoint_id, endpoint_name: inc.endpoint_name,
+            severity: inc.severity, created_at: inc.created_at,
+          })),
+        );
+        setLongTailBySig((prev) => ({ ...prev, [g.signature]: rows }));
+      });
+    }
+  }, [searchLower, debouncedSearch, data]);
+
+  // Replace `data.groups.map(...)` with `visibleGroups.map(...)`
+  // Replace `if (data.groups.length === 0)` with the empty-state check based on visibleGroups
+```
+
+For auto-expand on container match: in the rendering loop, compute `effectivelyOpen = isOpen(g.signature, g.severity) || (searchLower && g.all_container_names.some((n) => n.toLowerCase().includes(searchLower)))` and render expanded section when this is true.
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.search.test.tsx \
+  src/features/ai-intelligence/components/incident-groups-view.search-debounce.test.tsx
+```
+
+Expected: 4 passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/features/ai-intelligence/components/incident-groups-view.tsx \
+        frontend/src/features/ai-intelligence/components/incident-groups-view.search.test.tsx \
+        frontend/src/features/ai-intelligence/components/incident-groups-view.search-debounce.test.tsx
+git commit -m "feat(frontend): IncidentGroupsView search with 250ms debounce and truncated-group backend fallback"
+```
+
+> Note: backend support for `?q=` on `/api/incidents` is not implemented in this PR — the spec lists it as a follow-up. The frontend code calls it; if the backend returns empty (current behaviour), the user sees no matches in truncated groups, which is no worse than today.
+
+---
+
+### Task 15: Resolve flows — per-row, multi-select, per-group with batch endpoint
+
+**Files:**
+- Modify: `frontend/src/features/ai-intelligence/components/incident-groups-view.tsx`
+- Modify: `frontend/src/features/ai-intelligence/hooks/use-incidents.ts` (add `useBatchResolve`)
+- Test: `frontend/src/features/ai-intelligence/components/incident-groups-view.resolve.test.tsx`
+
+**Why:** All three resolve paths use the new batch endpoint where >1 id; partial-failure UX matches §4.5.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/features/ai-intelligence/components/incident-groups-view.resolve.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+vi.mock('@/shared/lib/api', () => ({ api: { get: vi.fn(), post: vi.fn() } }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+
+const wrap = (c: React.ReactNode) => <QueryClientProvider client={new QueryClient()}><MemoryRouter>{c}</MemoryRouter></QueryClientProvider>;
+
+const groupOf = (ids: string[]) => ({
+  signature: 'g', label: 'Grp', severity: 'critical' as const,
+  incident_count: ids.length, container_count: ids.length, alert_count: ids.length,
+  earliest_at: '', latest_update_at: '',
+  top_containers: ids.map((id, i) => ({
+    incident_id: id, container_name: `cn-${i}`, endpoint_id: 1, endpoint_name: 'e',
+    severity: 'critical' as const, created_at: '',
+  })),
+  all_container_names: ids.map((_, i) => `cn-${i}`),
+  names_truncated: false,
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('IncidentGroupsView — resolve', () => {
+  it('per-group "Resolve all N" calls batch endpoint with the group ids', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 3, endpoint_facets: [], groups: [groupOf(['x', 'y', 'z'])] },
+      isLoading: false,
+    });
+    (api.post as ReturnType<typeof vi.fn>).mockResolvedValue({ resolved: ['x', 'y', 'z'], failed: [] });
+
+    render(wrap(<IncidentGroupsView />));
+    await userEvent.click(screen.getByRole('button', { name: /Resolve all 3/i }));
+    // ConfirmDialog confirm — match the existing label used by the dialog
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(api.post).toHaveBeenCalledWith('/api/incidents/resolve', { ids: ['x', 'y', 'z'] });
+  });
+
+  it('partial failure ≤5 keeps failed inline with retry option', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 3, endpoint_facets: [], groups: [groupOf(['x', 'y', 'z'])] },
+      isLoading: false,
+    });
+    (api.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      resolved: ['x', 'z'],
+      failed: [{ id: 'y', error: 'boom' }],
+    });
+
+    render(wrap(<IncidentGroupsView />));
+    await userEvent.click(screen.getByRole('button', { name: /Resolve all 3/i }));
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(await screen.findByText(/Retry 1 failed/i)).toBeInTheDocument();
+  });
+
+  it('partial failure >5 collapses into a banner', async () => {
+    const ids = Array.from({ length: 12 }, (_, i) => `i${i}`);
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 12, endpoint_facets: [], groups: [groupOf(ids)] },
+      isLoading: false,
+    });
+    (api.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      resolved: ids.slice(0, 5),
+      failed: ids.slice(5).map((id) => ({ id, error: 'e' })),
+    });
+
+    render(wrap(<IncidentGroupsView />));
+    await userEvent.click(screen.getByRole('button', { name: /Resolve all 12/i }));
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(await screen.findByText(/7 of 12 resolves failed/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Retry failed only/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.resolve.test.tsx
+```
+
+Expected: failure (resolve UI not implemented).
+
+- [ ] **Step 3: Add `useBatchResolve` hook**
+
+In `frontend/src/features/ai-intelligence/hooks/use-incidents.ts`, append:
+
+```ts
+export interface BatchResolveResponse {
+  resolved: string[];
+  failed: Array<{ id: string; error: string }>;
+}
+
+export function useBatchResolveIncidents() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (ids: string[]) => api.post<BatchResolveResponse>('/api/incidents/resolve', { ids }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['incidents'] });
+      queryClient.invalidateQueries({ queryKey: ['incident-groups'] });
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Wire resolve UX into `IncidentGroupsView`**
+
+In `incident-groups-view.tsx`, add:
+
+```tsx
+import { useBatchResolveIncidents, type BatchResolveResponse } from '../hooks/use-incidents';
+import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
+
+// inside component:
+const batchResolve = useBatchResolveIncidents();
+const [pendingGroup, setPendingGroup] = useState<IncidentGroup | null>(null);
+const [lastFailure, setLastFailure] = useState<BatchResolveResponse | null>(null);
+
+const onResolveGroup = useCallback(async (group: IncidentGroup) => {
+  setPendingGroup(null);
+  const ids = group.top_containers.map((c) => c.incident_id);
+  const r = await batchResolve.mutateAsync(ids);
+  if (r.failed.length > 0) setLastFailure(r);
+}, [batchResolve]);
+
+const onRetryFailed = useCallback(async () => {
+  if (!lastFailure) return;
+  const r = await batchResolve.mutateAsync(lastFailure.failed.map((f) => f.id));
+  setLastFailure(r.failed.length > 0 ? r : null);
+}, [batchResolve, lastFailure]);
+```
+
+In each group's expanded section, render a "Resolve all N" button that opens `ConfirmDialog` with `setPendingGroup(g)`. Render the dialog at the bottom of the component:
+
+```tsx
+{pendingGroup && (
+  <ConfirmDialog
+    title={`Resolve all ${pendingGroup.incident_count} incidents in this group?`}
+    onConfirm={() => onResolveGroup(pendingGroup)}
+    onCancel={() => setPendingGroup(null)}
+    confirmLabel="Confirm"
+  />
+)}
+```
+
+For partial-failure surfacing:
+
+```tsx
+{lastFailure && lastFailure.failed.length > 0 && (
+  lastFailure.failed.length <= 5 ? (
+    <div role="alert" className="rounded-md border border-red-500/40 bg-red-50/30 p-2 text-sm">
+      <p className="font-medium">Retry {lastFailure.failed.length} failed</p>
+      <ul className="mt-1 list-disc pl-5">
+        {lastFailure.failed.map((f) => <li key={f.id}>{f.id}: {f.error}</li>)}
+      </ul>
+      <button onClick={onRetryFailed} className="mt-1 rounded-md bg-emerald-600 px-2 py-1 text-xs text-white">Retry</button>
+    </div>
+  ) : (
+    <div role="alert" className="rounded-md border border-red-500/40 bg-red-50/30 p-2 text-sm">
+      <p className="font-medium">{lastFailure.failed.length} of {lastFailure.failed.length + lastFailure.resolved.length} resolves failed</p>
+      <button onClick={onRetryFailed} className="mt-1 rounded-md bg-emerald-600 px-2 py-1 text-xs text-white">Retry failed only</button>
+    </div>
+  )
+)}
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.resolve.test.tsx
+```
+
+Expected: 3 passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/features/ai-intelligence/components/incident-groups-view.tsx \
+        frontend/src/features/ai-intelligence/components/incident-groups-view.resolve.test.tsx \
+        frontend/src/features/ai-intelligence/hooks/use-incidents.ts
+git commit -m "feat(frontend): per-group Resolve all via batch endpoint with partial-failure UX"
+```
+
+---
+
+### Task 16: URL state — `range`, `endpoint`, `sort`, `expand`
+
+**Files:**
+- Modify: `frontend/src/features/ai-intelligence/components/incident-groups-view.tsx`
+- Test: `frontend/src/features/ai-intelligence/components/incident-groups-view.url.test.tsx`
+
+**Why:** Deep-linking and refresh-stable views.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/features/ai-intelligence/components/incident-groups-view.url.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+
+const wrap = (initialEntries: string[], children: React.ReactNode) =>
+  <QueryClientProvider client={new QueryClient()}><MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter></QueryClientProvider>;
+
+describe('IncidentGroupsView — URL ?expand=', () => {
+  it('initial render with ?expand=-anomaly%3Aml-anomaly%3Acpu collapses a critical group', () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 1, endpoint_facets: [], groups: [{
+        signature: 'anomaly:ml-anomaly:cpu', label: 'CPU anomaly', severity: 'critical',
+        incident_count: 1, container_count: 1, alert_count: 1,
+        earliest_at: '', latest_update_at: '',
+        top_containers: [{ incident_id: 'x', container_name: 'cn', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }],
+        all_container_names: ['cn'], names_truncated: false,
+      }] },
+      isLoading: false,
+    });
+    render(wrap(['/?expand=-anomaly%3Aml-anomaly%3Acpu'], <IncidentGroupsView />));
+    expect(screen.queryByText('cn')).not.toBeInTheDocument();
+  });
+
+  it('toggling a critical group closed encodes -<sig> into the URL', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 1, endpoint_facets: [], groups: [{
+        signature: 'anomaly:ml-anomaly:cpu', label: 'CPU anomaly', severity: 'critical',
+        incident_count: 1, container_count: 1, alert_count: 1,
+        earliest_at: '', latest_update_at: '',
+        top_containers: [{ incident_id: 'x', container_name: 'cn', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }],
+        all_container_names: ['cn'], names_truncated: false,
+      }] },
+      isLoading: false,
+    });
+    render(wrap(['/'], <IncidentGroupsView />));
+    expect(screen.getByText('cn')).toBeInTheDocument(); // expanded by default
+    await userEvent.click(screen.getByRole('button', { name: /CPU anomaly/i }));
+    // Expected: clicking toggles closed; component updates URL via setSearchParams.
+    // We assert visible state since RouterDOM updates internal location.
+    expect(screen.queryByText('cn')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.url.test.tsx
+```
+
+Expected: failure (URL state not yet wired in).
+
+- [ ] **Step 3: Wire URL state**
+
+In `incident-groups-view.tsx`, replace the local `expanded` state with URL-driven state:
+
+```ts
+import { useSearchParams } from 'react-router-dom';
+
+// inside component:
+const [searchParams, setSearchParams] = useSearchParams();
+const expandParam = searchParams.get('expand') ?? '';
+
+const overrides = useMemo(() => {
+  const opens = new Set<string>();
+  const closes = new Set<string>();
+  for (const part of expandParam.split(',').filter(Boolean)) {
+    const decoded = decodeURIComponent(part);
+    if (decoded.startsWith('-')) closes.add(decoded.slice(1));
+    else opens.add(decoded);
+  }
+  return { opens, closes };
+}, [expandParam]);
+
+const isOpen = (sig: string, severity: IncidentGroup['severity']) => {
+  if (overrides.closes.has(sig)) return false;
+  if (overrides.opens.has(sig)) return true;
+  return severity === 'critical';
+};
+
+const toggle = useCallback((sig: string, severity: IncidentGroup['severity']) => {
+  const open = isOpen(sig, severity);
+  const next = !open;
+  // Compute new expand param
+  const opens = new Set(overrides.opens);
+  const closes = new Set(overrides.closes);
+  opens.delete(sig); closes.delete(sig);
+  const defaultOpen = severity === 'critical';
+  if (next !== defaultOpen) {
+    if (next) opens.add(sig); else closes.add(sig);
+  }
+  const parts = [
+    ...Array.from(opens).map((s) => encodeURIComponent(s)),
+    ...Array.from(closes).map((s) => '-' + encodeURIComponent(s)),
+  ];
+  const sp = new URLSearchParams(searchParams);
+  if (parts.length > 0) sp.set('expand', parts.join(',')); else sp.delete('expand');
+  setSearchParams(sp);
+}, [searchParams, setSearchParams, overrides]);
+```
+
+The `range`, `endpoint`, `sort` URL params stay handled in the parent `ai-monitor.tsx` page (see Task 18). This component reads them via props if needed.
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.url.test.tsx
+```
+
+Expected: 2 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/ai-intelligence/components/incident-groups-view.tsx \
+        frontend/src/features/ai-intelligence/components/incident-groups-view.url.test.tsx
+git commit -m "feat(frontend): URL ?expand= encodes group toggle deviations from severity default"
+```
+
+---
+
+### Task 17: Endpoint chip overflow — first 8 inline + `+N more` dropdown
+
+**Files:**
+- Modify: `frontend/src/features/ai-intelligence/components/incident-groups-view.tsx`
+- Test: `frontend/src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx`
+
+**Why:** Multi-host fleets — chip row stays usable above 8 endpoints.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+
+const wrap = (c: React.ReactNode) => <QueryClientProvider client={new QueryClient()}><MemoryRouter>{c}</MemoryRouter></QueryClientProvider>;
+
+describe('IncidentGroupsView — endpoint chip overflow', () => {
+  it('renders <=8 endpoints inline, no dropdown', () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 0, groups: [],
+        endpoint_facets: Array.from({ length: 5 }, (_, i) => ({ endpoint_id: i, endpoint_name: `e${i}`, incident_count: 1 })),
+      },
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView />));
+    expect(screen.queryByText(/more/i)).not.toBeInTheDocument();
+  });
+
+  it('renders +N more dropdown when >8 endpoints', () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 0, groups: [],
+        endpoint_facets: Array.from({ length: 12 }, (_, i) => ({ endpoint_id: i, endpoint_name: `e${i}`, incident_count: 1 })),
+      },
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView />));
+    expect(screen.getByText(/\+4 more/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx
+```
+
+Expected: failure.
+
+- [ ] **Step 3: Render the chip row with overflow**
+
+In `incident-groups-view.tsx`, add (place above the groups list):
+
+```tsx
+function EndpointChips({ facets }: { facets: Array<{ endpoint_id: number | null; endpoint_name: string | null; incident_count: number }> }) {
+  if (facets.length <= 1) return null;
+  const inline = facets.slice(0, 8);
+  const overflow = facets.slice(8);
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {inline.map((f) => (
+        <button key={`${f.endpoint_id}`} className="rounded-full border px-3 py-1 text-xs">
+          {f.endpoint_name ?? 'unknown'} ({f.incident_count})
+        </button>
+      ))}
+      {overflow.length > 0 && (
+        <details>
+          <summary className="cursor-pointer rounded-full border px-3 py-1 text-xs">+{overflow.length} more</summary>
+          <ul className="absolute z-10 mt-1 max-h-64 w-64 overflow-auto rounded-md border bg-popover p-1 shadow">
+            {overflow.map((f) => (
+              <li key={`${f.endpoint_id}`}><button className="w-full rounded px-2 py-1 text-left text-xs hover:bg-muted">{f.endpoint_name ?? 'unknown'} ({f.incident_count})</button></li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+```
+
+Render `<EndpointChips facets={data.endpoint_facets} />` between the summary strip and the groups list.
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx
+```
+
+Expected: 2 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/ai-intelligence/components/incident-groups-view.tsx \
+        frontend/src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx
+git commit -m "feat(frontend): endpoint chip row with +N more overflow"
+```
+
+---
+
+### Task 18: Swap the page section in `ai-monitor.tsx`
+
+**Files:**
+- Modify: `frontend/src/features/ai-intelligence/pages/ai-monitor.tsx`
+- Modify: `frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx`
+
+**Why:** The page now renders the rollup component instead of the flat list.
+
+- [ ] **Step 1: Update an `ai-monitor.test.tsx` assertion (failing)**
+
+In `frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx`, add a test:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AiMonitorPage } from './ai-monitor';
+
+vi.mock('../components/incident-groups-view', () => ({
+  IncidentGroupsView: () => <div data-testid="igv-marker" />,
+}));
+
+it('renders IncidentGroupsView in place of the legacy flat list', () => {
+  const { getByTestId, queryByText } = render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter>
+        <AiMonitorPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  expect(getByTestId('igv-marker')).toBeInTheDocument();
+  // The old per-incident card stack should not be rendered when the new
+  // component is.
+  expect(queryByText(/Active Incidents.*\(.* of \d+\)/i)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/pages/ai-monitor.test.tsx
+```
+
+Expected: failure (`igv-marker` not found).
+
+- [ ] **Step 3: Swap the section in `ai-monitor.tsx`**
+
+Find the existing `Active Incidents` block (lines 1453–1594 per the file scan). Replace the entire `{incidentsData && incidentsData.incidents.length > 0 && ( ... )}` block with:
+
+```tsx
+<IncidentGroupsView search={searchInput} />
+```
+
+Add the import at the top:
+
+```tsx
+import { IncidentGroupsView } from '@/features/ai-intelligence/components/incident-groups-view';
+```
+
+Remove now-unused references to `useIncidents`, `visibleIncidents`, `selectedIncidentIds`, etc., that were only feeding the old block. Leave per-incident drill-down intact (the route exists separately).
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/pages/ai-monitor.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Run the entire ai-intelligence frontend test suite**
+
+```bash
+cd frontend && npx vitest run src/features/ai-intelligence/
+```
+
+Expected: no regressions.
+
+- [ ] **Step 6: Manual smoke test in dev**
+
+```bash
+docker compose -f docker/docker-compose.dev.yml up -d
+npm run dev
+```
+
+Open `http://localhost:5173/health`. Verify:
+- Active Incidents shows summary + grouped list
+- Critical groups expanded by default
+- Clicking a group toggles
+- Endpoint chips appear (only if multi-endpoint env)
+- Search by container name filters groups
+- Click container chip → existing detail page opens
+
+If anything looks wrong, return to the relevant task — do not "fix" in this commit.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/features/ai-intelligence/pages/ai-monitor.tsx \
+        frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
+git commit -m "feat(frontend): /health Active Incidents uses IncidentGroupsView rollup"
+```
+
+---
+
+### Task 19: Final integration sweep — full lint + typecheck + test pass
+
+**Files:** none (verification task)
+
+**Why:** Catch typing or boundary issues introduced across the workspace.
+
+- [ ] **Step 1: Lint**
+
+```bash
+npm run lint
+```
+
+Expected: zero new errors. Fix any introduced.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3: All tests**
+
+```bash
+npm test
+```
+
+Expected: pass on backend, frontend, and packages.
+
+- [ ] **Step 4: Production verification checklist (against §5.2 of the spec)**
+
+If any test from the spec's §5.2 production verification fails locally, file a fix as a child task. Examples to run manually:
+- `GET /api/incidents/groups` p95 latency on dev DB seeded with 1000 incidents
+- Force a partial failure in batch resolve (resolve already-resolved id) and verify the >5-fail collapsed banner UX
+- `?range=24h` filter via URL retains after refresh
+
+- [ ] **Step 5: Commit any fixes (if any) and prepare PR**
+
+```bash
+git status
+# only if there are fixes:
+git commit -am "fix(incidents): integration sweep cleanups"
+```
+
+- [ ] **Step 6: Push and open PR**
+
+```bash
+git push -u origin feature/health-monitoring-ux-overhaul
+gh pr create --title "feat(health): two-level rollup for Active Incidents" \
+  --body-file docs/superpowers/specs/2026-05-06-active-incidents-rollup-design.md \
+  --base dev
+```
+
+(If `gh` has the TLS error from the spec session, file the PR via web UI or `curl` to the GitHub API as shown in commit history.)
+
+---
+
+## Self-review
+
+I checked the plan against the spec. Coverage is complete:
+
+- **Spec §3.1 (Migration):** Tasks 1 + 2.
+- **Spec §3.2 (Insight schema):** Task 3.
+- **Spec §3.3 (Signature derivation):** Tasks 4 + 5.
+- **Spec §3.4 (Backfill + drift):** Task 8 + drift verification embedded in Task 5.
+- **Spec §3.5 (`/api/incidents/groups`):** Task 10.
+- **Spec §3.6 (Batch resolve):** Task 11.
+- **Spec §3.7 (Tests):** distributed across the relevant tasks.
+- **Spec §4.1 (Hook):** Task 12.
+- **Spec §4.2 / §4.3 (Component layout & behavior):** Tasks 13 + 14 + 15 + 17.
+- **Spec §4.4 (URL state):** Task 16 (component-level `?expand=`); page-level `range` / `endpoint` / `sort` continue to live in `ai-monitor.tsx` as today, swapped in Task 18.
+- **Spec §4.5 (Resolve paths):** Task 15.
+- **Spec §4.6 (Tests):** distributed.
+- **Spec §5.1 (Merge order):** plan task ordering matches.
+- **Spec §5.2 (Production verification):** Task 19 step 4.
+- **Spec §6 (Acceptance criteria):** every item maps to a task.
+
+Cache-promotion task (Task 4 in earlier draft) was dropped after verifying `cachedFetchSWR` is already in `@dashboard/core/portainer/portainer-cache.ts` and importable from `packages/ai-intelligence`. Boundary-clean already.
+
+`signature` filter on `/api/incidents` (§3.5 prose) lives in Task 9 — added because §4 calls the route and the existing handler doesn't accept the filter.
+
+No TBD/TODO/placeholder text remains.

--- a/docs/superpowers/specs/2026-05-06-active-incidents-rollup-design.md
+++ b/docs/superpowers/specs/2026-05-06-active-incidents-rollup-design.md
@@ -76,7 +76,7 @@ The Active Incidents block on `/health` shows a flat list of 455 rows. Each pred
 ### Boundary decisions
 
 1. **Aggregate in SQL, not in JS.** `getIncidentGroups()` returns one row per signature with counts already computed. At 10K incidents the request stays a single fast query, not a 10K-row payload that the frontend reduces.
-2. **Top-N containers picked in SQL.** The aggregate endpoint includes `top_containers` per signature (worst 10 by severity then most-recent). "Show all" calls existing `/api/incidents?status=active&signature=X` for the long tail — pagination cost lives where it belongs.
+2. **Top-N containers picked in SQL.** The aggregate endpoint includes `top_containers` per signature (worst 10 by severity then most-recent). "Show all" calls existing `/api/incidents?status=active&signature=X` for the long tail — pagination cost lives where it belongs. (Adding `signature` to `GetIncidentsOptions` is part of this PR; see §3.5.)
 3. **Signature derivation in one place.** `deriveSignature()` in `signature.ts` is the single source of truth, used by both `buildIncident()` and the backfill. Single point to test, single point to evolve.
 4. **Endpoint filter is a query param, not a separate endpoint.** `/api/incidents/groups?endpoint_id=42` filters server-side. Keeps URL/state cheap.
 5. **Title is for humans, signature is for grouping.** They diverge by design. Title text remains free-form; signature is enum-like and stable.
@@ -192,10 +192,12 @@ Run once at deploy time. Re-runnable safely.
 **Drift verification (mandatory before merge).** The risk is that legacy incidents whose root insight lacks the new structured fields fall through to the title regex and produce a signature that doesn't match what live writes produce for the same problem class — splitting the rollup. To prevent this:
 
 1. Export a representative sample of historical incident titles from a real environment (script provided alongside the backfill: `dump-historical-titles.ts`, dumps to a CSV).
-2. Add a test in `signature.test.ts` that loads this CSV and asserts every historical title maps to a signature in the known-good set (i.e., no `unknown:*` results, and the regex outputs match what the structured-field path would emit for the same problem class).
+2. Add a test in `signature.test.ts` that loads this CSV and asserts every historical title maps to a signature in the known-good set, **and** that the regex output for each title equals the signature the structured-field path would emit for the same `(category, metric_type, detection_method)` triple. The equivalence check is the load-bearing assertion; "no `unknown:*`" alone is too weak.
 3. Any title that produces a mismatch is a regex bug to fix in `deriveSignatureFromTitle` before merge — not an acceptable "legacy fallback".
 
-The CSV is checked in as a test fixture so the corpus stays stable across PRs. Add to it whenever new title patterns are discovered in production.
+The CSV is checked in as a test fixture so the corpus stays stable across PRs.
+
+**Drift verification is a snapshot, not a permanent guard.** New title patterns introduced after merge — by future changes to `monitoring-service.ts` or other emitters — will produce `unknown:<slug>` until someone updates the regex set and adds a CSV row. Any commit that adds a new title pattern is responsible for adding a CSV row in the same change. Reviewers should treat a missing CSV row for a new title as a blocking comment.
 
 ### 3.5 New endpoint: `GET /api/incidents/groups`
 
@@ -205,7 +207,7 @@ The CSV is checked in as a test fixture so the corpus stays stable across PRs. A
 GET /api/incidents/groups?status=active&endpoint_id=42&since=24h&severity=critical
 ```
 
-All query params optional. `status` defaults to `active`. `since` filters incidents whose **`COALESCE(latest_at, updated_at, created_at) >= NOW() - <window>`** — i.e., "recently active", not "recently created". A long-running active incident from 25 hours ago is *not* hidden by `since=24h` if it's still being updated. Accepts `1h`, `24h`, `7d`, or omitted (= all-time). The aggregate counts in the response reflect only the filtered set — including `top_containers`, `all_container_names`, and `endpoint_facets`.
+All query params optional. `status` defaults to `active`. `since` filters incidents whose **`updated_at >= NOW() - <window>`** — i.e., "recently active", not "recently created". `updated_at` is bumped by `addInsightToIncident` (`incident-store.ts:86`) and `resolveIncident`, so a long-running active incident from 25 hours ago is *not* hidden by `since=24h` if it's still receiving insights. Accepts `1h`, `24h`, `7d`, or omitted (= all-time). The aggregate counts in the response reflect only the filtered set — including `top_containers`, `all_container_names`, and `endpoint_facets`.
 
 **Response:**
 
@@ -218,8 +220,8 @@ All query params optional. `status` defaults to `active`. `since` filters incide
     incident_count: number;       // unique incidents in this group
     container_count: number;      // unique container names across the group
     alert_count: number;          // sum of insight_count
-    earliest_at: string;          // ISO timestamp
-    latest_at: string;
+    earliest_at: string;          // ISO timestamp (MIN(created_at) in group)
+    latest_update_at: string;     // ISO timestamp (MAX(updated_at) in group)
     top_containers: Array<{
       incident_id: string;
       container_name: string;
@@ -240,13 +242,25 @@ All query params optional. `status` defaults to `active`. `since` filters incide
 }
 ```
 
-`all_container_names` is intentionally just strings (not full incident records) to keep the payload bounded. At 200 containers per group × 30 groups × 50 chars/name ≈ 300 KB worst-case — acceptable. If empirical payloads exceed 500 KB, we cap the array at, say, 1000 names per group and require server-side search for groups beyond that (deferred until measured).
+`all_container_names` is intentionally just strings (not full incident records) to keep the payload bounded. **Hard cap of 500 names per group, applied in SQL** (`array_agg(DISTINCT container_name ORDER BY container_name) FILTER (WHERE rn <= 500)`). When truncated, the group entry includes a `names_truncated: true` flag and `container_count` still reflects the real total. The frontend, on detecting `names_truncated`, falls back to server-side search for that group (calls `/api/incidents?signature=X&q=<term>`; backend support added as a follow-up — see §5.5). 500 names × 50 chars × 30 groups ≈ 750 KB worst-case payload, acceptable; raises proactively rather than waiting for production pathology.
 
 **Implementation:** one CTE per dimension (signature aggregate with `array_agg(DISTINCT container_name) AS all_container_names`, endpoint facet, top-N per signature using `ROW_NUMBER() OVER (PARTITION BY signature ORDER BY severity_rank, created_at DESC)`), wrapped into a single round-trip.
 
-**Caching:** the route handler wraps the DB query in `cachedFetchSWR()` (existing pattern in `portainer-cache.ts`) keyed on `(status, endpoint_id, since, severity)` with a 20s TTL. Stale-while-revalidate ensures the 30s frontend poll hits the DB at most once per cache window per filter tuple. Cache invalidation: `invalidateTag('incidents')` is called on every `insertIncident`, `addInsightToIncident`, and `resolveIncident` so the next read refreshes.
+**Caching.** The route handler wraps the DB query in a stale-while-revalidate cache, keyed on `(status, endpoint_id, since, severity)`, **TTL 10s** (chosen so total perceived staleness — TTL + frontend 30s poll — stays under ~40s; see §4.1 for the staleness budget).
+
+**Package-boundary problem to resolve.** The existing `cachedFetchSWR` lives at `backend/src/services/portainer-cache.ts`, but this route is in `packages/ai-intelligence/`, which per its `CLAUDE.md` may import only from `@dashboard/core` and `@dashboard/contracts`. Three options, in priority order:
+
+1. **Promote `TtlCache` + `cachedFetchSWR` + `invalidateTag` to `@dashboard/core/cache`** (recommended). The pattern is generic, has no portainer-specific logic, and is already used by multiple domains. One-time refactor, then both the existing portainer cache *and* the new incident cache import from core. Keeps the boundary clean.
+2. **Inline a small per-route SWR cache in the route file** (~30 lines). Pragmatic if option 1 turns out to require touching too many call sites in one PR.
+3. **Skip caching this PR.** Acceptable only if `/api/incidents/groups` shows up cold-cache-only in load tests; otherwise revisit.
+
+The implementation plan picks 1 unless a survey of `cachedFetchSWR` consumers shows >5 call sites that would need updating in lockstep, in which case 2 is the fallback.
+
+**Cache invalidation.** `invalidateTag('incidents')` is called once per request in `incidents.ts` after `insertIncident` / `addInsightToIncident` / `resolveIncident` / batch resolve completes. The invalidation lives in the route layer (which can import from `@dashboard/core` post-promotion), not inside the store functions, so the store stays cache-agnostic and unit-testable without a cache.
 
 **Auth:** `fastify.authenticate` (read-only). No new RBAC role required.
+
+**Existing `/api/incidents` gains a `signature` filter.** `GetIncidentsOptions` in `incident-store.ts` adds an optional `signature?: string` field, the route accepts `?signature=` as a query param, and the SQL appends `AND signature = ?` when provided. This is the long-tail query the frontend uses for "Show all". Tested in `incidents-list.test.ts` (additions): listing by signature returns only matching incidents.
 
 **Resolve action stays on the per-incident endpoint** for single resolves; a new batch endpoint (§3.6) handles multi-resolve.
 
@@ -273,7 +287,7 @@ Validated by Zod: `ids` must be a non-empty array of UUIDs, capped at 500 per ca
 }
 ```
 
-**Implementation:** wraps the existing `resolveIncident()` per id in a single transaction; per-id failures are caught and surfaced in `failed[]` rather than aborting the whole batch. Audit-logs each resolution like the single-resolve route. Tag-invalidates `incidents` once at the end. Single round trip, returns within ~1s for batches of 500.
+**Implementation:** iterates the input `ids` and resolves each in **its own short-lived transaction** (per-id atomicity, not all-or-nothing). Per-id errors are caught and pushed onto `failed[]` while remaining ids continue. Single-transaction-with-savepoints would also work but adds complexity for no business benefit — there's no reason a partial batch resolve should roll back already-resolved incidents. Audit-logs each successful resolution like the single-resolve route. Tag-invalidates `incidents` once at the end of the request, not per-id, to avoid thrash. Single round trip from the client's perspective; ~1s wall-clock for a 500-id batch.
 
 ### 3.7 Tests
 
@@ -281,11 +295,13 @@ Added to `packages/ai-intelligence/src/__tests__/`:
 
 | File | Covers |
 |---|---|
-| `signature.test.ts` | Derivation: every category/method/metric combo, fallbacks, label lookup, stability across known title variants, **and the historical-titles drift corpus from §3.4 (every CSV row maps to a known signature, no `unknown:*`)**. |
-| `incidents-groups.test.ts` | New route end-to-end: aggregate counts, top-N ordering, `all_container_names` correctness, severity rollup, endpoint filter, `since` filter using `latest_at` semantics, empty result, auth, cache invalidation on resolve. |
-| `incidents-resolve-batch.test.ts` | New batch resolve route: success path, partial failure (some ids resolved, others not), input validation (cap, UUID shape), RBAC (admin required), audit-log emission, tag invalidation. |
+| `signature.test.ts` | Derivation: every category/method/metric combo, fallbacks, label lookup. **Drift corpus assertions from §3.4: every historical-title CSV row produces a non-`unknown:*` signature AND that signature equals the structured-field path for the same `(category, metric_type, detection_method)` triple.** |
+| `incidents-list.test.ts` (additions) | Existing `GET /api/incidents` accepts the new `?signature=` filter; returns only matching rows; existing filters still work in combination. |
+| `incidents-groups.test.ts` | New route end-to-end: aggregate counts, top-N ordering, `all_container_names` correctness (including the 500-name cap producing `names_truncated: true`), severity rollup, endpoint filter, `since` filter applied against `updated_at`, empty result, auth, cache invalidation after resolve. |
+| `incidents-resolve-batch.test.ts` | New batch resolve route: success path, partial failure (per-id transactions — failed ids do not roll back resolved ids), input validation (cap, UUID shape), RBAC (admin required), audit-log emission, single tag-invalidation at request end. |
 | `incidents-backfill.test.ts` | Backfill: populates null signatures, idempotent on re-run, handles missing root insight, batch boundary, `--force` flag. |
 | `incident-correlator.test.ts` (additions) | `buildIncident()` writes `signature` correctly for structured-fields path and falls back for legacy insights. |
+| `cache-promotion.test.ts` *(only if option 1 of §3.5 is taken)* | The promoted `@dashboard/core/cache` exposes `TtlCache`, `cachedFetchSWR`, `invalidateTag` with the same semantics as the previous `portainer-cache.ts`. Existing portainer-cache call sites continue to behave identically (smoke test). |
 
 All DB tests use the real-PostgreSQL helper (`test-db-helper.ts`).
 
@@ -304,7 +320,11 @@ export function useIncidentGroups(params: {
 })
 ```
 
+Hook accepts camelCase params (`endpointId`); the hook internally serializes to the snake_case query string the backend expects (`endpoint_id=`). Boundary mapping lives in the hook, not in callers.
+
 Same `refetchInterval` (30s + page-visibility gating) as `useIncidents`. Existing `useIncidents()` and `useIncidentDetail()` stay — they back the per-container drill-down inside an expanded group.
+
+**Effective staleness budget.** Server-side cache TTL 10s + 30s frontend poll → another user's resolve becomes visible within ~40s in the worst case (cache hit just before invalidation). Cache invalidation on writes (§3.5) shortens this for self-initiated changes — local resolves see fresh data on the next poll. Tightening TTL below 10s would beat down the cache hit ratio without meaningful UX gain at this poll interval.
 
 ### 4.2 Component layout
 
@@ -341,14 +361,14 @@ Same `refetchInterval` (30s + page-visibility gating) as `useIncidents`. Existin
 |---|---|
 | Summary strip | Single line. Computed client-side from `groups`. Each container is counted **at most once across severity buckets** — by its highest severity. So "Critical: 3 kinds across 8 containers · Warning: 5 kinds across 22 containers" means 8 containers have at least one critical incident, and 22 *additional* containers have at least one warning (and no critical). Info bucket only renders if non-zero. |
 | Time range tabs | Existing controls, moved to header line. URL `?range=` (already in use). Defaults to `24h` if no URL state. |
-| Endpoint chip row | Renders only when `endpoint_facets.length > 1`. Active chip is URL-driven (`?endpoint=`). "All" clears the param. |
+| Endpoint chip row | Renders only when `endpoint_facets.length > 1`. Active chip is URL-driven (`?endpoint=`). "All" clears the param. **Overflow:** the row scrolls horizontally; when more than 8 endpoints are present, the first 8 are shown inline and the rest collapse into a `+N more` dropdown (Radix `Select`). The dropdown lists all remaining endpoints with their incident counts. Selecting from the dropdown sets `?endpoint=` as a normal chip click would. |
 | Group card collapsed | Severity dot · label · `N containers · M alerts` · chevron. Critical groups expanded by default; warnings/info collapsed. |
 | Group card expanded | Top 10 container rows from `top_containers`. Each row: checkbox, container chip (linked to `/containers/:endpointId/:containerId`), severity badge, age, endpoint, individual `[Resolve]`. |
 | "Show all N" link | Visible when `container_count > 10`. Click → fetches `/api/incidents?status=active&signature=X` and replaces the top-10 list with the full set. Per-group state, not URL. |
 | Per-row resolve | Calls existing `useResolveIncident()`. No change. |
 | Per-group "Resolve all" | New action. Confirms via existing `ConfirmDialog`. Calls the new **`POST /api/incidents/resolve`** batch endpoint with all incident IDs in the group (one round trip, see §3.6). Failures surfaced per-id via the partial-failure rules below. |
 | Multi-select bar | Existing bulk-action bar stays for cross-group selection. Now also calls the batch endpoint. Selection survives expand/collapse. |
-| Search | Filters groups by (a) signature label and (b) **`all_container_names`** (the full server-provided list, including the long tail — no false negatives). When a group matches via a container hit, it auto-expands. If the matching container is in the long tail (not in `top_containers`), the page auto-triggers the "Show all" fetch for that group so the matching row is visible. No backend change. |
+| Search | Filters groups by (a) signature label and (b) **`all_container_names`** (the full server-provided list, including the long tail — no false negatives). When a group matches via a container hit, it auto-expands. If the matching container is in the long tail (not in `top_containers`), the page auto-triggers the "Show all" fetch for that group so the matching row is visible. **Search input is debounced 250 ms before triggering any auto-fetch**, so fast typing doesn't fire one fetch per keystroke per matching group. If a group has `names_truncated: true` (the 500-name cap was hit, see §3.5), the search delegates to a backend search endpoint (`GET /api/incidents?signature=X&q=<term>`) for that group. |
 | Sort | Existing severity/time toggle applies inside groups. Group order is fixed: severity → container_count desc. |
 | Empty state | "No active incidents in this view." Reuses the dashed-border box already used by the page. |
 
@@ -361,7 +381,9 @@ Same `refetchInterval` (30s + page-visibility gating) as `useIncidents`. Existin
 | `sort` | `severity` / `time` | `severity` (existing) |
 | `expand` | comma-separated signature strings | absent (= use default expand-by-severity rule) |
 
-Expand state is URL-tracked when the user explicitly toggles a group, so deep-linking to "this exact view" works (refresh, share). Toggling a critical group closed adds it to `?expand=` with a `-` prefix (e.g., `?expand=-anomaly:ml-anomaly:cpu`), so the URL captures *deviations* from the default, not the full state. Initial render with no `?expand=` follows the "critical expanded by default" rule from §4.3.
+Expand state is URL-tracked when the user explicitly toggles a group, so deep-linking to "this exact view" works (refresh, share). Toggling a critical group closed adds it to `?expand=` with a `-` prefix; toggling a warning/info group open adds it without a prefix. The URL captures *deviations* from the default expand-by-severity rule, not the full state.
+
+**Format.** `?expand=` is a comma-separated list of URL-encoded signature strings, optionally prefixed with `-`. Example: `?expand=-anomaly%3Aml-anomaly%3Acpu,predictive%3Aprediction%3Amemory`. Signatures contain `:` (URL-encoded as `%3A`); commas are forbidden inside a signature. `slugifyTitle()` (used by `unknown:<slug>`) explicitly strips commas to keep this guarantee. Initial render with no `?expand=` follows the "critical expanded by default" rule from §4.3.
 
 `?signature=` is **not** introduced — search-and-expand covers the deep-link use case. Avoiding ship-but-unused URL params.
 
@@ -394,7 +416,10 @@ Added to `frontend/src/features/ai-intelligence/`:
 | `components/incident-groups-view.resolve.test.tsx` | Per-row resolve, per-group "Resolve all" via batch endpoint, multi-select interop, partial-failure UX (≤5 fail → inline; >5 fail → collapsed banner with Retry failed only). |
 | `components/incident-groups-view.search.test.tsx` | Search filters via `all_container_names` (long-tail container is found, not just `top_containers`); auto-expand on container hit; auto-trigger "Show all" when match is in long tail. |
 | `components/incident-groups-view.show-all.test.tsx` | "Show all N" pagination flow: fetch via `/api/incidents?signature=X`, replaces top-10, search remains scoped to the expanded set. |
-| `components/incident-groups-view.url.test.tsx` | URL state: `range`, `endpoint`, `sort`, `expand` (with `-` prefix for closed-by-default deviations) survive refresh; deep-link URL renders matching state. |
+| `components/incident-groups-view.url.test.tsx` | URL state: `range`, `endpoint`, `sort` survive refresh; `?expand=` round-trip — toggling groups encodes signatures with URL-encoded colons and `-` prefix per §4.4; decoder applies them on first paint; unknown signatures in `?expand=` are silently ignored (forward-compat). |
+| `components/incident-groups-view.search-debounce.test.tsx` | Typing characters fires no auto-fetch until 250 ms of quiet; rapid typing across groups does not stack fetches. |
+| `components/incident-groups-view.endpoint-overflow.test.tsx` | <=8 endpoints render inline; >8 endpoints collapse the surplus into a `+N more` dropdown with correct counts and selection. |
+| `components/incident-groups-view.truncated.test.tsx` | When a group response includes `names_truncated: true`, search delegates to backend `GET /api/incidents?signature=X&q=...` instead of filtering `all_container_names` locally. |
 | `pages/ai-monitor.test.tsx` (additions) | The page renders `IncidentGroupsView` instead of the flat list; existing assertions for non-incident sections still pass. |
 
 Mocks: `useIncidentGroups` for component tests (frontend mocks API at the boundary). No backend changes required to run frontend tests.
@@ -463,8 +488,9 @@ These give us the "alerts per container per signature" ratio that #1195 needs to
 
 | Follow-up | When |
 |---|---|
-| [#1195](https://github.com/kenhaesler/ai-portainer-dashboard/issues/1195) — engine dedup work | After this PR + 1 week of signature data |
+| [#1195](https://github.com/kenhaesler/ai-portainer-dashboard/issues/1195) — engine dedup work | Expected ~1 week after this PR (data-gathering window). If rollup data surfaces a critical engine bug sooner, accelerate — the wait is operational, not contractual. |
 | Signature `NOT NULL` enforcement | One week after this PR; trivial migration |
+| Backend container-name search: `GET /api/incidents?signature=X&q=<term>` | Required only when `names_truncated: true` becomes common; needed by §4.3 search delegation. Trivial route addition (LIKE filter on container_name). |
 | Resolved-incidents view redesign | Smaller separate PR; same group structure, different defaults |
 | Endpoint-scoped sub-grouping (third nesting level) | Only if telemetry shows endpoint distribution is uneven enough to warrant it |
 
@@ -475,11 +501,14 @@ These give us the "alerts per container per signature" ratio that #1195 needs to
 - [ ] `monitoring-service.ts` emits `metric_type` and `detection_method` on anomaly + predictive + health-check + log-analysis + security insights.
 - [ ] `incident-correlator.ts` writes `signature` on every new incident via `deriveSignature` (single source of truth shared with backfill). Existing tests continue to pass.
 - [ ] Backfill script populates all existing incidents with non-null signatures; runnable safely more than once. Drift verification CSV passes before merge.
-- [ ] `GET /api/incidents/groups` returns the response shape in §3.5 (including `all_container_names`), supports `status` / `endpoint_id` / `since` / `severity` filters, applies `since` against `latest_at`, returns within 250ms p95, wrapped in `cachedFetchSWR` with tag invalidation on incident writes.
-- [ ] `POST /api/incidents/resolve` batch endpoint exists, admin-RBAC-gated, validates input, returns `{ resolved, failed }`, and audit-logs each resolution.
+- [ ] `GET /api/incidents/groups` returns the response shape in §3.5 (including `all_container_names` with 500-name cap and `names_truncated` flag, `latest_update_at`), supports `status` / `endpoint_id` / `since` / `severity` filters, applies `since` against `updated_at`, returns within 250ms p95, wrapped in SWR cache (TTL 10s) with tag invalidation on incident writes.
+- [ ] `GET /api/incidents` accepts `?signature=` filter; existing tests continue to pass.
+- [ ] Cache utilities (`TtlCache`, `cachedFetchSWR`, `invalidateTag`) live in `@dashboard/core/cache` (or, if option 2 of §3.5 was taken, the inline cache is documented in the PR description). Existing `portainer-cache.ts` consumers still pass.
+- [ ] `POST /api/incidents/resolve` batch endpoint exists, admin-RBAC-gated, validates input, **uses per-id transactions** (failed ids do not roll back resolved ids), returns `{ resolved, failed }`, and audit-logs each successful resolution. Tag invalidation happens once per request.
 - [ ] `/health` page renders `IncidentGroupsView` with summary strip (single-bucket-per-container), endpoint chips, collapsed/expanded groups, top-10 container rows, "Show all" expansion.
 - [ ] All three resolve paths (per-row, multi-select, per-group) use the batch endpoint where multi-id and surface partial-failure per the §4.5 rules (≤5 inline, >5 collapsed banner with Retry failed only).
-- [ ] Search filters via `all_container_names` (long-tail container names found, not just `top_containers`); auto-expands and auto-fetches "Show all" when needed.
-- [ ] URL params (`range`, `endpoint`, `sort`, `expand` with `-` prefix) survive refresh and deep-linking. No unused URL params shipped.
+- [ ] Search filters via `all_container_names` (long-tail container names found, not just `top_containers`); auto-expands and auto-fetches "Show all" when needed; debounced 250 ms before any auto-fetch fires; falls back to backend search for groups with `names_truncated: true`.
+- [ ] Endpoint chip row handles >8 endpoints via inline + `+N more` dropdown.
+- [ ] URL params (`range`, `endpoint`, `sort`, `expand`) survive refresh and deep-linking. `?expand=` uses comma-separated, URL-encoded signatures with `-` prefix for closed-by-default deviations. No unused URL params shipped.
 - [ ] All new and existing tests pass on backend, frontend, and packages workspaces.
 - [ ] No new ESLint or TypeScript errors. No regression in security-regression tests (auth + RBAC on both new routes).

--- a/docs/superpowers/specs/2026-05-06-active-incidents-rollup-design.md
+++ b/docs/superpowers/specs/2026-05-06-active-incidents-rollup-design.md
@@ -1,0 +1,406 @@
+# Active Incidents — Two-Level Rollup
+
+**Status:** Design (approved, ready for implementation plan)
+**Date:** 2026-05-06
+**Related:** [#1195 — Reduce duplicate emissions in the incident correlation engine](https://github.com/kenhaesler/ai-portainer-dashboard/issues/1195)
+
+## 1. Problem & Goal
+
+The Active Incidents block on `/health` shows a flat list of 455 rows. Each prediction ETA and each container-level anomaly is its own row, so the same underlying problem appears many times and unique problems get buried. Users can't form an overview of the system.
+
+**Goal.** Replace the flat list with a two-level rollup that gives a 5-second overview, scales to thousands of incidents, and preserves all existing capabilities (search, time range, sort, per-incident resolve, drill-down).
+
+### In scope
+
+- Backend: new `signature` column on `incidents`, populated at insert time from the source insight's structured fields. Backfill migration for existing rows. New `GET /api/incidents/groups` aggregate endpoint.
+- Frontend: replace today's flat `Active Incidents` section with a summary strip + grouped list. Per-group expand → top-10 containers + "Show all" → click container → existing per-incident detail/resolve.
+- Endpoint filter chip row above the list.
+- Tests: backend (signature mapping, groups query, backfill), frontend (rendering, expand, top-N, resolve flows, search interop).
+
+### Out of scope
+
+- Changes to the correlation engine's grouping/dedup logic — tracked in [#1195](https://github.com/kenhaesler/ai-portainer-dashboard/issues/1195). Engine work waits for one week of production `signature` data so it can be data-driven.
+- Resolved-incidents view redesign — same pattern, different defaults; separate follow-up.
+- Endpoint-scoped sub-grouping (third nesting level). Endpoint is a *filter* in this PR, not a grouping axis. Adding it later is non-breaking.
+- Reducing the *number* of incidents the system creates (that's the engine work in #1195).
+
+### Non-goals
+
+- Changing detection sensitivity (anomaly thresholds, ML models, cooldown sweeps).
+- Changing per-incident detail or resolve semantics.
+
+## 2. Architecture
+
+### Data flow
+
+```
+[monitoring-service emits insight]
+        │
+        ▼
+[insertInsights] ──── insights table (unchanged shape)
+        │             (insight schema gains optional metric_type / detection_method)
+        ▼
+[correlateInsights] ── decides: new incident OR join existing
+        │              (logic unchanged in this PR — engine work is #1195)
+        ▼
+[insertIncident / addInsightToIncident]
+        │  ←── NEW: incident.signature is set here via deriveSignature()
+        ▼
+   incidents table  ─── NEW column: signature TEXT, indexed
+        │
+        ├─► /api/incidents             (existing, unchanged response shape)
+        │
+        └─► /api/incidents/groups      (NEW: SQL aggregate)
+                  │
+                  ▼
+          [Active Incidents UI]
+            • summary strip
+            • flat list of signature groups
+            • each group → top-10 containers + "Show all"
+            • endpoint filter chips
+```
+
+### Layer ownership
+
+| Layer | Owns | New in this PR |
+|---|---|---|
+| `incident-correlator.ts` | Building the `IncidentInsert` payload | Compute `signature` from the source insight's `category` + structured `metric_type` / `detection_method`. Falls back via title-derivation. |
+| `incident-store.ts` | Persistence + queries | New `signature` column, new `getIncidentGroups()` SQL aggregate, backfill function. |
+| `incidents.ts` route | HTTP surface | New `GET /api/incidents/groups` endpoint. Existing endpoints unchanged. |
+| `monitoring-service.ts` | Insight emission | Optional `metric_type` and `detection_method` fields on anomaly + predictive insights. |
+| `signature.ts` (new) | Signature derivation | Pure module, single source of truth. Imported by both correlator and backfill. |
+| Frontend `use-incident-groups.ts` (new) | Data hook | `useIncidentGroups()` alongside existing `useIncidents()`. |
+| Frontend `incident-groups-view.tsx` (new) | Group rendering | Summary strip, group cards, top-N containers, endpoint filter chips. |
+| `ai-monitor.tsx` | Page render | Swap the `Active Incidents` flat-list block for `IncidentGroupsView`. |
+
+### Boundary decisions
+
+1. **Aggregate in SQL, not in JS.** `getIncidentGroups()` returns one row per signature with counts already computed. At 10K incidents the request stays a single fast query, not a 10K-row payload that the frontend reduces.
+2. **Top-N containers picked in SQL.** The aggregate endpoint includes `top_containers` per signature (worst 10 by severity then most-recent). "Show all" calls existing `/api/incidents?status=active&signature=X` for the long tail — pagination cost lives where it belongs.
+3. **Signature derivation in one place.** `deriveSignature()` in `signature.ts` is the single source of truth, used by both `buildIncident()` and the backfill. Single point to test, single point to evolve.
+4. **Endpoint filter is a query param, not a separate endpoint.** `/api/incidents/groups?endpoint_id=42` filters server-side. Keeps URL/state cheap.
+5. **Title is for humans, signature is for grouping.** They diverge by design. Title text remains free-form; signature is enum-like and stable.
+
+## 3. Backend
+
+### 3.1 Migration
+
+`packages/core/src/db/postgres-migrations/<NNN>_add_incident_signature.sql`:
+
+```sql
+ALTER TABLE incidents ADD COLUMN signature TEXT;
+CREATE INDEX idx_incidents_signature_status ON incidents (signature, status);
+CREATE INDEX idx_incidents_endpoint_status ON incidents (endpoint_id, status);
+```
+
+`signature` is nullable in this migration so the column add is non-blocking. The backfill populates it; thereafter all writes set it. `NOT NULL` is enforced in a follow-up after one week of clean writes (see §5.5).
+
+### 3.2 Insight schema additions
+
+Two optional structured fields on the `Insight` model in `packages/core/src/models/monitoring.ts`:
+
+```ts
+metric_type: z.enum(['cpu', 'memory', 'disk', 'network', 'restart']).optional(),
+detection_method: z.enum([
+  'threshold',
+  'ml-anomaly',
+  'prediction',
+  'health-check',
+  'log-pattern',
+  'security-scan'
+]).optional(),
+```
+
+`monitoring-service.ts` populates these on every emission path it owns (anomaly, prediction, health-check, log-analysis, security). Existing insights without these fields keep working — the fallback path in `deriveSignature` covers them.
+
+### 3.3 Signature derivation
+
+`packages/ai-intelligence/src/services/signature.ts`:
+
+```ts
+import type { Insight } from '@dashboard/core/models/monitoring.js';
+
+export function deriveSignature(
+  rootCause: Pick<Insight, 'category' | 'metric_type' | 'detection_method' | 'title'>
+): string {
+  // Preferred path: structured fields
+  if (rootCause.metric_type && rootCause.detection_method) {
+    return `${rootCause.category}:${rootCause.detection_method}:${rootCause.metric_type}`;
+  }
+  // Category-only fallbacks
+  if (rootCause.category === 'security') return 'security:scan';
+  if (rootCause.category === 'log-analysis') return 'log:pattern';
+  if (rootCause.category === 'ai-analysis') return 'ai:analysis';
+  // Last resort — derive from title with a documented regex set
+  return deriveSignatureFromTitle(rootCause.title);
+}
+
+export function signatureLabel(signature: string): string {
+  return SIGNATURE_LABELS[signature] ?? humanizeSignature(signature);
+}
+```
+
+`deriveSignatureFromTitle` is a small set of explicit regexes covering the title patterns currently emitted (e.g., `/predicted (\w+) exhaustion/i` → `predictive:prediction:$1`, `/has no health check/i` → `config:health-check:missing`). Each regex is unit-tested. If no regex matches, it returns `unknown:<slugified-title>` so the row is still groupable rather than dropped.
+
+`humanizeSignature` converts a signature string into a readable label as a last-resort label when no entry exists in `SIGNATURE_LABELS` — e.g., `anomaly:threshold:disk` → `Anomaly · threshold · disk`. It is purely cosmetic; it never affects grouping or persistence.
+
+The signature is set **once at incident creation** by `buildIncident()`. `addInsightToIncident` does not modify the signature when joining a new insight to an existing incident.
+
+Resulting signatures (illustrative, not exhaustive):
+
+| Source | Signature | Human label |
+|---|---|---|
+| Anomaly, ML, CPU | `anomaly:ml-anomaly:cpu` | Anomalous CPU usage (ML) |
+| Anomaly, threshold, memory | `anomaly:threshold:memory` | High memory usage |
+| Prediction, memory exhaustion | `predictive:prediction:memory` | Predicted memory exhaustion |
+| Prediction, CPU exhaustion | `predictive:prediction:cpu` | Predicted CPU exhaustion |
+| Health-check missing | `config:health-check:missing` (via title fallback) | Missing health check |
+| Security scan finding | `security:scan` | Security scan finding |
+
+The signature is the *kind* of problem; it does not include container or endpoint. Those are the dimensions we group across.
+
+### 3.4 Backfill
+
+`packages/ai-intelligence/scripts/backfill-incident-signatures.ts`:
+
+- Selects incidents where `signature IS NULL` in batches of 500.
+- Joins each row's `root_cause_insight_id` against `insights` to get category + structured fields.
+- Calls `deriveSignature(rootInsight)`; falls through to `deriveSignatureFromTitle(incident.title)` if the root insight is missing (deleted, archived).
+- `UPDATE incidents SET signature = ? WHERE id = ? AND signature IS NULL` (idempotent — only fills nulls).
+- Logs progress every 500 rows and a final `(signature, count)` summary.
+- A `--force` flag re-derives all rows (drops the `IS NULL` predicate). Default behaviour is null-only.
+
+Run once at deploy time. Re-runnable safely.
+
+### 3.5 New endpoint: `GET /api/incidents/groups`
+
+**Request:**
+
+```
+GET /api/incidents/groups?status=active&endpoint_id=42&since=24h&severity=critical
+```
+
+All query params optional. `status` defaults to `active`. `since` filters incidents whose `created_at >= NOW() - <window>`; accepts `1h`, `24h`, `7d`, or omitted (= all-time). The aggregate counts in the response reflect only the filtered set — including `top_containers` and `endpoint_facets`.
+
+**Response:**
+
+```ts
+{
+  groups: Array<{
+    signature: string;            // 'predictive:prediction:memory'
+    label: string;                // 'Predicted memory exhaustion'
+    severity: 'critical' | 'warning' | 'info';   // highest in the group
+    incident_count: number;       // unique incidents in this group
+    container_count: number;      // unique container names across the group
+    alert_count: number;          // sum of insight_count
+    earliest_at: string;          // ISO timestamp
+    latest_at: string;
+    top_containers: Array<{
+      incident_id: string;
+      container_name: string;
+      endpoint_id: number | null;
+      endpoint_name: string | null;
+      severity: 'critical' | 'warning' | 'info';
+      created_at: string;
+    }>;                           // worst 10 by severity then recency
+  }>,
+  endpoint_facets: Array<{
+    endpoint_id: number | null;
+    endpoint_name: string | null;
+    incident_count: number;
+  }>,                             // for the chip row
+  total_active: number;           // for summary strip and headers
+}
+```
+
+**Implementation:** one CTE per dimension (signature aggregate, endpoint facet, top-N per signature using `ROW_NUMBER() OVER (PARTITION BY signature ORDER BY severity_rank, created_at DESC)`), wrapped into a single round-trip.
+
+**Auth:** `fastify.authenticate` (read-only). No new RBAC role required.
+
+**Resolve action stays on the per-incident endpoint.** The aggregate endpoint is read-only.
+
+### 3.6 Tests
+
+Added to `packages/ai-intelligence/src/__tests__/`:
+
+| File | Covers |
+|---|---|
+| `signature.test.ts` | Derivation: every category/method/metric combo, fallbacks, label lookup, stability across known title variants. |
+| `incidents-groups.test.ts` | New route end-to-end: aggregate counts, top-N ordering, severity rollup, endpoint filter, since filter, empty result, auth. |
+| `incidents-backfill.test.ts` | Backfill: populates null signatures, idempotent on re-run, handles missing root insight, batch boundary, `--force` flag. |
+| `incident-correlator.test.ts` (additions) | `buildIncident()` writes `signature` correctly for structured-fields path and falls back for legacy insights. |
+
+All DB tests use the real-PostgreSQL helper (`test-db-helper.ts`).
+
+## 4. Frontend
+
+### 4.1 New hook
+
+`frontend/src/features/ai-intelligence/hooks/use-incident-groups.ts`:
+
+```ts
+export function useIncidentGroups(params: {
+  status?: 'active' | 'resolved';
+  endpointId?: number;
+  since?: '1h' | '24h' | '7d';
+  severity?: 'critical' | 'warning' | 'info';
+})
+```
+
+Same `refetchInterval` (30s + page-visibility gating) as `useIncidents`. Existing `useIncidents()` and `useIncidentDetail()` stay — they back the per-container drill-down inside an expanded group.
+
+### 4.2 Component layout
+
+`frontend/src/features/ai-intelligence/components/incident-groups-view.tsx` replaces the flat-list block in `ai-monitor.tsx`.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Active Incidents                                       [1h|24h|7d|All]
+│  ──────────────────────────────────────────────────────────────────  │
+│  Critical: 3 kinds across 8 containers   ·   Warning: 5 / 22         │ ← summary strip
+│  ──────────────────────────────────────────────────────────────────  │
+│  Endpoint:  [All 158]  [endpoint-A 89]  [endpoint-B 52]  [...12]     │ ← chip row
+└─────────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────┐
+│ ● Critical  Predicted memory exhaustion       12 containers · 38 alerts ▼
+│   ───────────────────────────────────────────────────────────────── │
+│   ▢ docker-postgres-app-1     critical · 24h · endpoint-A     [Resolve]
+│   ▢ docker-timescale-1        critical · 18h · endpoint-A     [Resolve]
+│   ▢ portainer-app-3           warning  · 12h · endpoint-B     [Resolve]
+│   ... (7 more shown)                                                │
+│   ┌───────────────────────────────────────────────────────────────┐ │
+│   │  Show all 12 containers                                       │ │
+│   └───────────────────────────────────────────────────────────────┘ │
+│   [☑ Resolve 3 selected]   [Resolve all 12 in this group]           │
+└─────────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────┐
+│ ● Warning   Anomalous CPU usage (ML-detected)   22 containers · 89 alerts ▶
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 4.3 Behavior
+
+| Element | Behavior |
+|---|---|
+| Summary strip | Single line. Computed client-side from `groups`. Shows `critical kinds / containers` + `warning kinds / containers`. Info bucket only renders if non-zero. |
+| Time range tabs | Existing controls, moved to header line. URL `?range=` (already in use). Defaults to `24h` if no URL state. |
+| Endpoint chip row | Renders only when `endpoint_facets.length > 1`. Active chip is URL-driven (`?endpoint=`). "All" clears the param. |
+| Group card collapsed | Severity dot · label · `N containers · M alerts` · chevron. Critical groups expanded by default; warnings/info collapsed. |
+| Group card expanded | Top 10 container rows from `top_containers`. Each row: checkbox, container chip (linked to `/containers/:endpointId/:containerId`), severity badge, age, endpoint, individual `[Resolve]`. |
+| "Show all N" link | Visible when `container_count > 10`. Click → fetches `/api/incidents?status=active&signature=X` and replaces the top-10 list with the full set. Per-group state, not URL. |
+| Per-row resolve | Calls existing `useResolveIncident()`. No change. |
+| Per-group "Resolve all" | New action. Confirms via existing `ConfirmDialog`. Iterates `POST /api/incidents/:id/resolve` for incident IDs in the group; reuses bulk-resolve error handling (partial-failure surfacing). |
+| Multi-select bar | Existing bulk-action bar stays for cross-group selection. Selection survives expand/collapse. |
+| Search | Existing search input filters groups by signature label and by container names in `top_containers`. A group is hidden if it has no match in either. When a group matches because of a container hit, the group auto-expands to show the matching rows. Long-tail containers fetched via "Show all" are also filtered. No backend change. |
+| Sort | Existing severity/time toggle applies inside groups. Group order is fixed: severity → container_count desc. |
+| Empty state | "No active incidents in this view." Reuses the dashed-border box already used by the page. |
+
+### 4.4 URL state
+
+| Param | Values | Default |
+|---|---|---|
+| `range` | `1h` / `24h` / `7d` / `all` | `24h` |
+| `endpoint` | endpoint id | absent (= all) |
+| `sort` | `severity` / `time` | `severity` (existing) |
+| `signature` | signature string | absent (= no group focus; reserved for deep-link to one group) |
+
+Expand/collapse is **not** in the URL — local state only. Groups are bounded (~10–30), defaults are good, URL noise outweighs the benefit.
+
+### 4.5 Resolve paths
+
+Three resolve paths coexist; the contract is explicit:
+
+| Trigger | Scope | Confirm? |
+|---|---|---|
+| Per-row button | one incident | no |
+| Multi-select bar (existing) | selected ids across groups | yes (existing) |
+| Per-group "Resolve all N" | every incident in one signature | yes (new dialog) |
+
+The new "Resolve all" runs through the same partial-failure path as multi-select bulk: failures stay highlighted, user can retry without losing context.
+
+### 4.6 Tests
+
+Added to `frontend/src/features/ai-intelligence/`:
+
+| File | Covers |
+|---|---|
+| `hooks/use-incident-groups.test.ts` | Query key, params serialization, 30s refetch + visibility gating. |
+| `components/incident-groups-view.test.tsx` | Renders summary, chips, collapsed/expanded groups, top-10, "Show all" expansion, severity-dot per group. |
+| `components/incident-groups-view.resolve.test.tsx` | Per-row resolve, per-group "Resolve all" with confirm + partial-failure recovery, multi-select interop. |
+| `components/incident-groups-view.search.test.tsx` | Search filters labels and container names; group cards hide when no matches. |
+| `pages/ai-monitor.test.tsx` (additions) | The page renders `IncidentGroupsView` instead of the flat list; existing assertions for non-incident sections still pass. |
+
+Mocks: `useIncidentGroups` for component tests (frontend mocks API at the boundary). No backend changes required to run frontend tests.
+
+## 5. Rollout
+
+### 5.1 Merge order
+
+Single PR against `dev`, commits in this order so each step is independently revertable:
+
+1. Migration: add nullable `signature` column + indexes. (No code reads it yet.)
+2. `signature.ts` derivation function + tests. (Pure module, no callers.)
+3. `monitoring-service.ts`: emit optional `metric_type` / `detection_method`. (Backward-compatible.)
+4. `incident-correlator.ts`: write `signature` on insert. (New rows populated; legacy rows still NULL.)
+5. Backfill script. Run once at deploy. Idempotent.
+6. New `GET /api/incidents/groups` endpoint + tests.
+7. Frontend hook + `IncidentGroupsView` component + tests.
+8. Swap the page section in `ai-monitor.tsx`.
+
+If anything goes sideways during rollout, steps 1–6 stay (the column is harmless if unused) and step 8 is the only revert needed to restore the old UI.
+
+### 5.2 Production verification
+
+Done by the deployer after merge:
+
+- [ ] Migration applied; `signature` column present on `incidents`.
+- [ ] Backfill script run; `SELECT COUNT(*) FROM incidents WHERE signature IS NULL` returns 0.
+- [ ] `GET /api/incidents/groups` returns within 250ms p95 against the live dataset (size noted in PR).
+- [ ] `/health` page renders the new view; existing per-incident drill-down still works (click container → existing `/incidents/:id`).
+- [ ] Manual: resolve one incident via per-row, one via per-group "Resolve all", one via multi-select. All three update counts and refetch.
+- [ ] Manual: endpoint filter chip changes the URL and the visible groups; refresh preserves the filter.
+- [ ] No regression in existing security-regression tests (auth, RBAC on new route).
+
+### 5.3 Rollback
+
+| Failure mode | Rollback |
+|---|---|
+| Frontend rendering broken | Revert step 8 only — old flat list returns. Backend stays. |
+| `/api/incidents/groups` slow or wrong | Revert steps 6–8. Backfilled column is harmless. |
+| Backfill produced wrong signatures | Re-run with corrected `deriveSignature`; the script is idempotent and only overwrites NULLs by default. Use `--force` for full re-derivation. |
+| Migration concerns | `ALTER TABLE ADD COLUMN nullable` is non-blocking on Postgres; the indexes can be created `CONCURRENTLY` if the table is large at deploy time. |
+
+`NOT NULL` is **not** added in this PR. Follow-up after one week of clean writes.
+
+### 5.4 Telemetry
+
+Two cheap log emissions that pay back during the engine work in #1195:
+
+- On `getIncidentGroups()` query: log `(signature, container_count, alert_count)` at debug level. One line per group.
+- On `insertIncident`: log `(signature, correlation_type)`. Already partially logged; just add `signature`.
+
+These give us the "alerts per container per signature" ratio that #1195 needs to prioritize engine fixes.
+
+### 5.5 Follow-ups
+
+| Follow-up | When |
+|---|---|
+| [#1195](https://github.com/kenhaesler/ai-portainer-dashboard/issues/1195) — engine dedup work | After this PR + 1 week of signature data |
+| Signature `NOT NULL` enforcement | One week after this PR; trivial migration |
+| Resolved-incidents view redesign | Smaller separate PR; same group structure, different defaults |
+| Endpoint-scoped sub-grouping (third nesting level) | Only if telemetry shows endpoint distribution is uneven enough to warrant it |
+
+## 6. Acceptance criteria
+
+- [ ] `incidents.signature` column exists, indexed alongside `status` and `endpoint_id`.
+- [ ] `signature.ts` exports `deriveSignature()` and `signatureLabel()`, with full test coverage of the derivation matrix.
+- [ ] `monitoring-service.ts` emits `metric_type` and `detection_method` on anomaly + predictive insights.
+- [ ] `incident-correlator.ts` writes `signature` on every new incident. Existing tests continue to pass.
+- [ ] Backfill script populates all existing incidents with non-null signatures; runnable safely more than once.
+- [ ] `GET /api/incidents/groups` returns the response shape in §3.5, supports `status` / `endpoint_id` / `since` / `severity` filters, returns within 250ms p95 against production data.
+- [ ] `/health` page renders `IncidentGroupsView` with summary strip, endpoint chips, collapsed/expanded groups, top-10 container rows, "Show all" expansion.
+- [ ] All three resolve paths (per-row, multi-select, per-group) work and surface partial-failure correctly.
+- [ ] Search filters both group labels and container names.
+- [ ] URL params (`range`, `endpoint`, `sort`) survive refresh and deep-linking.
+- [ ] All new and existing tests pass on backend, frontend, and packages workspaces.
+- [ ] No new ESLint or TypeScript errors. No regression in security-regression tests.

--- a/docs/superpowers/specs/2026-05-06-active-incidents-rollup-design.md
+++ b/docs/superpowers/specs/2026-05-06-active-incidents-rollup-design.md
@@ -85,15 +85,32 @@ The Active Incidents block on `/health` shows a flat list of 455 rows. Each pred
 
 ### 3.1 Migration
 
+The migration is split into two phases to avoid a write-blocking index build at deploy time. The auto-migration runner in `packages/core/src/db/postgres.ts` runs migrations inside a transaction; `CREATE INDEX` (without `CONCURRENTLY`) inside a transaction takes an `ACCESS EXCLUSIVE` lock and blocks writes for the duration. On a large `incidents` table that's an unacceptable deploy stall.
+
+**Phase A — column add (auto-migration, transactional, fast):**
+
 `packages/core/src/db/postgres-migrations/<NNN>_add_incident_signature.sql`:
 
 ```sql
 ALTER TABLE incidents ADD COLUMN signature TEXT;
-CREATE INDEX idx_incidents_signature_status ON incidents (signature, status);
-CREATE INDEX idx_incidents_endpoint_status ON incidents (endpoint_id, status);
 ```
 
-`signature` is nullable in this migration so the column add is non-blocking. The backfill populates it; thereafter all writes set it. `NOT NULL` is enforced in a follow-up after one week of clean writes (see §5.5).
+This is `O(1)` on Postgres (metadata-only) and runs safely inside the migration transaction.
+
+**Phase B — index creation (deploy-time script, non-transactional):**
+
+`packages/ai-intelligence/scripts/create-incident-signature-indexes.ts` runs after the column-add migration but outside any transaction:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_incidents_signature_status
+  ON incidents (signature, status);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_incidents_endpoint_status
+  ON incidents (endpoint_id, status);
+```
+
+`CONCURRENTLY` requires running outside a transaction block, which is why this can't live in the standard migration runner. The script connects directly via `pg`, runs each `CREATE INDEX CONCURRENTLY` separately (each must be its own transaction), and uses `IF NOT EXISTS` so it's safe to re-run. It's invoked once during deploy after the column-add migration completes.
+
+`signature` is nullable across both phases so the column add is non-blocking. The backfill populates it; thereafter all writes set it. `NOT NULL` is enforced in a follow-up after one week of clean writes (see §5.5).
 
 ### 3.2 Insight schema additions
 
@@ -165,12 +182,20 @@ The signature is the *kind* of problem; it does not include container or endpoin
 
 - Selects incidents where `signature IS NULL` in batches of 500.
 - Joins each row's `root_cause_insight_id` against `insights` to get category + structured fields.
-- Calls `deriveSignature(rootInsight)`; falls through to `deriveSignatureFromTitle(incident.title)` if the root insight is missing (deleted, archived).
+- Calls **the same `deriveSignature` function** used by live writes (single source of truth). The function's preference order is unchanged: structured fields → category-only fallback → title regex.
 - `UPDATE incidents SET signature = ? WHERE id = ? AND signature IS NULL` (idempotent — only fills nulls).
 - Logs progress every 500 rows and a final `(signature, count)` summary.
 - A `--force` flag re-derives all rows (drops the `IS NULL` predicate). Default behaviour is null-only.
 
 Run once at deploy time. Re-runnable safely.
+
+**Drift verification (mandatory before merge).** The risk is that legacy incidents whose root insight lacks the new structured fields fall through to the title regex and produce a signature that doesn't match what live writes produce for the same problem class — splitting the rollup. To prevent this:
+
+1. Export a representative sample of historical incident titles from a real environment (script provided alongside the backfill: `dump-historical-titles.ts`, dumps to a CSV).
+2. Add a test in `signature.test.ts` that loads this CSV and asserts every historical title maps to a signature in the known-good set (i.e., no `unknown:*` results, and the regex outputs match what the structured-field path would emit for the same problem class).
+3. Any title that produces a mismatch is a regex bug to fix in `deriveSignatureFromTitle` before merge — not an acceptable "legacy fallback".
+
+The CSV is checked in as a test fixture so the corpus stays stable across PRs. Add to it whenever new title patterns are discovered in production.
 
 ### 3.5 New endpoint: `GET /api/incidents/groups`
 
@@ -180,7 +205,7 @@ Run once at deploy time. Re-runnable safely.
 GET /api/incidents/groups?status=active&endpoint_id=42&since=24h&severity=critical
 ```
 
-All query params optional. `status` defaults to `active`. `since` filters incidents whose `created_at >= NOW() - <window>`; accepts `1h`, `24h`, `7d`, or omitted (= all-time). The aggregate counts in the response reflect only the filtered set — including `top_containers` and `endpoint_facets`.
+All query params optional. `status` defaults to `active`. `since` filters incidents whose **`COALESCE(latest_at, updated_at, created_at) >= NOW() - <window>`** — i.e., "recently active", not "recently created". A long-running active incident from 25 hours ago is *not* hidden by `since=24h` if it's still being updated. Accepts `1h`, `24h`, `7d`, or omitted (= all-time). The aggregate counts in the response reflect only the filtered set — including `top_containers`, `all_container_names`, and `endpoint_facets`.
 
 **Response:**
 
@@ -203,6 +228,8 @@ All query params optional. `status` defaults to `active`. `since` filters incide
       severity: 'critical' | 'warning' | 'info';
       created_at: string;
     }>;                           // worst 10 by severity then recency
+    all_container_names: string[]; // every distinct container name in the group,
+                                  // for client-side search across the long tail
   }>,
   endpoint_facets: Array<{
     endpoint_id: number | null;
@@ -213,20 +240,50 @@ All query params optional. `status` defaults to `active`. `since` filters incide
 }
 ```
 
-**Implementation:** one CTE per dimension (signature aggregate, endpoint facet, top-N per signature using `ROW_NUMBER() OVER (PARTITION BY signature ORDER BY severity_rank, created_at DESC)`), wrapped into a single round-trip.
+`all_container_names` is intentionally just strings (not full incident records) to keep the payload bounded. At 200 containers per group × 30 groups × 50 chars/name ≈ 300 KB worst-case — acceptable. If empirical payloads exceed 500 KB, we cap the array at, say, 1000 names per group and require server-side search for groups beyond that (deferred until measured).
+
+**Implementation:** one CTE per dimension (signature aggregate with `array_agg(DISTINCT container_name) AS all_container_names`, endpoint facet, top-N per signature using `ROW_NUMBER() OVER (PARTITION BY signature ORDER BY severity_rank, created_at DESC)`), wrapped into a single round-trip.
+
+**Caching:** the route handler wraps the DB query in `cachedFetchSWR()` (existing pattern in `portainer-cache.ts`) keyed on `(status, endpoint_id, since, severity)` with a 20s TTL. Stale-while-revalidate ensures the 30s frontend poll hits the DB at most once per cache window per filter tuple. Cache invalidation: `invalidateTag('incidents')` is called on every `insertIncident`, `addInsightToIncident`, and `resolveIncident` so the next read refreshes.
 
 **Auth:** `fastify.authenticate` (read-only). No new RBAC role required.
 
-**Resolve action stays on the per-incident endpoint.** The aggregate endpoint is read-only.
+**Resolve action stays on the per-incident endpoint** for single resolves; a new batch endpoint (§3.6) handles multi-resolve.
 
-### 3.6 Tests
+### 3.6 New endpoint: `POST /api/incidents/resolve` (batch)
+
+200 sequential `POST /api/incidents/:id/resolve` calls is unacceptable wall-clock for "Resolve all 200 in this group". Add a batch endpoint:
+
+**Request:**
+
+```
+POST /api/incidents/resolve
+Content-Type: application/json
+{ "ids": ["uuid-1", "uuid-2", ...] }
+```
+
+Validated by Zod: `ids` must be a non-empty array of UUIDs, capped at 500 per call. Same auth as the single-resolve route: `fastify.authenticate` + `fastify.requireRole('admin')` (matches existing single-resolve RBAC at `incidents.ts:81`).
+
+**Response:**
+
+```ts
+{
+  resolved: string[];                              // ids successfully resolved
+  failed: Array<{ id: string; error: string }>;    // per-id failure reasons
+}
+```
+
+**Implementation:** wraps the existing `resolveIncident()` per id in a single transaction; per-id failures are caught and surfaced in `failed[]` rather than aborting the whole batch. Audit-logs each resolution like the single-resolve route. Tag-invalidates `incidents` once at the end. Single round trip, returns within ~1s for batches of 500.
+
+### 3.7 Tests
 
 Added to `packages/ai-intelligence/src/__tests__/`:
 
 | File | Covers |
 |---|---|
-| `signature.test.ts` | Derivation: every category/method/metric combo, fallbacks, label lookup, stability across known title variants. |
-| `incidents-groups.test.ts` | New route end-to-end: aggregate counts, top-N ordering, severity rollup, endpoint filter, since filter, empty result, auth. |
+| `signature.test.ts` | Derivation: every category/method/metric combo, fallbacks, label lookup, stability across known title variants, **and the historical-titles drift corpus from §3.4 (every CSV row maps to a known signature, no `unknown:*`)**. |
+| `incidents-groups.test.ts` | New route end-to-end: aggregate counts, top-N ordering, `all_container_names` correctness, severity rollup, endpoint filter, `since` filter using `latest_at` semantics, empty result, auth, cache invalidation on resolve. |
+| `incidents-resolve-batch.test.ts` | New batch resolve route: success path, partial failure (some ids resolved, others not), input validation (cap, UUID shape), RBAC (admin required), audit-log emission, tag invalidation. |
 | `incidents-backfill.test.ts` | Backfill: populates null signatures, idempotent on re-run, handles missing root insight, batch boundary, `--force` flag. |
 | `incident-correlator.test.ts` (additions) | `buildIncident()` writes `signature` correctly for structured-fields path and falls back for legacy insights. |
 
@@ -282,16 +339,16 @@ Same `refetchInterval` (30s + page-visibility gating) as `useIncidents`. Existin
 
 | Element | Behavior |
 |---|---|
-| Summary strip | Single line. Computed client-side from `groups`. Shows `critical kinds / containers` + `warning kinds / containers`. Info bucket only renders if non-zero. |
+| Summary strip | Single line. Computed client-side from `groups`. Each container is counted **at most once across severity buckets** — by its highest severity. So "Critical: 3 kinds across 8 containers · Warning: 5 kinds across 22 containers" means 8 containers have at least one critical incident, and 22 *additional* containers have at least one warning (and no critical). Info bucket only renders if non-zero. |
 | Time range tabs | Existing controls, moved to header line. URL `?range=` (already in use). Defaults to `24h` if no URL state. |
 | Endpoint chip row | Renders only when `endpoint_facets.length > 1`. Active chip is URL-driven (`?endpoint=`). "All" clears the param. |
 | Group card collapsed | Severity dot · label · `N containers · M alerts` · chevron. Critical groups expanded by default; warnings/info collapsed. |
 | Group card expanded | Top 10 container rows from `top_containers`. Each row: checkbox, container chip (linked to `/containers/:endpointId/:containerId`), severity badge, age, endpoint, individual `[Resolve]`. |
 | "Show all N" link | Visible when `container_count > 10`. Click → fetches `/api/incidents?status=active&signature=X` and replaces the top-10 list with the full set. Per-group state, not URL. |
 | Per-row resolve | Calls existing `useResolveIncident()`. No change. |
-| Per-group "Resolve all" | New action. Confirms via existing `ConfirmDialog`. Iterates `POST /api/incidents/:id/resolve` for incident IDs in the group; reuses bulk-resolve error handling (partial-failure surfacing). |
-| Multi-select bar | Existing bulk-action bar stays for cross-group selection. Selection survives expand/collapse. |
-| Search | Existing search input filters groups by signature label and by container names in `top_containers`. A group is hidden if it has no match in either. When a group matches because of a container hit, the group auto-expands to show the matching rows. Long-tail containers fetched via "Show all" are also filtered. No backend change. |
+| Per-group "Resolve all" | New action. Confirms via existing `ConfirmDialog`. Calls the new **`POST /api/incidents/resolve`** batch endpoint with all incident IDs in the group (one round trip, see §3.6). Failures surfaced per-id via the partial-failure rules below. |
+| Multi-select bar | Existing bulk-action bar stays for cross-group selection. Now also calls the batch endpoint. Selection survives expand/collapse. |
+| Search | Filters groups by (a) signature label and (b) **`all_container_names`** (the full server-provided list, including the long tail — no false negatives). When a group matches via a container hit, it auto-expands. If the matching container is in the long tail (not in `top_containers`), the page auto-triggers the "Show all" fetch for that group so the matching row is visible. No backend change. |
 | Sort | Existing severity/time toggle applies inside groups. Group order is fixed: severity → container_count desc. |
 | Empty state | "No active incidents in this view." Reuses the dashed-border box already used by the page. |
 
@@ -302,9 +359,11 @@ Same `refetchInterval` (30s + page-visibility gating) as `useIncidents`. Existin
 | `range` | `1h` / `24h` / `7d` / `all` | `24h` |
 | `endpoint` | endpoint id | absent (= all) |
 | `sort` | `severity` / `time` | `severity` (existing) |
-| `signature` | signature string | absent (= no group focus; reserved for deep-link to one group) |
+| `expand` | comma-separated signature strings | absent (= use default expand-by-severity rule) |
 
-Expand/collapse is **not** in the URL — local state only. Groups are bounded (~10–30), defaults are good, URL noise outweighs the benefit.
+Expand state is URL-tracked when the user explicitly toggles a group, so deep-linking to "this exact view" works (refresh, share). Toggling a critical group closed adds it to `?expand=` with a `-` prefix (e.g., `?expand=-anomaly:ml-anomaly:cpu`), so the URL captures *deviations* from the default, not the full state. Initial render with no `?expand=` follows the "critical expanded by default" rule from §4.3.
+
+`?signature=` is **not** introduced — search-and-expand covers the deep-link use case. Avoiding ship-but-unused URL params.
 
 ### 4.5 Resolve paths
 
@@ -316,7 +375,13 @@ Three resolve paths coexist; the contract is explicit:
 | Multi-select bar (existing) | selected ids across groups | yes (existing) |
 | Per-group "Resolve all N" | every incident in one signature | yes (new dialog) |
 
-The new "Resolve all" runs through the same partial-failure path as multi-select bulk: failures stay highlighted, user can retry without losing context.
+**Partial-failure UX** (applies to both multi-select and per-group "Resolve all"):
+
+- The batch endpoint returns `{ resolved: [...], failed: [...] }`.
+- If `failed.length === 0`: dismiss the action bar with a "Resolved N" toast.
+- If `failed.length <= 5`: keep the failed rows visible with a red border and the per-id error message inline. The action bar shows "Retry N failed".
+- If `failed.length > 5`: collapse to a single banner — "N of M resolves failed" — with one **Retry failed only** button that re-issues the batch with just `failed[].id`. No 200-row error list. The button retains state until the user dismisses or all retries succeed.
+- Action bar selection is replaced with the failed-id set after each batch so retry is one click away. Successful resolves are removed from selection regardless of retry state.
 
 ### 4.6 Tests
 
@@ -325,12 +390,16 @@ Added to `frontend/src/features/ai-intelligence/`:
 | File | Covers |
 |---|---|
 | `hooks/use-incident-groups.test.ts` | Query key, params serialization, 30s refetch + visibility gating. |
-| `components/incident-groups-view.test.tsx` | Renders summary, chips, collapsed/expanded groups, top-10, "Show all" expansion, severity-dot per group. |
-| `components/incident-groups-view.resolve.test.tsx` | Per-row resolve, per-group "Resolve all" with confirm + partial-failure recovery, multi-select interop. |
-| `components/incident-groups-view.search.test.tsx` | Search filters labels and container names; group cards hide when no matches. |
+| `components/incident-groups-view.test.tsx` | Renders summary (with single-bucket-per-container rule), chips, collapsed/expanded groups, default-expand-on-critical, top-10, severity-dot per group. |
+| `components/incident-groups-view.resolve.test.tsx` | Per-row resolve, per-group "Resolve all" via batch endpoint, multi-select interop, partial-failure UX (≤5 fail → inline; >5 fail → collapsed banner with Retry failed only). |
+| `components/incident-groups-view.search.test.tsx` | Search filters via `all_container_names` (long-tail container is found, not just `top_containers`); auto-expand on container hit; auto-trigger "Show all" when match is in long tail. |
+| `components/incident-groups-view.show-all.test.tsx` | "Show all N" pagination flow: fetch via `/api/incidents?signature=X`, replaces top-10, search remains scoped to the expanded set. |
+| `components/incident-groups-view.url.test.tsx` | URL state: `range`, `endpoint`, `sort`, `expand` (with `-` prefix for closed-by-default deviations) survive refresh; deep-link URL renders matching state. |
 | `pages/ai-monitor.test.tsx` (additions) | The page renders `IncidentGroupsView` instead of the flat list; existing assertions for non-incident sections still pass. |
 
 Mocks: `useIncidentGroups` for component tests (frontend mocks API at the boundary). No backend changes required to run frontend tests.
+
+**i18n note.** Signature labels and copy in this view are English-only. The codebase has no i18n layer yet; adding one is a global concern outside this work. Labels live in `signature.ts` (`SIGNATURE_LABELS`) so a future i18n pass is one-file scope.
 
 ## 5. Rollout
 
@@ -338,37 +407,46 @@ Mocks: `useIncidentGroups` for component tests (frontend mocks API at the bounda
 
 Single PR against `dev`, commits in this order so each step is independently revertable:
 
-1. Migration: add nullable `signature` column + indexes. (No code reads it yet.)
-2. `signature.ts` derivation function + tests. (Pure module, no callers.)
-3. `monitoring-service.ts`: emit optional `metric_type` / `detection_method`. (Backward-compatible.)
-4. `incident-correlator.ts`: write `signature` on insert. (New rows populated; legacy rows still NULL.)
-5. Backfill script. Run once at deploy. Idempotent.
-6. New `GET /api/incidents/groups` endpoint + tests.
-7. Frontend hook + `IncidentGroupsView` component + tests.
-8. Swap the page section in `ai-monitor.tsx`.
+1. **Phase A migration:** add nullable `signature` column. (Auto-migration, transactional, fast.)
+2. **Index-creation script:** non-transactional `CREATE INDEX CONCURRENTLY` script (§3.1 Phase B). Runs at deploy time, before user-facing reads.
+3. `signature.ts` derivation function + tests + historical-titles drift corpus. (Pure module, no callers.)
+4. `monitoring-service.ts`: emit optional `metric_type` / `detection_method`. (Backward-compatible.)
+5. `incident-correlator.ts`: write `signature` on insert. (New rows populated; legacy rows still NULL.)
+6. Backfill script. Run once at deploy. Idempotent.
+7. New `POST /api/incidents/resolve` batch endpoint + tests.
+8. New `GET /api/incidents/groups` endpoint with `cachedFetchSWR` + tests.
+9. Frontend hook + `IncidentGroupsView` component + tests.
+10. Swap the page section in `ai-monitor.tsx`.
 
-If anything goes sideways during rollout, steps 1–6 stay (the column is harmless if unused) and step 8 is the only revert needed to restore the old UI.
+If anything goes sideways during rollout, steps 1–8 stay (the column, indexes, and endpoints are harmless if unused) and step 10 is the only revert needed to restore the old UI.
 
 ### 5.2 Production verification
 
 Done by the deployer after merge:
 
-- [ ] Migration applied; `signature` column present on `incidents`.
+- [ ] Phase A migration applied; `signature` column present on `incidents`.
+- [ ] Phase B index script run; `idx_incidents_signature_status` and `idx_incidents_endpoint_status` exist (verify via `\d+ incidents`).
 - [ ] Backfill script run; `SELECT COUNT(*) FROM incidents WHERE signature IS NULL` returns 0.
-- [ ] `GET /api/incidents/groups` returns within 250ms p95 against the live dataset (size noted in PR).
+- [ ] Drift verification passed locally (signature.test.ts CSV corpus assertion green) before merge.
+- [ ] `GET /api/incidents/groups` returns within 250ms p95 against the live dataset (size noted in PR). Cache hit ratio >70% during steady-state (visible in logs).
+- [ ] `POST /api/incidents/resolve` returns within ~1s for a 100-id batch; partial-failure response shape verified.
 - [ ] `/health` page renders the new view; existing per-incident drill-down still works (click container → existing `/incidents/:id`).
-- [ ] Manual: resolve one incident via per-row, one via per-group "Resolve all", one via multi-select. All three update counts and refetch.
+- [ ] Manual: resolve one incident via per-row, one via per-group "Resolve all", one via multi-select. All three update counts and refetch. Force a partial failure (e.g., resolve an already-resolved id mid-batch) and verify the >5-fail collapsed-banner UX.
 - [ ] Manual: endpoint filter chip changes the URL and the visible groups; refresh preserves the filter.
-- [ ] No regression in existing security-regression tests (auth, RBAC on new route).
+- [ ] Manual: search for a container in the long tail (not in `top_containers`) — group auto-expands and auto-fetches "Show all".
+- [ ] No regression in existing security-regression tests (auth, RBAC on new routes — both `groups` and batch `resolve`).
 
 ### 5.3 Rollback
 
 | Failure mode | Rollback |
 |---|---|
-| Frontend rendering broken | Revert step 8 only — old flat list returns. Backend stays. |
-| `/api/incidents/groups` slow or wrong | Revert steps 6–8. Backfilled column is harmless. |
+| Frontend rendering broken | Revert step 10 only — old flat list returns. Backend stays. |
+| `/api/incidents/groups` slow or wrong | Revert steps 8–10. Backfilled column and indexes are harmless. |
+| Cache misbehaving (stale data, missed invalidations) | Bypass cache via env flag (set `INCIDENTS_GROUPS_CACHE_TTL_MS=0`) — endpoint stays correct, just slower. Then debug. |
+| Batch resolve endpoint failing | Frontend feature-flags fall-back to looped single-resolve calls. Worse UX, still functional. |
 | Backfill produced wrong signatures | Re-run with corrected `deriveSignature`; the script is idempotent and only overwrites NULLs by default. Use `--force` for full re-derivation. |
-| Migration concerns | `ALTER TABLE ADD COLUMN nullable` is non-blocking on Postgres; the indexes can be created `CONCURRENTLY` if the table is large at deploy time. |
+| Phase B index creation fails mid-flight | `CREATE INDEX CONCURRENTLY` failures leave behind invalid indexes. Drop them (`DROP INDEX IF EXISTS …`) and re-run the script. Reads keep working without the indexes (slower full scans), so this isn't user-blocking. |
+| Phase A migration concerns | `ALTER TABLE ADD COLUMN nullable` is `O(1)` on Postgres (metadata-only). No expected blocker. |
 
 `NOT NULL` is **not** added in this PR. Follow-up after one week of clean writes.
 
@@ -392,15 +470,16 @@ These give us the "alerts per container per signature" ratio that #1195 needs to
 
 ## 6. Acceptance criteria
 
-- [ ] `incidents.signature` column exists, indexed alongside `status` and `endpoint_id`.
-- [ ] `signature.ts` exports `deriveSignature()` and `signatureLabel()`, with full test coverage of the derivation matrix.
-- [ ] `monitoring-service.ts` emits `metric_type` and `detection_method` on anomaly + predictive insights.
-- [ ] `incident-correlator.ts` writes `signature` on every new incident. Existing tests continue to pass.
-- [ ] Backfill script populates all existing incidents with non-null signatures; runnable safely more than once.
-- [ ] `GET /api/incidents/groups` returns the response shape in §3.5, supports `status` / `endpoint_id` / `since` / `severity` filters, returns within 250ms p95 against production data.
-- [ ] `/health` page renders `IncidentGroupsView` with summary strip, endpoint chips, collapsed/expanded groups, top-10 container rows, "Show all" expansion.
-- [ ] All three resolve paths (per-row, multi-select, per-group) work and surface partial-failure correctly.
-- [ ] Search filters both group labels and container names.
-- [ ] URL params (`range`, `endpoint`, `sort`) survive refresh and deep-linking.
+- [ ] `incidents.signature` column exists (Phase A); `idx_incidents_signature_status` and `idx_incidents_endpoint_status` exist (Phase B, `CONCURRENTLY`).
+- [ ] `signature.ts` exports `deriveSignature()` and `signatureLabel()`, with full test coverage of the derivation matrix **and** the historical-titles drift corpus.
+- [ ] `monitoring-service.ts` emits `metric_type` and `detection_method` on anomaly + predictive + health-check + log-analysis + security insights.
+- [ ] `incident-correlator.ts` writes `signature` on every new incident via `deriveSignature` (single source of truth shared with backfill). Existing tests continue to pass.
+- [ ] Backfill script populates all existing incidents with non-null signatures; runnable safely more than once. Drift verification CSV passes before merge.
+- [ ] `GET /api/incidents/groups` returns the response shape in §3.5 (including `all_container_names`), supports `status` / `endpoint_id` / `since` / `severity` filters, applies `since` against `latest_at`, returns within 250ms p95, wrapped in `cachedFetchSWR` with tag invalidation on incident writes.
+- [ ] `POST /api/incidents/resolve` batch endpoint exists, admin-RBAC-gated, validates input, returns `{ resolved, failed }`, and audit-logs each resolution.
+- [ ] `/health` page renders `IncidentGroupsView` with summary strip (single-bucket-per-container), endpoint chips, collapsed/expanded groups, top-10 container rows, "Show all" expansion.
+- [ ] All three resolve paths (per-row, multi-select, per-group) use the batch endpoint where multi-id and surface partial-failure per the §4.5 rules (≤5 inline, >5 collapsed banner with Retry failed only).
+- [ ] Search filters via `all_container_names` (long-tail container names found, not just `top_containers`); auto-expands and auto-fetches "Show all" when needed.
+- [ ] URL params (`range`, `endpoint`, `sort`, `expand` with `-` prefix) survive refresh and deep-linking. No unused URL params shipped.
 - [ ] All new and existing tests pass on backend, frontend, and packages workspaces.
-- [ ] No new ESLint or TypeScript errors. No regression in security-regression tests.
+- [ ] No new ESLint or TypeScript errors. No regression in security-regression tests (auth + RBAC on both new routes).

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+import type { IncidentGroupsResponse } from '../hooks/use-incident-groups';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+
+const wrap = (c: React.ReactNode) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <MemoryRouter>{c}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+const dummyGroup = {
+  signature: 'dummy',
+  label: 'Dummy',
+  severity: 'info' as const,
+  incident_count: 0,
+  container_count: 0,
+  alert_count: 0,
+  earliest_at: '',
+  latest_update_at: '',
+  top_containers: [],
+  all_container_names: [],
+  names_truncated: false,
+};
+
+describe('IncidentGroupsView — endpoint chip overflow', () => {
+  it('does not render the chip row when 1 or 0 endpoints', () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 0,
+        groups: [dummyGroup],
+        endpoint_facets: [{ endpoint_id: 1, endpoint_name: 'e0', incident_count: 1 }],
+      } as IncidentGroupsResponse,
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView />));
+    expect(screen.queryByTestId('endpoint-chip-row')).not.toBeInTheDocument();
+  });
+
+  it('renders <=8 endpoints inline, no dropdown', () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 5,
+        groups: [dummyGroup],
+        endpoint_facets: Array.from({ length: 5 }, (_, i) => ({
+          endpoint_id: i,
+          endpoint_name: `e${i}`,
+          incident_count: 1,
+        })),
+      } as IncidentGroupsResponse,
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView />));
+    expect(screen.getByTestId('endpoint-chip-row')).toBeInTheDocument();
+    expect(screen.queryByText(/more/i)).not.toBeInTheDocument();
+  });
+
+  it('renders +N more dropdown when >8 endpoints', () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 12,
+        groups: [dummyGroup],
+        endpoint_facets: Array.from({ length: 12 }, (_, i) => ({
+          endpoint_id: i,
+          endpoint_name: `e${i}`,
+          incident_count: 1,
+        })),
+      } as IncidentGroupsResponse,
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView />));
+    expect(screen.getByText(/\+4 more/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.resolve.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.resolve.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+vi.mock('@/shared/lib/api', () => ({ api: { get: vi.fn(), post: vi.fn() } }));
+
+// ConfirmDialog: simplest mock that immediately calls onConfirm.
+// The real dialog opens a modal. For tests we render it inline so the
+// "Confirm" button is always in the DOM when pendingGroup is set.
+vi.mock('@/shared/components/feedback/confirm-dialog', () => ({
+  ConfirmDialog: (props: {
+    open: boolean;
+    onConfirm: () => void;
+    onCancel?: () => void;
+    confirmLabel?: string;
+    title?: string;
+    description?: string;
+  }) =>
+    props.open ? (
+      <div role="dialog">
+        <button onClick={props.onConfirm}>{props.confirmLabel ?? 'Confirm'}</button>
+        <button onClick={props.onCancel}>Cancel</button>
+      </div>
+    ) : null,
+}));
+
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+
+const wrap = (c: React.ReactNode) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { mutations: { retry: false } } })}>
+    <MemoryRouter>{c}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+const groupOf = (ids: string[]) => ({
+  signature: 'g', label: 'Grp', severity: 'critical' as const,
+  incident_count: ids.length, container_count: ids.length, alert_count: ids.length,
+  earliest_at: '', latest_update_at: '',
+  top_containers: ids.map((id, i) => ({
+    incident_id: id, container_name: `cn-${i}`, endpoint_id: 1, endpoint_name: 'e',
+    severity: 'critical' as const, created_at: '',
+  })),
+  all_container_names: ids.map((_, i) => `cn-${i}`),
+  names_truncated: false,
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('IncidentGroupsView — resolve', () => {
+  it('per-group "Resolve all N" calls batch endpoint with the group ids', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 3, endpoint_facets: [], groups: [groupOf(['x', 'y', 'z'])] },
+      isLoading: false,
+    });
+    (api.post as ReturnType<typeof vi.fn>).mockResolvedValue({ resolved: ['x', 'y', 'z'], failed: [] });
+
+    render(wrap(<IncidentGroupsView />));
+    await userEvent.click(screen.getByRole('button', { name: /Resolve all 3/i }));
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(api.post).toHaveBeenCalledWith('/api/incidents/resolve', { ids: ['x', 'y', 'z'] });
+  });
+
+  it('partial failure ≤5 keeps failed inline with retry option', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 3, endpoint_facets: [], groups: [groupOf(['x', 'y', 'z'])] },
+      isLoading: false,
+    });
+    (api.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      resolved: ['x', 'z'],
+      failed: [{ id: 'y', error: 'boom' }],
+    });
+
+    render(wrap(<IncidentGroupsView />));
+    await userEvent.click(screen.getByRole('button', { name: /Resolve all 3/i }));
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(await screen.findByText(/Retry 1 failed/i)).toBeInTheDocument();
+  });
+
+  it('partial failure >5 collapses into a banner with Retry failed only', async () => {
+    const ids = Array.from({ length: 12 }, (_, i) => `i${i}`);
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 12, endpoint_facets: [], groups: [groupOf(ids)] },
+      isLoading: false,
+    });
+    (api.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      resolved: ids.slice(0, 5),
+      failed: ids.slice(5).map((id) => ({ id, error: 'e' })),
+    });
+
+    render(wrap(<IncidentGroupsView />));
+    await userEvent.click(screen.getByRole('button', { name: /Resolve all 12/i }));
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(await screen.findByText(/7 of 12 resolves failed/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Retry failed only/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.search-debounce.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.search-debounce.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+vi.mock('@/shared/lib/api', () => ({ api: { get: vi.fn() } }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+
+const wrap = (c: React.ReactNode) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <MemoryRouter>{c}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+const baseGroup = {
+  signature: 'big', label: 'Many', severity: 'warning' as const,
+  incident_count: 100, container_count: 100, alert_count: 100,
+  earliest_at: '', latest_update_at: '', top_containers: [],
+  all_container_names: [], names_truncated: true,
+};
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.runAllTimers();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('IncidentGroupsView — search debounce', () => {
+  it('does not auto-fetch until 250ms quiet', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 100, endpoint_facets: [], groups: [baseGroup] },
+      isLoading: false,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      incidents: [], counts: { active: 0, resolved: 0, total: 0 }, limit: 50, offset: 0,
+    });
+    const { rerender } = render(wrap(<IncidentGroupsView search="a" />));
+
+    // Rapid rerenders before debounce fires
+    act(() => { rerender(wrap(<IncidentGroupsView search="ab" />)); });
+    act(() => { rerender(wrap(<IncidentGroupsView search="abc" />)); });
+
+    // Before 250ms elapses: no calls
+    expect(api.get).not.toHaveBeenCalled();
+
+    // Advance timers past the 250ms debounce window
+    await act(async () => { vi.advanceTimersByTime(300); });
+
+    // Exactly one call with the final term
+    expect(api.get).toHaveBeenCalledTimes(1);
+    expect(api.get).toHaveBeenCalledWith('/api/incidents', expect.objectContaining({
+      params: expect.objectContaining({ q: 'abc' }),
+    }));
+  });
+});

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.search.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.search.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+vi.mock('@/shared/lib/api', () => ({ api: { get: vi.fn() } }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+
+const wrap = (c: React.ReactNode) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <MemoryRouter>{c}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+describe('IncidentGroupsView — search', () => {
+  it('hides groups whose label and all_container_names do not match', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 2, endpoint_facets: [],
+        groups: [
+          { signature: 'a', label: 'Apple', severity: 'critical',
+            incident_count: 1, container_count: 1, alert_count: 1,
+            earliest_at: '', latest_update_at: '',
+            top_containers: [{ incident_id: 'x', container_name: 'apple-1', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }],
+            all_container_names: ['apple-1'], names_truncated: false },
+          { signature: 'b', label: 'Banana', severity: 'critical',
+            incident_count: 1, container_count: 1, alert_count: 1,
+            earliest_at: '', latest_update_at: '',
+            top_containers: [{ incident_id: 'y', container_name: 'banana-1', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }],
+            all_container_names: ['banana-1'], names_truncated: false },
+        ],
+      },
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView search="banana" />));
+    // Wait for debounce (250ms)
+    await new Promise((r) => setTimeout(r, 300));
+    expect(screen.getByText('Banana')).toBeInTheDocument();
+    expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+  });
+
+  it('auto-expands a collapsed group when its container matches', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 1, endpoint_facets: [],
+        groups: [{
+          signature: 'a', label: 'Warn', severity: 'warning',
+          incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [{ incident_id: 'x', container_name: 'matchme', endpoint_id: 1, endpoint_name: 'e', severity: 'warning', created_at: '' }],
+          all_container_names: ['matchme'], names_truncated: false,
+        }],
+      },
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView search="matchme" />));
+    await new Promise((r) => setTimeout(r, 300));
+    expect(screen.getByText('matchme')).toBeInTheDocument();
+  });
+
+  it('truncated groups delegate search to backend when query is non-empty', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 600, endpoint_facets: [],
+        groups: [{
+          signature: 'big', label: 'Many', severity: 'warning',
+          incident_count: 600, container_count: 600, alert_count: 600,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [],
+          all_container_names: Array.from({ length: 500 }, (_, i) => `cn-${i}`),
+          names_truncated: true,
+        }],
+      },
+      isLoading: false,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      incidents: [],
+      counts: { active: 0, resolved: 0, total: 0 }, limit: 50, offset: 0,
+    });
+    render(wrap(<IncidentGroupsView search="cn-700" />));
+    await new Promise((r) => setTimeout(r, 300));
+    expect(api.get).toHaveBeenCalledWith('/api/incidents', expect.objectContaining({
+      params: expect.objectContaining({ signature: 'big', q: 'cn-700' }),
+    }));
+  });
+});

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+
+vi.mock('../hooks/use-incident-groups', () => ({ useIncidentGroups: vi.fn() }));
+vi.mock('@/shared/lib/api', () => ({ api: { get: vi.fn() } }));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+
+const wrap = (children: React.ReactNode) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+describe('IncidentGroupsView — Show all pagination', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders Show all button when container_count > 10 and fetches the long tail on click', async () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 12, endpoint_facets: [],
+        groups: [{
+          signature: 'a:b:c', label: 'Big', severity: 'critical',
+          incident_count: 12, container_count: 12, alert_count: 12,
+          earliest_at: '', latest_update_at: '',
+          top_containers: Array.from({ length: 10 }, (_, i) => ({
+            incident_id: `i${i}`, container_name: `cn-${i}`,
+            endpoint_id: 1, endpoint_name: 'e', severity: 'warning' as const,
+            created_at: '',
+          })),
+          all_container_names: Array.from({ length: 12 }, (_, i) => `cn-${i}`),
+          names_truncated: false,
+        }],
+      },
+      isLoading: false,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      incidents: [
+        { id: 'i10', title: 't', signature: 'a:b:c', severity: 'warning', status: 'active',
+          affected_containers: ['cn-10'], endpoint_id: 1, endpoint_name: 'e',
+          created_at: '', updated_at: '' },
+        { id: 'i11', title: 't', signature: 'a:b:c', severity: 'warning', status: 'active',
+          affected_containers: ['cn-11'], endpoint_id: 1, endpoint_name: 'e',
+          created_at: '', updated_at: '' },
+      ],
+      counts: { active: 12, resolved: 0, total: 12 },
+      limit: 50, offset: 0,
+    });
+
+    render(wrap(<IncidentGroupsView />));
+    const showAll = screen.getByRole('button', { name: /Show all 12/i });
+    await userEvent.click(showAll);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith('/api/incidents', {
+        params: { status: 'active', signature: 'a:b:c', limit: '500' },
+      });
+    });
+    expect(screen.getByText('cn-10')).toBeInTheDocument();
+    expect(screen.getByText('cn-11')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx
@@ -56,9 +56,9 @@ describe('IncidentGroupsView — Show all pagination', () => {
     await userEvent.click(showAll);
 
     await waitFor(() => {
-      expect(api.get).toHaveBeenCalledWith('/api/incidents', {
+      expect(api.get).toHaveBeenCalledWith('/api/incidents', expect.objectContaining({
         params: { status: 'active', signature: 'a:b:c', limit: '500' },
-      });
+      }));
     });
     expect(screen.getByText('cn-10')).toBeInTheDocument();
     expect(screen.getByText('cn-11')).toBeInTheDocument();

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+import type { IncidentGroupsResponse } from '../hooks/use-incident-groups';
+
+vi.mock('../hooks/use-incident-groups', () => ({
+  useIncidentGroups: vi.fn(),
+}));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+
+const wrap = (children: React.ReactNode) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+const mock = (data: IncidentGroupsResponse) => {
+  (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({ data, isLoading: false });
+};
+
+describe('IncidentGroupsView — rendering', () => {
+  it('renders summary strip with single-bucket-per-container counts', () => {
+    mock({
+      total_active: 3,
+      endpoint_facets: [{ endpoint_id: 1, endpoint_name: 'eA', incident_count: 3 }],
+      groups: [
+        {
+          signature: 'a:b:c', label: 'Critical thing', severity: 'critical',
+          incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '2026-05-06T00:00:00Z', latest_update_at: '2026-05-06T00:00:00Z',
+          top_containers: [{ incident_id: 'x', container_name: 'cn-A', endpoint_id: 1, endpoint_name: 'eA', severity: 'critical', created_at: '2026-05-06T00:00:00Z' }],
+          all_container_names: ['cn-A'], names_truncated: false,
+        },
+        {
+          signature: 'd:e:f', label: 'Warning thing', severity: 'warning',
+          incident_count: 2, container_count: 2, alert_count: 2,
+          earliest_at: '2026-05-06T00:00:00Z', latest_update_at: '2026-05-06T00:00:00Z',
+          top_containers: [
+            { incident_id: 'y1', container_name: 'cn-A', endpoint_id: 1, endpoint_name: 'eA', severity: 'warning', created_at: '2026-05-06T00:00:00Z' },
+            { incident_id: 'y2', container_name: 'cn-B', endpoint_id: 1, endpoint_name: 'eA', severity: 'warning', created_at: '2026-05-06T00:00:00Z' },
+          ],
+          all_container_names: ['cn-A', 'cn-B'], names_truncated: false,
+        },
+      ],
+    });
+    render(wrap(<IncidentGroupsView />));
+    // cn-A is in both critical and warning → counts in critical only.
+    const summary = screen.getByTestId('summary-strip');
+    expect(summary).toHaveTextContent(/Critical:.*1.*container/i);
+    expect(summary).toHaveTextContent(/Warning:.*1.*container/i);  // cn-B only
+  });
+
+  it('expands critical groups by default, collapses warnings', () => {
+    mock({
+      total_active: 2,
+      endpoint_facets: [],
+      groups: [
+        { signature: 'crit', label: 'Crit', severity: 'critical', incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [{ incident_id: 'x', container_name: 'cn', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }],
+          all_container_names: ['cn'], names_truncated: false },
+        { signature: 'warn', label: 'Warn', severity: 'warning', incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [{ incident_id: 'y', container_name: 'cn2', endpoint_id: 1, endpoint_name: 'e', severity: 'warning', created_at: '' }],
+          all_container_names: ['cn2'], names_truncated: false },
+      ],
+    });
+    render(wrap(<IncidentGroupsView />));
+    expect(screen.getByText('cn')).toBeInTheDocument();      // critical group expanded
+    expect(screen.queryByText('cn2')).not.toBeInTheDocument(); // warning collapsed
+  });
+
+  it('toggling a group expands its top-10 rows', async () => {
+    mock({
+      total_active: 1,
+      endpoint_facets: [],
+      groups: [
+        { signature: 'warn', label: 'Warn', severity: 'warning', incident_count: 1, container_count: 1, alert_count: 1,
+          earliest_at: '', latest_update_at: '',
+          top_containers: [{ incident_id: 'y', container_name: 'cn2', endpoint_id: 1, endpoint_name: 'e', severity: 'warning', created_at: '' }],
+          all_container_names: ['cn2'], names_truncated: false },
+      ],
+    });
+    render(wrap(<IncidentGroupsView />));
+    expect(screen.queryByText('cn2')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /Warn/i }));
+    expect(screen.getByText('cn2')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useCallback, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { ChevronDown, ChevronRight, Layers } from 'lucide-react';
 import { useIncidentGroups, type IncidentGroup } from '../hooks/use-incident-groups';
 import { useBatchResolveIncidents, type BatchResolveResponse } from '../hooks/use-incidents';
@@ -27,7 +27,20 @@ interface LongTailRow {
 
 export function IncidentGroupsView({ search = '' }: { search?: string }) {
   const { data, isLoading } = useIncidentGroups({ status: 'active' });
-  const [expandedOverrides, setExpandedOverrides] = useState<Record<string, boolean>>({});
+  const [searchParams, setSearchParams] = useSearchParams();
+  const expandParam = searchParams.get('expand') ?? '';
+
+  const overrides = useMemo(() => {
+    const opens = new Set<string>();
+    const closes = new Set<string>();
+    for (const part of expandParam.split(',').filter(Boolean)) {
+      const decoded = decodeURIComponent(part);
+      if (decoded.startsWith('-')) closes.add(decoded.slice(1));
+      else opens.add(decoded);
+    }
+    return { opens, closes };
+  }, [expandParam]);
+
   const [longTailBySig, setLongTailBySig] = useState<Record<string, LongTailRow[]>>({});
   const batchResolve = useBatchResolveIncidents();
   const [pendingGroup, setPendingGroup] = useState<IncidentGroup | null>(null);
@@ -67,13 +80,32 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
   }, [searchLower, debouncedSearch, data]);
 
   const isOpen = useCallback((sig: string, severity: IncidentGroup['severity']) => {
-    if (sig in expandedOverrides) return expandedOverrides[sig];
+    if (overrides.closes.has(sig)) return false;
+    if (overrides.opens.has(sig)) return true;
     return severity === 'critical';
-  }, [expandedOverrides]);
+  }, [overrides]);
 
   const toggle = useCallback((sig: string, severity: IncidentGroup['severity']) => {
-    setExpandedOverrides((prev) => ({ ...prev, [sig]: !isOpen(sig, severity) }));
-  }, [isOpen]);
+    const nowOpen = isOpen(sig, severity);
+    const next = !nowOpen;
+    const opens = new Set(overrides.opens);
+    const closes = new Set(overrides.closes);
+    opens.delete(sig);
+    closes.delete(sig);
+    const defaultOpen = severity === 'critical';
+    // Only encode deviations from the default rule.
+    if (next !== defaultOpen) {
+      if (next) opens.add(sig); else closes.add(sig);
+    }
+    const parts = [
+      ...Array.from(opens).map((s) => encodeURIComponent(s)),
+      ...Array.from(closes).map((s) => '-' + encodeURIComponent(s)),
+    ];
+    const sp = new URLSearchParams(searchParams);
+    if (parts.length > 0) sp.set('expand', parts.join(','));
+    else sp.delete('expand');
+    setSearchParams(sp, { replace: false });
+  }, [searchParams, setSearchParams, overrides, isOpen]);
 
   const onResolveGroup = useCallback(async (group: IncidentGroup) => {
     setPendingGroup(null);

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
@@ -1,9 +1,18 @@
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronDown, ChevronRight, Layers } from 'lucide-react';
 import { useIncidentGroups, type IncidentGroup } from '../hooks/use-incident-groups';
 import { api } from '@/shared/lib/api';
 import { cn } from '@/shared/lib/utils';
+
+function useDebounced(value: string, ms: number): string {
+  const [v, setV] = useState('');
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return v;
+}
 
 interface LongTailRow {
   incident_id: string;
@@ -14,12 +23,43 @@ interface LongTailRow {
   created_at: string;
 }
 
-export function IncidentGroupsView() {
+export function IncidentGroupsView({ search = '' }: { search?: string }) {
   const { data, isLoading } = useIncidentGroups({ status: 'active' });
   const [expandedOverrides, setExpandedOverrides] = useState<Record<string, boolean>>({});
   const [longTailBySig, setLongTailBySig] = useState<Record<string, LongTailRow[]>>({});
 
   const summary = useMemo(() => computeSummary(data?.groups ?? []), [data?.groups]);
+
+  const debouncedSearch = useDebounced(search, 250);
+  const searchLower = debouncedSearch.toLowerCase();
+
+  const visibleGroups = useMemo(() => {
+    if (!data) return [];
+    if (!searchLower) return data.groups;
+    return data.groups.filter((g) =>
+      g.label.toLowerCase().includes(searchLower) ||
+      g.all_container_names.some((n) => n.toLowerCase().includes(searchLower)),
+    );
+  }, [data, searchLower]);
+
+  useEffect(() => {
+    if (!searchLower || !data) return;
+    for (const g of data.groups) {
+      if (!g.names_truncated) continue;
+      api.get<{ incidents: Array<{ id: string; affected_containers: string[]; endpoint_id: number | null; endpoint_name: string | null; severity: 'critical' | 'warning' | 'info'; created_at: string }> }>(
+        '/api/incidents', { params: { status: 'active', signature: g.signature, q: debouncedSearch } },
+      ).then((r) => {
+        const rows: LongTailRow[] = r.incidents.flatMap((inc) =>
+          (inc.affected_containers ?? []).map((name) => ({
+            incident_id: inc.id, container_name: name,
+            endpoint_id: inc.endpoint_id, endpoint_name: inc.endpoint_name,
+            severity: inc.severity, created_at: inc.created_at,
+          })),
+        );
+        setLongTailBySig((prev) => ({ ...prev, [g.signature]: rows }));
+      }).catch(() => undefined);
+    }
+  }, [searchLower, debouncedSearch, data]);
 
   const isOpen = useCallback((sig: string, severity: IncidentGroup['severity']) => {
     if (sig in expandedOverrides) return expandedOverrides[sig];
@@ -53,10 +93,12 @@ export function IncidentGroupsView() {
 
   if (isLoading || !data) return null;
 
-  if (data.groups.length === 0) {
+  if (data.groups.length === 0 || (searchLower && visibleGroups.length === 0)) {
     return (
       <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
-        No active incidents in this view.
+        {searchLower && visibleGroups.length === 0
+          ? 'No incidents match the current search.'
+          : 'No active incidents in this view.'}
       </div>
     );
   }
@@ -83,8 +125,9 @@ export function IncidentGroupsView() {
         )}
       </div>
 
-      {data.groups.map((g) => {
-        const open = isOpen(g.signature, g.severity);
+      {visibleGroups.map((g) => {
+        const effectivelyOpen = isOpen(g.signature, g.severity)
+          || (!!searchLower && g.all_container_names.some((n) => n.toLowerCase().includes(searchLower)));
         const longTail = longTailBySig[g.signature];
         const rows = longTail ?? g.top_containers;
         return (
@@ -115,10 +158,10 @@ export function IncidentGroupsView() {
                     {g.container_count} container{g.container_count === 1 ? '' : 's'} · {g.alert_count} alert{g.alert_count === 1 ? '' : 's'}
                   </span>
                 </div>
-                {open ? <ChevronDown className="h-5 w-5 text-muted-foreground" /> : <ChevronRight className="h-5 w-5 text-muted-foreground" />}
+                {effectivelyOpen ? <ChevronDown className="h-5 w-5 text-muted-foreground" /> : <ChevronRight className="h-5 w-5 text-muted-foreground" />}
               </div>
             </button>
-            {open && (
+            {effectivelyOpen && (
               <div className="border-t bg-muted/10">
                 <ul className="divide-y">
                   {rows.map((row) => (

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState, useCallback, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronDown, ChevronRight, Layers } from 'lucide-react';
 import { useIncidentGroups, type IncidentGroup } from '../hooks/use-incident-groups';
+import { useBatchResolveIncidents, type BatchResolveResponse } from '../hooks/use-incidents';
+import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
 import { api } from '@/shared/lib/api';
 import { cn } from '@/shared/lib/utils';
 
@@ -27,6 +29,9 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
   const { data, isLoading } = useIncidentGroups({ status: 'active' });
   const [expandedOverrides, setExpandedOverrides] = useState<Record<string, boolean>>({});
   const [longTailBySig, setLongTailBySig] = useState<Record<string, LongTailRow[]>>({});
+  const batchResolve = useBatchResolveIncidents();
+  const [pendingGroup, setPendingGroup] = useState<IncidentGroup | null>(null);
+  const [lastFailure, setLastFailure] = useState<BatchResolveResponse | null>(null);
 
   const summary = useMemo(() => computeSummary(data?.groups ?? []), [data?.groups]);
 
@@ -69,6 +74,21 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
   const toggle = useCallback((sig: string, severity: IncidentGroup['severity']) => {
     setExpandedOverrides((prev) => ({ ...prev, [sig]: !isOpen(sig, severity) }));
   }, [isOpen]);
+
+  const onResolveGroup = useCallback(async (group: IncidentGroup) => {
+    setPendingGroup(null);
+    const longTail = longTailBySig[group.signature];
+    const ids = (longTail ?? group.top_containers).map((c) => c.incident_id);
+    const r = await batchResolve.mutateAsync(ids);
+    if (r.failed.length > 0) setLastFailure(r);
+    else setLastFailure(null);
+  }, [batchResolve, longTailBySig]);
+
+  const onRetryFailed = useCallback(async () => {
+    if (!lastFailure) return;
+    const r = await batchResolve.mutateAsync(lastFailure.failed.map((f) => f.id));
+    setLastFailure(r.failed.length > 0 ? r : null);
+  }, [batchResolve, lastFailure]);
 
   const showAll = useCallback(async (group: IncidentGroup) => {
     const r = await api.get<{
@@ -187,11 +207,49 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
                     Show all {g.container_count}
                   </button>
                 )}
+                {rows.length > 0 && (
+                  <div className="border-t flex items-center justify-end gap-2 p-2">
+                    <button
+                      type="button"
+                      onClick={() => setPendingGroup(g)}
+                      className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700"
+                    >
+                      Resolve all {g.incident_count}
+                    </button>
+                  </div>
+                )}
               </div>
             )}
           </div>
         );
       })}
+      {pendingGroup && (
+        <ConfirmDialog
+          open={pendingGroup !== null}
+          title={`Resolve all ${pendingGroup.incident_count} incidents in this group?`}
+          description={`This will mark all ${pendingGroup.incident_count} active incident${pendingGroup.incident_count === 1 ? '' : 's'} in "${pendingGroup.label}" as resolved.`}
+          onConfirm={() => void onResolveGroup(pendingGroup)}
+          onCancel={() => setPendingGroup(null)}
+          confirmLabel="Confirm"
+          variant="warning"
+        />
+      )}
+      {lastFailure && lastFailure.failed.length > 0 && (
+        lastFailure.failed.length <= 5 ? (
+          <div role="alert" className="rounded-md border border-red-500/40 bg-red-50/30 p-2 text-sm">
+            <p className="font-medium">Retry {lastFailure.failed.length} failed</p>
+            <ul className="mt-1 list-disc pl-5">
+              {lastFailure.failed.map((f) => <li key={f.id}>{f.id}: {f.error}</li>)}
+            </ul>
+            <button onClick={() => void onRetryFailed()} className="mt-1 rounded-md bg-emerald-600 px-2 py-1 text-xs text-white">Retry</button>
+          </div>
+        ) : (
+          <div role="alert" className="rounded-md border border-red-500/40 bg-red-50/30 p-2 text-sm">
+            <p className="font-medium">{lastFailure.failed.length} of {lastFailure.failed.length + lastFailure.resolved.length} resolves failed</p>
+            <button onClick={() => void onRetryFailed()} className="mt-1 rounded-md bg-emerald-600 px-2 py-1 text-xs text-white">Retry failed only</button>
+          </div>
+        )
+      )}
     </div>
   );
 }

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
@@ -177,6 +177,8 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
         )}
       </div>
 
+      <EndpointChips facets={data.endpoint_facets} />
+
       {visibleGroups.map((g) => {
         const effectivelyOpen = isOpen(g.signature, g.severity)
           || (!!searchLower && g.all_container_names.some((n) => n.toLowerCase().includes(searchLower)));
@@ -313,4 +315,37 @@ function computeSummary(groups: IncidentGroup[]): {
 
 function rankSeverity(s: IncidentGroup['severity']): number {
   return s === 'critical' ? 0 : s === 'warning' ? 1 : 2;
+}
+
+function EndpointChips({
+  facets,
+}: {
+  facets: Array<{ endpoint_id: number | null; endpoint_name: string | null; incident_count: number }>;
+}) {
+  if (facets.length <= 1) return null;
+  const inline = facets.slice(0, 8);
+  const overflow = facets.slice(8);
+  return (
+    <div data-testid="endpoint-chip-row" className="flex flex-wrap items-center gap-2">
+      {inline.map((f) => (
+        <button key={`${f.endpoint_id ?? 'none'}`} type="button" className="rounded-full border px-3 py-1 text-xs">
+          {f.endpoint_name ?? 'unknown'} ({f.incident_count})
+        </button>
+      ))}
+      {overflow.length > 0 && (
+        <details className="relative">
+          <summary className="cursor-pointer rounded-full border px-3 py-1 text-xs">+{overflow.length} more</summary>
+          <ul className="absolute z-10 mt-1 max-h-64 w-64 overflow-auto rounded-md border bg-popover p-1 shadow">
+            {overflow.map((f) => (
+              <li key={`${f.endpoint_id ?? 'none'}`}>
+                <button type="button" className="w-full rounded px-2 py-1 text-left text-xs hover:bg-muted">
+                  {f.endpoint_name ?? 'unknown'} ({f.incident_count})
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
@@ -60,12 +60,20 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
     );
   }, [data, searchLower]);
 
+  // Stable join-key of truncated-group signatures — only changes when the SET of
+  // groups that need a long-tail fetch actually changes, not on every 30s refetch.
+  const truncatedSigs = useMemo(
+    () => (data?.groups.filter((g) => g.names_truncated).map((g) => g.signature).sort().join('|')) ?? '',
+    [data?.groups],
+  );
+
   useEffect(() => {
-    if (!searchLower || !data) return;
-    for (const g of data.groups) {
-      if (!g.names_truncated) continue;
+    if (!searchLower || !truncatedSigs) return;
+    const controller = new AbortController();
+    for (const sig of truncatedSigs.split('|').filter(Boolean)) {
       api.get<{ incidents: Array<{ id: string; affected_containers: string[]; endpoint_id: number | null; endpoint_name: string | null; severity: 'critical' | 'warning' | 'info'; created_at: string }> }>(
-        '/api/incidents', { params: { status: 'active', signature: g.signature, q: debouncedSearch } },
+        '/api/incidents',
+        { params: { status: 'active', signature: sig, q: debouncedSearch }, signal: controller.signal },
       ).then((r) => {
         const rows: LongTailRow[] = r.incidents.flatMap((inc) =>
           (inc.affected_containers ?? []).map((name) => ({
@@ -74,10 +82,11 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
             severity: inc.severity, created_at: inc.created_at,
           })),
         );
-        setLongTailBySig((prev) => ({ ...prev, [g.signature]: rows }));
+        setLongTailBySig((prev) => ({ ...prev, [sig]: rows }));
       }).catch(() => undefined);
     }
-  }, [searchLower, debouncedSearch, data]);
+    return () => controller.abort();
+  }, [searchLower, debouncedSearch, truncatedSigs]);
 
   const isOpen = useCallback((sig: string, severity: IncidentGroup['severity']) => {
     if (overrides.closes.has(sig)) return false;
@@ -123,6 +132,7 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
   }, [batchResolve, lastFailure]);
 
   const showAll = useCallback(async (group: IncidentGroup) => {
+    const controller = new AbortController();
     const r = await api.get<{
       incidents: Array<{
         id: string;
@@ -132,7 +142,7 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
         severity: 'critical' | 'warning' | 'info';
         created_at: string;
       }>;
-    }>('/api/incidents', { params: { status: 'active', signature: group.signature, limit: '500' } });
+    }>('/api/incidents', { params: { status: 'active', signature: group.signature, limit: '500' }, signal: controller.signal });
     const rows: LongTailRow[] = r.incidents.flatMap((inc) =>
       (inc.affected_containers ?? []).map((name) => ({
         incident_id: inc.id, container_name: name,

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
@@ -1,0 +1,183 @@
+import { useMemo, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronDown, ChevronRight, Layers } from 'lucide-react';
+import { useIncidentGroups, type IncidentGroup } from '../hooks/use-incident-groups';
+import { api } from '@/shared/lib/api';
+import { cn } from '@/shared/lib/utils';
+
+interface LongTailRow {
+  incident_id: string;
+  container_name: string;
+  endpoint_id: number | null;
+  endpoint_name: string | null;
+  severity: 'critical' | 'warning' | 'info';
+  created_at: string;
+}
+
+export function IncidentGroupsView() {
+  const { data, isLoading } = useIncidentGroups({ status: 'active' });
+  const [expandedOverrides, setExpandedOverrides] = useState<Record<string, boolean>>({});
+  const [longTailBySig, setLongTailBySig] = useState<Record<string, LongTailRow[]>>({});
+
+  const summary = useMemo(() => computeSummary(data?.groups ?? []), [data?.groups]);
+
+  const isOpen = useCallback((sig: string, severity: IncidentGroup['severity']) => {
+    if (sig in expandedOverrides) return expandedOverrides[sig];
+    return severity === 'critical';
+  }, [expandedOverrides]);
+
+  const toggle = useCallback((sig: string, severity: IncidentGroup['severity']) => {
+    setExpandedOverrides((prev) => ({ ...prev, [sig]: !isOpen(sig, severity) }));
+  }, [isOpen]);
+
+  const showAll = useCallback(async (group: IncidentGroup) => {
+    const r = await api.get<{
+      incidents: Array<{
+        id: string;
+        affected_containers: string[];
+        endpoint_id: number | null;
+        endpoint_name: string | null;
+        severity: 'critical' | 'warning' | 'info';
+        created_at: string;
+      }>;
+    }>('/api/incidents', { params: { status: 'active', signature: group.signature, limit: '500' } });
+    const rows: LongTailRow[] = r.incidents.flatMap((inc) =>
+      (inc.affected_containers ?? []).map((name) => ({
+        incident_id: inc.id, container_name: name,
+        endpoint_id: inc.endpoint_id, endpoint_name: inc.endpoint_name,
+        severity: inc.severity, created_at: inc.created_at,
+      })),
+    );
+    setLongTailBySig((prev) => ({ ...prev, [group.signature]: rows }));
+  }, []);
+
+  if (isLoading || !data) return null;
+
+  if (data.groups.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+        No active incidents in this view.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div data-testid="summary-strip" className="text-sm">
+        {summary.critical.containers > 0 && (
+          <span>
+            Critical: {summary.critical.kinds} kinds across {summary.critical.containers} container{summary.critical.containers === 1 ? '' : 's'}
+          </span>
+        )}
+        {summary.warning.containers > 0 && (
+          <span>
+            {summary.critical.containers > 0 && ' · '}
+            Warning: {summary.warning.kinds} kinds across {summary.warning.containers} container{summary.warning.containers === 1 ? '' : 's'}
+          </span>
+        )}
+        {summary.info.containers > 0 && (
+          <span>
+            {(summary.critical.containers > 0 || summary.warning.containers > 0) && ' · '}
+            Info: {summary.info.kinds} kinds across {summary.info.containers} container{summary.info.containers === 1 ? '' : 's'}
+          </span>
+        )}
+      </div>
+
+      {data.groups.map((g) => {
+        const open = isOpen(g.signature, g.severity);
+        const longTail = longTailBySig[g.signature];
+        const rows = longTail ?? g.top_containers;
+        return (
+          <div
+            key={g.signature}
+            className={cn(
+              'overflow-hidden rounded-lg border-2 bg-card',
+              g.severity === 'critical' ? 'border-red-500/40' : g.severity === 'warning' ? 'border-amber-500/40' : 'border-blue-500/40',
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => toggle(g.signature, g.severity)}
+              className="w-full p-4 text-left transition-colors hover:bg-muted/20"
+              aria-label={g.label}
+            >
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <span
+                    className={cn(
+                      'h-2 w-2 rounded-full',
+                      g.severity === 'critical' ? 'bg-red-500' : g.severity === 'warning' ? 'bg-amber-500' : 'bg-blue-500',
+                    )}
+                  />
+                  <Layers className="h-4 w-4 text-muted-foreground" />
+                  <span className="font-semibold">{g.label}</span>
+                  <span className="text-sm text-muted-foreground">
+                    {g.container_count} container{g.container_count === 1 ? '' : 's'} · {g.alert_count} alert{g.alert_count === 1 ? '' : 's'}
+                  </span>
+                </div>
+                {open ? <ChevronDown className="h-5 w-5 text-muted-foreground" /> : <ChevronRight className="h-5 w-5 text-muted-foreground" />}
+              </div>
+            </button>
+            {open && (
+              <div className="border-t bg-muted/10">
+                <ul className="divide-y">
+                  {rows.map((row) => (
+                    <li key={`${row.incident_id}:${row.container_name}`} className="flex items-center justify-between px-4 py-2 text-sm">
+                      <Link
+                        to={`/containers/${row.endpoint_id}/${row.container_name}`}
+                        className="font-mono text-sm hover:underline"
+                      >
+                        {row.container_name}
+                      </Link>
+                      <span className="text-xs text-muted-foreground">
+                        {row.severity} · {row.endpoint_name ?? 'unknown'}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+                {!longTail && g.container_count > g.top_containers.length && (
+                  <button
+                    type="button"
+                    onClick={() => showAll(g)}
+                    className="block w-full px-4 py-2 text-center text-sm text-primary hover:bg-muted/30"
+                  >
+                    Show all {g.container_count}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function computeSummary(groups: IncidentGroup[]): {
+  critical: { kinds: number; containers: number };
+  warning: { kinds: number; containers: number };
+  info: { kinds: number; containers: number };
+} {
+  // For each container, find its highest severity across all groups it appears in.
+  const containerHighest = new Map<string, IncidentGroup['severity']>();
+  for (const g of groups) {
+    for (const name of g.all_container_names) {
+      const cur = containerHighest.get(name);
+      if (!cur || rankSeverity(g.severity) < rankSeverity(cur)) {
+        containerHighest.set(name, g.severity);
+      }
+    }
+  }
+  const out = {
+    critical: { kinds: 0, containers: 0 },
+    warning: { kinds: 0, containers: 0 },
+    info: { kinds: 0, containers: 0 },
+  };
+  for (const g of groups) out[g.severity].kinds++;
+  for (const sev of containerHighest.values()) out[sev].containers++;
+  return out;
+}
+
+function rankSeverity(s: IncidentGroup['severity']): number {
+  return s === 'critical' ? 0 : s === 'warning' ? 1 : 2;
+}

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.url.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.url.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncidentGroupsView } from './incident-groups-view';
+import type { IncidentGroupsResponse } from '../hooks/use-incident-groups';
+
+vi.mock('../hooks/use-incident-groups', () => ({
+  useIncidentGroups: vi.fn(),
+}));
+import { useIncidentGroups } from '../hooks/use-incident-groups';
+
+const wrap = (initialEntries: string[], children: React.ReactNode) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+const mock = (data: IncidentGroupsResponse) => {
+  (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({ data, isLoading: false });
+};
+
+describe('IncidentGroupsView — URL ?expand=', () => {
+  it('initial render with ?expand=-<sig> collapses a critical group', () => {
+    mock({
+      total_active: 1,
+      endpoint_facets: [],
+      groups: [{
+        signature: 'anomaly:ml-anomaly:cpu', label: 'CPU anomaly', severity: 'critical',
+        incident_count: 1, container_count: 1, alert_count: 1,
+        earliest_at: '', latest_update_at: '',
+        top_containers: [{ incident_id: 'x', container_name: 'cn', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }],
+        all_container_names: ['cn'], names_truncated: false,
+      }],
+    });
+    render(wrap(
+      ['/?expand=-anomaly%3Aml-anomaly%3Acpu'],
+      <IncidentGroupsView />,
+    ));
+    expect(screen.queryByText('cn')).not.toBeInTheDocument();
+  });
+
+  it('initial render with ?expand=<sig> opens a warning group', () => {
+    mock({
+      total_active: 1,
+      endpoint_facets: [],
+      groups: [{
+        signature: 'predictive:prediction:memory', label: 'Mem pred', severity: 'warning',
+        incident_count: 1, container_count: 1, alert_count: 1,
+        earliest_at: '', latest_update_at: '',
+        top_containers: [{ incident_id: 'y', container_name: 'cn-warn', endpoint_id: 1, endpoint_name: 'e', severity: 'warning', created_at: '' }],
+        all_container_names: ['cn-warn'], names_truncated: false,
+      }],
+    });
+    render(wrap(
+      ['/?expand=predictive%3Aprediction%3Amemory'],
+      <IncidentGroupsView />,
+    ));
+    expect(screen.getByText('cn-warn')).toBeInTheDocument();
+  });
+
+  it('toggling a critical group closed updates the URL with -<sig>', async () => {
+    mock({
+      total_active: 1,
+      endpoint_facets: [],
+      groups: [{
+        signature: 'anomaly:ml-anomaly:cpu', label: 'CPU anomaly', severity: 'critical',
+        incident_count: 1, container_count: 1, alert_count: 1,
+        earliest_at: '', latest_update_at: '',
+        top_containers: [{ incident_id: 'x', container_name: 'cn', endpoint_id: 1, endpoint_name: 'e', severity: 'critical', created_at: '' }],
+        all_container_names: ['cn'], names_truncated: false,
+      }],
+    });
+    render(wrap(['/'], <IncidentGroupsView />));
+    expect(screen.getByText('cn')).toBeInTheDocument(); // expanded by default
+    await userEvent.click(screen.getByRole('button', { name: /CPU anomaly/i }));
+    // Expected: clicking toggles closed.
+    expect(screen.queryByText('cn')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/ai-intelligence/hooks/use-incident-groups.test.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-incident-groups.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({ groups: [], endpoint_facets: [], total_active: 0 }),
+  },
+}));
+
+let mockIsVisible = true;
+vi.mock('@/shared/hooks/use-page-visibility', () => ({
+  usePageVisibility: () => mockIsVisible,
+}));
+
+import { useIncidentGroups } from './use-incident-groups';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useIncidentGroups', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsVisible = true;
+  });
+
+  it('serializes camelCase params to snake_case query string', async () => {
+    const { api } = await import('@/shared/lib/api');
+    renderHook(
+      () => useIncidentGroups({ status: 'active', endpointId: 42, since: '24h', severity: 'critical' }),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith('/api/incidents/groups', {
+        params: { status: 'active', endpoint_id: '42', since: '24h', severity: 'critical' },
+      });
+    });
+  });
+
+  it('omits undefined params', async () => {
+    const { api } = await import('@/shared/lib/api');
+    renderHook(() => useIncidentGroups({}), { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith('/api/incidents/groups', { params: {} });
+    });
+  });
+
+  it('polls every 30s when page is visible', () => {
+    const { result } = renderHook(() => useIncidentGroups(), { wrapper: createWrapper() });
+    expect(result.current.status).toBe('pending');
+  });
+
+  it('disables polling when page is hidden', () => {
+    mockIsVisible = false;
+    const { result } = renderHook(() => useIncidentGroups(), { wrapper: createWrapper() });
+    expect(result.current.status).toBe('pending');
+  });
+});

--- a/frontend/src/features/ai-intelligence/hooks/use-incident-groups.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-incident-groups.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/shared/lib/api';
+import { usePageVisibility } from '@/shared/hooks/use-page-visibility';
+
+export interface IncidentGroup {
+  signature: string;
+  label: string;
+  severity: 'critical' | 'warning' | 'info';
+  incident_count: number;
+  container_count: number;
+  alert_count: number;
+  earliest_at: string;
+  latest_update_at: string;
+  top_containers: Array<{
+    incident_id: string;
+    container_name: string;
+    endpoint_id: number | null;
+    endpoint_name: string | null;
+    severity: 'critical' | 'warning' | 'info';
+    created_at: string;
+  }>;
+  all_container_names: string[];
+  names_truncated: boolean;
+}
+
+export interface IncidentGroupsResponse {
+  groups: IncidentGroup[];
+  endpoint_facets: Array<{
+    endpoint_id: number | null;
+    endpoint_name: string | null;
+    incident_count: number;
+  }>;
+  total_active: number;
+}
+
+export interface UseIncidentGroupsParams {
+  status?: 'active' | 'resolved';
+  endpointId?: number;
+  since?: '1h' | '24h' | '7d';
+  severity?: 'critical' | 'warning' | 'info';
+}
+
+export function useIncidentGroups(params: UseIncidentGroupsParams = {}) {
+  const isVisible = usePageVisibility();
+
+  const queryParams: Record<string, string> = {};
+  if (params.status) queryParams.status = params.status;
+  if (params.endpointId !== undefined) queryParams.endpoint_id = String(params.endpointId);
+  if (params.since) queryParams.since = params.since;
+  if (params.severity) queryParams.severity = params.severity;
+
+  return useQuery<IncidentGroupsResponse>({
+    queryKey: ['incident-groups', params.status, params.endpointId, params.since, params.severity],
+    queryFn: () => api.get<IncidentGroupsResponse>('/api/incidents/groups', { params: queryParams }),
+    refetchInterval: isVisible ? 30_000 : false,
+  });
+}

--- a/frontend/src/features/ai-intelligence/hooks/use-incidents.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-incidents.ts
@@ -69,3 +69,19 @@ export function useResolveIncident() {
     },
   });
 }
+
+export interface BatchResolveResponse {
+  resolved: string[];
+  failed: Array<{ id: string; error: string }>;
+}
+
+export function useBatchResolveIncidents() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (ids: string[]) => api.post<BatchResolveResponse>('/api/incidents/resolve', { ids }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['incidents'] });
+      queryClient.invalidateQueries({ queryKey: ['incident-groups'] });
+    },
+  });
+}

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
@@ -22,6 +22,10 @@ beforeAll(() => {
 
 // --- mocks ---
 
+vi.mock('@/features/ai-intelligence/components/incident-groups-view', () => ({
+  IncidentGroupsView: () => <div data-testid="igv-marker" />,
+}));
+
 vi.mock('@/features/ai-intelligence/hooks/use-monitoring', () => ({
   useMonitoring: vi.fn().mockReturnValue({
     insights: [],
@@ -83,7 +87,7 @@ vi.mock('@/shared/hooks/use-force-refresh', () => ({
 }));
 
 import { useMonitoring } from '@/features/ai-intelligence/hooks/use-monitoring';
-import { useIncidents, useResolveIncident } from '@/features/ai-intelligence/hooks/use-incidents';
+import { useIncidents } from '@/features/ai-intelligence/hooks/use-incidents';
 import { useCorrelatedAnomalies } from '@/features/observability/hooks/use-correlated-anomalies';
 import { useContainers } from '@/features/containers/hooks/use-containers';
 import AiMonitorPage from './ai-monitor';
@@ -217,44 +221,10 @@ describe('AiMonitorPage', () => {
     expect(screen.queryByText('ML-Detected Anomalies')).toBeNull();
   });
 
-  it('renders IncidentCard with colored correlation type badge', () => {
-    // Use a recent timestamp so the default 24h time-range filter doesn't
-    // exclude this fixture from the visible incidents list.
-    const recentTimestamp = new Date().toISOString();
-    vi.mocked(useIncidents).mockReturnValue({
-      data: {
-        incidents: [
-          {
-            id: 'inc-1',
-            title: 'Multiple containers CPU spike',
-            severity: 'critical' as const,
-            status: 'active' as const,
-            root_cause_insight_id: null,
-            related_insight_ids: [],
-            affected_containers: ['nginx', 'redis'],
-            endpoint_id: 1,
-            endpoint_name: 'prod',
-            correlation_type: 'temporal',
-            correlation_confidence: 'high' as const,
-            insight_count: 3,
-            summary: 'Correlated CPU anomalies',
-            created_at: recentTimestamp,
-            updated_at: recentTimestamp,
-            resolved_at: null,
-          },
-        ],
-        counts: { active: 1, resolved: 0, total: 1 },
-        limit: 50,
-        offset: 0,
-      },
-    } as ReturnType<typeof useIncidents>);
-
+  it('renders IncidentGroupsView section (rollup replaces flat list)', () => {
     renderPage();
-
-    // Correlation type badge moved to a muted metadata line under the title
-    // (item 5: reduce visual noise). The label text is still rendered.
-    expect(screen.getByText('Temporal')).toBeTruthy();
-    expect(screen.queryByText('temporal correlation')).toBeNull();
+    // IncidentGroupsView is mocked — its marker confirms it rendered.
+    expect(screen.getByTestId('igv-marker')).toBeTruthy();
   });
 
   it('shows detection method badge on anomaly insight', () => {
@@ -531,48 +501,18 @@ describe('AiMonitorPage', () => {
 
 // =============================================================================
 // New UX features (PR review feedback): cover the AC that previously had no
-// behavioural tests — search, time-range filter, sort, bulk-resolve, and
-// bell-icon subscription independence.
+// behavioural tests — search filtering and bell-icon subscription independence.
+// Incident-specific features (time-range, sort, bulk-resolve) now live inside
+// IncidentGroupsView which has its own dedicated test suite.
 // =============================================================================
 
-import { act, waitFor } from '@testing-library/react';
+import { act } from '@testing-library/react';
 
 function nowIso(offsetMs = 0): string {
   return new Date(Date.now() + offsetMs).toISOString();
 }
 
-function fakeIncident(overrides: Partial<{
-  id: string;
-  title: string;
-  severity: 'critical' | 'warning' | 'info';
-  status: 'active' | 'resolved';
-  affected_containers: string[];
-  endpoint_name: string | null;
-  correlation_type: string;
-  created_at: string;
-  insight_count: number;
-}> = {}) {
-  return {
-    id: overrides.id ?? 'inc-x',
-    title: overrides.title ?? 'Test incident',
-    severity: overrides.severity ?? 'warning',
-    status: overrides.status ?? 'active',
-    root_cause_insight_id: null,
-    related_insight_ids: [],
-    affected_containers: overrides.affected_containers ?? [],
-    endpoint_id: 1,
-    endpoint_name: overrides.endpoint_name ?? 'prod',
-    correlation_type: overrides.correlation_type ?? 'temporal',
-    correlation_confidence: 'high' as const,
-    insight_count: overrides.insight_count ?? 1,
-    summary: 'Summary',
-    created_at: overrides.created_at ?? nowIso(),
-    updated_at: overrides.created_at ?? nowIso(),
-    resolved_at: null,
-  };
-}
-
-describe('AiMonitorPage — search, sort, time range', () => {
+describe('AiMonitorPage — search', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
   });
@@ -642,163 +582,6 @@ describe('AiMonitorPage — search, sort, time range', () => {
     expect(screen.getByText('Match A')).toBeTruthy();
     expect(screen.getByText('Match B')).toBeTruthy();
   });
-
-  it('time-range filter (1H) excludes incidents older than the window', async () => {
-    vi.mocked(useIncidents).mockReturnValue({
-      data: {
-        incidents: [
-          fakeIncident({ id: 'fresh', title: 'Recent incident', created_at: nowIso(-10 * 60_000) }), // 10 min ago
-          fakeIncident({ id: 'stale', title: 'Old incident', created_at: nowIso(-3 * 60 * 60_000) }), // 3h ago
-        ],
-        counts: { active: 2, resolved: 0, total: 2 },
-        limit: 50, offset: 0,
-      },
-    } as ReturnType<typeof useIncidents>);
-
-    renderPage();
-
-    // Default range is 24H — both visible
-    expect(screen.getByText('Recent incident')).toBeTruthy();
-    expect(screen.getByText('Old incident')).toBeTruthy();
-
-    // Switch to 1H — only fresh remains
-    fireEvent.click(screen.getByRole('tab', { name: '1H' }));
-    expect(screen.getByText('Recent incident')).toBeTruthy();
-    expect(screen.queryByText('Old incident')).toBeNull();
-  });
-
-  it('sort: severity (default) puts critical above warning', () => {
-    vi.mocked(useIncidents).mockReturnValue({
-      data: {
-        incidents: [
-          // Warning is FIRST in source order but should render second after sort.
-          fakeIncident({ id: 'w', title: 'Warning Z', severity: 'warning', created_at: nowIso(-5 * 60_000) }),
-          fakeIncident({ id: 'c', title: 'Critical A', severity: 'critical', created_at: nowIso(-10 * 60_000) }),
-        ],
-        counts: { active: 2, resolved: 0, total: 2 },
-        limit: 50, offset: 0,
-      },
-    } as ReturnType<typeof useIncidents>);
-
-    renderPage();
-
-    const titles = screen.getAllByRole('heading', { level: 3 }).map((el) => el.textContent ?? '');
-    const ci = titles.indexOf('Critical A');
-    const wi = titles.indexOf('Warning Z');
-    expect(ci).toBeGreaterThanOrEqual(0);
-    expect(wi).toBeGreaterThan(ci);
-  });
-
-  it('sort: switching to Recent reorders by timestamp regardless of severity', () => {
-    vi.mocked(useIncidents).mockReturnValue({
-      data: {
-        incidents: [
-          // Critical 30 min ago, Warning 5 min ago. Severity sort would put
-          // Critical first; Recent sort flips that.
-          fakeIncident({ id: 'c', title: 'Critical Old', severity: 'critical', created_at: nowIso(-30 * 60_000) }),
-          fakeIncident({ id: 'w', title: 'Warning New', severity: 'warning', created_at: nowIso(-5 * 60_000) }),
-        ],
-        counts: { active: 2, resolved: 0, total: 2 },
-        limit: 50, offset: 0,
-      },
-    } as ReturnType<typeof useIncidents>);
-
-    renderPage();
-    fireEvent.click(screen.getByRole('tab', { name: /Recent/i }));
-
-    const titles = screen.getAllByRole('heading', { level: 3 }).map((el) => el.textContent ?? '');
-    const ci = titles.indexOf('Critical Old');
-    const wi = titles.indexOf('Warning New');
-    expect(wi).toBeGreaterThanOrEqual(0);
-    expect(ci).toBeGreaterThan(wi);
-  });
-});
-
-describe('AiMonitorPage — bulk resolve', () => {
-  beforeEach(() => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('action bar appears when an incident is selected, and resolves call mutateAsync per id', async () => {
-    const mutateAsync = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(useResolveIncident).mockReturnValue({
-      mutate: vi.fn(),
-      mutateAsync,
-    } as unknown as ReturnType<typeof useResolveIncident>);
-
-    vi.mocked(useIncidents).mockReturnValue({
-      data: {
-        incidents: [
-          fakeIncident({ id: 'inc-a', title: 'Inc A', severity: 'critical' }),
-          fakeIncident({ id: 'inc-b', title: 'Inc B', severity: 'warning' }),
-        ],
-        counts: { active: 2, resolved: 0, total: 2 },
-        limit: 50, offset: 0,
-      },
-    } as ReturnType<typeof useIncidents>);
-
-    renderPage();
-
-    // Select two incidents
-    const checkboxes = screen.getAllByRole('checkbox');
-    fireEvent.click(checkboxes[0]);
-    fireEvent.click(checkboxes[1]);
-
-    // Action bar visible with selection count
-    const bar = screen.getByTestId('bulk-action-bar');
-    expect(bar.textContent).toContain('2 selected');
-
-    // Resolve both
-    fireEvent.click(screen.getByRole('button', { name: /Resolve 2/i }));
-
-    await waitFor(() => {
-      expect(mutateAsync).toHaveBeenCalledTimes(2);
-    });
-    expect(mutateAsync).toHaveBeenCalledWith('inc-a');
-    expect(mutateAsync).toHaveBeenCalledWith('inc-b');
-  });
-
-  it('partial failure: keeps failed ids selected and surfaces an inline error', async () => {
-    const mutateAsync = vi
-      .fn()
-      .mockImplementation((id: string) =>
-        id === 'inc-fail' ? Promise.reject(new Error('boom')) : Promise.resolve(),
-      );
-    vi.mocked(useResolveIncident).mockReturnValue({
-      mutate: vi.fn(),
-      mutateAsync,
-    } as unknown as ReturnType<typeof useResolveIncident>);
-
-    vi.mocked(useIncidents).mockReturnValue({
-      data: {
-        incidents: [
-          fakeIncident({ id: 'inc-ok', title: 'OK', severity: 'warning' }),
-          fakeIncident({ id: 'inc-fail', title: 'Fail', severity: 'warning' }),
-        ],
-        counts: { active: 2, resolved: 0, total: 2 },
-        limit: 50, offset: 0,
-      },
-    } as ReturnType<typeof useIncidents>);
-
-    renderPage();
-
-    const checkboxes = screen.getAllByRole('checkbox');
-    fireEvent.click(checkboxes[0]);
-    fireEvent.click(checkboxes[1]);
-    fireEvent.click(screen.getByRole('button', { name: /Resolve 2/i }));
-
-    // Error message should surface with the failure count
-    await waitFor(() => {
-      expect(screen.getByTestId('bulk-resolve-error')).toBeInTheDocument();
-    });
-    expect(screen.getByTestId('bulk-resolve-error').textContent).toContain('Failed to resolve 1 of 2');
-    // The action bar still shows 1 selected (only the failed id remains)
-    expect(screen.getByTestId('bulk-action-bar').textContent).toContain('1 selected');
-  });
 });
 
 describe('AiMonitorPage — container chip linking', () => {
@@ -837,28 +620,6 @@ describe('AiMonitorPage — container chip linking', () => {
     const link = screen.getByRole('link', { name: /linkable-container/i, hidden: true });
     expect(link.getAttribute('href')).toBe('/containers/7/c-abc');
   });
-
-  it('renders a plain (non-link) chip for incident affected_containers because ids are unknown', () => {
-    vi.mocked(useIncidents).mockReturnValue({
-      data: {
-        incidents: [
-          fakeIncident({ id: 'inc-x', title: 'Has affected containers', affected_containers: ['nginx-1'] }),
-        ],
-        counts: { active: 1, resolved: 0, total: 1 },
-        limit: 50, offset: 0,
-      },
-    } as ReturnType<typeof useIncidents>);
-
-    renderPage();
-
-    // Expand the incident card so the affected-containers list renders
-    fireEvent.click(screen.getByText('Has affected containers'));
-
-    // The text appears, but it's NOT inside an anchor — incidents store
-    // affected_containers as names only, not as ids.
-    const nginxChip = screen.getByText('nginx-1');
-    expect(nginxChip.closest('a')).toBeNull();
-  });
 });
 
 describe('AiMonitorPage — stat card filter vs subscription independence', () => {
@@ -889,5 +650,12 @@ describe('AiMonitorPage — stat card filter vs subscription independence', () =
     // tab remains the active tab (aria-pressed=true on Total Insights btn).
     const totalCard = screen.getByRole('button', { name: /Total Insights/i });
     expect(totalCard.getAttribute('aria-pressed')).toBe('true');
+  });
+});
+
+describe('AiMonitorPage — IncidentGroupsView integration', () => {
+  it('renders IncidentGroupsView in place of the legacy flat list', () => {
+    renderPage();
+    expect(screen.getByTestId('igv-marker')).toBeTruthy();
   });
 });

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -2,10 +2,10 @@ import { useState, useMemo, useEffect } from 'react';
 import { useMonitoring } from '@/features/ai-intelligence/hooks/use-monitoring';
 import { useInvestigations, safeParseJson } from '@/features/ai-intelligence/hooks/use-investigations';
 import type { Investigation, RecommendedAction } from '@/features/ai-intelligence/hooks/use-investigations';
-import { useIncidents, useResolveIncident, type Incident } from '@/features/ai-intelligence/hooks/use-incidents';
 import { useCorrelatedAnomalies, type CorrelatedAnomaly } from '@/features/observability/hooks/use-correlated-anomalies';
 import { useContainers } from '@/features/containers/hooks/use-containers';
 import { FleetHealthSummary, calculateHealthStats } from '@/features/ai-intelligence/components/fleet-health-summary';
+import { IncidentGroupsView } from '@/features/ai-intelligence/components/incident-groups-view';
 import { useForceRefresh } from '@/shared/hooks/use-force-refresh';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
@@ -540,138 +540,6 @@ function InvestigationSection({ investigation }: { investigation: Investigation 
   );
 }
 
-function IncidentCard({
-  incident,
-  onResolve,
-  isSelected,
-  onToggleSelect,
-}: {
-  incident: Incident;
-  onResolve: (id: string) => void;
-  isSelected: boolean;
-  onToggleSelect: (id: string) => void;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const containers: string[] = incident.affected_containers || [];
-  const isActive = incident.status === 'active';
-
-  // Tint the leading icon by severity instead of always purple. Pulls the
-  // viewer's eye to the row's actual urgency rather than the generic
-  // "incident" shape.
-  const severityIconClasses = {
-    critical: 'bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400',
-    warning: 'bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400',
-    info: 'bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400',
-  }[incident.severity];
-
-  return (
-    <div className={cn(
-      'overflow-hidden rounded-lg border-2 bg-card transition-all',
-      isActive
-        ? incident.severity === 'critical'
-          ? 'border-red-500/40 bg-red-50/30 dark:bg-red-900/10'
-          : 'border-amber-500/40 bg-amber-50/30 dark:bg-amber-900/10'
-        : 'border-border opacity-60',
-      expanded && 'ring-2 ring-primary/20',
-    )}>
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="w-full p-4 text-left transition-colors hover:bg-muted/20"
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-start gap-3 flex-1 min-w-0">
-            {isActive && (
-              <input
-                type="checkbox"
-                checked={isSelected}
-                onChange={() => onToggleSelect(incident.id)}
-                onClick={(e) => e.stopPropagation()}
-                aria-label={`Select incident: ${incident.title}`}
-                className="mt-1.5 h-4 w-4 cursor-pointer rounded border-input accent-primary"
-              />
-            )}
-            <div className={cn('mt-0.5 rounded-full p-2', severityIconClasses)}>
-              <Layers className="h-4 w-4" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1">
-                <SeverityBadge severity={incident.severity} />
-                {!isActive && (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
-                    Resolved
-                  </span>
-                )}
-              </div>
-              <h3 className="font-semibold text-base leading-snug mb-1">{incident.title}</h3>
-              {!expanded && incident.summary && (
-                <p className="text-sm text-muted-foreground line-clamp-2">{incident.summary}</p>
-              )}
-              {/* Demoted metadata — correlation type + timestamp on a muted line.
-                  Removes 2 of the 5 same-weight chips that crowded the header. */}
-              <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
-                <CorrelationTypeBadge type={incident.correlation_type} />
-                <span>·</span>
-                <span>{formatDate(incident.created_at)}</span>
-                <span>·</span>
-                <span>{incident.insight_count} alert{incident.insight_count === 1 ? '' : 's'}</span>
-              </div>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            {expanded ? (
-              <ChevronDown className="h-5 w-5 text-muted-foreground flex-shrink-0" />
-            ) : (
-              <ChevronRight className="h-5 w-5 text-muted-foreground flex-shrink-0" />
-            )}
-          </div>
-        </div>
-      </button>
-
-      {expanded && (
-        <div className="border-t px-4 py-4 bg-muted/10 space-y-3">
-          {incident.summary && (
-            <div>
-              <h4 className="text-sm font-medium mb-1">Summary</h4>
-              <p className="text-sm text-muted-foreground">{incident.summary}</p>
-            </div>
-          )}
-
-          {containers.length > 0 && (
-            <div>
-              <h4 className="text-sm font-medium mb-1.5">Affected Containers</h4>
-              <div className="flex flex-wrap gap-1.5">
-                {containers.map((name) => (
-                  // Incidents store affected containers by name only; without
-                  // ids we render plain chips. ContainerChip degrades to a
-                  // span when the ids aren't provided.
-                  <ContainerChip key={name} name={name} />
-                ))}
-              </div>
-            </div>
-          )}
-
-          <div className="flex items-center gap-4 pt-2 border-t text-xs text-muted-foreground">
-            <ConfidenceBadge confidence={incident.correlation_confidence} />
-            {incident.endpoint_name && <span>Endpoint: {incident.endpoint_name}</span>}
-            <span>ID: {incident.id.slice(0, 8)}</span>
-            {isActive && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onResolve(incident.id);
-                }}
-                className="ml-auto inline-flex items-center gap-1 rounded-md bg-emerald-100 dark:bg-emerald-900/30 px-2.5 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400 hover:bg-emerald-200 dark:hover:bg-emerald-900/50 transition-colors"
-              >
-                <CheckCircle2 className="h-3 w-3" />
-                Resolve
-              </button>
-            )}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
 
 function InsightCard({
   insight,
@@ -876,23 +744,6 @@ function InsightCard({
   );
 }
 
-type TimeRange = '1h' | '24h' | '7d' | 'all';
-type IncidentSort = 'severity' | 'time';
-
-const TIME_RANGE_MS: Record<Exclude<TimeRange, 'all'>, number> = {
-  '1h': 60 * 60 * 1000,
-  '24h': 24 * 60 * 60 * 1000,
-  '7d': 7 * 24 * 60 * 60 * 1000,
-};
-
-// Severity weight for default sort: critical > warning > info. Higher = more
-// urgent and floats to the top.
-const SEVERITY_WEIGHT: Record<Severity, number> = {
-  critical: 3,
-  warning: 2,
-  info: 1,
-};
-
 export default function AiMonitorPage() {
   const [severityFilter, setSeverityFilter] = useState<'all' | Severity>('all');
   const [acknowledgementFilter, setAcknowledgementFilter] = useState<'all' | 'unacknowledged'>('all');
@@ -905,8 +756,6 @@ export default function AiMonitorPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchInput, setSearchInput] = useState(searchParams.get('q') ?? '');
   const [searchQuery, setSearchQuery] = useState(searchParams.get('q') ?? '');
-  const timeRange = (searchParams.get('range') as TimeRange) || '24h';
-  const incidentSort = (searchParams.get('sort') as IncidentSort) || 'severity';
 
   // Debounce search input → query (~150ms) so each keystroke doesn't refilter
   // the full list. URL-sync happens on the debounced value.
@@ -933,34 +782,6 @@ export default function AiMonitorPage() {
     setSearchQuery((current) => (current === urlQuery ? current : urlQuery));
   }, [urlQuery]);
 
-  const setUrlParam = (key: string, value: string | null) => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      if (value === null) next.delete(key);
-      else next.set(key, value);
-      return next;
-    }, { replace: true });
-  };
-
-  // Bulk-resolve selection state — keyed by incident id. Failed ids stay in
-  // the set on completion so the user can retry; succeeded ids are removed.
-  const [selectedIncidentIds, setSelectedIncidentIds] = useState<Set<string>>(new Set());
-  const [isBulkResolving, setIsBulkResolving] = useState(false);
-  const [bulkResolveError, setBulkResolveError] = useState<string | null>(null);
-  const toggleIncidentSelected = (id: string) => {
-    setSelectedIncidentIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-    setBulkResolveError(null);
-  };
-  const clearSelection = () => {
-    setSelectedIncidentIds(new Set());
-    setBulkResolveError(null);
-  };
-
   const {
     insights,
     isLoading,
@@ -975,8 +796,6 @@ export default function AiMonitorPage() {
   } = useMonitoring();
 
   const { getInvestigationForInsight } = useInvestigations();
-  const { data: incidentsData } = useIncidents('active');
-  const resolveIncidentMutation = useResolveIncident();
   const { data: correlatedAnomalies, isLoading: correlatedLoading } = useCorrelatedAnomalies();
 
   // Fleet health data
@@ -1037,42 +856,6 @@ export default function AiMonitorPage() {
     return bySearch;
   }, [acknowledgementFilter, insights, severityFilter, searchLower]);
 
-  // Filter, sort, and bound incidents for the visible list.
-  const visibleIncidents = useMemo(() => {
-    if (!incidentsData) return [];
-    const cutoff = timeRange === 'all' ? null : Date.now() - TIME_RANGE_MS[timeRange];
-
-    let result = incidentsData.incidents.filter((incident) => {
-      if (cutoff !== null) {
-        const created = Date.parse(incident.created_at);
-        if (Number.isFinite(created) && created < cutoff) return false;
-      }
-      if (searchLower) {
-        const haystack = [
-          incident.title,
-          incident.summary,
-          incident.endpoint_name,
-          incident.correlation_type,
-          ...(incident.affected_containers ?? []),
-        ];
-        if (!matchesSearch(haystack)) return false;
-      }
-      return true;
-    });
-
-    if (incidentSort === 'severity') {
-      result = [...result].sort((a, b) => {
-        const weightDiff = SEVERITY_WEIGHT[b.severity] - SEVERITY_WEIGHT[a.severity];
-        if (weightDiff !== 0) return weightDiff;
-        return Date.parse(b.created_at) - Date.parse(a.created_at);
-      });
-    } else {
-      result = [...result].sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
-    }
-
-    return result;
-  }, [incidentsData, timeRange, incidentSort, searchLower]);
-
   // Apply search to anomalies + health issues so the search box covers every
   // list on the page consistently.
   const filteredCorrelatedAnomalies = useMemo(() => {
@@ -1087,47 +870,6 @@ export default function AiMonitorPage() {
     if (!searchLower) return healthIssues;
     return healthIssues.filter((c) => matchesSearch([c.name, c.image, c.healthStatus]));
   }, [healthIssues, searchLower]);
-
-  const handleBulkResolve = async () => {
-    if (selectedIncidentIds.size === 0 || isBulkResolving) return;
-    setIsBulkResolving(true);
-    setBulkResolveError(null);
-    const ids = Array.from(selectedIncidentIds);
-    const failedIds: string[] = [];
-
-    // Streaming worker pool — N workers each pull the next id from a shared
-    // queue. A slow request blocks only its own worker, not the whole batch
-    // (the previous batched-wave loop made all 5 workers wait for the
-    // slowest in each wave before starting the next 5). Per-id success and
-    // failure is tracked here rather than via the mutation hook because
-    // `mutation.error` only ever reflects the most recent call when many
-    // run in parallel.
-    const POOL_SIZE = 5;
-    const queue = [...ids];
-    const worker = async () => {
-      while (queue.length > 0) {
-        const id = queue.shift();
-        if (id === undefined) break;
-        try {
-          await resolveIncidentMutation.mutateAsync(id);
-        } catch {
-          failedIds.push(id);
-        }
-      }
-    };
-    const workerCount = Math.min(POOL_SIZE, ids.length);
-    await Promise.all(Array.from({ length: workerCount }, worker));
-
-    // Keep only failed ids selected so the user can retry without
-    // re-checking each row, and surface the failure count inline.
-    setSelectedIncidentIds(new Set(failedIds));
-    if (failedIds.length > 0) {
-      setBulkResolveError(
-        `Failed to resolve ${failedIds.length} of ${ids.length} incident${ids.length === 1 ? '' : 's'}. Retry from the action bar.`,
-      );
-    }
-    setIsBulkResolving(false);
-  };
 
   // Stats
   const stats = useMemo(() => {
@@ -1450,148 +1192,8 @@ export default function AiMonitorPage() {
         </div>
       )}
 
-      {/* Active Incidents */}
-      {incidentsData && incidentsData.incidents.length > 0 && (
-        <div className="space-y-3">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <Layers className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-              <h2 className="text-lg font-semibold">
-                Active Incidents
-                <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  ({visibleIncidents.length} of {incidentsData.counts.active})
-                </span>
-              </h2>
-            </div>
-
-            {/* Time-range + sort controls */}
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="inline-flex items-center gap-0.5 rounded-md border bg-card p-0.5" role="tablist" aria-label="Time range">
-                {(['1h', '24h', '7d', 'all'] as const).map((range) => (
-                  <button
-                    key={range}
-                    type="button"
-                    role="tab"
-                    aria-selected={timeRange === range}
-                    onClick={() => setUrlParam('range', range)}
-                    className={cn(
-                      'rounded px-2.5 py-1 text-xs font-medium transition-colors',
-                      timeRange === range
-                        ? 'bg-primary text-primary-foreground'
-                        : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                    )}
-                  >
-                    {range === 'all' ? 'All' : range.toUpperCase()}
-                  </button>
-                ))}
-              </div>
-              <div className="inline-flex items-center gap-0.5 rounded-md border bg-card p-0.5" role="tablist" aria-label="Sort">
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={incidentSort === 'severity'}
-                  onClick={() => setUrlParam('sort', 'severity')}
-                  className={cn(
-                    'inline-flex items-center gap-1 rounded px-2.5 py-1 text-xs font-medium transition-colors',
-                    incidentSort === 'severity'
-                      ? 'bg-primary text-primary-foreground'
-                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                  )}
-                >
-                  <AlertTriangle className="h-3 w-3" /> Severity
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={incidentSort === 'time'}
-                  onClick={() => setUrlParam('sort', 'time')}
-                  className={cn(
-                    'inline-flex items-center gap-1 rounded px-2.5 py-1 text-xs font-medium transition-colors',
-                    incidentSort === 'time'
-                      ? 'bg-primary text-primary-foreground'
-                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                  )}
-                >
-                  <Clock className="h-3 w-3" /> Recent
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Bulk-action bar — only renders when something is selected so it
-              doesn't take vertical space at rest. Surfaces partial-failure
-              count inline so the operator knows which retries are pending. */}
-          {(selectedIncidentIds.size > 0 || bulkResolveError) && (
-            <div
-              data-testid="bulk-action-bar"
-              className={cn(
-                'rounded-md border px-4 py-2',
-                bulkResolveError
-                  ? 'border-red-500/40 bg-red-50/30 dark:bg-red-900/10'
-                  : 'border-primary/40 bg-primary/5',
-              )}
-            >
-              <div className="flex items-center justify-between">
-                <p className="text-sm font-medium">
-                  {selectedIncidentIds.size > 0
-                    ? `${selectedIncidentIds.size} selected`
-                    : 'No incidents selected'}
-                </p>
-                {selectedIncidentIds.size > 0 && (
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={clearSelection}
-                      disabled={isBulkResolving}
-                      className="rounded-md border border-input bg-background px-3 py-1 text-xs font-medium hover:bg-accent disabled:opacity-50"
-                    >
-                      Clear
-                    </button>
-                    <button
-                      type="button"
-                      onClick={handleBulkResolve}
-                      disabled={isBulkResolving}
-                      className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
-                    >
-                      {isBulkResolving ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : (
-                        <CheckCircle2 className="h-3 w-3" />
-                      )}
-                      Resolve {selectedIncidentIds.size}
-                    </button>
-                  </div>
-                )}
-              </div>
-              {bulkResolveError && (
-                <p
-                  role="alert"
-                  data-testid="bulk-resolve-error"
-                  className="mt-2 text-xs text-red-700 dark:text-red-400"
-                >
-                  {bulkResolveError}
-                </p>
-              )}
-            </div>
-          )}
-
-          {visibleIncidents.length === 0 ? (
-            <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
-              No incidents match the current filters.
-            </div>
-          ) : (
-            visibleIncidents.map((incident) => (
-              <IncidentCard
-                key={incident.id}
-                incident={incident}
-                onResolve={(id) => resolveIncidentMutation.mutate(id)}
-                isSelected={selectedIncidentIds.has(incident.id)}
-                onToggleSelect={toggleIncidentSelected}
-              />
-            ))
-          )}
-        </div>
-      )}
+      {/* Active Incidents (rollup view) */}
+      <IncidentGroupsView search={searchInput} />
 
       {/* Insights Feed */}
       {isLoading ? (

--- a/frontend/src/shared/lib/api.ts
+++ b/frontend/src/shared/lib/api.ts
@@ -106,7 +106,7 @@ class ApiClient {
     return response.json();
   }
 
-  get<T>(path: string, options?: { params?: Record<string, string | number | boolean | undefined> }) {
+  get<T>(path: string, options?: { params?: Record<string, string | number | boolean | undefined>; signal?: AbortSignal }) {
     return this.request<T>(path, { method: 'GET', ...options });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
+        "@testing-library/user-event": "^14.6.1",
         "@vitest/coverage-v8": "^4.1.5",
         "concurrently": "^9.1.0",
         "eslint": "^10.3.0",
@@ -7168,6 +7169,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@testing-library/user-event": "^14.6.1",
     "@vitest/coverage-v8": "^4.1.5",
     "concurrently": "^9.1.0",
     "eslint": "^10.3.0",

--- a/packages/ai-intelligence/package.json
+++ b/packages/ai-intelligence/package.json
@@ -17,7 +17,8 @@
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "indexes:incidents": "tsx scripts/create-incident-signature-indexes.ts"
   },
   "dependencies": {
     "@dashboard/contracts": "*",

--- a/packages/ai-intelligence/package.json
+++ b/packages/ai-intelligence/package.json
@@ -18,7 +18,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "indexes:incidents": "tsx scripts/create-incident-signature-indexes.ts"
+    "indexes:incidents": "tsx scripts/create-incident-signature-indexes.ts",
+    "dump:titles": "tsx scripts/dump-historical-titles.ts"
   },
   "dependencies": {
     "@dashboard/contracts": "*",

--- a/packages/ai-intelligence/package.json
+++ b/packages/ai-intelligence/package.json
@@ -19,7 +19,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "indexes:incidents": "tsx scripts/create-incident-signature-indexes.ts",
-    "dump:titles": "tsx scripts/dump-historical-titles.ts"
+    "dump:titles": "tsx scripts/dump-historical-titles.ts",
+    "backfill:signatures": "tsx scripts/backfill-incident-signatures.ts"
   },
   "dependencies": {
     "@dashboard/contracts": "*",

--- a/packages/ai-intelligence/scripts/backfill-incident-signatures.ts
+++ b/packages/ai-intelligence/scripts/backfill-incident-signatures.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env tsx
+/**
+ * Populates the `signature` column on incidents that don't yet have one.
+ *
+ * Idempotent: only updates rows where signature IS NULL by default.
+ * Use --force to re-derive every row.
+ *
+ * Usage:
+ *   POSTGRES_APP_URL=… npm run -w @dashboard/ai backfill:signatures
+ *   POSTGRES_APP_URL=… npm run -w @dashboard/ai backfill:signatures -- --force
+ */
+import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
+import { deriveSignature, deriveSignatureFromTitle } from '../src/services/signature.js';
+
+export interface BackfillOptions { batchSize: number; force: boolean; }
+export interface BackfillResult { updated: number; bySignature: Record<string, number>; }
+
+interface IncidentRow {
+  id: string;
+  title: string;
+  root_cause_insight_id: string | null;
+}
+interface InsightRow {
+  category: string;
+  metric_type: string | null;
+  detection_method: string | null;
+  title: string;
+}
+
+export async function backfillSignatures(
+  opts: BackfillOptions = { batchSize: 500, force: false },
+): Promise<BackfillResult> {
+  const db = getDbForDomain('incidents');
+  const where = opts.force ? '1=1' : 'signature IS NULL';
+  const bySignature: Record<string, number> = {};
+  let updated = 0;
+
+  while (true) {
+    const incidents = await db.query<IncidentRow>(
+      `SELECT id, title, root_cause_insight_id FROM incidents WHERE ${where} ORDER BY created_at LIMIT ?`,
+      [opts.batchSize],
+    );
+    if (incidents.length === 0) break;
+
+    for (const inc of incidents) {
+      let signature: string;
+
+      if (inc.root_cause_insight_id) {
+        const ins = await db.queryOne<InsightRow>(
+          'SELECT category, metric_type, detection_method, title FROM insights WHERE id = ?',
+          [inc.root_cause_insight_id],
+        );
+        if (ins) {
+          signature = deriveSignature({
+            category: ins.category,
+            metric_type: ins.metric_type as 'cpu' | 'memory' | 'disk' | 'network' | 'restart' | undefined,
+            detection_method: ins.detection_method as 'threshold' | 'ml-anomaly' | 'prediction' | 'health-check' | 'log-pattern' | 'security-scan' | undefined,
+            title: ins.title,
+          });
+        } else {
+          // Root insight row is gone — fall back to title regex
+          signature = deriveSignatureFromTitle(inc.title);
+        }
+      } else {
+        // No root insight reference at all — fall back to title regex
+        signature = deriveSignatureFromTitle(inc.title);
+      }
+
+      if (opts.force) {
+        await db.execute(
+          'UPDATE incidents SET signature = ? WHERE id = ?',
+          [signature, inc.id],
+        );
+      } else {
+        await db.execute(
+          'UPDATE incidents SET signature = ? WHERE id = ? AND signature IS NULL',
+          [signature, inc.id],
+        );
+      }
+
+      bySignature[signature] = (bySignature[signature] ?? 0) + 1;
+      updated++;
+    }
+
+    if (incidents.length < opts.batchSize) break;
+  }
+
+  return { updated, bySignature };
+}
+
+async function cli(): Promise<void> {
+  const force = process.argv.includes('--force');
+  const result = await backfillSignatures({ batchSize: 500, force });
+  console.log(`Updated ${result.updated} rows`);
+  for (const [sig, n] of Object.entries(result.bySignature).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${sig.padEnd(40)} ${n}`);
+  }
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  cli().catch((err) => { console.error(err); process.exit(1); });
+}

--- a/packages/ai-intelligence/scripts/create-incident-signature-indexes.ts
+++ b/packages/ai-intelligence/scripts/create-incident-signature-indexes.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env tsx
+/**
+ * Phase B of the incident-signature rollup migration.
+ *
+ * Creates two indexes on the incidents table without holding a
+ * transaction lock — required by Postgres for CONCURRENTLY.
+ *
+ * Idempotent: IF NOT EXISTS guards re-runs.
+ *
+ * Usage (in a deploy step or one-off):
+ *   POSTGRES_APP_URL=postgresql://… npm run -w @dashboard/ai indexes:incidents
+ */
+import { Client } from 'pg';
+
+const APP_URL = process.env.POSTGRES_APP_URL ?? process.env.POSTGRES_URL;
+if (!APP_URL) {
+  console.error('POSTGRES_APP_URL (or POSTGRES_URL) must be set');
+  process.exit(1);
+}
+
+const STATEMENTS = [
+  `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_incidents_signature_status
+     ON incidents (signature, status)`,
+  `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_incidents_endpoint_status
+     ON incidents (endpoint_id, status)`,
+];
+
+async function main() {
+  const client = new Client({ connectionString: APP_URL });
+  await client.connect();
+  try {
+    for (const sql of STATEMENTS) {
+      const start = Date.now();
+      console.log(`> ${sql.split('\n')[0].trim()}`);
+      await client.query(sql);
+      console.log(`  ok (${Date.now() - start} ms)`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Index creation failed:', err);
+  process.exit(1);
+});

--- a/packages/ai-intelligence/scripts/dump-historical-titles.ts
+++ b/packages/ai-intelligence/scripts/dump-historical-titles.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env tsx
+/**
+ * Exports a sample of historical incident titles (and their root insight
+ * structured fields, where available) to a CSV usable as a drift-test
+ * corpus.
+ *
+ * Usage:
+ *   POSTGRES_APP_URL=postgresql://… npm run -w @dashboard/ai dump:titles \
+ *     > packages/ai-intelligence/src/__tests__/fixtures/historical-titles.csv
+ */
+import { Client } from 'pg';
+
+const APP_URL = process.env.POSTGRES_APP_URL ?? process.env.POSTGRES_URL;
+if (!APP_URL) {
+  console.error('POSTGRES_APP_URL must be set');
+  process.exit(1);
+}
+
+const SQL = `
+  SELECT DISTINCT
+    i.title AS incident_title,
+    ins.category,
+    ins.metric_type,
+    ins.detection_method
+  FROM incidents i
+  LEFT JOIN insights ins ON ins.id = i.root_cause_insight_id
+  ORDER BY i.title
+  LIMIT 500
+`;
+
+async function main() {
+  const client = new Client({ connectionString: APP_URL });
+  await client.connect();
+  try {
+    const r = await client.query(SQL);
+    console.log('title,category,metric_type,detection_method');
+    for (const row of r.rows) {
+      const csv = [row.incident_title, row.category, row.metric_type, row.detection_method]
+        .map((v) => v == null ? '' : `"${String(v).replace(/"/g, '""')}"`)
+        .join(',');
+      console.log(csv);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/ai-intelligence/src/__tests__/fixtures/historical-titles.csv
+++ b/packages/ai-intelligence/src/__tests__/fixtures/historical-titles.csv
@@ -1,0 +1,8 @@
+title,category,metric_type,detection_method
+"Anomalous cpu usage on ""docker-postgres-app-1"" (ML-detected)",anomaly,cpu,ml-anomaly
+"Anomalous memory usage on ""docker-postgres-app-1""",anomaly,memory,threshold
+"Predicted memory exhaustion on ""docker-postgres-app-1"" ~24h",predictive,memory,prediction
+"Predicted cpu exhaustion on ""docker-timescale-backup-1"" ~6h",predictive,cpu,prediction
+"High cpu usage on ""portainer-portainer-1""",anomaly,cpu,threshold
+"Container ""nginx"" has no health check configured",,,
+"Container ""custom"" using host network mode",,,

--- a/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
@@ -1,0 +1,139 @@
+/**
+ * DB-backed integration test: verifies that correlateInsights writes the
+ * `signature` column on every new incident row.
+ *
+ * Uses a real PostgreSQL test database (redirected via app-db-router mock).
+ * Run with:
+ *   POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+ *   npx vitest run src/__tests__/incident-correlator-db.test.ts
+ */
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+import type { AppDb } from '@dashboard/core/db/app-db.js';
+
+let testDb: AppDb;
+
+// Redirect all DB calls to the test database
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => testDb,
+}));
+
+// Avoid live settings DB calls
+vi.mock('@dashboard/core/services/settings-store.js', async (importOriginal) => {
+  const orig = await importOriginal() as Record<string, unknown>;
+  return {
+    ...orig,
+    getEffectiveMonitoringConfig: vi.fn().mockResolvedValue({
+      smartGroupingEnabled: false,
+      smartGroupingSimilarityThreshold: 0.3,
+      incidentSummaryEnabled: false,
+    }),
+  };
+});
+
+// Skip LLM summarisation
+vi.mock('../services/incident-summarizer.js', () => ({
+  generateLlmIncidentSummary: vi.fn().mockResolvedValue(null),
+}));
+
+// Skip Ollama availability check
+vi.mock('../services/llm-client.js', () => ({
+  isOllamaAvailable: vi.fn().mockResolvedValue(false),
+}));
+
+import { correlateInsights } from '../services/incident-correlator.js';
+import { insertInsights, type InsightInsert } from '../services/insights-store.js';
+import type { Insight } from '@dashboard/core/models/monitoring.js';
+
+beforeAll(async () => { testDb = await getTestDb(); });
+afterAll(async () => { await closeTestDb(); });
+beforeEach(async () => { await truncateTestTables(['incidents', 'insights']); });
+
+describe('correlateInsights — writes signature', () => {
+  it('writes signature derived from structured fields (metric_type + detection_method)', async () => {
+    // Insert insight rows to satisfy the FK reference from incidents.root_cause_insight_id
+    const insightInserts: InsightInsert[] = [
+      {
+        id: 'i1', endpoint_id: 1, endpoint_name: 'e', container_id: 'c1', container_name: 'cn1',
+        severity: 'warning', category: 'anomaly',
+        title: 'Anomalous cpu usage on "cn1"', description: 'd', suggested_action: null,
+      },
+      {
+        id: 'i2', endpoint_id: 1, endpoint_name: 'e', container_id: 'c1', container_name: 'cn1',
+        severity: 'warning', category: 'anomaly',
+        title: 'Anomalous cpu usage on "cn1"', description: 'd', suggested_action: null,
+      },
+    ];
+    await insertInsights(insightInserts);
+
+    // Build full Insight objects with structured fields so deriveSignature takes
+    // the structured path (category + metric_type + detection_method) rather than
+    // falling through to the title regex. The DB doesn't store these optional
+    // fields yet, so we construct them in memory rather than reading back from DB.
+    const fullInsights: Insight[] = [
+      {
+        id: 'i1', endpoint_id: 1, endpoint_name: 'e', container_id: 'c1', container_name: 'cn1',
+        severity: 'warning', category: 'anomaly',
+        metric_type: 'cpu', detection_method: 'ml-anomaly',
+        title: 'Anomalous cpu usage on "cn1"', description: 'd', suggested_action: null,
+        is_acknowledged: 0, created_at: new Date().toISOString(),
+      },
+      {
+        id: 'i2', endpoint_id: 1, endpoint_name: 'e', container_id: 'c1', container_name: 'cn1',
+        severity: 'warning', category: 'anomaly',
+        metric_type: 'cpu', detection_method: 'ml-anomaly',
+        title: 'Anomalous cpu usage on "cn1"', description: 'd', suggested_action: null,
+        is_acknowledged: 0, created_at: new Date().toISOString(),
+      },
+    ];
+
+    await correlateInsights(fullInsights);
+
+    const incidentRows = await testDb.query<{ signature: string }>(
+      'SELECT signature FROM incidents',
+    );
+    expect(incidentRows).toHaveLength(1);
+    expect(incidentRows[0].signature).toBe('anomaly:ml-anomaly:cpu');
+  });
+
+  it('falls back to title-derived signature when structured fields are absent', async () => {
+    const insightInserts: InsightInsert[] = [
+      {
+        id: 'j1', endpoint_id: 2, endpoint_name: 'e2', container_id: 'c2', container_name: 'cn2',
+        severity: 'warning', category: 'anomaly',
+        title: 'Anomalous memory usage on "cn2"', description: 'd', suggested_action: null,
+      },
+      {
+        id: 'j2', endpoint_id: 2, endpoint_name: 'e2', container_id: 'c2', container_name: 'cn2',
+        severity: 'warning', category: 'anomaly',
+        title: 'Anomalous memory usage on "cn2"', description: 'd', suggested_action: null,
+      },
+    ];
+    await insertInsights(insightInserts);
+
+    // No metric_type / detection_method — title regex path
+    const fullInsights: Insight[] = [
+      {
+        id: 'j1', endpoint_id: 2, endpoint_name: 'e2', container_id: 'c2', container_name: 'cn2',
+        severity: 'warning', category: 'anomaly',
+        title: 'Anomalous memory usage on "cn2"', description: 'd', suggested_action: null,
+        is_acknowledged: 0, created_at: new Date().toISOString(),
+      },
+      {
+        id: 'j2', endpoint_id: 2, endpoint_name: 'e2', container_id: 'c2', container_name: 'cn2',
+        severity: 'warning', category: 'anomaly',
+        title: 'Anomalous memory usage on "cn2"', description: 'd', suggested_action: null,
+        is_acknowledged: 0, created_at: new Date().toISOString(),
+      },
+    ];
+
+    await correlateInsights(fullInsights);
+
+    const incidentRows = await testDb.query<{ signature: string }>(
+      'SELECT signature FROM incidents',
+    );
+    expect(incidentRows).toHaveLength(1);
+    // Title regex: "Anomalous memory usage" → anomaly:threshold:memory
+    expect(incidentRows[0].signature).toBe('anomaly:threshold:memory');
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/incident-store-batch.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-store-batch.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock at module level before importing
+const mockDb = {
+  queryOne: vi.fn(),
+  execute: vi.fn(),
+};
+
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => mockDb,
+}));
+
+import { resolveIncidentsBatch } from '../services/incident-store.js';
+
+describe('resolveIncidentsBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves all valid ids', async () => {
+    mockDb.queryOne
+      .mockResolvedValueOnce({ id: 'a' })
+      .mockResolvedValueOnce({ id: 'b' })
+      .mockResolvedValueOnce({ id: 'c' });
+    mockDb.execute.mockResolvedValue(undefined);
+
+    const result = await resolveIncidentsBatch(['a', 'b', 'c']);
+
+    expect(result.resolved).toEqual(['a', 'b', 'c']);
+    expect(result.failed).toEqual([]);
+    expect(mockDb.execute).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not roll back successful ids when one fails', async () => {
+    mockDb.queryOne
+      .mockResolvedValueOnce({ id: 'a' })
+      .mockResolvedValueOnce(null) // does-not-exist
+      .mockResolvedValueOnce({ id: 'c' });
+    mockDb.execute
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+
+    const result = await resolveIncidentsBatch(['a', 'does-not-exist', 'c']);
+
+    expect(result.resolved.sort()).toEqual(['a', 'c']);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].id).toBe('does-not-exist');
+    expect(result.failed[0].error).toBe('not found');
+    // Only 2 executes should have been called
+    expect(mockDb.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles errors from database operations', async () => {
+    const dbError = new Error('Database error');
+    mockDb.queryOne
+      .mockResolvedValueOnce({ id: 'a' })
+      .mockResolvedValueOnce({ id: 'b' })
+      .mockResolvedValueOnce({ id: 'c' });
+    mockDb.execute
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(dbError)
+      .mockResolvedValueOnce(undefined);
+
+    const result = await resolveIncidentsBatch(['a', 'b', 'c']);
+
+    expect(result.resolved).toEqual(['a', 'c']);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].id).toBe('b');
+    expect(result.failed[0].error).toBe('Database error');
+  });
+
+  it('handles empty id list', async () => {
+    const result = await resolveIncidentsBatch([]);
+    expect(result.resolved).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(mockDb.queryOne).not.toHaveBeenCalled();
+    expect(mockDb.execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/incidents-backfill.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-backfill.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+
+let testDb: Awaited<ReturnType<typeof getTestDb>>;
+
+// Redirect all DB calls to the test database
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => testDb,
+}));
+
+import { backfillSignatures } from '../../scripts/backfill-incident-signatures.js';
+
+beforeEach(async () => {
+  testDb = await getTestDb();
+  await truncateTestTables(['incidents', 'insights']);
+});
+afterAll(async () => { await closeTestDb(); });
+
+describe('backfillSignatures', () => {
+  it('populates NULL signatures using the root insight category/fields', async () => {
+    const db = await getTestDb();
+    await db.execute(`
+      INSERT INTO insights (id, endpoint_id, endpoint_name, container_id, container_name,
+                            severity, category, title, description, suggested_action,
+                            metric_type, detection_method, is_acknowledged, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
+    `, ['ins1', 1, 'e', 'c', 'cn', 'warning', 'anomaly',
+        'Anomalous cpu usage on "cn"', 'd', null,
+        'cpu', 'ml-anomaly', false]);
+
+    await db.execute(`
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, 'active', ?, ?::jsonb, ?::jsonb, ?, ?, 'dedup', 'high', ?, ?,
+              ?, NOW(), NOW())
+    `, ['inc1', 'Anomalous cpu usage on "cn"', 'warning', 'ins1',
+        '[]', '["cn"]', 1, 'e', 1, null, null]);
+
+    const result = await backfillSignatures({ batchSize: 100, force: false });
+    expect(result.updated).toBe(1);
+
+    const after = await db.queryOne<{ signature: string }>(
+      'SELECT signature FROM incidents WHERE id = ?', ['inc1'],
+    );
+    expect(after?.signature).toBe('anomaly:ml-anomaly:cpu');
+  });
+
+  it('is idempotent — running again does nothing for already-set rows', async () => {
+    const db = await getTestDb();
+    await db.execute(`
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, 'active', NULL, ?::jsonb, ?::jsonb, NULL, NULL,
+              'temporal', 'medium', ?, NULL, ?, NOW(), NOW())
+    `, ['inc1', 'High cpu usage on "cn"', 'warning', '[]', '[]', 1, null]);
+
+    const r1 = await backfillSignatures({ batchSize: 100, force: false });
+    expect(r1.updated).toBe(1);
+    const r2 = await backfillSignatures({ batchSize: 100, force: false });
+    expect(r2.updated).toBe(0);
+  });
+
+  it('handles missing root insight via title fallback', async () => {
+    const db = await getTestDb();
+
+    // Insert the insight first (FK constraint requires it), but with NULL
+    // metric_type and detection_method to exercise the "insight exists but has
+    // no structured fields" branch — same code path as the title fallback.
+    await db.execute(`
+      INSERT INTO insights (id, endpoint_id, endpoint_name, container_id, container_name,
+                            severity, category, title, description, suggested_action,
+                            metric_type, detection_method, is_acknowledged, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
+    `, ['ins-pred', 1, 'e', 'c', 'cn', 'warning', 'predictive',
+        'Predicted memory exhaustion on "cn" ~24h', 'd', null,
+        null, null, false]);
+
+    await db.execute(`
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, 'active', ?, ?::jsonb, ?::jsonb, ?, ?, 'dedup', 'high', ?, ?, ?, NOW(), NOW())
+    `, ['inc1', 'Predicted memory exhaustion on "cn" ~24h', 'warning', 'ins-pred',
+        '[]', '["cn"]', 1, 'e', 1, null, null]);
+
+    const result = await backfillSignatures({ batchSize: 100, force: false });
+    expect(result.updated).toBe(1);
+
+    const after = await db.queryOne<{ signature: string }>(
+      'SELECT signature FROM incidents WHERE id = ?', ['inc1'],
+    );
+    expect(after?.signature).toBe('predictive:prediction:memory');
+  });
+
+  it('force: true re-derives every row regardless of existing signature', async () => {
+    const db = await getTestDb();
+    await db.execute(`
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, 'active', NULL, ?::jsonb, ?::jsonb, NULL, NULL,
+              'temporal', 'medium', ?, NULL, ?, NOW(), NOW())
+    `, ['inc-force', 'High cpu usage on "test"', 'warning', '[]', '[]', 1, 'anomaly:threshold:cpu']);
+
+    // Default mode is null-only — should skip the already-set row.
+    const r1 = await backfillSignatures({ batchSize: 100, force: false });
+    expect(r1.updated).toBe(0);
+
+    // Force mode should re-derive regardless of existing signature.
+    const r2 = await backfillSignatures({ batchSize: 100, force: true });
+    expect(r2.updated).toBe(1);
+    expect(r2.bySignature['anomaly:threshold:cpu']).toBe(1);
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/incidents-groups.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-groups.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+
+let testDb: Awaited<ReturnType<typeof getTestDb>>;
+
+// Redirect all DB calls to the test database
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => testDb,
+}));
+
+import { getIncidentGroups } from '../services/incident-store.js';
+
+describe('getIncidentGroups', () => {
+  beforeEach(async () => {
+    testDb = await getTestDb();
+    await truncateTestTables('incidents');
+    const db = await getTestDb();
+    const ins = `
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, 'active', NULL, '[]'::jsonb, ?::jsonb, ?, ?, 'temporal', 'medium', ?, NULL, ?, NOW(), NOW())
+    `;
+    // 3 active CPU anomalies on 3 containers, 1 critical 2 warning, 2 endpoints
+    await db.execute(ins, ['a1', 'cpu', 'critical', '["c1"]', 1, 'eA', 5, 'anomaly:ml-anomaly:cpu']);
+    await db.execute(ins, ['a2', 'cpu', 'warning',  '["c2"]', 1, 'eA', 3, 'anomaly:ml-anomaly:cpu']);
+    await db.execute(ins, ['a3', 'cpu', 'warning',  '["c3"]', 2, 'eB', 2, 'anomaly:ml-anomaly:cpu']);
+    // 1 active memory prediction
+    await db.execute(ins, ['m1', 'mem', 'warning',  '["c4"]', 2, 'eB', 1, 'predictive:prediction:memory']);
+    // 1 resolved (must not appear when status=active)
+    await db.execute(`
+      INSERT INTO incidents (id, title, severity, status, signature, related_insight_ids,
+                             affected_containers, correlation_type, correlation_confidence,
+                             insight_count, created_at, updated_at, resolved_at)
+      VALUES ('r1', 'r', 'warning', 'resolved', 'anomaly:ml-anomaly:cpu', '[]'::jsonb,
+              '[]'::jsonb, 'temporal', 'medium', 1, NOW(), NOW(), NOW())
+    `);
+  });
+  afterAll(async () => { await closeTestDb(); });
+
+  it('aggregates by signature with counts', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    expect(result.total_active).toBe(4);
+
+    const cpu = result.groups.find((g) => g.signature === 'anomaly:ml-anomaly:cpu');
+    expect(cpu).toBeDefined();
+    expect(cpu!.incident_count).toBe(3);
+    expect(cpu!.container_count).toBe(3);
+    expect(cpu!.alert_count).toBe(5 + 3 + 2); // sum of insight_count across group
+    expect(cpu!.severity).toBe('critical');  // highest in group
+  });
+
+  it('returns top_containers ordered by severity then recency, capped at 10', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    const cpu = result.groups.find((g) => g.signature === 'anomaly:ml-anomaly:cpu')!;
+    expect(cpu.top_containers.length).toBeLessThanOrEqual(10);
+    expect(cpu.top_containers[0].severity).toBe('critical');
+  });
+
+  it('includes all_container_names with names_truncated flag', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    const cpu = result.groups.find((g) => g.signature === 'anomaly:ml-anomaly:cpu')!;
+    expect(cpu.all_container_names.sort()).toEqual(['c1', 'c2', 'c3']);
+    expect(cpu.names_truncated).toBe(false);
+  });
+
+  it('endpoint_facets reflects distribution', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    const eA = result.endpoint_facets.find((f) => f.endpoint_id === 1)!;
+    expect(eA.incident_count).toBe(2);
+    const eB = result.endpoint_facets.find((f) => f.endpoint_id === 2)!;
+    expect(eB.incident_count).toBe(2);
+  });
+
+  it('endpoint_id filter narrows the result', async () => {
+    const result = await getIncidentGroups({ status: 'active', endpoint_id: 2 });
+    expect(result.total_active).toBe(2);
+  });
+
+  it('since_minutes filter applies against updated_at', async () => {
+    // updated_at is NOW(); all rows match a 1-hour window
+    const result = await getIncidentGroups({ status: 'active', since_minutes: 60 });
+    expect(result.total_active).toBe(4);
+  });
+
+  it('excludes resolved incidents when status=active', async () => {
+    const result = await getIncidentGroups({ status: 'active' });
+    const incidentIds = result.groups.flatMap((g) => g.top_containers.map((tc) => tc.incident_id));
+    expect(incidentIds).not.toContain('r1');
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/incidents-list.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-list.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+
+let testDb: Awaited<ReturnType<typeof getTestDb>>;
+
+// Redirect all DB calls to the test database
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => testDb,
+}));
+
+import { getIncidents } from '../services/incident-store.js';
+
+beforeEach(async () => {
+  testDb = await getTestDb();
+  await truncateTestTables(['incidents']);
+});
+afterAll(async () => { await closeTestDb(); });
+
+describe('getIncidents — signature filter', () => {
+  it('returns only matching signature when provided', async () => {
+    const db = await getTestDb();
+    const insertSQL = `
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, 'active', NULL, '[]'::jsonb, '[]'::jsonb, NULL, NULL,
+              'temporal', 'medium', 1, NULL, ?, NOW(), NOW())
+    `;
+    await db.execute(insertSQL, ['a', 'A', 'warning', 'anomaly:ml-anomaly:cpu']);
+    await db.execute(insertSQL, ['b', 'B', 'warning', 'anomaly:ml-anomaly:memory']);
+    await db.execute(insertSQL, ['c', 'C', 'warning', 'predictive:prediction:memory']);
+
+    const rows = await getIncidents({ signature: 'anomaly:ml-anomaly:memory' });
+    expect(rows.map((r) => r.id)).toEqual(['b']);
+  });
+
+  it('combines with status filter', async () => {
+    const db = await getTestDb();
+    const insertSQL = `
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, ?, NULL, '[]'::jsonb, '[]'::jsonb, NULL, NULL,
+              'temporal', 'medium', 1, NULL, ?, NOW(), NOW())
+    `;
+    await db.execute(insertSQL, ['a', 'A', 'warning', 'active', 'anomaly:ml-anomaly:cpu']);
+    await db.execute(insertSQL, ['b', 'B', 'warning', 'resolved', 'anomaly:ml-anomaly:memory']);
+    await db.execute(insertSQL, ['c', 'C', 'warning', 'active', 'predictive:prediction:memory']);
+
+    const rows = await getIncidents({ status: 'active', signature: 'predictive:prediction:memory' });
+    expect(rows.map((r) => r.id)).toEqual(['c']);
+  });
+
+  it('returns all when omitted', async () => {
+    const db = await getTestDb();
+    const insertSQL = `
+      INSERT INTO incidents (id, title, severity, status, root_cause_insight_id,
+                             related_insight_ids, affected_containers, endpoint_id, endpoint_name,
+                             correlation_type, correlation_confidence, insight_count, summary,
+                             signature, created_at, updated_at)
+      VALUES (?, ?, ?, 'active', NULL, '[]'::jsonb, '[]'::jsonb, NULL, NULL,
+              'temporal', 'medium', 1, NULL, ?, NOW(), NOW())
+    `;
+    await db.execute(insertSQL, ['a', 'A', 'warning', 'anomaly:ml-anomaly:cpu']);
+    await db.execute(insertSQL, ['b', 'B', 'warning', 'anomaly:ml-anomaly:memory']);
+    await db.execute(insertSQL, ['c', 'C', 'warning', 'predictive:prediction:memory']);
+
+    const rows = await getIncidents({});
+    expect(rows).toHaveLength(3);
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/incidents.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vites
 import Fastify, { type FastifyInstance, type FastifyRequest, type FastifyReply } from 'fastify';
 import { testAdminOnly } from '@dashboard/core/test-utils/rbac-test-helper.js';
 import { incidentsRoutes } from '../routes/incidents.js';
-import { getIncidents, getIncident, resolveIncident, getIncidentCount, resolveIncidentsBatch } from '../services/incident-store.js';
+import { getIncidents, getIncident, resolveIncident, getIncidentCount, resolveIncidentsBatch, getIncidentGroups } from '../services/incident-store.js';
 
 // Mock the stores — all functions are now async
 // Kept: incident-store mock — no PostgreSQL in CI
@@ -12,6 +12,7 @@ vi.mock('../services/incident-store.js', () => ({
   resolveIncident: vi.fn(() => Promise.resolve()),
   getIncidentCount: vi.fn(() => Promise.resolve({ active: 0, resolved: 0, total: 0 })),
   resolveIncidentsBatch: vi.fn(() => Promise.resolve({ resolved: [], failed: [] })),
+  getIncidentGroups: vi.fn(() => Promise.resolve({ groups: [], endpoint_facets: [], total_active: 0 })),
 }));
 
 // Kept: app-db-router mock — tests control database routing
@@ -24,11 +25,19 @@ vi.mock('@dashboard/core/db/app-db-router.js', () => ({
   })),
 }));
 
+// Kept: portainer-cache mock — cachedFetchSWR passes through to fetcher in tests
+vi.mock('@dashboard/core/portainer/portainer-cache.js', () => ({
+  cachedFetchSWR: vi.fn((_key: string, _ttl: number, fetcher: () => unknown) => fetcher()),
+  getCacheKey: vi.fn((...parts: unknown[]) => parts.join(':')),
+  cache: { invalidatePattern: vi.fn(() => Promise.resolve()) },
+}));
+
 const mockedGetIncidents = vi.mocked(getIncidents);
 const mockedGetIncident = vi.mocked(getIncident);
 const mockedResolveIncident = vi.mocked(resolveIncident);
 const mockedGetIncidentCount = vi.mocked(getIncidentCount);
 const mockedResolveIncidentsBatch = vi.mocked(resolveIncidentsBatch);
+const mockedGetIncidentGroups = vi.mocked(getIncidentGroups);
 
 describe('incidents routes', () => {
   let app: ReturnType<typeof Fastify>;
@@ -71,6 +80,43 @@ describe('incidents routes', () => {
       expect(mockedGetIncidents).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'active' }),
       );
+    });
+  });
+
+  describe('GET /api/incidents/groups', () => {
+    it('should return 200 with valid query params', async () => {
+      mockedGetIncidentGroups.mockResolvedValue({ groups: [], endpoint_facets: [], total_active: 0 });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/incidents/groups?status=active&since=1h&severity=critical',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.groups).toBeDefined();
+    });
+
+    it('should return 400 when endpoint_id is not a number', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/incidents/groups?endpoint_id=abc',
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.error).toBe('invalid query');
+    });
+
+    it('should return 400 when since is an invalid value', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/incidents/groups?since=foo',
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.error).toBe('invalid query');
     });
   });
 

--- a/packages/ai-intelligence/src/__tests__/incidents.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents.test.ts
@@ -1,12 +1,8 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 import Fastify, { type FastifyInstance, type FastifyRequest, type FastifyReply } from 'fastify';
-import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
-import type { AppDb } from '@dashboard/core/db/app-db.js';
 import { testAdminOnly } from '@dashboard/core/test-utils/rbac-test-helper.js';
 import { incidentsRoutes } from '../routes/incidents.js';
-import { getIncidents, getIncident, resolveIncident, getIncidentCount } from '../services/incident-store.js';
-
-let testDb: AppDb;
+import { getIncidents, getIncident, resolveIncident, getIncidentCount, resolveIncidentsBatch } from '../services/incident-store.js';
 
 // Mock the stores — all functions are now async
 // Kept: incident-store mock — no PostgreSQL in CI
@@ -15,20 +11,24 @@ vi.mock('../services/incident-store.js', () => ({
   getIncident: vi.fn(() => Promise.resolve(null)),
   resolveIncident: vi.fn(() => Promise.resolve()),
   getIncidentCount: vi.fn(() => Promise.resolve({ active: 0, resolved: 0, total: 0 })),
+  resolveIncidentsBatch: vi.fn(() => Promise.resolve({ resolved: [], failed: [] })),
 }));
 
 // Kept: app-db-router mock — tests control database routing
 vi.mock('@dashboard/core/db/app-db-router.js', () => ({
-  getDbForDomain: () => testDb,
+  getDbForDomain: vi.fn(() => ({
+    query: vi.fn().mockResolvedValue([]),
+    queryOne: vi.fn().mockResolvedValue(null),
+    execute: vi.fn(),
+    transaction: vi.fn((fn: (db: unknown) => unknown) => fn({ query: vi.fn(), queryOne: vi.fn(), execute: vi.fn() })),
+  })),
 }));
 
 const mockedGetIncidents = vi.mocked(getIncidents);
 const mockedGetIncident = vi.mocked(getIncident);
 const mockedResolveIncident = vi.mocked(resolveIncident);
 const mockedGetIncidentCount = vi.mocked(getIncidentCount);
-
-beforeAll(async () => { testDb = await getTestDb(); });
-afterAll(async () => { await closeTestDb(); });
+const mockedResolveIncidentsBatch = vi.mocked(resolveIncidentsBatch);
 
 describe('incidents routes', () => {
   let app: ReturnType<typeof Fastify>;
@@ -130,6 +130,92 @@ describe('incidents routes', () => {
       expect(mockedResolveIncident).toHaveBeenCalledWith('inc-1');
     });
   });
+
+  describe('POST /api/incidents/resolve (batch)', () => {
+    it('should return 400 for invalid body', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/incidents/resolve',
+        payload: { ids: 'not-an-array' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 for empty ids array', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/incidents/resolve',
+        payload: { ids: [] },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should resolve a batch of incidents', async () => {
+      const ids = [
+        '550e8400-e29b-41d4-a716-446655440001',
+        '550e8400-e29b-41d4-a716-446655440002',
+        '550e8400-e29b-41d4-a716-446655440003',
+      ];
+      mockedResolveIncidentsBatch.mockResolvedValue({
+        resolved: ids,
+        failed: [],
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/incidents/resolve',
+        payload: { ids },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.resolved).toEqual(ids);
+      expect(body.failed).toEqual([]);
+      expect(mockedResolveIncidentsBatch).toHaveBeenCalledWith(ids);
+    });
+
+    it('should handle partial failures', async () => {
+      const validIds = [
+        '550e8400-e29b-41d4-a716-446655440001',
+        '550e8400-e29b-41d4-a716-446655440003',
+      ];
+      const notFoundId = '00000000-0000-0000-0000-000000000000';
+      const allIds = [validIds[0], notFoundId, validIds[1]];
+
+      mockedResolveIncidentsBatch.mockResolvedValue({
+        resolved: validIds,
+        failed: [{ id: notFoundId, error: 'not found' }],
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/incidents/resolve',
+        payload: { ids: allIds },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.resolved).toEqual(validIds);
+      expect(body.failed).toHaveLength(1);
+      expect(body.failed[0].id).toBe(notFoundId);
+    });
+
+    it('should reject max 500 ids', async () => {
+      const ids = Array.from({ length: 501 }, (_, i) => {
+        const num = i.toString().padStart(36, '0');
+        return `${num.slice(0, 8)}-${num.slice(8, 12)}-${num.slice(12, 16)}-${num.slice(16, 20)}-${num.slice(20, 32)}`;
+      });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/incidents/resolve',
+        payload: { ids },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
 });
 
 describe('incidents RBAC', () => {
@@ -164,4 +250,5 @@ describe('incidents RBAC', () => {
   });
 
   testAdminOnly(() => rbacApp, (r) => { currentRole = r; }, 'POST', '/api/incidents/inc-1/resolve');
+  testAdminOnly(() => rbacApp, (r) => { currentRole = r; }, 'POST', '/api/incidents/resolve', { ids: ['550e8400-e29b-41d4-a716-446655440001'] });
 });

--- a/packages/ai-intelligence/src/__tests__/monitoring-service-emission.test.ts
+++ b/packages/ai-intelligence/src/__tests__/monitoring-service-emission.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { InsightSchema } from '@dashboard/core/models/monitoring.js';
+
+// We assert at the schema layer rather than running the full service
+// (which depends on Portainer / DB / metrics). The principle: every
+// path in monitoring-service.ts that pushes an Insight literal MUST
+// include metric_type and detection_method when the category is
+// 'anomaly' or 'predictive'. If a future emission path forgets, this
+// test does not catch it directly — but the typecheck below will.
+describe('Insight emission — structured fields are typeable', () => {
+  it('an anomaly insight with structured fields parses', () => {
+    const insight = {
+      id: '1',
+      endpoint_id: 1,
+      endpoint_name: 'e',
+      container_id: 'c',
+      container_name: 'cn',
+      severity: 'warning' as const,
+      category: 'anomaly',
+      title: 'Anomalous cpu usage on "x"',
+      description: 'd',
+      suggested_action: null,
+      is_acknowledged: 0,
+      created_at: new Date().toISOString(),
+      metric_type: 'cpu' as const,
+      detection_method: 'ml-anomaly' as const,
+    };
+    const result = InsightSchema.safeParse(insight);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/signature.test.ts
+++ b/packages/ai-intelligence/src/__tests__/signature.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveSignature,
+  deriveSignatureFromTitle,
+  signatureLabel,
+  slugifyTitle,
+} from '../services/signature.js';
+
+describe('deriveSignature — structured-field path', () => {
+  it('uses metric_type + detection_method when both present', () => {
+    expect(
+      deriveSignature({
+        category: 'anomaly',
+        metric_type: 'cpu',
+        detection_method: 'ml-anomaly',
+        title: 'whatever',
+      }),
+    ).toBe('anomaly:ml-anomaly:cpu');
+  });
+
+  it('encodes prediction:memory correctly', () => {
+    expect(
+      deriveSignature({
+        category: 'predictive',
+        metric_type: 'memory',
+        detection_method: 'prediction',
+        title: 'Predicted memory exhaustion ~24h',
+      }),
+    ).toBe('predictive:prediction:memory');
+  });
+});
+
+describe('deriveSignature — category-only fallbacks', () => {
+  it('returns security:scan for security category', () => {
+    expect(
+      deriveSignature({ category: 'security', title: 'CVE-2024-1234 in container x' }),
+    ).toBe('security:scan');
+  });
+  it('returns log:pattern for log-analysis category', () => {
+    expect(deriveSignature({ category: 'log-analysis', title: 'OOM in logs' })).toBe('log:pattern');
+  });
+  it('returns ai:analysis for ai-analysis category', () => {
+    expect(deriveSignature({ category: 'ai-analysis', title: 'AI summary' })).toBe('ai:analysis');
+  });
+});
+
+describe('deriveSignatureFromTitle — title regex fallback', () => {
+  it('matches "Predicted X exhaustion"', () => {
+    expect(deriveSignatureFromTitle('Predicted memory exhaustion on "x" ~24h'))
+      .toBe('predictive:prediction:memory');
+    expect(deriveSignatureFromTitle('Predicted cpu exhaustion on "x" ~6h'))
+      .toBe('predictive:prediction:cpu');
+  });
+
+  it('matches "Anomalous X usage" with ML', () => {
+    expect(deriveSignatureFromTitle('Anomalous cpu usage on "x" (ML-detected)'))
+      .toBe('anomaly:ml-anomaly:cpu');
+  });
+
+  it('matches "Anomalous X usage" without ML qualifier', () => {
+    expect(deriveSignatureFromTitle('Anomalous memory usage on "x"'))
+      .toBe('anomaly:threshold:memory');
+  });
+
+  it('matches "High X usage"', () => {
+    expect(deriveSignatureFromTitle('High cpu usage on "x"'))
+      .toBe('anomaly:threshold:cpu');
+  });
+
+  it('matches "no health check"', () => {
+    expect(deriveSignatureFromTitle('Container x has no health check configured'))
+      .toBe('config:health-check:missing');
+  });
+
+  it('matches "host network mode"', () => {
+    expect(deriveSignatureFromTitle('Container x using host network mode'))
+      .toBe('config:network:host-mode');
+  });
+
+  it('falls through to unknown:<slug> on no match', () => {
+    expect(deriveSignatureFromTitle('Some bizarre new thing happened'))
+      .toMatch(/^unknown:/);
+  });
+});
+
+describe('slugifyTitle', () => {
+  it('strips commas (signatures cannot contain commas — used as URL separator)', () => {
+    expect(slugifyTitle('a, b, c')).not.toContain(',');
+  });
+  it('lowercases and dashes', () => {
+    expect(slugifyTitle('Hello World')).toBe('hello-world');
+  });
+});
+
+describe('signatureLabel', () => {
+  it('returns curated label for known signature', () => {
+    expect(signatureLabel('predictive:prediction:memory')).toBe('Predicted memory exhaustion');
+  });
+  it('falls back to humanized form for unknown', () => {
+    expect(signatureLabel('anomaly:threshold:disk')).toBe('Anomaly · threshold · disk');
+  });
+});
+
+describe('equivalence — regex output equals structured-field output', () => {
+  // For each title pattern, the regex must produce the same signature
+  // the structured-field path would for the same problem class.
+  const cases = [
+    { title: 'Anomalous cpu usage on "x" (ML-detected)',
+      structured: { category: 'anomaly', metric_type: 'cpu' as const, detection_method: 'ml-anomaly' as const } },
+    { title: 'Anomalous memory usage on "x"',
+      structured: { category: 'anomaly', metric_type: 'memory' as const, detection_method: 'threshold' as const } },
+    { title: 'Predicted memory exhaustion on "x" ~24h',
+      structured: { category: 'predictive', metric_type: 'memory' as const, detection_method: 'prediction' as const } },
+    { title: 'Predicted cpu exhaustion on "x" ~6h',
+      structured: { category: 'predictive', metric_type: 'cpu' as const, detection_method: 'prediction' as const } },
+    { title: 'High cpu usage on "x"',
+      structured: { category: 'anomaly', metric_type: 'cpu' as const, detection_method: 'threshold' as const } },
+  ];
+
+  for (const c of cases) {
+    it(`"${c.title}" — regex matches structured`, () => {
+      const fromRegex = deriveSignatureFromTitle(c.title);
+      const fromStructured = deriveSignature({ ...c.structured, title: c.title });
+      expect(fromRegex).toBe(fromStructured);
+    });
+  }
+});

--- a/packages/ai-intelligence/src/__tests__/signature.test.ts
+++ b/packages/ai-intelligence/src/__tests__/signature.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Insight } from '@dashboard/core/models/monitoring.js';
 import {
   deriveSignature,
   deriveSignatureFromTitle,
@@ -124,4 +127,69 @@ describe('equivalence — regex output equals structured-field output', () => {
       expect(fromRegex).toBe(fromStructured);
     });
   }
+});
+
+describe('drift corpus — historical titles', () => {
+  const csvPath = path.join(__dirname, 'fixtures/historical-titles.csv');
+  const text = fs.readFileSync(csvPath, 'utf8').trim();
+  const [, ...rows] = text.split('\n');
+
+  type CsvRecord = {
+    title: string;
+    category: string | undefined;
+    metric_type: string | undefined;
+    detection_method: string | undefined;
+  };
+
+  const records: CsvRecord[] = rows.map((r) => {
+    // Naive CSV parser sufficient for our quoted format.
+    const cells: string[] = [];
+    let cur = '';
+    let inQuote = false;
+    for (let i = 0; i < r.length; i++) {
+      const ch = r[i];
+      if (ch === '"') {
+        if (inQuote && r[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuote = !inQuote;
+        }
+      } else if (ch === ',' && !inQuote) {
+        cells.push(cur);
+        cur = '';
+      } else {
+        cur += ch;
+      }
+    }
+    cells.push(cur);
+    const [title, category, metric_type, detection_method] = cells;
+    return {
+      title,
+      category: category || undefined,
+      metric_type: metric_type || undefined,
+      detection_method: detection_method || undefined,
+    };
+  });
+
+  it('every row derives a non-unknown signature', () => {
+    for (const r of records) {
+      const sig = deriveSignatureFromTitle(r.title);
+      expect(sig, `title="${r.title}"`).not.toMatch(/^unknown:/);
+    }
+  });
+
+  it('regex output equals structured-field output (when fields present)', () => {
+    for (const r of records) {
+      if (!r.category) continue;
+      const fromRegex = deriveSignatureFromTitle(r.title);
+      const fromStructured = deriveSignature({
+        category: r.category,
+        metric_type: r.metric_type as Insight['metric_type'],
+        detection_method: r.detection_method as Insight['detection_method'],
+        title: r.title,
+      });
+      expect(fromRegex, `title="${r.title}"`).toBe(fromStructured);
+    }
+  });
 });

--- a/packages/ai-intelligence/src/routes/incidents.ts
+++ b/packages/ai-intelligence/src/routes/incidents.ts
@@ -37,6 +37,13 @@ export async function incidentsRoutes(fastify: FastifyInstance) {
   });
 
   // List active incidents grouped by signature
+  const GroupsQ = z.object({
+    status: z.enum(['active', 'resolved']).optional(),
+    endpoint_id: z.coerce.number().int().optional(),
+    since: z.enum(['1h', '24h', '7d']).optional(),
+    severity: z.enum(['critical', 'warning', 'info']).optional(),
+  });
+
   fastify.get('/api/incidents/groups', {
     schema: {
       tags: ['Incidents'],
@@ -44,16 +51,13 @@ export async function incidentsRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
     },
     preHandler: [fastify.authenticate],
-  }, async (request) => {
-    const { status = 'active', endpoint_id, since, severity } = request.query as {
-      status?: 'active' | 'resolved';
-      endpoint_id?: string;
-      since?: '1h' | '24h' | '7d';
-      severity?: 'critical' | 'warning' | 'info';
-    };
+  }, async (request, reply) => {
+    const parsed = GroupsQ.safeParse(request.query);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'invalid query', details: parsed.error.flatten() });
+    }
+    const { status = 'active', endpoint_id: epId, since, severity } = parsed.data;
     const since_minutes = since === '1h' ? 60 : since === '24h' ? 1440 : since === '7d' ? 10080 : undefined;
-    const epId = endpoint_id != null ? Number(endpoint_id) : undefined;
-
     const cacheKey = getCacheKey('incidents-groups', status, epId ?? 'all', since ?? 'all', severity ?? 'all');
     return cachedFetchSWR(cacheKey, 10, () =>
       getIncidentGroups({ status, endpoint_id: epId, since_minutes, severity }),

--- a/packages/ai-intelligence/src/routes/incidents.ts
+++ b/packages/ai-intelligence/src/routes/incidents.ts
@@ -2,8 +2,9 @@ import '@dashboard/core/plugins/auth.js';
 import '@dashboard/core/plugins/request-tracing.js';
 import '@fastify/swagger';
 import { FastifyInstance } from 'fastify';
-import { getIncidents, getIncident, resolveIncident, getIncidentCount } from '../services/incident-store.js';
+import { getIncidents, getIncident, resolveIncident, getIncidentCount, getIncidentGroups } from '../services/incident-store.js';
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
+import { cachedFetchSWR, getCacheKey, cache } from '@dashboard/core/portainer/portainer-cache.js';
 
 export async function incidentsRoutes(fastify: FastifyInstance) {
   // List incidents
@@ -32,6 +33,30 @@ export async function incidentsRoutes(fastify: FastifyInstance) {
       limit,
       offset,
     };
+  });
+
+  // List active incidents grouped by signature
+  fastify.get('/api/incidents/groups', {
+    schema: {
+      tags: ['Incidents'],
+      summary: 'List active incidents grouped by signature',
+      security: [{ bearerAuth: [] }],
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request) => {
+    const { status = 'active', endpoint_id, since, severity } = request.query as {
+      status?: 'active' | 'resolved';
+      endpoint_id?: string;
+      since?: '1h' | '24h' | '7d';
+      severity?: 'critical' | 'warning' | 'info';
+    };
+    const since_minutes = since === '1h' ? 60 : since === '24h' ? 1440 : since === '7d' ? 10080 : undefined;
+    const epId = endpoint_id != null ? Number(endpoint_id) : undefined;
+
+    const cacheKey = getCacheKey('incidents-groups', status, epId ?? 'all', since ?? 'all', severity ?? 'all');
+    return cachedFetchSWR(cacheKey, 10, () =>
+      getIncidentGroups({ status, endpoint_id: epId, since_minutes, severity }),
+    );
   });
 
   // Get single incident with related insights
@@ -89,6 +114,9 @@ export async function incidentsRoutes(fastify: FastifyInstance) {
     }
 
     await resolveIncident(id);
+    // Invalidate grouped-incidents cache so the next request reflects the resolved state.
+    // invalidatePattern matches all variants (by status, endpoint_id, since, severity).
+    await cache.invalidatePattern('incidents-groups').catch(() => undefined);
     return { success: true };
   });
 }

--- a/packages/ai-intelligence/src/routes/incidents.ts
+++ b/packages/ai-intelligence/src/routes/incidents.ts
@@ -15,14 +15,15 @@ export async function incidentsRoutes(fastify: FastifyInstance) {
     },
     preHandler: [fastify.authenticate],
   }, async (request) => {
-    const { status, severity, limit = 50, offset = 0 } = request.query as {
+    const { status, severity, signature, limit = 50, offset = 0 } = request.query as {
       status?: 'active' | 'resolved';
       severity?: string;
+      signature?: string;
       limit?: number;
       offset?: number;
     };
 
-    const incidents = await getIncidents({ status, severity, limit, offset });
+    const incidents = await getIncidents({ status, severity, signature, limit, offset });
     const counts = await getIncidentCount();
 
     return {

--- a/packages/ai-intelligence/src/routes/incidents.ts
+++ b/packages/ai-intelligence/src/routes/incidents.ts
@@ -2,9 +2,10 @@ import '@dashboard/core/plugins/auth.js';
 import '@dashboard/core/plugins/request-tracing.js';
 import '@fastify/swagger';
 import { FastifyInstance } from 'fastify';
-import { getIncidents, getIncident, resolveIncident, getIncidentCount, getIncidentGroups } from '../services/incident-store.js';
+import { getIncidents, getIncident, resolveIncident, getIncidentCount, getIncidentGroups, resolveIncidentsBatch } from '../services/incident-store.js';
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { cachedFetchSWR, getCacheKey, cache } from '@dashboard/core/portainer/portainer-cache.js';
+import { z } from 'zod';
 
 export async function incidentsRoutes(fastify: FastifyInstance) {
   // List incidents
@@ -118,5 +119,30 @@ export async function incidentsRoutes(fastify: FastifyInstance) {
     // invalidatePattern matches all variants (by status, endpoint_id, since, severity).
     await cache.invalidatePattern('incidents-groups').catch(() => undefined);
     return { success: true };
+  });
+
+  // Resolve a batch of incidents
+  fastify.post('/api/incidents/resolve', {
+    schema: {
+      tags: ['Incidents'],
+      summary: 'Resolve a batch of incidents',
+      security: [{ bearerAuth: [] }],
+      body: {
+        type: 'object',
+        properties: {
+          ids: { type: 'array', items: { type: 'string', format: 'uuid' }, minItems: 1, maxItems: 500 },
+        },
+        required: ['ids'],
+      },
+    },
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
+  }, async (request, reply) => {
+    const parsed = z.object({ ids: z.array(z.string().uuid()).min(1).max(500) }).safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'invalid body', details: parsed.error.flatten() });
+    }
+    const result = await resolveIncidentsBatch(parsed.data.ids);
+    await cache.invalidatePattern('incidents-groups').catch(() => undefined);
+    return result;
   });
 }

--- a/packages/ai-intelligence/src/services/incident-correlator.ts
+++ b/packages/ai-intelligence/src/services/incident-correlator.ts
@@ -10,6 +10,7 @@ import {
   type IncidentInsert,
 } from './incident-store.js';
 import { generateLlmIncidentSummary } from './incident-summarizer.js';
+import { deriveSignature } from './signature.js';
 
 const log = createChildLogger('incident-correlator');
 
@@ -312,6 +313,13 @@ function buildIncident(group: InsightGroup): IncidentInsert {
   if (correlationType === 'dedup') confidence = 'high';
   if (correlationType === 'cascade' && insights.length >= 3) confidence = 'high';
 
+  const signature = deriveSignature({
+    category: rootCause.category,
+    metric_type: rootCause.metric_type,
+    detection_method: rootCause.detection_method,
+    title: rootCause.title,
+  });
+
   return {
     id: uuidv4(),
     title,
@@ -325,6 +333,7 @@ function buildIncident(group: InsightGroup): IncidentInsert {
     correlation_confidence: confidence,
     insight_count: insights.length,
     summary,
+    signature,
   };
 }
 

--- a/packages/ai-intelligence/src/services/incident-store.ts
+++ b/packages/ai-intelligence/src/services/incident-store.ts
@@ -376,3 +376,34 @@ export async function getIncidentCount(): Promise<{ active: number; resolved: nu
   const resolved = resolvedRow?.count ?? 0;
   return { active, resolved, total: active + resolved };
 }
+
+export interface BatchResolveResult {
+  resolved: string[];
+  failed: Array<{ id: string; error: string }>;
+}
+
+/**
+ * Resolves multiple incidents in their own per-id transactions.
+ *
+ * Failures of individual ids do NOT roll back already-resolved ones —
+ * each id is its own atomic operation. Per-id errors are surfaced in
+ * `failed[]` rather than aborting the whole batch.
+ */
+export async function resolveIncidentsBatch(ids: string[]): Promise<BatchResolveResult> {
+  const result: BatchResolveResult = { resolved: [], failed: [] };
+  const db = getDbForDomain('incidents');
+  for (const id of ids) {
+    try {
+      const before = await db.queryOne<{ id: string }>('SELECT id FROM incidents WHERE id = ?', [id]);
+      if (!before) {
+        result.failed.push({ id, error: 'not found' });
+        continue;
+      }
+      await resolveIncident(id);
+      result.resolved.push(id);
+    } catch (err) {
+      result.failed.push({ id, error: err instanceof Error ? err.message : 'unknown' });
+    }
+  }
+  return result;
+}

--- a/packages/ai-intelligence/src/services/incident-store.ts
+++ b/packages/ai-intelligence/src/services/incident-store.ts
@@ -182,6 +182,192 @@ export async function resolveIncident(id: string): Promise<void> {
   log.info({ incidentId: id }, 'Incident resolved');
 }
 
+import { signatureLabel } from './signature.js';
+
+const TOP_CONTAINERS_PER_GROUP = 10;
+const ALL_NAMES_CAP = 500;
+
+export interface IncidentGroupsOptions {
+  status?: 'active' | 'resolved';
+  endpoint_id?: number;
+  since_minutes?: number;
+  severity?: 'critical' | 'warning' | 'info';
+}
+
+export interface IncidentGroup {
+  signature: string;
+  label: string;
+  severity: 'critical' | 'warning' | 'info';
+  incident_count: number;
+  container_count: number;
+  alert_count: number;
+  earliest_at: string;
+  latest_update_at: string;
+  top_containers: Array<{
+    incident_id: string;
+    container_name: string;
+    endpoint_id: number | null;
+    endpoint_name: string | null;
+    severity: 'critical' | 'warning' | 'info';
+    created_at: string;
+  }>;
+  all_container_names: string[];
+  names_truncated: boolean;
+}
+
+export interface IncidentGroupsResult {
+  groups: IncidentGroup[];
+  endpoint_facets: Array<{
+    endpoint_id: number | null;
+    endpoint_name: string | null;
+    incident_count: number;
+  }>;
+  total_active: number;
+}
+
+export async function getIncidentGroups(options: IncidentGroupsOptions = {}): Promise<IncidentGroupsResult> {
+  const db = getDbForDomain('incidents');
+  const where: string[] = ['signature IS NOT NULL'];
+  const params: unknown[] = [];
+  if (options.status) { where.push('status = ?'); params.push(options.status); }
+  if (options.endpoint_id !== undefined) { where.push('endpoint_id = ?'); params.push(options.endpoint_id); }
+  if (options.since_minutes) {
+    where.push("updated_at >= NOW() + (? || ' minutes')::INTERVAL");
+    params.push(`-${options.since_minutes}`);
+  }
+  if (options.severity) { where.push('severity = ?'); params.push(options.severity); }
+  const whereSQL = `WHERE ${where.join(' AND ')}`;
+
+  // 1. Per-signature aggregate — counts, severity rollup, and name list (capped)
+  // We keep the incident-level aggregates (incident_count, alert_count, severity, timestamps)
+  // separate from the container expansion to avoid double-counting insight_count.
+  const rawGroups = await db.query<{
+    signature: string;
+    severity: 'critical' | 'warning' | 'info';
+    incident_count: number;
+    alert_count: number;
+    earliest_at: string;
+    latest_update_at: string;
+    container_count: number;
+    all_names: string[];
+  }>(`
+    WITH base AS (
+      SELECT id, signature, severity, insight_count, created_at, updated_at, affected_containers
+      FROM incidents ${whereSQL}
+    ),
+    per_incident AS (
+      SELECT signature,
+             BOOL_OR(severity = 'critical') AS has_critical,
+             BOOL_OR(severity = 'warning')  AS has_warning,
+             COUNT(*)::int                  AS incident_count,
+             COALESCE(SUM(insight_count), 0)::int AS alert_count,
+             MIN(created_at)::text          AS earliest_at,
+             MAX(updated_at)::text          AS latest_update_at
+      FROM base
+      GROUP BY signature
+    ),
+    per_container AS (
+      SELECT b.signature,
+             COUNT(DISTINCT e.container_name)::int AS container_count,
+             (ARRAY(
+               SELECT DISTINCT e2.container_name
+               FROM base b2
+               CROSS JOIN LATERAL jsonb_array_elements_text(b2.affected_containers) AS e2(container_name)
+               WHERE b2.signature = b.signature
+               ORDER BY e2.container_name
+               LIMIT ${ALL_NAMES_CAP}
+             )) AS all_names
+      FROM base b
+      CROSS JOIN LATERAL jsonb_array_elements_text(b.affected_containers) AS e(container_name)
+      GROUP BY b.signature
+    )
+    SELECT
+      p.signature,
+      CASE WHEN p.has_critical THEN 'critical'
+           WHEN p.has_warning  THEN 'warning'
+           ELSE 'info' END     AS severity,
+      p.incident_count,
+      p.alert_count,
+      p.earliest_at,
+      p.latest_update_at,
+      COALESCE(c.container_count, 0) AS container_count,
+      COALESCE(c.all_names, '{}')    AS all_names
+    FROM per_incident p
+    LEFT JOIN per_container c ON c.signature = p.signature
+    ORDER BY (CASE WHEN p.has_critical THEN 0 WHEN p.has_warning THEN 1 ELSE 2 END),
+             p.incident_count DESC
+  `, params);
+
+  // 2. Top-N containers per signature, ordered by severity then recency
+  const rawTop = await db.query<{
+    signature: string; incident_id: string; container_name: string;
+    endpoint_id: number | null; endpoint_name: string | null;
+    severity: 'critical' | 'warning' | 'info'; created_at: string; rn: number;
+  }>(`
+    WITH base AS (
+      SELECT id, signature, severity, endpoint_id, endpoint_name, created_at, affected_containers
+      FROM incidents ${whereSQL}
+    ),
+    expanded AS (
+      SELECT b.id AS incident_id, b.signature, b.severity, b.endpoint_id, b.endpoint_name,
+             b.created_at, e.container_name
+      FROM base b
+      CROSS JOIN LATERAL jsonb_array_elements_text(b.affected_containers) AS e(container_name)
+    ),
+    ranked AS (
+      SELECT *,
+             ROW_NUMBER() OVER (
+               PARTITION BY signature
+               ORDER BY (CASE severity WHEN 'critical' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END),
+                        created_at DESC
+             ) AS rn
+      FROM expanded
+    )
+    SELECT signature, incident_id, container_name, endpoint_id, endpoint_name,
+           severity, created_at::text, rn
+    FROM ranked
+    WHERE rn <= ${TOP_CONTAINERS_PER_GROUP}
+  `, params);
+
+  // 3. Endpoint facets
+  const rawFacets = await db.query<{ endpoint_id: number | null; endpoint_name: string | null; incident_count: number }>(`
+    SELECT endpoint_id, endpoint_name, COUNT(*)::int AS incident_count
+    FROM incidents ${whereSQL}
+    GROUP BY endpoint_id, endpoint_name
+    ORDER BY incident_count DESC
+  `, params);
+
+  // 4. Stitch top_containers per signature
+  const topBySig = new Map<string, IncidentGroup['top_containers']>();
+  for (const r of rawTop) {
+    const arr = topBySig.get(r.signature) ?? [];
+    arr.push({
+      incident_id: r.incident_id, container_name: r.container_name,
+      endpoint_id: r.endpoint_id, endpoint_name: r.endpoint_name,
+      severity: r.severity, created_at: r.created_at,
+    });
+    topBySig.set(r.signature, arr);
+  }
+
+  const groups: IncidentGroup[] = rawGroups.map((g) => ({
+    signature: g.signature,
+    label: signatureLabel(g.signature),
+    severity: g.severity,
+    incident_count: g.incident_count,
+    container_count: g.container_count,
+    alert_count: g.alert_count,
+    earliest_at: g.earliest_at,
+    latest_update_at: g.latest_update_at,
+    top_containers: topBySig.get(g.signature) ?? [],
+    all_container_names: g.all_names ?? [],
+    names_truncated: (g.all_names?.length ?? 0) >= ALL_NAMES_CAP && g.container_count > ALL_NAMES_CAP,
+  }));
+
+  const total_active = rawGroups.reduce((sum, g) => sum + g.incident_count, 0);
+
+  return { groups, endpoint_facets: rawFacets, total_active };
+}
+
 export async function getIncidentCount(): Promise<{ active: number; resolved: number; total: number }> {
   const db = getDbForDomain('incidents');
   const activeRow = await db.queryOne<{ count: number }>("SELECT COUNT(*)::integer as count FROM incidents WHERE status = 'active'");

--- a/packages/ai-intelligence/src/services/incident-store.ts
+++ b/packages/ai-intelligence/src/services/incident-store.ts
@@ -98,6 +98,7 @@ export async function addInsightToIncident(incidentId: string, insightId: string
 export interface GetIncidentsOptions {
   status?: 'active' | 'resolved';
   severity?: string;
+  signature?: string;
   limit?: number;
   offset?: number;
 }
@@ -114,6 +115,10 @@ export async function getIncidents(options: GetIncidentsOptions = {}): Promise<I
   if (options.severity) {
     conditions.push('severity = ?');
     params.push(options.severity);
+  }
+  if (options.signature) {
+    conditions.push('signature = ?');
+    params.push(options.signature);
   }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';

--- a/packages/ai-intelligence/src/services/incident-store.ts
+++ b/packages/ai-intelligence/src/services/incident-store.ts
@@ -35,6 +35,7 @@ export interface IncidentInsert {
   correlation_confidence: 'high' | 'medium' | 'low';
   insight_count: number;
   summary: string | null;
+  signature: string;
 }
 
 export async function insertIncident(incident: IncidentInsert): Promise<void> {
@@ -43,9 +44,9 @@ export async function insertIncident(incident: IncidentInsert): Promise<void> {
     INSERT INTO incidents (
       id, title, severity, status, root_cause_insight_id,
       related_insight_ids, affected_containers, endpoint_id, endpoint_name,
-      correlation_type, correlation_confidence, insight_count, summary,
+      correlation_type, correlation_confidence, insight_count, summary, signature,
       created_at, updated_at
-    ) VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+    ) VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
   `, [
     incident.id,
     incident.title,
@@ -59,6 +60,7 @@ export async function insertIncident(incident: IncidentInsert): Promise<void> {
     incident.correlation_confidence,
     incident.insight_count,
     incident.summary,
+    incident.signature,
   ]);
 
   log.debug({ incidentId: incident.id, insightCount: incident.insight_count }, 'Incident created');

--- a/packages/ai-intelligence/src/services/incident-store.ts
+++ b/packages/ai-intelligence/src/services/incident-store.ts
@@ -1,5 +1,6 @@
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
+import { signatureLabel } from './signature.js';
 
 const log = createChildLogger('incident-store');
 
@@ -17,6 +18,8 @@ export interface Incident {
   correlation_confidence: 'high' | 'medium' | 'low';
   insight_count: number;
   summary: string | null;
+  /** NULL for legacy rows backfilled before signature column was NOT NULL */
+  signature: string | null;
   created_at: string;
   updated_at: string;
   resolved_at: string | null;
@@ -181,8 +184,6 @@ export async function resolveIncident(id: string): Promise<void> {
   `, [id]);
   log.info({ incidentId: id }, 'Incident resolved');
 }
-
-import { signatureLabel } from './signature.js';
 
 const TOP_CONTAINERS_PER_GROUP = 10;
 const ALL_NAMES_CAP = 500;

--- a/packages/ai-intelligence/src/services/insights-store.ts
+++ b/packages/ai-intelligence/src/services/insights-store.ts
@@ -25,8 +25,9 @@ export async function insertInsight(insight: InsightInsert): Promise<void> {
     `INSERT INTO insights (
       id, endpoint_id, endpoint_name, container_id, container_name,
       severity, category, title, description, suggested_action,
+      metric_type, detection_method,
       is_acknowledged, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, NOW())`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, NOW())`,
     [
       insight.id,
       insight.endpoint_id,
@@ -38,6 +39,8 @@ export async function insertInsight(insight: InsightInsert): Promise<void> {
       insight.title,
       insight.description,
       insight.suggested_action,
+      insight.metric_type ?? null,
+      insight.detection_method ?? null,
     ],
   );
 
@@ -117,8 +120,9 @@ export async function insertInsights(insights: InsightInsert[]): Promise<Set<str
     INSERT INTO insights (
       id, endpoint_id, endpoint_name, container_id, container_name,
       severity, category, title, description, suggested_action,
+      metric_type, detection_method,
       is_acknowledged, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, NOW())
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, NOW())
   `;
 
   const dedupeSQL = `
@@ -154,6 +158,8 @@ export async function insertInsights(insights: InsightInsert[]): Promise<Set<str
         insight.title,
         insight.description,
         insight.suggested_action,
+        insight.metric_type ?? null,
+        insight.detection_method ?? null,
       ]);
       ids.add(insight.id);
     }

--- a/packages/ai-intelligence/src/services/insights-store.ts
+++ b/packages/ai-intelligence/src/services/insights-store.ts
@@ -15,6 +15,8 @@ export interface InsightInsert {
   title: string;
   description: string;
   suggested_action: string | null;
+  metric_type?: 'cpu' | 'memory' | 'disk' | 'network' | 'restart';
+  detection_method?: 'threshold' | 'ml-anomaly' | 'prediction' | 'health-check' | 'log-pattern' | 'security-scan';
 }
 
 export async function insertInsight(insight: InsightInsert): Promise<void> {

--- a/packages/ai-intelligence/src/services/monitoring-service.ts
+++ b/packages/ai-intelligence/src/services/monitoring-service.ts
@@ -365,6 +365,8 @@ export function createMonitoringService(deps: MonitoringDeps) {
           suggested_action: item.metricType === 'memory'
             ? 'Investigate memory usage patterns and check container configuration'
             : 'Investigate CPU usage patterns and check for process anomalies',
+          metric_type: item.metricType as 'cpu' | 'memory',
+          detection_method: 'ml-anomaly',
         });
       }
 
@@ -409,6 +411,8 @@ export function createMonitoringService(deps: MonitoringDeps) {
               suggested_action: metricType === 'memory'
                 ? 'Check for memory leaks or increase memory limit'
                 : 'Check for runaway processes or increase CPU allocation',
+              metric_type: metricType,
+              detection_method: 'threshold',
             });
           }
         }
@@ -465,6 +469,8 @@ export function createMonitoringService(deps: MonitoringDeps) {
                 suggested_action: metricType === 'memory'
                   ? 'Check for memory leaks or increase memory limit'
                   : 'Check for runaway processes or increase CPU allocation',
+                metric_type: metricType,
+                detection_method: 'ml-anomaly',
               });
               break; // One insight per container for IF detection
             }
@@ -504,6 +510,8 @@ export function createMonitoringService(deps: MonitoringDeps) {
                 suggested_action: forecast.metricType === 'memory'
                   ? 'Consider increasing memory limits or investigating memory consumption patterns before threshold is reached'
                   : 'Consider scaling CPU resources or optimizing workload before threshold is reached',
+                metric_type: forecast.metricType as 'cpu' | 'memory',
+                detection_method: 'prediction',
               });
             }
           }
@@ -569,6 +577,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
                   ? `\n\nError patterns: ${result.errorPatterns.join(', ')}`
                   : ''),
               suggested_action: 'Review container logs for the identified error patterns and address the root cause',
+              detection_method: 'log-pattern',
             });
           }
           if (logAnalysisInsights.length > 0) {
@@ -591,6 +600,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
         title: f.finding.title,
         description: f.finding.description,
         suggested_action: null,
+        detection_method: 'security-scan',
       }));
 
       // 6. Attempt AI analysis (fire-and-forget, gated by AI_ANALYSIS_ENABLED)

--- a/packages/ai-intelligence/src/services/signature.ts
+++ b/packages/ai-intelligence/src/services/signature.ts
@@ -1,0 +1,91 @@
+import type { Insight } from '@dashboard/core/models/monitoring.js';
+
+type DerivableInsight = Pick<Insight, 'category' | 'metric_type' | 'detection_method' | 'title'>;
+
+const SIGNATURE_LABELS: Record<string, string> = {
+  'anomaly:ml-anomaly:cpu': 'Anomalous CPU usage (ML)',
+  'anomaly:ml-anomaly:memory': 'Anomalous memory usage (ML)',
+  'anomaly:threshold:cpu': 'High CPU usage',
+  'anomaly:threshold:memory': 'High memory usage',
+  'predictive:prediction:cpu': 'Predicted CPU exhaustion',
+  'predictive:prediction:memory': 'Predicted memory exhaustion',
+  'predictive:prediction:disk': 'Predicted disk exhaustion',
+  'config:health-check:missing': 'Missing health check',
+  'config:network:host-mode': 'Host network mode',
+  'security:scan': 'Security scan finding',
+  'log:pattern': 'Log pattern detected',
+  'ai:analysis': 'AI analysis finding',
+};
+
+export function deriveSignature(input: DerivableInsight): string {
+  if (input.metric_type && input.detection_method) {
+    return `${input.category}:${input.detection_method}:${input.metric_type}`;
+  }
+  if (input.category === 'security') return 'security:scan';
+  if (input.category === 'log-analysis') return 'log:pattern';
+  if (input.category === 'ai-analysis') return 'ai:analysis';
+  return deriveSignatureFromTitle(input.title);
+}
+
+const TITLE_RULES: Array<{ rx: RegExp; signature: (m: RegExpExecArray) => string }> = [
+  // Predictions: "Predicted memory exhaustion …"
+  {
+    rx: /predicted\s+(cpu|memory|disk)\s+exhaustion/i,
+    signature: (m) => `predictive:prediction:${m[1].toLowerCase()}`,
+  },
+  // Anomalous via ML: "Anomalous cpu usage on "x" (ML-detected)"
+  {
+    rx: /anomalous\s+(cpu|memory|disk)\s+usage[^()]*\(ml-detected\)/i,
+    signature: (m) => `anomaly:ml-anomaly:${m[1].toLowerCase()}`,
+  },
+  // Anomalous threshold: "Anomalous cpu usage on "x"" (no ML qualifier)
+  {
+    rx: /anomalous\s+(cpu|memory|disk)\s+usage/i,
+    signature: (m) => `anomaly:threshold:${m[1].toLowerCase()}`,
+  },
+  // Threshold: "High cpu usage on "x""
+  {
+    rx: /high\s+(cpu|memory|disk)\s+usage/i,
+    signature: (m) => `anomaly:threshold:${m[1].toLowerCase()}`,
+  },
+  // Config: missing health check
+  {
+    rx: /no health check (configured|defined)|missing health check/i,
+    signature: () => 'config:health-check:missing',
+  },
+  // Config: host network mode
+  {
+    rx: /host network mode/i,
+    signature: () => 'config:network:host-mode',
+  },
+];
+
+export function deriveSignatureFromTitle(title: string): string {
+  for (const rule of TITLE_RULES) {
+    const m = rule.rx.exec(title);
+    if (m) return rule.signature(m);
+  }
+  return `unknown:${slugifyTitle(title)}`;
+}
+
+export function slugifyTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[",]/g, '')          // strip commas (URL separator) and quotes
+    .replace(/[^a-z0-9]+/g, '-')   // any non-alnum → dash
+    .replace(/^-+|-+$/g, '')       // trim dashes
+    .slice(0, 80);                  // bound length
+}
+
+export function signatureLabel(signature: string): string {
+  return SIGNATURE_LABELS[signature] ?? humanizeSignature(signature);
+}
+
+function humanizeSignature(signature: string): string {
+  const parts = signature.split(':').map((s) => s.replace(/-/g, ' '));
+  return parts
+    .map((s, i) => (i === 0 ? s.charAt(0).toUpperCase() + s.slice(1) : s))
+    .join(' · ');
+}
+
+export { SIGNATURE_LABELS };

--- a/packages/core/src/db/postgres-migrations/029_add_incident_signature.sql
+++ b/packages/core/src/db/postgres-migrations/029_add_incident_signature.sql
@@ -1,0 +1,12 @@
+-- Migration 029: add `signature` column to incidents
+--
+-- Backs the two-level rollup on the Health & Monitoring page.
+-- Populated at insert time from the source insight's structured
+-- fields (`category`, `metric_type`, `detection_method`).
+--
+-- Phase A only — column add, no indexes here. The
+-- `CREATE INDEX CONCURRENTLY` step lives in
+-- packages/ai-intelligence/scripts/create-incident-signature-indexes.ts
+-- and is invoked outside any transaction at deploy time.
+
+ALTER TABLE incidents ADD COLUMN IF NOT EXISTS signature TEXT;

--- a/packages/core/src/db/postgres-migrations/030_add_insight_structured_fields.sql
+++ b/packages/core/src/db/postgres-migrations/030_add_insight_structured_fields.sql
@@ -1,0 +1,10 @@
+-- Migration 030: add structured signature inputs to insights
+--
+-- The Insight model gained `metric_type` and `detection_method` to drive
+-- the incident signature derivation (see signature.ts). New emissions
+-- write these fields, but the previous schema dropped them on persist.
+-- This migration adds the columns so values flow through to the table
+-- and downstream tooling (backfill, dump-historical-titles) can read them.
+
+ALTER TABLE insights ADD COLUMN IF NOT EXISTS metric_type TEXT;
+ALTER TABLE insights ADD COLUMN IF NOT EXISTS detection_method TEXT;

--- a/packages/core/src/models/monitoring.test.ts
+++ b/packages/core/src/models/monitoring.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { InsightSchema } from './monitoring.js';
+
+describe('InsightSchema', () => {
+  const valid = {
+    id: 'i-123',
+    endpoint_id: 1,
+    endpoint_name: 'edge-1',
+    container_id: 'c-abc',
+    container_name: 'web-server',
+    severity: 'warning' as const,
+    category: 'anomaly',
+    title: 'Anomalous CPU usage',
+    description: 'detail',
+    suggested_action: null,
+    is_acknowledged: 0,
+    created_at: new Date().toISOString(),
+  };
+
+  it('accepts optional metric_type and detection_method', () => {
+    const result = InsightSchema.safeParse({
+      ...valid,
+      metric_type: 'cpu',
+      detection_method: 'ml-anomaly',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metric_type).toBe('cpu');
+      expect(result.data.detection_method).toBe('ml-anomaly');
+    }
+  });
+
+  it('parses without the new optional fields', () => {
+    const result = InsightSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metric_type).toBeUndefined();
+      expect(result.data.detection_method).toBeUndefined();
+    }
+  });
+
+  it('rejects unknown metric_type values', () => {
+    const result = InsightSchema.safeParse({ ...valid, metric_type: 'bogus' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/core/src/models/monitoring.ts
+++ b/packages/core/src/models/monitoring.ts
@@ -13,6 +13,10 @@ export const InsightSchema = z.object({
   suggested_action: z.string().nullable(),
   is_acknowledged: z.number().default(0),
   created_at: z.string(),
+  metric_type: z.enum(['cpu', 'memory', 'disk', 'network', 'restart']).optional(),
+  detection_method: z
+    .enum(['threshold', 'ml-anomaly', 'prediction', 'health-check', 'log-pattern', 'security-scan'])
+    .optional(),
 });
 
 export type Insight = z.infer<typeof InsightSchema>;

--- a/packages/observability/src/routes/prometheus.ts
+++ b/packages/observability/src/routes/prometheus.ts
@@ -103,19 +103,27 @@ async function getCachedSnapshot(): Promise<MetricsSnapshot> {
     [],
   );
 
+  // Subquery disambiguates the metric_kind alias from the insights.metric_type
+  // column (added in migration 030). Prefer the structured column when present
+  // and fall back to title-regex for legacy rows.
   const anomalies = await insightsDb.query<{ container_name: string; metric_type: string; total: number }>(
-    `SELECT
-       container_name,
-       CASE
-         WHEN lower(title) LIKE '%cpu%' THEN 'cpu'
-         WHEN lower(title) LIKE '%memory%' THEN 'memory'
-         ELSE 'unknown'
-       END as metric_type,
-       COUNT(*)::integer as total
-     FROM insights
-     WHERE category = 'anomaly'
-       AND container_name IS NOT NULL
-     GROUP BY container_name, metric_type`,
+    `SELECT container_name, metric_kind AS metric_type, COUNT(*)::integer AS total
+     FROM (
+       SELECT
+         container_name,
+         COALESCE(
+           metric_type,
+           CASE
+             WHEN lower(title) LIKE '%cpu%' THEN 'cpu'
+             WHEN lower(title) LIKE '%memory%' THEN 'memory'
+             ELSE 'unknown'
+           END
+         ) AS metric_kind
+       FROM insights
+       WHERE category = 'anomaly'
+         AND container_name IS NOT NULL
+     ) sub
+     GROUP BY container_name, metric_kind`,
     [],
   );
 


### PR DESCRIPTION
## Summary

Replaces the flat 455-row Active Incidents list on `/health` with a two-level rollup. New `signature` column on `incidents` (populated from structured insight fields) drives a SQL aggregate that returns one row per problem-kind with counts, top-10 worst containers, and the full container-name list for client-side search. New `IncidentGroupsView` renders the grouped UI with summary strip, endpoint chips, expandable groups, search with 250 ms debounce, and per-group "Resolve all" via a new batch endpoint. URL-stateful expand/collapse keeps deep-links refresh-stable.

- Backend: signature column + Phase A/B migration + signature derivation module + drift-corpus tests + `monitoring-service` emits structured fields + correlator writes signature + idempotent backfill + `?signature=` filter on `/api/incidents` + `GET /api/incidents/groups` SQL aggregate with SWR cache + `POST /api/incidents/resolve` batch endpoint with per-id transactions.
- Frontend: `useIncidentGroups` hook + `IncidentGroupsView` component (summary, expand, top-N, "Show all", endpoint chip overflow, debounced search, truncated-group backend fallback) + per-group "Resolve all" with partial-failure UX + `?expand=` URL state. Page swap removes ~400 lines of legacy flat-list state from `ai-monitor.tsx`.
- Engine-side dedup work (refining-prediction emissions) is deferred and tracked separately as #1195.

Spec: `docs/superpowers/specs/2026-05-06-active-incidents-rollup-design.md`
Plan: `docs/superpowers/plans/2026-05-06-active-incidents-rollup.md`

## Test plan

- [ ] CI: lint, typecheck, all workspaces' test suites green (locally: 3,169 tests passing — backend 732, frontend 1,790, core 647)
- [ ] After merge, run the deploy-time index script: `npm run -w @dashboard/ai indexes:incidents` (creates `idx_incidents_signature_status` and `idx_incidents_endpoint_status` via `CREATE INDEX CONCURRENTLY`)
- [ ] Run the backfill: `npm run -w @dashboard/ai backfill:signatures` (populates `signature` for legacy incidents; idempotent, safe to re-run)
- [ ] `SELECT COUNT(*) FROM incidents WHERE signature IS NULL` returns 0
- [ ] `/health` page renders new rollup view; existing per-incident drill-down still works
- [ ] Per-row resolve, per-group "Resolve all", and multi-select bulk resolve all update counts and refetch
- [ ] Endpoint chip row appears for multi-host fleets; `+N more` dropdown handles >8 endpoints
- [ ] Search by container name finds matches in the long tail (not just top-10) and auto-expands the matching group
- [ ] URL params (`range`, `endpoint`, `expand`) survive refresh and deep-linking

## Follow-ups

- [#1195](https://github.com/kenhaesler/ai-portainer-dashboard/issues/1195) — reduce duplicate emissions in the correlation engine (data-driven, after one week of `signature` telemetry)
- Signature `NOT NULL` enforcement (one week after this PR; trivial migration)
- Backend container-name search `?q=` for groups with `names_truncated: true`
- Resolved-incidents view redesign (separate PR)