### PR TITLE
fix(llm): wire per-feature model/temperature through chatStream

### DIFF
--- a/docs/superpowers/plans/2026-05-08-per-feature-llm-model-wiring.md
+++ b/docs/superpowers/plans/2026-05-08-per-feature-llm-model-wiring.md
@@ -1,0 +1,720 @@
+# Per-Feature LLM Model Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire every LLM consumer through the existing feature-aware `getEffectiveLlmConfig(feature)` resolver so per-feature model and temperature overrides configured in Prompt Profiles actually take effect at runtime.
+
+**Architecture:** Single-PR refactor. Switch the resolver import in `chatStream` (the funnel for ~12 of ~15 inference sites) to the feature-aware variant in `prompt-store.ts`, add an optional `feature` parameter, and update each call site to pass its feature key. Update the `LLMInterface` contract so cross-domain consumers (security, observability, operations) can pass through DI. Spread `temperature` into request bodies when the resolver returns one.
+
+**Tech Stack:** TypeScript, Vitest, Fastify 5, OpenAI-compatible chat-completions API. No new dependencies. No DB migration. No UI changes.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-per-feature-llm-model-wiring-design.md`
+
+---
+
+## File Structure
+
+**Modified files (12):**
+
+- `packages/ai-intelligence/src/services/llm-client.ts` — add `feature` param to `chatStream`/`chatStreamInner`, switch resolver, spread temperature.
+- `packages/contracts/src/interfaces/llm-interface.ts` — add optional `feature` param to `chatStream`.
+- `packages/ai-intelligence/src/sockets/llm-chat.ts` — direct fetch site; switch resolver, pass `chat_assistant`, spread temperature.
+- `packages/ai-intelligence/src/routes/llm.ts` — direct fetch sites; switch resolver for AI search (`command_palette`) and test-prompt (use request `feature`); spread temperature where applicable.
+- `packages/ai-intelligence/src/routes/correlations.ts` — pass `correlation_insights` to `chatStream`.
+- `packages/ai-intelligence/src/services/log-analyzer.ts` — pass `log_analyzer`.
+- `packages/ai-intelligence/src/services/monitoring-service.ts` — pass `monitoring_analysis`.
+- `packages/ai-intelligence/src/services/anomaly-explainer.ts` — pass `anomaly_explainer` (two call sites).
+- `packages/ai-intelligence/src/services/incident-summarizer.ts` — pass `incident_summarizer`.
+- `packages/ai-intelligence/src/services/investigation-service.ts` — pass `root_cause`.
+- `packages/security/src/services/pcap-analysis-service.ts` — pass `pcap_analyzer`.
+- `packages/observability/src/routes/forecasts.ts` — pass `capacity_forecast`.
+- `packages/observability/src/routes/metrics.ts` — pass `metrics_summary`.
+- `packages/operations/src/services/remediation-service.ts` — pass `remediation` (two call sites).
+
+**New test:**
+
+- `packages/ai-intelligence/src/__tests__/anomaly-explainer.test.ts` — extend with a profile-driven model test (or add a new test file `__tests__/per-feature-model-wiring.test.ts` if cleaner).
+
+**No deletions. No new production source files.**
+
+The `feature` parameter type is `string` in the contract (matching the existing `getEffectivePrompt(domain: string)` precedent). Inside ai-intelligence, callers use the typed `PromptFeature` union. The feature-aware resolver in `prompt-store.ts` already accepts `PromptFeature | undefined`; callers from outside the package pass narrower string literals, validated by the resolver's ignore-unknown-feature behavior (a setting key like `prompts.<unknown>.model` simply doesn't exist, falling back to global).
+
+---
+
+## Sanity Check Before Starting
+
+- [ ] **Step 0a: Confirm branch is `dev` (current state)**
+
+The brainstorming session left a doc commit on `dev`. The user opted to leave it. New work continues on `dev` per their instruction.
+
+Run: `git status && git log --oneline -3`
+Expected: clean tree (or only untracked plan files), HEAD = `9ceddccc docs(spec): per-feature LLM model wiring fix`.
+
+- [ ] **Step 0b: Confirm baseline tests pass**
+
+Run: `cd packages/ai-intelligence && npx vitest run src/__tests__/prompt-store.test.ts`
+Expected: PASS — the resolver itself is correct; the bug is only that consumers don't call it.
+
+---
+
+## Task 1: Add Failing Test for Per-Feature Model Wiring
+
+This is the diagnostic test. It must FAIL on current `dev`, proving the bug. It must PASS after Task 3.
+
+**Files:**
+- Create: `packages/ai-intelligence/src/__tests__/per-feature-model-wiring.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/ai-intelligence/src/__tests__/per-feature-model-wiring.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocks must be hoisted before importing the module under test.
+const mockGetEffectiveLlmConfigPromptStore = vi.fn();
+const mockGetEffectiveLlmConfigGlobal = vi.fn();
+const mockGetEffectivePrompt = vi.fn();
+const mockInsertLlmTrace = vi.fn().mockResolvedValue(undefined);
+const mockLlmFetch = vi.fn();
+
+vi.mock('../services/prompt-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/prompt-store.js')>();
+  return {
+    ...actual,
+    getEffectiveLlmConfig: mockGetEffectiveLlmConfigPromptStore,
+    getEffectivePrompt: mockGetEffectivePrompt,
+  };
+});
+
+vi.mock('@dashboard/core/services/settings-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dashboard/core/services/settings-store.js')>();
+  return {
+    ...actual,
+    getEffectiveLlmConfig: mockGetEffectiveLlmConfigGlobal,
+  };
+});
+
+vi.mock('../services/llm-trace-store.js', () => ({
+  insertLlmTrace: mockInsertLlmTrace,
+}));
+
+// Mock fetch wrapper used internally by chatStream (llmFetch lives in llm-client itself,
+// so we mock global fetch instead — simpler).
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetEffectivePrompt.mockResolvedValue('test prompt');
+  mockInsertLlmTrace.mockResolvedValue(undefined);
+
+  // Stub fetch with a minimal SSE response that emits one delta then [DONE].
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(
+      'data: {"choices":[{"delta":{"content":"hello"}}]}\n\ndata: [DONE]\n\n',
+      { status: 200, headers: { 'content-type': 'text/event-stream' } },
+    ),
+  ) as unknown as typeof fetch;
+});
+
+describe('chatStream — per-feature model resolution', () => {
+  it('uses the feature-aware resolver when a feature key is passed', async () => {
+    mockGetEffectiveLlmConfigPromptStore.mockResolvedValue({
+      apiUrl: 'http://localhost:9999',
+      apiToken: 'tok',
+      model: 'feature-specific-model',
+      authType: 'bearer',
+      maxTokens: 1000,
+      maxToolIterations: 5,
+    });
+
+    const { chatStream } = await import('../services/llm-client.js');
+
+    await chatStream(
+      [{ role: 'user', content: 'hi' }],
+      'system',
+      () => {},
+      'anomaly_explainer',
+    );
+
+    expect(mockGetEffectiveLlmConfigPromptStore).toHaveBeenCalledWith('anomaly_explainer');
+
+    // Verify the request body sent to the LLM uses the feature-specific model.
+    const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(fetchCall[1].body as string);
+    expect(body.model).toBe('feature-specific-model');
+  });
+
+  it('includes temperature in the request body when the resolver returns one', async () => {
+    mockGetEffectiveLlmConfigPromptStore.mockResolvedValue({
+      apiUrl: 'http://localhost:9999',
+      apiToken: 'tok',
+      model: 'm',
+      authType: 'bearer',
+      maxTokens: 1000,
+      maxToolIterations: 5,
+      temperature: 0.2,
+    });
+
+    const { chatStream } = await import('../services/llm-client.js');
+
+    await chatStream(
+      [{ role: 'user', content: 'hi' }],
+      'system',
+      () => {},
+      'log_analyzer',
+    );
+
+    const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(fetchCall[1].body as string);
+    expect(body.temperature).toBe(0.2);
+  });
+
+  it('omits temperature when the resolver does not return one', async () => {
+    mockGetEffectiveLlmConfigPromptStore.mockResolvedValue({
+      apiUrl: 'http://localhost:9999',
+      apiToken: 'tok',
+      model: 'm',
+      authType: 'bearer',
+      maxTokens: 1000,
+      maxToolIterations: 5,
+    });
+
+    const { chatStream } = await import('../services/llm-client.js');
+
+    await chatStream(
+      [{ role: 'user', content: 'hi' }],
+      'system',
+      () => {},
+    );
+
+    const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(fetchCall[1].body as string);
+    expect(body.temperature).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/ai-intelligence && npx vitest run src/__tests__/per-feature-model-wiring.test.ts`
+
+Expected: FAIL on the first test — `chatStream` only accepts 3 args, the 4th `feature` is unused, and it currently calls the global resolver. Either a TypeScript error on the 4-arg call, or `mockGetEffectiveLlmConfigPromptStore` is never called.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add packages/ai-intelligence/src/__tests__/per-feature-model-wiring.test.ts
+git commit -m "test(llm): add failing test for per-feature model wiring"
+```
+
+---
+
+## Task 2: Update `LLMInterface` Contract
+
+**Files:**
+- Modify: `packages/contracts/src/interfaces/llm-interface.ts`
+
+- [ ] **Step 1: Add optional `feature` to `chatStream`**
+
+Current contract (lines 14-22):
+
+```ts
+export interface LLMInterface {
+  isAvailable(): Promise<boolean>;
+  chatStream(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    onChunk: (chunk: string) => void,
+  ): Promise<string>;
+  buildInfrastructureContext(
+    endpoints: NormalizedEndpoint[],
+    containers: NormalizedContainer[],
+    insights: Insight[],
+  ): string;
+  /** Retrieve the effective system prompt for a named domain (e.g. 'pcap_analyzer'). */
+  getEffectivePrompt(domain: string): Promise<string>;
+}
+```
+
+Replace `chatStream` signature with:
+
+```ts
+  /**
+   * Stream an LLM chat completion. Pass `feature` (e.g. 'pcap_analyzer',
+   * 'capacity_forecast') so per-feature model and temperature overrides
+   * from the active prompt profile take effect.
+   */
+  chatStream(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    onChunk: (chunk: string) => void,
+    feature?: string,
+  ): Promise<string>;
+```
+
+- [ ] **Step 2: Verify the contracts package builds**
+
+Run: `npm run build -w @dashboard/contracts`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/contracts/src/interfaces/llm-interface.ts
+git commit -m "feat(contracts): add optional feature param to LLMInterface.chatStream"
+```
+
+---
+
+## Task 3: Implement Feature-Aware `chatStream`
+
+This makes the failing test from Task 1 pass.
+
+**Files:**
+- Modify: `packages/ai-intelligence/src/services/llm-client.ts`
+
+- [ ] **Step 1: Switch resolver import and add `PromptFeature` type import**
+
+Current imports (line ~7):
+
+```ts
+import { getEffectiveLlmConfig } from '@dashboard/core/services/settings-store.js';
+```
+
+Replace with:
+
+```ts
+import { getEffectiveLlmConfig, type PromptFeature } from './prompt-store.js';
+```
+
+The feature-aware resolver returns the same shape as the global resolver, plus an optional `temperature?: number`. It calls the global resolver internally as a fallback, so behavior with `feature === undefined` is identical to today.
+
+- [ ] **Step 2: Add `feature` parameter to `chatStream` and `chatStreamInner`**
+
+Current `chatStream` (lines ~191-201):
+
+```ts
+export async function chatStream(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  onChunk: (chunk: string) => void,
+): Promise<string> {
+  return llmLimit(() =>
+    withSpan('LLM chat', 'llm-service', 'client', () =>
+      chatStreamInner(messages, systemPrompt, onChunk),
+    ),
+  );
+}
+```
+
+Replace with:
+
+```ts
+export async function chatStream(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  onChunk: (chunk: string) => void,
+  feature?: PromptFeature,
+): Promise<string> {
+  return llmLimit(() =>
+    withSpan('LLM chat', 'llm-service', 'client', () =>
+      chatStreamInner(messages, systemPrompt, onChunk, feature),
+    ),
+  );
+}
+```
+
+Current `chatStreamInner` signature (lines ~203-208):
+
+```ts
+async function chatStreamInner(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  onChunk: (chunk: string) => void,
+): Promise<string> {
+  const llmConfig = await getEffectiveLlmConfig();
+```
+
+Replace with:
+
+```ts
+async function chatStreamInner(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  onChunk: (chunk: string) => void,
+  feature?: PromptFeature,
+): Promise<string> {
+  const llmConfig = await getEffectiveLlmConfig(feature);
+```
+
+- [ ] **Step 3: Spread temperature into request body**
+
+Current request body (around line 239):
+
+```ts
+      body: JSON.stringify({
+        model: llmConfig.model,
+        messages: fullMessages,
+        stream: true,
+      }),
+```
+
+Replace with:
+
+```ts
+      body: JSON.stringify({
+        model: llmConfig.model,
+        messages: fullMessages,
+        stream: true,
+        ...(typeof (llmConfig as { temperature?: number }).temperature === 'number'
+          ? { temperature: (llmConfig as { temperature?: number }).temperature }
+          : {}),
+      }),
+```
+
+(The cast is needed because the global resolver shape doesn't declare `temperature` but the feature-aware one optionally adds it.)
+
+- [ ] **Step 4: Run the failing test from Task 1 to verify it now passes**
+
+Run: `cd packages/ai-intelligence && npx vitest run src/__tests__/per-feature-model-wiring.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full ai-intelligence test suite to catch regressions**
+
+Run: `cd packages/ai-intelligence && npx vitest run`
+Expected: PASS. If `llm-client.test.ts` or any consumer-test mocks `chatStream` with the old 3-arg signature, the test still passes because `feature` is optional. Investigate any new failures before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ai-intelligence/src/services/llm-client.ts
+git commit -m "fix(llm): wire chatStream through feature-aware resolver"
+```
+
+---
+
+## Task 4: Update Direct Fetch Sites in ai-intelligence
+
+These two call sites build their own request bodies and don't go through `chatStream`. They need separate edits.
+
+**Files:**
+- Modify: `packages/ai-intelligence/src/sockets/llm-chat.ts`
+- Modify: `packages/ai-intelligence/src/routes/llm.ts`
+
+### Step group A: `sockets/llm-chat.ts` — chat socket handler
+
+- [ ] **Step 1: Switch resolver import**
+
+Current import (line ~6):
+
+```ts
+import { getEffectiveLlmConfig } from '@dashboard/core/services/settings-store.js';
+```
+
+Replace with:
+
+```ts
+import { getEffectiveLlmConfig } from '../services/prompt-store.js';
+```
+
+- [ ] **Step 2: Pass feature key at call site**
+
+Current line ~605:
+
+```ts
+      const llmConfig = await getEffectiveLlmConfig();
+      const selectedModel = data.model || llmConfig.model;
+```
+
+Replace with:
+
+```ts
+      const llmConfig = await getEffectiveLlmConfig('chat_assistant');
+      const selectedModel = data.model || llmConfig.model;
+```
+
+- [ ] **Step 3: Spread temperature into the chat completion request body in this file**
+
+Search for the `JSON.stringify({ model: selectedModel, messages: ..., stream: true` pattern in `llm-chat.ts` (it's a few lines below the `selectedModel` resolution). Add the same conditional `temperature` spread used in Task 3 Step 3:
+
+```ts
+        ...(typeof (llmConfig as { temperature?: number }).temperature === 'number'
+          ? { temperature: (llmConfig as { temperature?: number }).temperature }
+          : {}),
+```
+
+If the user explicitly supplies a temperature in the socket payload (`data.temperature`), that wins over `llmConfig.temperature`. Inspect the file to confirm whether `data.temperature` exists; if it does, prefer it: `temperature: data.temperature ?? llmConfig.temperature` (only spread when defined).
+
+### Step group B: `routes/llm.ts` — AI search and test-prompt
+
+- [ ] **Step 4: Switch resolver import in `routes/llm.ts`**
+
+Current import (line ~13):
+
+```ts
+import { getEffectiveLlmConfig } from '@dashboard/core/services/settings-store.js';
+```
+
+Replace with:
+
+```ts
+import { getEffectiveLlmConfig } from '../services/prompt-store.js';
+import type { PromptFeature } from '../services/prompt-store.js';
+```
+
+(`PROMPT_FEATURES` and `PromptFeature` are already imported a few lines later — consolidate imports as needed; do not duplicate.)
+
+- [ ] **Step 5: AI search route (line ~92) — pass `command_palette`**
+
+Current:
+
+```ts
+    const llmConfig = await getEffectiveLlmConfig();
+    const { query } = request.body;
+    const startTime = Date.now();
+
+    const searchModel = llmConfig.model;
+```
+
+Replace with:
+
+```ts
+    const llmConfig = await getEffectiveLlmConfig('command_palette');
+    const { query } = request.body;
+    const startTime = Date.now();
+
+    const searchModel = llmConfig.model;
+```
+
+Then in the request body construction (around line 130), add the temperature spread:
+
+```ts
+        body: JSON.stringify({
+          model: searchModel,
+          messages,
+          stream: false,
+          response_format: { type: 'json_object' },
+          ...(typeof (llmConfig as { temperature?: number }).temperature === 'number'
+            ? { temperature: (llmConfig as { temperature?: number }).temperature }
+            : {}),
+        }),
+```
+
+- [ ] **Step 6: Test-prompt route (line ~301) — pass the request's `feature`**
+
+Current:
+
+```ts
+    const llmConfig = await getEffectiveLlmConfig();
+    const effectiveModel = model && model.trim() ? model.trim() : llmConfig.model;
+```
+
+Replace with:
+
+```ts
+    const llmConfig = await getEffectiveLlmConfig(feature as PromptFeature);
+    const effectiveModel = model && model.trim() ? model.trim() : llmConfig.model;
+```
+
+The `feature` variable is already extracted from the request body and validated against `PROMPT_FEATURES` earlier in the handler, so the cast is safe.
+
+The test-prompt request body already supports `temperature` from the request directly (line ~325: `...(temperature !== undefined ? { temperature } : {})`). Leave that as-is — explicit user input from the test UI takes precedence over profile config; this matches the existing behavior where the user is testing a specific override.
+
+- [ ] **Step 7: Test-connection route (line ~245) — leave unchanged**
+
+This route only lists models; it does not run inference. The global resolver remains correct here. No edit needed but the import line was already changed in Step 4 — verify the file still compiles.
+
+- [ ] **Step 8: Models list route (line ~421) — leave unchanged**
+
+Same reason as Step 7.
+
+- [ ] **Step 9: Run ai-intelligence tests**
+
+Run: `cd packages/ai-intelligence && npx vitest run`
+Expected: PASS. Pay attention to `llm-chat.test.ts` and `llm.test.ts`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/ai-intelligence/src/sockets/llm-chat.ts packages/ai-intelligence/src/routes/llm.ts
+git commit -m "fix(llm): wire chat socket and AI search through feature-aware resolver"
+```
+
+---
+
+## Task 5: Pass Feature Keys at `chatStream` Call Sites in ai-intelligence
+
+Each call site adds the feature key as a 4th argument.
+
+**Files:**
+- Modify: `packages/ai-intelligence/src/routes/correlations.ts:312`
+- Modify: `packages/ai-intelligence/src/services/log-analyzer.ts:37`
+- Modify: `packages/ai-intelligence/src/services/monitoring-service.ts:621`
+- Modify: `packages/ai-intelligence/src/services/anomaly-explainer.ts:33` and `:131`
+- Modify: `packages/ai-intelligence/src/services/incident-summarizer.ts:29`
+- Modify: `packages/ai-intelligence/src/services/investigation-service.ts:398`
+
+For each call, add the feature key as the 4th argument to the existing `chatStream(...)` call. Examples:
+
+- [ ] **Step 1: `correlations.ts:312`**
+
+Find:
+```ts
+      const response = await chatStream(
+        messages,
+        await getEffectivePrompt('correlation_insights'),
+        onChunk,
+      );
+```
+
+Add `'correlation_insights'` as 4th argument:
+```ts
+      const response = await chatStream(
+        messages,
+        await getEffectivePrompt('correlation_insights'),
+        onChunk,
+        'correlation_insights',
+      );
+```
+
+- [ ] **Step 2: `log-analyzer.ts:37`**
+
+Find the `chatStream(...)` call, add `'log_analyzer'` as 4th arg.
+
+- [ ] **Step 3: `monitoring-service.ts:621`**
+
+Add `'monitoring_analysis'` as 4th arg.
+
+- [ ] **Step 4: `anomaly-explainer.ts:33` and `:131`**
+
+Both call sites take `'anomaly_explainer'` as 4th arg.
+
+- [ ] **Step 5: `incident-summarizer.ts:29`**
+
+Add `'incident_summarizer'` as 4th arg.
+
+- [ ] **Step 6: `investigation-service.ts:398`**
+
+Add `'root_cause'` as 4th arg.
+
+- [ ] **Step 7: Run ai-intelligence tests**
+
+Run: `cd packages/ai-intelligence && npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ai-intelligence/src/routes/correlations.ts packages/ai-intelligence/src/services/log-analyzer.ts packages/ai-intelligence/src/services/monitoring-service.ts packages/ai-intelligence/src/services/anomaly-explainer.ts packages/ai-intelligence/src/services/incident-summarizer.ts packages/ai-intelligence/src/services/investigation-service.ts
+git commit -m "fix(llm): pass feature keys at ai-intelligence chatStream call sites"
+```
+
+---
+
+## Task 6: Pass Feature Keys at Cross-Domain `chatStream` Call Sites
+
+These consumers receive `chatStream` via the `LLMInterface` adapter built in `wiring.ts`. The interface change in Task 2 already exposed the optional `feature` parameter.
+
+**Files:**
+- Modify: `packages/security/src/services/pcap-analysis-service.ts:326`
+- Modify: `packages/observability/src/routes/forecasts.ts:190`
+- Modify: `packages/observability/src/routes/metrics.ts:310`
+- Modify: `packages/operations/src/services/remediation-service.ts:323` and `:337`
+
+- [ ] **Step 1: `pcap-analysis-service.ts:326`**
+
+Find the `await llm.chatStream(...)` call (3-arg). Add `'pcap_analyzer'` as 4th argument.
+
+- [ ] **Step 2: `forecasts.ts:190`**
+
+Add `'capacity_forecast'` as 4th argument.
+
+- [ ] **Step 3: `metrics.ts:310`**
+
+Add `'metrics_summary'` as 4th argument.
+
+- [ ] **Step 4: `remediation-service.ts:323` and `:337`**
+
+Both call sites take `'remediation'` as 4th argument.
+
+- [ ] **Step 5: Build the affected packages**
+
+Run: `npm run build -w @dashboard/security -w @dashboard/observability -w @dashboard/operations`
+Expected: success.
+
+- [ ] **Step 6: Run cross-domain tests**
+
+Run: `npx vitest run -w @dashboard/security -w @dashboard/observability -w @dashboard/operations`
+
+If `vitest run -w` is not how this monorepo runs cross-package tests, fall back to:
+
+```
+cd packages/security && npx vitest run
+cd packages/observability && npx vitest run
+cd packages/operations && npx vitest run
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/security/src/services/pcap-analysis-service.ts packages/observability/src/routes/forecasts.ts packages/observability/src/routes/metrics.ts packages/operations/src/services/remediation-service.ts
+git commit -m "fix(llm): pass feature keys at cross-domain chatStream call sites"
+```
+
+---
+
+## Task 7: End-to-End Verification
+
+- [ ] **Step 1: Type check the whole repo**
+
+Run: `npm run typecheck`
+Expected: zero errors.
+
+- [ ] **Step 2: Lint the whole repo**
+
+Run: `npm run lint`
+Expected: zero errors.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 4: Manual verification (optional but recommended)**
+
+In a running dev environment:
+
+1. Open Settings → AI & LLM → Prompt Profiles.
+2. Create a new profile, set `model = "test-model-XYZ"` for the `anomaly_explainer` feature, save and activate.
+3. Trigger an anomaly explanation (or call the relevant endpoint).
+4. Inspect the LLM trace store (`SELECT model FROM llm_traces ORDER BY created_at DESC LIMIT 1`) and confirm `model = test-model-XYZ`.
+
+This step is informational only; do not block on it.
+
+- [ ] **Step 5: Final commit if any followups**
+
+If lint or typecheck surfaced cleanups, commit them as a final pass:
+
+```bash
+git add -A
+git commit -m "chore: lint and typecheck cleanup after llm wiring fix"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: every call site listed in the spec has a corresponding step. Open question on `llm-feedback.ts:279` is intentionally out of scope per the spec — no task added.
+- No placeholders.
+- Type consistency: `feature?: string` in the contract; `feature?: PromptFeature` inside ai-intelligence — narrower at the call site, wider at the boundary. Consistent across all tasks.
+- Bucket layer / new UI: out of scope per the spec.
+
+## Rollback
+
+Each task ends in a self-contained commit. To rollback any single phase:
+
+```bash
+git revert <commit-sha>
+```
+
+To rollback the entire feature, revert all commits authored on this branch in reverse order. No DB migration, no setting key changes — settings written via the existing Profile UI continue to work either way.

--- a/docs/superpowers/specs/2026-05-08-per-feature-llm-model-wiring-design.md
+++ b/docs/superpowers/specs/2026-05-08-per-feature-llm-model-wiring-design.md
@@ -1,0 +1,199 @@
+# Per-Feature LLM Model Wiring — Design
+
+Status: approved (2026-05-08)
+Author: brainstorming session
+Tracking: TBD (link issue/PR after creation)
+
+## Summary
+
+Per-feature `model` and `temperature` overrides configured via Prompt Profiles are stored correctly but never take effect at runtime. Every LLM call resolves the model from the global `getEffectiveLlmConfig()` exported by `@dashboard/core/services/settings-store.js`, which has no knowledge of the active profile's per-feature overrides.
+
+This change wires every LLM consumer through the existing feature-aware resolver in `packages/ai-intelligence/src/services/prompt-store.ts`, so that profile-level per-feature model and temperature settings actually drive the LLM request.
+
+No new UI is added. No new resolution layer is introduced. No DB migration. The existing Profile editor in `tab-ai-llm.tsx` already provides the per-feature configuration surface.
+
+## Problem
+
+The codebase has two functions named `getEffectiveLlmConfig`:
+
+1. **Global resolver** — `packages/core/src/services/settings-store.ts`. Returns `{ apiUrl, apiToken, model, authType, maxTokens, maxToolIterations }`. Knows nothing about features.
+2. **Feature-aware resolver** — `packages/ai-intelligence/src/services/prompt-store.ts`. Wraps the global resolver and overrides `model` / `temperature` based on resolution order: per-feature setting (`prompts.<feature>.model`) → active profile's per-feature config → global default.
+
+Every LLM call site imports the **global** resolver. The feature-aware resolver is exported but never called from outside `prompt-store.ts`.
+
+Result: a user who creates a profile that pins `qwen3:32b` for `root_cause` and `llama3.2:1b` for `chat_assistant` sees no behavioural difference. Both calls hit whatever model is set in the global LLM config.
+
+## Approach
+
+Switch every LLM call site that represents a known `PromptFeature` to the feature-aware resolver. Pass the feature key through the call stack to the resolver.
+
+The resolution chain is unchanged from what already exists in `prompt-store.ts`:
+
+```
+prompts.<feature>.model setting    (highest priority — individual override)
+        ↓ if absent
+active profile.prompts[feature].model    (profile-level override)
+        ↓ if absent
+global config (settings DB or env LLM_MODEL)    (fallback)
+```
+
+Same chain applies to `temperature`.
+
+## Call Site Changes
+
+### Direct edits in `packages/ai-intelligence`
+
+| File | Line | Feature key |
+|------|------|-------------|
+| `sockets/llm-chat.ts` | 605 | `chat_assistant` |
+| `routes/llm.ts` | 92 (AI search) | `command_palette` |
+| `routes/llm.ts` | 301 (test-prompt) | use `feature` param from request body |
+| `routes/correlations.ts` | 312 | `correlation_insights` |
+| `services/log-analyzer.ts` | 37 | `log_analyzer` |
+| `services/monitoring-service.ts` | 621 | `monitoring_analysis` |
+| `services/anomaly-explainer.ts` | 33, 131 | `anomaly_explainer` |
+| `services/incident-summarizer.ts` | 29 | `incident_summarizer` |
+| `services/investigation-service.ts` | 398 | `root_cause` |
+
+### Cross-domain consumers (via `LlmInterface` DI)
+
+| File | Line | Feature key |
+|------|------|-------------|
+| `packages/security/src/services/pcap-analysis-service.ts` | 326 | `pcap_analyzer` |
+| `packages/observability/src/routes/forecasts.ts` | 190 | `capacity_forecast` |
+| `packages/observability/src/routes/metrics.ts` | 310 | `metrics_summary` |
+| `packages/operations/src/services/remediation-service.ts` | 323, 337 | `remediation` |
+
+### Intentionally unchanged
+
+| File | Line | Reason |
+|------|------|--------|
+| `routes/llm.ts` | 245 (test-connection) | Lists models for UI; no LLM inference |
+| `routes/llm.ts` | 421 (list models) | Lists models; no LLM inference |
+| `services/llm-client.ts` | 397 (`isLlmAvailable`) | Reachability ping; no inference |
+| `routes/llm-feedback.ts` | 279 (feedback analysis) | Admin-only, no matching `PromptFeature`; deferred |
+
+## Code Shape
+
+### `chatStream` — central funnel
+
+`chatStream` is the central funnel for most inference sites (correlations, log analyzer, monitoring service, anomaly explainer, incident summarizer, investigation service, plus the cross-domain consumers: pcap, forecasts, metrics, remediation). Adding an optional `feature` parameter handles them centrally; only three direct fetch sites (`sockets/llm-chat.ts:605`, `routes/llm.ts:92`, `routes/llm.ts:301`) need separate edits.
+
+```ts
+// packages/ai-intelligence/src/services/llm-client.ts
+import { getEffectiveLlmConfig } from './prompt-store.js';  // swap from core
+import type { PromptFeature } from './prompt-store.js';
+
+export async function chatStream(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  onChunk: (chunk: string) => void,
+  feature?: PromptFeature,
+): Promise<string> {
+  return llmLimit(() =>
+    withSpan('LLM chat', 'llm-service', 'client', () =>
+      chatStreamInner(messages, systemPrompt, onChunk, feature),
+    ),
+  );
+}
+
+async function chatStreamInner(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  onChunk: (chunk: string) => void,
+  feature?: PromptFeature,
+): Promise<string> {
+  const llmConfig = await getEffectiveLlmConfig(feature);
+  // ... existing body ...
+
+  const requestBody = {
+    model: llmConfig.model,
+    messages: fullMessages,
+    stream: true,
+    ...(llmConfig.temperature !== undefined ? { temperature: llmConfig.temperature } : {}),
+  };
+}
+```
+
+### `LlmInterface` contract
+
+```ts
+// packages/contracts/src/interfaces/llm-interface.ts
+export interface LlmInterface {
+  chatStream(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    onChunk: (chunk: string) => void,
+    feature?: PromptFeature,
+  ): Promise<string>;
+}
+```
+
+`PromptFeature` must be exported from `@dashboard/contracts` (re-exported from a shared location) so cross-domain packages can pass it without importing from `@dashboard/ai-intelligence`. Cleanest path: define the type union in `@dashboard/contracts/schemas/prompt-feature.ts` and have `prompt-store.ts` import it.
+
+### Direct call sites (non-`chatStream`)
+
+For `sockets/llm-chat.ts:605` and `routes/llm.ts:92` (which build their own fetch bodies), swap the import to the feature-aware resolver and inject the feature key:
+
+```ts
+import { getEffectiveLlmConfig } from '../services/prompt-store.js';
+// ...
+const llmConfig = await getEffectiveLlmConfig('chat_assistant');
+```
+
+Both sites also need to spread `temperature` into their request bodies if present, so profile temperature overrides take effect.
+
+## Temperature in Request Bodies
+
+Today, `chatStreamInner` does not include `temperature` in the OpenAI request. Most direct call sites (`routes/llm.ts:92`, `sockets/llm-chat.ts:605`) also omit it. After this change, every call site that obtains an `llmConfig` via the feature-aware resolver must conditionally include `temperature` in the request body when defined:
+
+```ts
+...(llmConfig.temperature !== undefined ? { temperature: llmConfig.temperature } : {})
+```
+
+Profiles that don't set a temperature continue to use the provider default.
+
+## Testing
+
+### Unit
+
+Extend `packages/ai-intelligence/src/services/prompt-store.test.ts`:
+
+- `getEffectiveLlmConfig(feature)` returns the profile's per-feature `model` when the active profile defines it for that feature.
+- `getEffectiveLlmConfig(feature)` returns the profile's per-feature `temperature` when defined.
+- Per-feature setting (`prompts.<feature>.model`) takes priority over profile config.
+- Falls back to global config when no profile or feature-level override exists.
+- `getEffectiveLlmConfig()` (no feature) returns global config unchanged.
+
+### Integration
+
+Add a test (or extend an existing service test) that:
+
+1. Creates a non-default profile setting `model = "test-model-X"` for `anomaly_explainer`.
+2. Activates that profile.
+3. Calls `explainAnomaly(...)` with a mocked `fetch`.
+4. Asserts the OpenAI request body's `model` field equals `"test-model-X"`.
+
+Repeat for one cross-domain feature (e.g. `pcap_analyzer`) to verify the DI path works.
+
+### Regression
+
+- Existing `tab-ai-llm.test.tsx` profile editor tests continue to pass.
+- Existing `chatStream` tests in `llm-client.test.ts` continue to pass when called without a feature key.
+
+## Open Questions Resolved During Brainstorm
+
+- **Should this introduce a higher-level "buckets" UI (Chat / Analysis / Summarization) on top of per-feature?** — No. Defer. The Profiles UI already covers per-feature configuration; adding buckets duplicates the concept.
+- **Should `routes/llm-feedback.ts:279` get a new `feedback_analysis` feature key?** — No. Defer. Admin-only, low-volume, not user-facing. Adding a new feature creates UI surface (Profiles editor, fixtures, default prompts) for marginal gain.
+
+## Rollback
+
+Single-PR change. Rollback = `git revert`. No DB migration. No setting key changes. Existing `prompts.<feature>.model` values in the settings table remain valid and continue to be respected by the resolver.
+
+## Out of Scope
+
+- Bucket-level abstraction (Chat / Analysis / Summarization)
+- New `feedback_analysis` feature
+- New default-models settings panel separate from Profiles
+- Per-call temperature configuration through `chatStream` arguments (continues to come from profile config only)
+- Changes to `max_tokens` resolution (stays a single global value)

--- a/packages/ai-intelligence/src/__tests__/anomaly-explainer.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-explainer.test.ts
@@ -54,6 +54,7 @@ describe('anomaly-explainer', () => {
         ]),
         expect.any(String),
         expect.any(Function),
+        'anomaly_explainer',
       );
     });
 

--- a/packages/ai-intelligence/src/__tests__/llm-chat.test.ts
+++ b/packages/ai-intelligence/src/__tests__/llm-chat.test.ts
@@ -59,6 +59,7 @@ vi.mock('@dashboard/core/services/settings-store.js', () => ({
 
 vi.mock('../services/prompt-store.js', () => ({
   getEffectivePrompt: vi.fn(() => 'You are an AI assistant.'),
+  getEffectiveLlmConfig: mockGetEffectiveLlmConfig,
 }));
 
 import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';

--- a/packages/ai-intelligence/src/__tests__/llm.test.ts
+++ b/packages/ai-intelligence/src/__tests__/llm.test.ts
@@ -16,12 +16,19 @@ const { DEFAULT_LLM_CONFIG } = vi.hoisted(() => ({
   },
 }));
 
+// Single shared mock function for getEffectiveLlmConfig — both
+// settings-store (test-connection, models-list routes) and prompt-store
+// (AI search, test-prompt routes) wire to the same mock so per-test
+// `mockGetEffectiveLlmConfig.mockReturnValue(...)` overrides apply
+// regardless of which route the request hits.
+const { mockGetEffectiveLlmConfig } = vi.hoisted(() => ({
+  mockGetEffectiveLlmConfig: vi.fn(),
+}));
+
 vi.mock('@dashboard/core/services/settings-store.js', () => ({
-  getEffectiveLlmConfig: vi.fn().mockReturnValue({ ...DEFAULT_LLM_CONFIG }),
+  getEffectiveLlmConfig: mockGetEffectiveLlmConfig,
   getSetting: vi.fn().mockReturnValue(undefined),
 }));
-import { getEffectiveLlmConfig } from '@dashboard/core/services/settings-store.js';
-const mockGetEffectiveLlmConfig = vi.mocked(getEffectiveLlmConfig);
 
 vi.mock('../services/llm-trace-store.js', async () =>
   (await import('../test-utils/mock-llm.js')).createLlmTraceStoreMock()
@@ -38,6 +45,7 @@ import { flushTestCache, closeTestRedis } from '@dashboard/core/test-utils/test-
 
 vi.mock('../services/prompt-store.js', () => ({
   getEffectivePrompt: vi.fn().mockReturnValue('default prompt'),
+  getEffectiveLlmConfig: mockGetEffectiveLlmConfig,
   PROMPT_FEATURES: [
     { key: 'chat_assistant', label: 'Chat Assistant', description: 'Main AI chat' },
     { key: 'anomaly_explainer', label: 'Anomaly Explainer', description: 'Explains anomalies' },

--- a/packages/ai-intelligence/src/__tests__/per-feature-model-wiring.test.ts
+++ b/packages/ai-intelligence/src/__tests__/per-feature-model-wiring.test.ts
@@ -1,0 +1,149 @@
+// packages/ai-intelligence/src/__tests__/per-feature-model-wiring.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setConfigForTest, resetConfig } from '@dashboard/core/config/index.js';
+import { chatStream } from '../services/llm-client.js';
+
+const DEFAULT_LLM_CONFIG = {
+  apiUrl: 'http://localhost:9999/v1/chat/completions',
+  apiToken: 'tok',
+  model: 'default-model',
+  authType: 'bearer' as const,
+  maxTokens: 1000,
+  maxToolIterations: 5,
+};
+
+const mockGetEffectiveLlmConfigPromptStore = vi.fn();
+const mockGetEffectiveLlmConfigGlobal = vi.fn();
+const mockGetEffectivePrompt = vi.fn();
+const mockInsertLlmTrace = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/prompt-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/prompt-store.js')>();
+  return {
+    ...actual,
+    getEffectiveLlmConfig: mockGetEffectiveLlmConfigPromptStore,
+    getEffectivePrompt: mockGetEffectivePrompt,
+  };
+});
+
+vi.mock('@dashboard/core/services/settings-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dashboard/core/services/settings-store.js')>();
+  return {
+    ...actual,
+    getEffectiveLlmConfig: (...args: unknown[]) => mockGetEffectiveLlmConfigGlobal(...args),
+  };
+});
+
+vi.mock('../services/llm-trace-store.js', () => ({
+  insertLlmTrace: (...args: unknown[]) => mockInsertLlmTrace(...args),
+}));
+
+// Mock undici (the production code uses undici.fetch, NOT globalThis.fetch).
+const mockUndiciFetch = vi.fn();
+vi.mock('undici', () => ({
+  Agent: vi.fn(),
+  fetch: (...args: unknown[]) => mockUndiciFetch(...args),
+}));
+
+function mockSseResponse(payload: string) {
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(payload));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockGetEffectivePrompt.mockResolvedValue('test prompt');
+  mockInsertLlmTrace.mockResolvedValue(undefined);
+  // Provide a valid default config from the global resolver so that, in the
+  // current (pre-Task-3) code, chatStream still reaches the fetch step. This
+  // ensures these tests fail at the wiring assertion stage, not at a
+  // precondition crash like "Cannot read properties of undefined".
+  mockGetEffectiveLlmConfigGlobal.mockResolvedValue({ ...DEFAULT_LLM_CONFIG });
+  mockUndiciFetch.mockResolvedValue(
+    mockSseResponse('data: {"choices":[{"delta":{"content":"hello"}}]}\n\ndata: [DONE]\n\n'),
+  );
+  setConfigForTest({ LLM_VERIFY_SSL: true, LLM_REQUEST_TIMEOUT: 120000 });
+});
+
+afterEach(() => {
+  resetConfig();
+});
+
+describe('chatStream — per-feature model resolution', () => {
+  it('uses the feature-aware resolver when a feature key is passed', async () => {
+    mockGetEffectiveLlmConfigPromptStore.mockResolvedValue({
+      apiUrl: 'http://localhost:9999/v1/chat/completions',
+      apiToken: 'tok',
+      model: 'feature-specific-model',
+      authType: 'bearer',
+      maxTokens: 1000,
+      maxToolIterations: 5,
+    });
+
+    await chatStream(
+      [{ role: 'user', content: 'hi' }],
+      'system',
+      () => {},
+      // @ts-expect-error remove after Task 3 when signature is updated to accept feature key
+      'anomaly_explainer',
+    );
+
+    expect(mockGetEffectiveLlmConfigPromptStore).toHaveBeenCalledWith('anomaly_explainer');
+    // Lock in the migration: after Task 3 the global resolver must NOT be
+    // called from chatStream — the feature-aware resolver replaces it.
+    expect(mockGetEffectiveLlmConfigGlobal).not.toHaveBeenCalled();
+
+    const fetchCall = mockUndiciFetch.mock.calls[0];
+    const body = JSON.parse(fetchCall[1].body as string);
+    expect(body.model).toBe('feature-specific-model');
+  });
+
+  it('includes temperature in the request body when the resolver returns one', async () => {
+    mockGetEffectiveLlmConfigPromptStore.mockResolvedValue({
+      apiUrl: 'http://localhost:9999/v1/chat/completions',
+      apiToken: 'tok',
+      model: 'm',
+      authType: 'bearer',
+      maxTokens: 1000,
+      maxToolIterations: 5,
+      temperature: 0.2,
+    });
+
+    await chatStream(
+      [{ role: 'user', content: 'hi' }],
+      'system',
+      () => {},
+      // @ts-expect-error remove after Task 3 when signature is updated to accept feature key
+      'log_analyzer',
+    );
+
+    const fetchCall = mockUndiciFetch.mock.calls[0];
+    const body = JSON.parse(fetchCall[1].body as string);
+    expect(body.temperature).toBe(0.2);
+  });
+
+  it('omits temperature when the resolver does not return one', async () => {
+    mockGetEffectiveLlmConfigPromptStore.mockResolvedValue({
+      apiUrl: 'http://localhost:9999/v1/chat/completions',
+      apiToken: 'tok',
+      model: 'm',
+      authType: 'bearer',
+      maxTokens: 1000,
+      maxToolIterations: 5,
+    });
+
+    await chatStream([{ role: 'user', content: 'hi' }], 'system', () => {});
+
+    const fetchCall = mockUndiciFetch.mock.calls[0];
+    const body = JSON.parse(fetchCall[1].body as string);
+    expect(body.temperature).toBeUndefined();
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/per-feature-model-wiring.test.ts
+++ b/packages/ai-intelligence/src/__tests__/per-feature-model-wiring.test.ts
@@ -12,10 +12,19 @@ const DEFAULT_LLM_CONFIG = {
   maxToolIterations: 5,
 };
 
-const mockGetEffectiveLlmConfigPromptStore = vi.fn();
-const mockGetEffectiveLlmConfigGlobal = vi.fn();
-const mockGetEffectivePrompt = vi.fn();
-const mockInsertLlmTrace = vi.fn().mockResolvedValue(undefined);
+const {
+  mockGetEffectiveLlmConfigPromptStore,
+  mockGetEffectiveLlmConfigGlobal,
+  mockGetEffectivePrompt,
+  mockInsertLlmTrace,
+  mockUndiciFetch,
+} = vi.hoisted(() => ({
+  mockGetEffectiveLlmConfigPromptStore: vi.fn(),
+  mockGetEffectiveLlmConfigGlobal: vi.fn(),
+  mockGetEffectivePrompt: vi.fn(),
+  mockInsertLlmTrace: vi.fn().mockResolvedValue(undefined),
+  mockUndiciFetch: vi.fn(),
+}));
 
 vi.mock('../services/prompt-store.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../services/prompt-store.js')>();
@@ -39,7 +48,6 @@ vi.mock('../services/llm-trace-store.js', () => ({
 }));
 
 // Mock undici (the production code uses undici.fetch, NOT globalThis.fetch).
-const mockUndiciFetch = vi.fn();
 vi.mock('undici', () => ({
   Agent: vi.fn(),
   fetch: (...args: unknown[]) => mockUndiciFetch(...args),
@@ -92,7 +100,6 @@ describe('chatStream — per-feature model resolution', () => {
       [{ role: 'user', content: 'hi' }],
       'system',
       () => {},
-      // @ts-expect-error remove after Task 3 when signature is updated to accept feature key
       'anomaly_explainer',
     );
 
@@ -121,7 +128,6 @@ describe('chatStream — per-feature model resolution', () => {
       [{ role: 'user', content: 'hi' }],
       'system',
       () => {},
-      // @ts-expect-error remove after Task 3 when signature is updated to accept feature key
       'log_analyzer',
     );
 

--- a/packages/ai-intelligence/src/routes/correlations.ts
+++ b/packages/ai-intelligence/src/routes/correlations.ts
@@ -313,6 +313,7 @@ export async function correlationRoutes(fastify: FastifyInstance, opts: Correlat
         [{ role: 'user', content: prompt }],
         await getEffectivePrompt('correlation_insights'),
         () => {},
+        'correlation_insights',
       );
 
       const { insights, summary } = parseInsightsResponse(response.trim(), topPairs);

--- a/packages/ai-intelligence/src/routes/llm.ts
+++ b/packages/ai-intelligence/src/routes/llm.ts
@@ -88,11 +88,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
       },
     },
   }, async (request) => {
-    const llmConfig = await getEffectiveLlmConfig('command_palette');
     const { query } = request.body;
-    const startTime = Date.now();
-
-    const searchModel = llmConfig.model;
 
     const guardResult = isPromptInjection(query);
     if (guardResult.blocked) {
@@ -102,6 +98,11 @@ export async function llmRoutes(fastify: FastifyInstance) {
         description: 'Prompt-injection guardrail',
       };
     }
+
+    const llmConfig = await getEffectiveLlmConfig('command_palette');
+    const startTime = Date.now();
+
+    const searchModel = llmConfig.model;
 
     try {
       const infraContext = await getInfrastructureSummary();

--- a/packages/ai-intelligence/src/routes/llm.ts
+++ b/packages/ai-intelligence/src/routes/llm.ts
@@ -10,8 +10,7 @@ import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { normalizeEndpoint, normalizeContainer } from '@dashboard/core/portainer/portainer-normalizers.js';
 import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
-import { getEffectiveLlmConfig } from '@dashboard/core/services/settings-store.js';
-import { getEffectivePrompt, PROMPT_FEATURES, type PromptFeature } from '../services/prompt-store.js';
+import { getEffectivePrompt, getEffectiveLlmConfig, PROMPT_FEATURES, type PromptFeature } from '../services/prompt-store.js';
 import { insertLlmTrace } from '../services/llm-trace-store.js';
 import { LlmQueryBodySchema, LlmTestConnectionBodySchema, LlmModelsQuerySchema, LlmTestPromptBodySchema } from '@dashboard/core/models/api-schemas.js';
 import { PROMPT_TEST_FIXTURES } from '../services/prompt-test-fixtures.js';
@@ -89,7 +88,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
       },
     },
   }, async (request) => {
-    const llmConfig = await getEffectiveLlmConfig();
+    const llmConfig = await getEffectiveLlmConfig('command_palette');
     const { query } = request.body;
     const startTime = Date.now();
 
@@ -132,6 +131,9 @@ export async function llmRoutes(fastify: FastifyInstance) {
           messages,
           stream: false,
           response_format: { type: 'json_object' },
+          ...(typeof (llmConfig as { temperature?: number }).temperature === 'number'
+            ? { temperature: (llmConfig as { temperature?: number }).temperature }
+            : {}),
         }),
         signal: AbortSignal.timeout(60_000),
       });
@@ -298,7 +300,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
       return { success: false, error: `No test fixture for feature: ${feature}` };
     }
 
-    const llmConfig = await getEffectiveLlmConfig();
+    const llmConfig = await getEffectiveLlmConfig(feature as PromptFeature);
     const effectiveModel = model && model.trim() ? model.trim() : llmConfig.model;
 
     const messages = [

--- a/packages/ai-intelligence/src/routes/llm.ts
+++ b/packages/ai-intelligence/src/routes/llm.ts
@@ -131,9 +131,7 @@ export async function llmRoutes(fastify: FastifyInstance) {
           messages,
           stream: false,
           response_format: { type: 'json_object' },
-          ...(typeof (llmConfig as { temperature?: number }).temperature === 'number'
-            ? { temperature: (llmConfig as { temperature?: number }).temperature }
-            : {}),
+          ...(llmConfig.temperature !== undefined ? { temperature: llmConfig.temperature } : {}),
         }),
         signal: AbortSignal.timeout(60_000),
       });

--- a/packages/ai-intelligence/src/services/anomaly-explainer.ts
+++ b/packages/ai-intelligence/src/services/anomaly-explainer.ts
@@ -34,6 +34,7 @@ export async function explainAnomaly(
         [{ role: 'user', content: userPrompt }],
         await getEffectivePrompt('anomaly_explainer'),
         (chunk) => { response += chunk; },
+        'anomaly_explainer',
       );
 
       const trimmed = response.trim();
@@ -132,6 +133,7 @@ export async function explainAnomalies(
       [{ role: 'user', content: userPrompt }],
       await getEffectivePrompt('anomaly_explainer'),
       (chunk) => { response += chunk; },
+      'anomaly_explainer',
     );
 
     const parsed = parseBatchResponse(response.trim(), toExplain.length);

--- a/packages/ai-intelligence/src/services/incident-summarizer.ts
+++ b/packages/ai-intelligence/src/services/incident-summarizer.ts
@@ -30,6 +30,7 @@ export async function generateLlmIncidentSummary(
       [{ role: 'user', content: userPrompt }],
       await getEffectivePrompt('incident_summarizer'),
       (chunk) => { response += chunk; },
+      'incident_summarizer',
     );
 
     const trimmed = response.trim();

--- a/packages/ai-intelligence/src/services/investigation-service.ts
+++ b/packages/ai-intelligence/src/services/investigation-service.ts
@@ -399,6 +399,7 @@ async function runInvestigation(investigationId: string, insight: Insight): Prom
       [{ role: 'user', content: prompt }],
       await getEffectivePrompt('root_cause'),
       (chunk) => { llmResponse += chunk; },
+      'root_cause',
     );
 
     // Phase 3: Parse and store

--- a/packages/ai-intelligence/src/services/llm-client.ts
+++ b/packages/ai-intelligence/src/services/llm-client.ts
@@ -242,9 +242,7 @@ async function chatStreamInner(
         model: llmConfig.model,
         messages: fullMessages,
         stream: true,
-        ...(typeof (llmConfig as { temperature?: number }).temperature === 'number'
-          ? { temperature: (llmConfig as { temperature?: number }).temperature }
-          : {}),
+        ...(llmConfig.temperature !== undefined ? { temperature: llmConfig.temperature } : {}),
       }),
       signal: AbortSignal.timeout(requestTimeoutMs),
     });

--- a/packages/ai-intelligence/src/services/llm-client.ts
+++ b/packages/ai-intelligence/src/services/llm-client.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import pLimit from 'p-limit';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { getConfig } from '@dashboard/core/config/index.js';
-import { getEffectiveLlmConfig } from '@dashboard/core/services/settings-store.js';
+import { getEffectiveLlmConfig, type PromptFeature } from './prompt-store.js';
 import { insertLlmTrace } from './llm-trace-store.js';
 import { withSpan } from '@dashboard/core/tracing/trace-context.js';
 import { scrubPii, scrubPiiDeep } from '@dashboard/core/utils/pii-scrubber.js';
@@ -192,10 +192,11 @@ export async function chatStream(
   messages: ChatMessage[],
   systemPrompt: string,
   onChunk: (chunk: string) => void,
+  feature?: PromptFeature,
 ): Promise<string> {
   return llmLimit(() =>
     withSpan('LLM chat', 'llm-service', 'client', () =>
-      chatStreamInner(messages, systemPrompt, onChunk),
+      chatStreamInner(messages, systemPrompt, onChunk, feature),
     ),
   );
 }
@@ -204,8 +205,9 @@ async function chatStreamInner(
   messages: ChatMessage[],
   systemPrompt: string,
   onChunk: (chunk: string) => void,
+  feature?: PromptFeature,
 ): Promise<string> {
-  const llmConfig = await getEffectiveLlmConfig();
+  const llmConfig = await getEffectiveLlmConfig(feature);
   const config = getConfig();
   const startTime = Date.now();
   const requestTimeoutMs = config.LLM_REQUEST_TIMEOUT;
@@ -240,6 +242,9 @@ async function chatStreamInner(
         model: llmConfig.model,
         messages: fullMessages,
         stream: true,
+        ...(typeof (llmConfig as { temperature?: number }).temperature === 'number'
+          ? { temperature: (llmConfig as { temperature?: number }).temperature }
+          : {}),
       }),
       signal: AbortSignal.timeout(requestTimeoutMs),
     });

--- a/packages/ai-intelligence/src/services/log-analyzer.ts
+++ b/packages/ai-intelligence/src/services/log-analyzer.ts
@@ -38,6 +38,7 @@ export async function analyzeContainerLogs(
       [{ role: 'user', content: `Analyze these container logs from "${containerName}":\n\n${logs.slice(0, 4000)}` }],
       await getEffectivePrompt('log_analyzer'),
       (chunk) => { response += chunk; },
+      'log_analyzer',
     );
 
     const trimmed = response.trim();

--- a/packages/ai-intelligence/src/services/monitoring-service.ts
+++ b/packages/ai-intelligence/src/services/monitoring-service.ts
@@ -622,6 +622,7 @@ export function createMonitoringService(deps: MonitoringDeps) {
               [{ role: 'user', content: analysisPrompt }],
               systemPrompt,
               (chunk) => { aiResponse += chunk; },
+              'monitoring_analysis',
             );
 
             if (aiResponse.trim()) {

--- a/packages/ai-intelligence/src/services/prompt-store.ts
+++ b/packages/ai-intelligence/src/services/prompt-store.ts
@@ -144,6 +144,14 @@ export async function getEffectivePrompt(feature: PromptFeature): Promise<string
 }
 
 /**
+ * Effective LLM config for a feature: global config + optional per-feature
+ * temperature override. Tracks any future shape changes in the global config.
+ */
+export type EffectiveLlmConfig = Awaited<ReturnType<typeof getGlobalLlmConfig>> & {
+  temperature?: number;
+};
+
+/**
  * Returns LLM config for a specific feature, allowing per-feature model
  * and temperature overrides.
  * Resolution order:
@@ -151,7 +159,7 @@ export async function getEffectivePrompt(feature: PromptFeature): Promise<string
  * 2. Active profile's model/temperature for this feature
  * 3. Global LLM config
  */
-export async function getEffectiveLlmConfig(feature?: PromptFeature) {
+export async function getEffectiveLlmConfig(feature?: PromptFeature): Promise<EffectiveLlmConfig> {
   const global = await getGlobalLlmConfig();
 
   if (!feature) return global;

--- a/packages/ai-intelligence/src/sockets/llm-chat.ts
+++ b/packages/ai-intelligence/src/sockets/llm-chat.ts
@@ -459,9 +459,7 @@ async function streamLlmCall(
       messages,
       stream: true,
       max_tokens: llmConfig.maxTokens,
-      ...(typeof (llmConfig as { temperature?: number }).temperature === 'number'
-        ? { temperature: (llmConfig as { temperature?: number }).temperature }
-        : {}),
+      ...(llmConfig.temperature !== undefined ? { temperature: llmConfig.temperature } : {}),
     }),
     signal,
   });

--- a/packages/ai-intelligence/src/sockets/llm-chat.ts
+++ b/packages/ai-intelligence/src/sockets/llm-chat.ts
@@ -3,8 +3,7 @@ import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { normalizeEndpoint, normalizeContainer } from '@dashboard/core/portainer/portainer-normalizers.js';
 import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
-import { getEffectiveLlmConfig } from '@dashboard/core/services/settings-store.js';
-import { getEffectivePrompt } from '../services/prompt-store.js';
+import { getEffectivePrompt, getEffectiveLlmConfig } from '../services/prompt-store.js';
 import { insertLlmTrace } from '../services/llm-trace-store.js';
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { randomUUID } from 'crypto';
@@ -460,6 +459,9 @@ async function streamLlmCall(
       messages,
       stream: true,
       max_tokens: llmConfig.maxTokens,
+      ...(typeof (llmConfig as { temperature?: number }).temperature === 'number'
+        ? { temperature: (llmConfig as { temperature?: number }).temperature }
+        : {}),
     }),
     signal,
   });
@@ -602,7 +604,7 @@ export function setupLlmNamespace(ns: Namespace, infraLogs: InfrastructureLogsIn
       // Emit status updates so the frontend can show progress during long waits
       socket.emit('chat:status', { message: 'Preparing request...', phase: 'init' });
 
-      const llmConfig = await getEffectiveLlmConfig();
+      const llmConfig = await getEffectiveLlmConfig('chat_assistant');
       const selectedModel = data.model || llmConfig.model;
 
       // Get or create session history. The canary registry is keyed on

--- a/packages/contracts/src/interfaces/llm-interface.ts
+++ b/packages/contracts/src/interfaces/llm-interface.ts
@@ -14,10 +14,16 @@ export interface ChatMessage {
  */
 export interface LLMInterface {
   isAvailable(): Promise<boolean>;
+  /**
+   * Stream an LLM chat completion. Pass `feature` (e.g. 'pcap_analyzer',
+   * 'capacity_forecast') so per-feature model and temperature overrides
+   * from the active prompt profile take effect.
+   */
   chatStream(
     messages: ChatMessage[],
     systemPrompt: string,
     onChunk: (chunk: string) => void,
+    feature?: string,
   ): Promise<string>;
   buildInfrastructureContext(
     endpoints: NormalizedEndpoint[],

--- a/packages/observability/src/__tests__/metrics-route.test.ts
+++ b/packages/observability/src/__tests__/metrics-route.test.ts
@@ -372,6 +372,7 @@ describe('metrics routes', () => {
         ]),
         expect.any(String),
         expect.any(Function),
+        'metrics_summary',
       );
     });
 

--- a/packages/observability/src/routes/forecasts.ts
+++ b/packages/observability/src/routes/forecasts.ts
@@ -191,6 +191,7 @@ export async function forecastRoutes(fastify: FastifyInstance, opts: { llm?: LLM
         [{ role: 'user', content: prompt }],
         systemPrompt,
         () => {}, // no streaming needed for this endpoint
+        'capacity_forecast',
       );
 
       const trimmed = narrative.trim();

--- a/packages/observability/src/routes/metrics.ts
+++ b/packages/observability/src/routes/metrics.ts
@@ -313,6 +313,7 @@ Endpoint ID: ${endpointId}`;
         (chunk: string) => {
           reply.raw.write(`data: ${JSON.stringify({ chunk })}\n\n`);
         },
+        'metrics_summary',
       );
       reply.raw.write(`data: ${JSON.stringify({ done: true })}\n\n`);
     } catch (err) {

--- a/packages/operations/src/services/remediation-service.ts
+++ b/packages/operations/src/services/remediation-service.ts
@@ -326,6 +326,7 @@ async function enrichActionWithLlmAnalysis(
       (chunk) => {
         rawResponse += chunk;
       },
+      'remediation',
     );
 
     let parsed = tryParseRemediationAnalysis(rawResponse);
@@ -344,6 +345,7 @@ async function enrichActionWithLlmAnalysis(
         (chunk) => {
           retryResponse += chunk;
         },
+        'remediation',
       );
       parsed = tryParseRemediationAnalysis(retryResponse);
 

--- a/packages/security/src/services/pcap-analysis-service.ts
+++ b/packages/security/src/services/pcap-analysis-service.ts
@@ -327,6 +327,7 @@ export async function analyzeCapture(captureId: string, llm: LLMInterface): Prom
     [{ role: 'user', content: prompt }],
     await llm.getEffectivePrompt('pcap_analyzer'),
     (chunk) => { llmResponse += chunk; },
+    'pcap_analyzer',
   );
 
   // Phase 3: Parse and store


### PR DESCRIPTION
## Summary
- Threads a feature key through `LLMInterface.chatStream` so per-feature Prompt Profile settings (model, temperature) actually take effect at runtime.
- Switches all `chatStream` call sites in `ai-intelligence` and cross-domain consumers to pass the feature key, replacing reliance on the global `getEffectiveLlmConfig()`.
- Formalizes the resolver return as `EffectiveLlmConfig` and wires the chat socket and AI Search through the feature-aware resolver.

## Background
See `docs/superpowers/specs/2026-05-08-per-feature-llm-model-wiring-design.md` and the corresponding plan. Bug: per-feature model/temperature configured in Prompt Profiles never took effect because consumers called the global resolver instead of the feature-aware variant.

## Test plan
- [x] Frontend test suite (1828 tests) — passed locally via pre-push hook
- [ ] CI: backend + frontend type/lint/test
- [ ] CI: Docker Build (the reason this PR was opened)
- [ ] Manual: change model in a Prompt Profile, confirm chat socket / AI Search / cross-domain chat use it

🤖 Generated with [Claude Code](https://claude.com/claude-code)