### PR TITLE
fix(incidents): correlation engine dedup fixes (#1195)

### DIFF
--- a/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
@@ -172,7 +172,7 @@ describe('correlator — long-running anomaly joins existing incident regardless
         insight_count, summary, signature, created_at, updated_at, root_cause_insight_id
       ) VALUES (
         'inc-old', 'Anomalous cpu usage on "c1" (ML-detected)', 'warning', 'active',
-        '["seed-insight"]'::jsonb, '["c1"]'::jsonb,
+        '["seed-insight"]'::jsonb, '["web-app"]'::jsonb,
         1, 'eA', 'temporal', 'medium', 1, NULL,
         'anomaly:ml-anomaly:cpu', NOW() - INTERVAL '30 minutes',
         NOW() - INTERVAL '30 minutes', 'seed-insight'
@@ -223,7 +223,7 @@ describe('correlator — long-running anomaly joins existing incident regardless
         insight_count, summary, signature, created_at, updated_at, root_cause_insight_id
       ) VALUES (
         'inc-cpu', 'cpu', 'warning', 'active',
-        '["seed-cpu"]'::jsonb, '["c1"]'::jsonb, 1, 'eA',
+        '["seed-cpu"]'::jsonb, '["web-app"]'::jsonb, 1, 'eA',
         'temporal', 'medium', 1, NULL, 'anomaly:ml-anomaly:cpu',
         NOW() - INTERVAL '10 minutes', NOW() - INTERVAL '10 minutes', 'seed-cpu'
       )

--- a/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
@@ -54,8 +54,6 @@ function makeInsight(overrides: Partial<Insight> & Pick<Insight, 'id' | 'contain
     description: 'd',
     suggested_action: null,
     is_acknowledged: 0,
-    metric_type: undefined,
-    detection_method: undefined,
     ...overrides,
   } as Insight;
 }

--- a/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
@@ -45,6 +45,21 @@ import { correlateInsights } from '../services/incident-correlator.js';
 import { insertInsights, type InsightInsert } from '../services/insights-store.js';
 import type { Insight } from '@dashboard/core/models/monitoring.js';
 
+function makeInsight(overrides: Partial<Insight> & Pick<Insight, 'id' | 'container_id' | 'container_name' | 'category' | 'created_at'>): Insight {
+  return {
+    endpoint_id: 1,
+    endpoint_name: 'eA',
+    severity: 'warning',
+    title: '',
+    description: 'd',
+    suggested_action: null,
+    is_acknowledged: 0,
+    metric_type: undefined,
+    detection_method: undefined,
+    ...overrides,
+  } as Insight;
+}
+
 beforeAll(async () => { testDb = await getTestDb(); });
 afterAll(async () => { await closeTestDb(); });
 beforeEach(async () => { await truncateTestTables(['incidents', 'insights']); });
@@ -135,5 +150,99 @@ describe('correlateInsights — writes signature', () => {
     expect(incidentRows).toHaveLength(1);
     // Title regex: "Anomalous memory usage" → anomaly:threshold:memory
     expect(incidentRows[0].signature).toBe('anomaly:threshold:memory');
+  });
+});
+
+describe('correlator — long-running anomaly joins existing incident regardless of age', () => {
+  it('absorbs a new insight into an active incident older than the 5-minute correlation window', async () => {
+    // Seed the original insight FIRST (FK: incidents.root_cause_insight_id → insights.id).
+    await testDb.execute(`
+      INSERT INTO insights (id, endpoint_id, endpoint_name, container_id, container_name,
+                            severity, category, title, description, suggested_action,
+                            metric_type, detection_method, is_acknowledged, created_at)
+      VALUES ('seed-insight', 1, 'eA', 'c1', 'web-app', 'warning', 'anomaly',
+              'Anomalous cpu usage on "c1" (ML-detected)', '...', NULL,
+              'cpu', 'ml-anomaly', false, NOW() - INTERVAL '30 minutes')
+    `);
+    // Seed an active incident created 30 minutes ago for c1 + cpu ML signature.
+    await testDb.execute(`
+      INSERT INTO incidents (
+        id, title, severity, status, related_insight_ids, affected_containers,
+        endpoint_id, endpoint_name, correlation_type, correlation_confidence,
+        insight_count, summary, signature, created_at, updated_at, root_cause_insight_id
+      ) VALUES (
+        'inc-old', 'Anomalous cpu usage on "c1" (ML-detected)', 'warning', 'active',
+        '["seed-insight"]'::jsonb, '["c1"]'::jsonb,
+        1, 'eA', 'temporal', 'medium', 1, NULL,
+        'anomaly:ml-anomaly:cpu', NOW() - INTERVAL '30 minutes',
+        NOW() - INTERVAL '30 minutes', 'seed-insight'
+      )
+    `);
+
+    const newInsight: Insight = makeInsight({
+      id: 'fresh',
+      container_id: 'c1',
+      container_name: 'web-app',
+      category: 'anomaly',
+      metric_type: 'cpu',
+      detection_method: 'ml-anomaly',
+      title: 'Anomalous cpu usage on "c1" (ML-detected)',
+      created_at: new Date().toISOString(),
+    });
+
+    const result = await correlateInsights([newInsight]);
+    expect(result.insightsGrouped).toBe(1);
+    expect(result.insightsUngrouped).toBe(0);
+
+    // The new insight is now part of the existing 30-minute-old incident.
+    const updated = await testDb.queryOne<{ related_insight_ids: string[]; insight_count: number }>(
+      'SELECT related_insight_ids, insight_count FROM incidents WHERE id = ?',
+      ['inc-old'],
+    );
+    expect(updated?.related_insight_ids).toContain('fresh');
+    // insight_count = related_insight_ids.length + 1 (root cause); seeded with
+    // ["seed-insight"] + now "fresh" appended → 2 related + 1 root = 3.
+    expect(updated?.insight_count).toBe(3);
+  });
+
+  it('does NOT join an active incident when the signature differs', async () => {
+    // CPU incident already exists, new memory anomaly should NOT join it.
+    // Seed insight FIRST (FK: incidents.root_cause_insight_id → insights.id).
+    await testDb.execute(`
+      INSERT INTO insights (id, endpoint_id, endpoint_name, container_id, container_name,
+                            severity, category, title, description, suggested_action,
+                            metric_type, detection_method, is_acknowledged, created_at)
+      VALUES ('seed-cpu', 1, 'eA', 'c1', 'web-app', 'warning', 'anomaly',
+              'Anomalous cpu usage on "c1" (ML-detected)', '...', NULL,
+              'cpu', 'ml-anomaly', false, NOW() - INTERVAL '10 minutes')
+    `);
+    await testDb.execute(`
+      INSERT INTO incidents (
+        id, title, severity, status, related_insight_ids, affected_containers,
+        endpoint_id, endpoint_name, correlation_type, correlation_confidence,
+        insight_count, summary, signature, created_at, updated_at, root_cause_insight_id
+      ) VALUES (
+        'inc-cpu', 'cpu', 'warning', 'active',
+        '["seed-cpu"]'::jsonb, '["c1"]'::jsonb, 1, 'eA',
+        'temporal', 'medium', 1, NULL, 'anomaly:ml-anomaly:cpu',
+        NOW() - INTERVAL '10 minutes', NOW() - INTERVAL '10 minutes', 'seed-cpu'
+      )
+    `);
+
+    const memoryAnomaly: Insight = makeInsight({
+      id: 'fresh-mem',
+      container_id: 'c1',
+      container_name: 'web-app',
+      category: 'anomaly',
+      metric_type: 'memory',
+      detection_method: 'ml-anomaly',
+      title: 'Anomalous memory usage on "c1" (ML-detected)',
+      created_at: new Date().toISOString(),
+    });
+
+    const result = await correlateInsights([memoryAnomaly]);
+    // New memory anomaly is ungrouped (different signature than existing cpu incident).
+    expect(result.insightsGrouped).toBe(0);
+    expect(result.insightsUngrouped).toBe(1);
   });
 });

--- a/packages/ai-intelligence/src/__tests__/incident-correlator.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-correlator.test.ts
@@ -223,6 +223,37 @@ describe('incident-correlator', () => {
       expect(call.summary).toContain('2');
     });
 
+    it('cascade gate uses structured insight.metric_type when present, not the title regex', async () => {
+      // Both titles match the regex with the SAME metric word "cpu", so the
+      // legacy regex-based path would conclude both are CPU anomalies and skip
+      // the cascade. Structured metric_type fields say one is cpu, the other
+      // memory — so the cascade gate should fire when using structured fields.
+      const cpuAnomaly = makeInsight({
+        id: 'i-cpu',
+        container_id: 'c1', container_name: 'app-1',
+        endpoint_id: 1,
+        category: 'anomaly', metric_type: 'cpu', detection_method: 'ml-anomaly',
+        title: 'Anomalous cpu usage on "app-1" (ML-detected)',
+        severity: 'critical',
+      });
+      const memoryAnomaly = makeInsight({
+        id: 'i-mem',
+        container_id: 'c2', container_name: 'app-2',
+        endpoint_id: 1,
+        category: 'anomaly', metric_type: 'memory', detection_method: 'ml-anomaly',
+        // Title says "cpu" but the structured field says memory — the structured
+        // field is authoritative.
+        title: 'Anomalous cpu usage on "app-2" (ML-detected)',
+        severity: 'critical',
+      });
+
+      const result = await correlateInsights([cpuAnomaly, memoryAnomaly]);
+      // Two distinct metric types on two containers → cascade gate passes,
+      // a single multi-insight incident is created (not two singletons).
+      expect(result.incidentsCreated).toBe(1);
+      expect(result.insightsGrouped).toBe(2);
+    });
+
     it('should add insight to existing incident when match found', async () => {
       mockedGetActiveIncidentForContainer.mockResolvedValueOnce({
         id: 'existing-incident',

--- a/packages/ai-intelligence/src/__tests__/insights-store.test.ts
+++ b/packages/ai-intelligence/src/__tests__/insights-store.test.ts
@@ -103,6 +103,81 @@ describe('insights-store', () => {
       expect(rows).toHaveLength(2); // original-1 + unique-1
     });
 
+    it('deduplicates predictions whose title carries a refining ETA, by (category, metric_type, detection_method)', async () => {
+      const first: InsightInsert = makeInsight({
+        id: 'pred-1',
+        category: 'predictive',
+        metric_type: 'memory',
+        detection_method: 'prediction',
+        title: 'Predicted memory exhaustion on "web-app" ~24h',
+      });
+      const second: InsightInsert = makeInsight({
+        id: 'pred-2',
+        category: 'predictive',
+        metric_type: 'memory',
+        detection_method: 'prediction',
+        title: 'Predicted memory exhaustion on "web-app" ~20h',
+      });
+
+      const insertedIds = await insertInsights([first]);
+      expect(insertedIds.has('pred-1')).toBe(true);
+
+      const insertedIdsAgain = await insertInsights([second]);
+      expect(insertedIdsAgain.has('pred-2')).toBe(false);
+
+      const rows = await testDb.query<{ id: string }>('SELECT id FROM insights WHERE container_id = ?', ['c1']);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe('pred-1');
+    });
+
+    it('does NOT dedupe when category matches but metric_type differs (CPU prediction vs memory prediction)', async () => {
+      const cpu: InsightInsert = makeInsight({
+        id: 'pred-cpu', category: 'predictive', metric_type: 'cpu', detection_method: 'prediction',
+        title: 'Predicted CPU exhaustion on "web-app"',
+      });
+      const memory: InsightInsert = makeInsight({
+        id: 'pred-mem', category: 'predictive', metric_type: 'memory', detection_method: 'prediction',
+        title: 'Predicted memory exhaustion on "web-app"',
+      });
+
+      await insertInsights([cpu]);
+      await insertInsights([memory]);
+
+      const rows = await testDb.query<{ id: string }>(
+        'SELECT id FROM insights WHERE container_id = ? ORDER BY id',
+        ['c1'],
+      );
+      expect(rows.map((r) => r.id).sort()).toEqual(['pred-cpu', 'pred-mem']);
+    });
+
+    it('falls back to title-based dedup when metric_type and detection_method are both null (legacy insights)', async () => {
+      const first: InsightInsert = makeInsight({
+        id: 'leg-1',
+        category: 'security',
+        title: 'Vulnerable image: foo:1.2.3',
+      });
+      const second: InsightInsert = makeInsight({
+        id: 'leg-2',
+        category: 'security',
+        title: 'Vulnerable image: foo:1.2.3',
+      });
+      const different: InsightInsert = makeInsight({
+        id: 'leg-3',
+        category: 'security',
+        title: 'Vulnerable image: bar:9.9.9',
+      });
+
+      await insertInsights([first]);
+      await insertInsights([second]);
+      await insertInsights([different]);
+
+      const rows = await testDb.query<{ id: string }>(
+        'SELECT id FROM insights WHERE container_id = ? ORDER BY id',
+        ['c1'],
+      );
+      expect(rows.map((r) => r.id).sort()).toEqual(['leg-1', 'leg-3']);
+    });
+
     it('skips deduplication for insights without container_id', async () => {
       const insights = [makeInsight({ id: 'no-container', container_id: null })];
 

--- a/packages/ai-intelligence/src/services/incident-correlator.ts
+++ b/packages/ai-intelligence/src/services/incident-correlator.ts
@@ -70,7 +70,7 @@ export async function correlateInsights(
       const sig = deriveSignature(insight);
       const existing = await getActiveIncidentForContainer(insight.container_name, sig);
       if (existing) {
-        await addInsightToIncident(existing.id, insight.id, insight.container_name ?? undefined);
+        await addInsightToIncident(existing.id, insight.id, insight.container_name);
         result.insightsGrouped = 1;
         log.debug({ incidentId: existing.id, insightId: insight.id }, 'Added insight to existing incident');
         return result;
@@ -142,7 +142,7 @@ export async function correlateInsights(
         const sig = deriveSignature(insight);
         const existing = await getActiveIncidentForContainer(insight.container_name, sig);
         if (existing) {
-          await addInsightToIncident(existing.id, insight.id, insight.container_name ?? undefined);
+          await addInsightToIncident(existing.id, insight.id, insight.container_name);
           result.insightsGrouped++;
           continue;
         }

--- a/packages/ai-intelligence/src/services/incident-correlator.ts
+++ b/packages/ai-intelligence/src/services/incident-correlator.ts
@@ -236,7 +236,7 @@ function groupByCorrelation(
       // Require at least 2 distinct anomaly types (e.g., cpu + memory)
       // to avoid cascade alerts from the same metric spiking on multiple containers
       const distinctTypes = new Set(
-        cascadeInsights.map((i) => extractMetricType(i.title)),
+        cascadeInsights.map((i) => extractMetricType(i)),
       );
 
       if (distinctTypes.size >= 2) {
@@ -268,13 +268,19 @@ function groupByCorrelation(
 }
 
 /**
- * Extract the metric type from an anomaly insight title.
- * Titles follow the pattern: 'Anomalous cpu usage on "container"'
- * Falls back to the full title if pattern doesn't match.
+ * Extract the metric type from an anomaly insight.
+ *
+ * Reads the structured `insight.metric_type` field first (populated by
+ * monitoring-service.ts since migration 030). Falls back to the legacy
+ * title regex (`Anomalous <metric> usage`) for older insights that
+ * predate the structured field. The title fallback returns the full
+ * title when the regex doesn't match — same behaviour as before, kept
+ * for cascade-gate continuity on legacy data.
  */
-function extractMetricType(title: string): string {
-  const match = /anomalous\s+(\w+)\s+usage/i.exec(title);
-  return match ? match[1].toLowerCase() : title;
+function extractMetricType(insight: Insight): string {
+  if (insight.metric_type) return insight.metric_type;
+  const match = /anomalous\s+(\w+)\s+usage/i.exec(insight.title);
+  return match ? match[1].toLowerCase() : insight.title;
 }
 
 function groupByContainerAndMetric(insights: Insight[]): Insight[][] {

--- a/packages/ai-intelligence/src/services/incident-correlator.ts
+++ b/packages/ai-intelligence/src/services/incident-correlator.ts
@@ -66,9 +66,9 @@ export async function correlateInsights(
   if (anomalyInsights.length === 1) {
     const insight = anomalyInsights[0];
     // Check if it fits into an existing active incident
-    if (insight.container_id) {
+    if (insight.container_name) {
       const sig = deriveSignature(insight);
-      const existing = await getActiveIncidentForContainer(insight.container_id, sig);
+      const existing = await getActiveIncidentForContainer(insight.container_name, sig);
       if (existing) {
         await addInsightToIncident(existing.id, insight.id, insight.container_name ?? undefined);
         result.insightsGrouped = 1;
@@ -138,9 +138,9 @@ export async function correlateInsights(
     if (group.insights.length < 2) {
       // Single insight — check for existing incident to join
       const insight = group.insights[0];
-      if (insight.container_id) {
+      if (insight.container_name) {
         const sig = deriveSignature(insight);
-        const existing = await getActiveIncidentForContainer(insight.container_id, sig);
+        const existing = await getActiveIncidentForContainer(insight.container_name, sig);
         if (existing) {
           await addInsightToIncident(existing.id, insight.id, insight.container_name ?? undefined);
           result.insightsGrouped++;

--- a/packages/ai-intelligence/src/services/incident-correlator.ts
+++ b/packages/ai-intelligence/src/services/incident-correlator.ts
@@ -67,7 +67,8 @@ export async function correlateInsights(
     const insight = anomalyInsights[0];
     // Check if it fits into an existing active incident
     if (insight.container_id) {
-      const existing = await getActiveIncidentForContainer(insight.container_id, correlationWindowMinutes);
+      const sig = deriveSignature(insight);
+      const existing = await getActiveIncidentForContainer(insight.container_id, sig);
       if (existing) {
         await addInsightToIncident(existing.id, insight.id, insight.container_name ?? undefined);
         result.insightsGrouped = 1;
@@ -138,7 +139,8 @@ export async function correlateInsights(
       // Single insight — check for existing incident to join
       const insight = group.insights[0];
       if (insight.container_id) {
-        const existing = await getActiveIncidentForContainer(insight.container_id, correlationWindowMinutes);
+        const sig = deriveSignature(insight);
+        const existing = await getActiveIncidentForContainer(insight.container_id, sig);
         if (existing) {
           await addInsightToIncident(existing.id, insight.id, insight.container_name ?? undefined);
           result.insightsGrouped++;

--- a/packages/ai-intelligence/src/services/incident-store.ts
+++ b/packages/ai-intelligence/src/services/incident-store.ts
@@ -139,41 +139,35 @@ export async function getIncident(id: string): Promise<Incident | null> {
   return db.queryOne<Incident>('SELECT * FROM incidents WHERE id = ?', [id]);
 }
 
+/**
+ * Find an active incident that already covers `(signature, containerId)`.
+ *
+ * Matches `incidents.signature = ? AND status = 'active' AND containers
+ * include containerId` regardless of incident age. The previous version
+ * filtered to incidents created within `withinMinutes` (default 5), which
+ * caused continuous-emission scenarios (a 1-hour-long anomaly) to spawn
+ * dozens of ungrouped singletons after the original incident aged past
+ * the window. Fixed in #1195.
+ *
+ * Returns the most recently updated matching incident if multiple exist
+ * (same signature on same container is rare but possible across
+ * resolved-then-reopened cycles).
+ */
 export async function getActiveIncidentForContainer(
   containerId: string,
-  withinMinutes: number,
+  signature: string,
 ): Promise<Incident | undefined> {
   const db = getDbForDomain('incidents');
-  // Find an active incident that includes this container and was created recently
   const incidents = await db.query<Incident>(`
     SELECT * FROM incidents
     WHERE status = 'active'
-      AND created_at >= NOW() + (? || ' minutes')::INTERVAL
-    ORDER BY created_at DESC
-  `, [`-${withinMinutes}`]);
+      AND signature = ?
+      AND affected_containers @> ?::jsonb
+    ORDER BY updated_at DESC
+    LIMIT 1
+  `, [signature, JSON.stringify([containerId])]);
 
-  // Check if any incident's affected containers or related insights reference this container
-  for (const incident of incidents) {
-    if (incident.endpoint_id !== null) {
-      // Check related insights for matching container
-      const relatedIds: string[] = incident.related_insight_ids;
-      const rootId = incident.root_cause_insight_id;
-      const allIds = rootId ? [rootId, ...relatedIds] : relatedIds;
-
-      if (allIds.length === 0) continue;
-
-      const placeholders = allIds.map(() => '?').join(',');
-      const match = await db.queryOne(`
-        SELECT 1 FROM insights
-        WHERE id IN (${placeholders}) AND container_id = ?
-        LIMIT 1
-      `, [...allIds, containerId]);
-
-      if (match) return incident;
-    }
-  }
-
-  return undefined;
+  return incidents[0];
 }
 
 export async function resolveIncident(id: string): Promise<void> {

--- a/packages/ai-intelligence/src/services/incident-store.ts
+++ b/packages/ai-intelligence/src/services/incident-store.ts
@@ -140,21 +140,24 @@ export async function getIncident(id: string): Promise<Incident | null> {
 }
 
 /**
- * Find an active incident that already covers `(signature, containerId)`.
+ * Find an active incident that already covers `(signature, containerName)`.
  *
- * Matches `incidents.signature = ? AND status = 'active' AND containers
- * include containerId` regardless of incident age. The previous version
- * filtered to incidents created within `withinMinutes` (default 5), which
- * caused continuous-emission scenarios (a 1-hour-long anomaly) to spawn
- * dozens of ungrouped singletons after the original incident aged past
- * the window. Fixed in #1195.
+ * Matches `incidents.signature = ? AND status = 'active' AND
+ * affected_containers @> [containerName]` regardless of incident age. The
+ * `affected_containers` column stores container NAMES (not container IDs)
+ * — see other queries in this file that lateral-unnest the column with the
+ * `container_name` alias, and `buildIncident()` in incident-correlator.ts
+ * which populates it from `insight.container_name`.
  *
- * Returns the most recently updated matching incident if multiple exist
- * (same signature on same container is rare but possible across
- * resolved-then-reopened cycles).
+ * The previous implementation filtered to incidents created within
+ * `withinMinutes` (default 5), which caused continuous-emission scenarios
+ * (a 1-hour-long anomaly) to spawn dozens of ungrouped singletons after
+ * the original incident aged past the window. Fixed in #1195.
+ *
+ * Returns the most recently updated matching incident if multiple exist.
  */
 export async function getActiveIncidentForContainer(
-  containerId: string,
+  containerName: string,
   signature: string,
 ): Promise<Incident | undefined> {
   const db = getDbForDomain('incidents');
@@ -165,7 +168,7 @@ export async function getActiveIncidentForContainer(
       AND affected_containers @> ?::jsonb
     ORDER BY updated_at DESC
     LIMIT 1
-  `, [signature, JSON.stringify([containerId])]);
+  `, [signature, JSON.stringify([containerName])]);
 
   return incidents[0];
 }

--- a/packages/ai-intelligence/src/services/insights-store.ts
+++ b/packages/ai-intelligence/src/services/insights-store.ts
@@ -4,6 +4,9 @@ import type { Insight } from '@dashboard/core/models/monitoring.js';
 
 const log = createChildLogger('insights-store');
 
+/** Minutes within which a duplicate insight is suppressed. */
+const DEDUP_WINDOW_MINUTES = 60;
+
 export interface InsightInsert {
   id: string;
   endpoint_id: number | null;
@@ -141,7 +144,7 @@ export async function insertInsights(insights: InsightInsert[]): Promise<Set<str
       AND category = ?
       AND metric_type = ?
       AND detection_method = ?
-      AND created_at >= NOW() - INTERVAL '60 minutes'
+      AND created_at >= NOW() - (${DEDUP_WINDOW_MINUTES} || ' minutes')::INTERVAL
   `;
 
   const dedupeTitleSQL = `
@@ -149,7 +152,7 @@ export async function insertInsights(insights: InsightInsert[]): Promise<Set<str
     WHERE container_id = ?
       AND category = ?
       AND title = ?
-      AND created_at >= NOW() - INTERVAL '60 minutes'
+      AND created_at >= NOW() - (${DEDUP_WINDOW_MINUTES} || ' minutes')::INTERVAL
   `;
 
   const insertedIds = await db.transaction(async (txDb) => {

--- a/packages/ai-intelligence/src/services/insights-store.ts
+++ b/packages/ai-intelligence/src/services/insights-store.ts
@@ -108,8 +108,14 @@ export async function getRecentInsights(minutes: number, limit: number = 500): P
 
 /**
  * Batch insert insights in a single transaction with deduplication.
- * Skips insights where (container_id, category, title) already exists within the last 60 minutes.
- * Returns the set of actually-inserted insight IDs so callers can filter downstream operations.
+ *
+ * Within the last 60 minutes, skips insights that match an existing row by:
+ * - `(container_id, category, metric_type, detection_method)` when both
+ *   structured fields are present (anomaly / threshold / prediction emitters)
+ * - `(container_id, category, title)` otherwise (legacy / free-text insights)
+ *
+ * Returns the set of actually-inserted insight IDs so callers can filter
+ * downstream operations.
  */
 export async function insertInsights(insights: InsightInsert[]): Promise<Set<string>> {
   if (insights.length === 0) return new Set();
@@ -125,9 +131,24 @@ export async function insertInsights(insights: InsightInsert[]): Promise<Set<str
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, NOW())
   `;
 
-  const dedupeSQL = `
+  // Two dedup queries: structured for insights that carry metric_type +
+  // detection_method (anomaly, threshold, prediction — title-stable signature),
+  // and the legacy title-based key for insights without those columns
+  // (security scans, free-text log patterns, ai-analysis findings).
+  const dedupeStructuredSQL = `
     SELECT COUNT(*)::integer as cnt FROM insights
-    WHERE container_id = ? AND category = ? AND title = ?
+    WHERE container_id = ?
+      AND category = ?
+      AND metric_type = ?
+      AND detection_method = ?
+      AND created_at >= NOW() - INTERVAL '60 minutes'
+  `;
+
+  const dedupeTitleSQL = `
+    SELECT COUNT(*)::integer as cnt FROM insights
+    WHERE container_id = ?
+      AND category = ?
+      AND title = ?
       AND created_at >= NOW() - INTERVAL '60 minutes'
   `;
 
@@ -136,13 +157,25 @@ export async function insertInsights(insights: InsightInsert[]): Promise<Set<str
     for (const insight of insights) {
       // Deduplication check
       if (insight.container_id) {
-        const row = await txDb.queryOne<{ cnt: number }>(dedupeSQL, [
-          insight.container_id,
-          insight.category,
-          insight.title,
-        ]);
+        const useStructuredKey = insight.metric_type && insight.detection_method;
+        const row = useStructuredKey
+          ? await txDb.queryOne<{ cnt: number }>(dedupeStructuredSQL, [
+              insight.container_id,
+              insight.category,
+              insight.metric_type,
+              insight.detection_method,
+            ])
+          : await txDb.queryOne<{ cnt: number }>(dedupeTitleSQL, [
+              insight.container_id,
+              insight.category,
+              insight.title,
+            ]);
         if (row && row.cnt > 0) {
-          log.debug({ containerId: insight.container_id, category: insight.category, title: insight.title }, 'Duplicate insight skipped');
+          log.debug({
+            containerId: insight.container_id,
+            category: insight.category,
+            dedupKey: useStructuredKey ? 'structured' : 'title',
+          }, 'Duplicate insight skipped');
           continue;
         }
       }

--- a/packages/ai-intelligence/src/services/insights-store.ts
+++ b/packages/ai-intelligence/src/services/insights-store.ts
@@ -160,7 +160,7 @@ export async function insertInsights(insights: InsightInsert[]): Promise<Set<str
     for (const insight of insights) {
       // Deduplication check
       if (insight.container_id) {
-        const useStructuredKey = insight.metric_type && insight.detection_method;
+        const useStructuredKey = Boolean(insight.metric_type && insight.detection_method);
         const row = useStructuredKey
           ? await txDb.queryOne<{ cnt: number }>(dedupeStructuredSQL, [
               insight.container_id,


### PR DESCRIPTION
## Summary

Fixes the three code-level duplication bugs in the incident correlation engine documented in [#1195 "Confirmed Issues"](https://github.com/kenhaesler/ai-portainer-dashboard/issues/1195) so refining predictions and long-running anomalies stop emitting duplicate insights and ungrouped singletons.

The "Open for Research" items in the same issue (non-anomaly correlation expansion, prediction TTL audit, cooldown sweep mapping, alerts-per-container telemetry) need ≥1 week of production `signature` data from the merged UX rollup and are explicitly out of scope.

## Changes

### Fix 1 — Insight dedup keys on structured signature, not literal title (`faba9502`, `26bc1028`)

`insertInsights()` now dedupes on `(container_id, category, metric_type, detection_method)` when both structured fields are present, falling back to the legacy `(container_id, category, title)` key for insights without those columns. Refining prediction ETAs (`~24h`, `~20h`, `~16h`) collapse to one insight per `(container, signature)` per 60-minute window. The 60-minute window is now a `DEDUP_WINDOW_MINUTES` constant.

### Fix 2 — Active-incident lookup by signature, regardless of age (`8e2a5467`, `b3c757c9`)

`getActiveIncidentForContainer(containerId, withinMinutes)` is replaced by `getActiveIncidentForContainer(containerName, signature)`, matching `(status='active', signature, container)` regardless of incident age. The previous 5-minute window meant a 1-hour anomaly produced 1 incident in the first 5 minutes and then 11 ungrouped singletons over the next 55. The follow-up commit corrects a bug-of-a-bug — `affected_containers` stores container *names*, not IDs, so the parameter and both correlator callers were renamed accordingly.

### Fix 3 — Cascade gating reads structured `metric_type`, not title regex (`654e0379`)

`extractMetricType(title: string)` is replaced by `extractMetricType(insight: Insight)`, reading `insight.metric_type` first and falling back to the title regex only for legacy insights. Title-copy changes (translations, new metric kinds) no longer silently break cascade detection.

## Test Plan

- [x] Backend: `cd packages/ai-intelligence && POSTGRES_TEST_URL=... npx vitest run` — **758/758 passing**
- [x] Backend typecheck (ai-intelligence package): **13 pre-existing test-file errors, no new errors introduced** (verified by re-running `tsc -b` against base `aad13e83`).
- [x] All three bugs each ship with at least one regression test:
  - `insights-store.test.ts` — 3 new cases for refining-ETA dedup, differing metric_type, legacy fallback.
  - `incident-correlator-db.test.ts` — 2 new cases for long-running-anomaly absorption, signature-mismatch isolation.
  - `incident-correlator.test.ts` — 1 new case for structured-`metric_type`-overrides-title.

## Out of Scope (deferred)

- Confirmed Issue 2 from the issue body (correlation only fires for `category === 'anomaly'`) is partly an "Open for Research" decision. The fix here only ensures dedup at insight-insertion time catches refining predictions; whether `predictive` / `security` / `ai-analysis` insights should join incidents needs production data.
- The 5-item "Open for Research" table in #1195 needs ≥1 week of `signature` data after the UX rollup merge.
- Per-signature `alerts_per_container` telemetry — research-driven follow-up.

## Implementation Plan

`docs/superpowers/plans/2026-05-07-incident-engine-dedup-1195.md` (in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
