### PR TITLE
Refactor Traefik OTLP ingestion docs and config for two variants

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -301,10 +301,35 @@ POSTGRES_APP_PASSWORD=CHANGE_ME_BEFORE_PRODUCTION
 # Server
 PORT=3051
 LOG_LEVEL=info
-# Optional: External/LAN URL that edge endpoints can reach (used for Beyla deploys).
-# DASHBOARD_EXTERNAL_URL=http://192.168.178.20:3051
-# Hostname used in Traefik routing rules (without protocol or port).
+# Optional: External URL that Beyla on edge endpoints uses to reach the dashboard's
+# OTLP ingest endpoint. The /api/traces/otlp path is appended automatically — set
+# the base origin only. The dashboard prefers this over the request Host header
+# when generating Beyla deployment manifests via POST /api/ebpf/deploy/:endpointId.
+#
+# Pick one of the following based on your topology:
+#   1) Dashboard behind Traefik on HTTPS:443 (recommended for production):
+#      DASHBOARD_EXTERNAL_URL=https://dashboard.example.com
+#   2) Direct backend port over LAN (no Traefik):
+#      DASHBOARD_EXTERNAL_URL=http://192.168.178.20:3051
+# DASHBOARD_EXTERNAL_URL=https://dashboard.example.com
+
+# Hostname used in the Traefik router rule on the backend container
+# (see traefik.http.routers.beyla-otlp.rule label in docker-compose.yml). Must
+# match the hostname your existing Traefik already terminates TLS for. Set this
+# whenever the backend is fronted by Traefik — compose will fail to start without
+# it (the label uses :? to enforce it).
 # DASHBOARD_DOMAIN=dashboard.example.com
+
+# Source CIDRs allowed to POST to /api/traces/otlp via Traefik. The middleware
+# rejects everything else with 403 before the request reaches the backend.
+# Default covers RFC1918 private ranges. Add edge endpoint public IPs, VPN
+# ranges, or your CDN egress when traffic arrives from outside the LAN.
+# BEYLA_ALLOWED_SOURCE_CIDRS=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+
+# Beyla OTLP ingest rate limit at Traefik (per-source-IP). Beyla batches ~every
+# 16s so 100 req/s average is generous for most fleets. Tune up when scaling out.
+# BEYLA_RATE_LIMIT_AVERAGE=100
+# BEYLA_RATE_LIMIT_BURST=200
 # Trusted proxy IPs/CIDRs for Fastify trustProxy (#1099). Comma-separated list of
 # IPs or CIDR ranges that may set X-Forwarded-* headers. Leave unset to trust all
 # upstream hops (default — appropriate when the app sits behind the bundled nginx
@@ -353,8 +378,11 @@ LOG_LEVEL=info
 # LOG_SHIPPING_FLUSH_INTERVAL_MS=5000
 
 # eBPF Trace Ingestion (Grafana Beyla)
-# Enable to accept OTLP traces from Beyla or other OpenTelemetry exporters
-# See docker/beyla/beyla.yml for the Beyla sidecar configuration
+# Enable to accept OTLP traces from Beyla or other OpenTelemetry exporters.
+# When the dashboard is behind Traefik on 443, the bundled labels on the backend
+# container route POST /api/traces/otlp on websecure to the backend — set
+# DASHBOARD_DOMAIN above so the router rule matches. See
+# docs/ebpf-trace-ingestion.md "Option C" for the full Traefik recipe.
 # TRACES_INGESTION_ENABLED=false
 # TRACES_INGESTION_API_KEY=  # Required when TRACES_INGESTION_ENABLED=true
 

--- a/docker/docker-compose.beyla.yml
+++ b/docker/docker-compose.beyla.yml
@@ -1,14 +1,32 @@
 # Grafana Beyla - eBPF auto-instrumentation sidecar
+#
+# Use this overlay when you want a Beyla instance on the dashboard's own docker
+# host (e.g. to observe services co-located with the dashboard). For Beyla on
+# remote endpoints, use the dashboard UI: eBPF Coverage → Deploy, which deploys
+# Beyla via the Portainer API. See docs/ebpf-trace-ingestion.md for the full
+# picture.
+#
 # Usage:
-#   docker compose -f docker/docker-compose.dev.yml -f docker/beyla/beyla.yml up
-#   OR with profile: docker compose --profile ebpf up
+#   docker compose -f docker/docker-compose.yml -f docker/docker-compose.beyla.yml up -d
+#   OR with profile: docker compose --profile ebpf up -d
 #
 # Prerequisites:
 #   - Linux kernel 5.8+ with BTF support
 #   - Docker host must allow --privileged or SYS_ADMIN + SYS_PTRACE capabilities
 #   - macOS/Windows Docker Desktop: works inside Linux VM but cannot instrument host processes
+#   - Set TRACES_INGESTION_ENABLED=true and TRACES_INGESTION_API_KEY in .env
 #
-# Set TRACES_INGESTION_ENABLED=true and TRACES_INGESTION_API_KEY in .env
+# OTLP endpoint resolution:
+#   Defaults to https://${DASHBOARD_DOMAIN}/api/traces/otlp so traffic flows
+#   through the existing Traefik on 443 — identical to the path used for
+#   remote-endpoint deployments, so traces converge into a single ingest route
+#   with the same auth/middleware chain.
+#
+#   For setups without Traefik (or to bypass it on the same host), override:
+#     BEYLA_OTLP_ENDPOINT=http://backend:3051/api/traces/otlp
+#   This uses the internal dashboard-net directly. The HTTP allowlist and rate
+#   limit in the Traefik label are NOT applied on this path — the backend's own
+#   API-key check still enforces auth.
 
 services:
   beyla:
@@ -18,15 +36,20 @@ services:
     init: true
     environment:
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT:-80,443,3000-9999}"
-      BEYLA_SERVICE_NAMESPACE: "portainer-apps"
-      # Beyla auto-appends /v1/traces to the base endpoint URL
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://backend:443/api/traces/otlp"
+      BEYLA_SERVICE_NAMESPACE: "${BEYLA_SERVICE_NAMESPACE:-dashboard-host}"
+      # Beyla auto-appends /v1/traces to the base endpoint URL. The default goes
+      # through Traefik on 443 so this sidecar uses the same ingest path as
+      # remote-endpoint deployments. Override BEYLA_OTLP_ENDPOINT to bypass
+      # Traefik (e.g. http://backend:3051/api/traces/otlp on the internal net),
+      # in which case DASHBOARD_DOMAIN is no longer required at compose time —
+      # set BEYLA_OTLP_ENDPOINT in .env and leave DASHBOARD_DOMAIN unset.
+      OTEL_EXPORTER_OTLP_ENDPOINT: "${BEYLA_OTLP_ENDPOINT:-https://${DASHBOARD_DOMAIN:?DASHBOARD_DOMAIN is required (or set BEYLA_OTLP_ENDPOINT to a full URL)}/api/traces/otlp}"
       OTEL_EXPORTER_OTLP_PROTOCOL: "http/json"
       # Disable metrics export — we only ingest traces
       OTEL_METRICS_EXPORTER: "none"
       BEYLA_TRACE_PRINTER: "disabled"
       # Header format: key=value (no spaces, no colon)
-      OTEL_EXPORTER_OTLP_HEADERS: "X-API-Key=${TRACES_INGESTION_API_KEY:-}"
+      OTEL_EXPORTER_OTLP_HEADERS: "X-API-Key=${TRACES_INGESTION_API_KEY:?TRACES_INGESTION_API_KEY is required}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /sys/kernel/security:/sys/kernel/security:ro
@@ -34,5 +57,6 @@ services:
       - dashboard-net
     depends_on:
       - backend
+    restart: unless-stopped
     profiles:
       - ebpf

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -148,11 +148,18 @@ services:
       traefik.http.routers.beyla-otlp.service: beyla-backend
       # Service: backend Fastify on port 3051
       traefik.http.services.beyla-backend.loadbalancer.server.port: "3051"
-      # Middleware: restrict to Beyla source networks (replace CIDRs with your actual ranges)
-      traefik.http.middlewares.beyla-ip-allow.ipallowlist.sourcerange: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
-      # Middleware: rate limit — 100 req/s average, burst up to 200
-      traefik.http.middlewares.beyla-rate-limit.ratelimit.average: "100"
-      traefik.http.middlewares.beyla-rate-limit.ratelimit.burst: "200"
+      # Middleware: restrict to Beyla source networks.
+      # Defaults to RFC1918 private ranges. Override with BEYLA_ALLOWED_SOURCE_CIDRS
+      # (comma-separated CIDRs) when edge endpoints reach the dashboard from public
+      # IPs, behind a known NAT, or via a VPN with non-private ranges. Traefik sees
+      # the source IP of the immediate upstream — if a CDN sits in front of Traefik,
+      # add that CDN's egress ranges here.
+      traefik.http.middlewares.beyla-ip-allow.ipallowlist.sourcerange: "${BEYLA_ALLOWED_SOURCE_CIDRS:-10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}"
+      # Middleware: rate limit — defaults to 100 req/s average, burst up to 200.
+      # Beyla batches roughly every 16s so this is generous for most fleets; tune via
+      # BEYLA_RATE_LIMIT_AVERAGE / BEYLA_RATE_LIMIT_BURST when scaling out.
+      traefik.http.middlewares.beyla-rate-limit.ratelimit.average: "${BEYLA_RATE_LIMIT_AVERAGE:-100}"
+      traefik.http.middlewares.beyla-rate-limit.ratelimit.burst: "${BEYLA_RATE_LIMIT_BURST:-200}"
     deploy:
       resources:
         limits:

--- a/docs/ebpf-trace-ingestion.md
+++ b/docs/ebpf-trace-ingestion.md
@@ -332,37 +332,80 @@ This instruments services visible from the dashboard's Docker network.
 
 ### Option C: Production via Traefik on HTTPS 443
 
-Use this when endpoint firewalls allow only `443` and direct access to backend `:3051` is blocked.
+Use this when endpoint firewalls allow only `443` and direct access to backend `:3051` is blocked, or when you want a single uniform ingest path across local and remote endpoints. Two variants are supported.
 
-1. Set required env vars:
+#### C1: Existing Traefik with Docker label discovery (recommended)
 
-```env
-DASHBOARD_EXTERNAL_URL=https://dashboard.example.com
-TRACES_INGESTION_ENABLED=true
-TRACES_INGESTION_API_KEY=your-secret-api-key-here
-```
+Use this when you already run Traefik on the host with the Docker provider — e.g. Traefik already fronts the dashboard frontend on 443. The backend container ships with Traefik labels (`docker/docker-compose.yml` ~lines 139–159) that add a dedicated POST-only route for `/api/traces/otlp` directly to the backend on `:3051`, bypassing the frontend nginx for OTLP payloads. No file-provider config and no second Traefik instance are needed.
 
-2. Start dashboard with the Traefik OTLP overlay:
+1. Set required env vars in `.env`:
 
-```bash
-docker compose -f docker/docker-compose.yml -f docker/docker-compose.traefik-otlp.yml up -d
-```
+   ```env
+   # Origin Beyla uses to reach the dashboard (no trailing slash, no /api/...)
+   DASHBOARD_EXTERNAL_URL=https://dashboard.example.com
+   # Hostname the Traefik router rule matches on the backend
+   DASHBOARD_DOMAIN=dashboard.example.com
+   # Ingest auth
+   TRACES_INGESTION_ENABLED=true
+   TRACES_INGESTION_API_KEY=your-secret-api-key-here
+   # Optional: tune the IP allowlist and rate limit baked into the labels
+   # BEYLA_ALLOWED_SOURCE_CIDRS=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+   # BEYLA_RATE_LIMIT_AVERAGE=100
+   # BEYLA_RATE_LIMIT_BURST=200
+   ```
 
-3. Set Beyla exporter endpoint on each remote endpoint:
+2. Make sure your existing Traefik can see the backend:
+   - Attach the Traefik container to the `dashboard-net` network created by `docker-compose.yml` (`docker network connect ai-portainer-dashboard_dashboard-net <traefik-container>` if running outside this compose project), so it can route to `backend:3051`.
+   - Confirm Traefik runs with `--providers.docker=true` and a `websecure` entrypoint on `:443` with TLS configured for `DASHBOARD_DOMAIN`.
 
-```env
-OTEL_EXPORTER_OTLP_ENDPOINT=https://dashboard.example.com/api/traces/otlp
-OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-OTEL_EXPORTER_OTLP_HEADERS=X-API-Key=your-secret-api-key-here
-```
+3. Start the dashboard stack as usual:
 
-Repository assets for this mode:
+   ```bash
+   docker compose -f docker/docker-compose.yml up -d
+   ```
+
+   Verify the route was published:
+
+   ```bash
+   curl -X POST https://dashboard.example.com/api/traces/otlp \
+     -H "Content-Type: application/json" \
+     -H "X-API-Key: your-secret-api-key-here" \
+     -d '{"resourceSpans":[]}'
+   # → {"accepted":0}
+   ```
+
+4. Deploy Beyla to your Portainer endpoints from the dashboard:
+   - Open **eBPF Coverage** in the dashboard sidebar.
+   - Click **Sync Endpoints** to pull the latest list from Portainer.
+   - For each endpoint, click **Deploy**. The backend resolves the OTLP endpoint from `DASHBOARD_EXTERNAL_URL` and creates a privileged `grafana/beyla:latest` container on the target endpoint via the Portainer API, pointing at `https://dashboard.example.com/api/traces/otlp`.
+
+#### C2: Dedicated OTLP-only Traefik (no existing Traefik on host)
+
+Use this when nothing else owns port 443 on the host and you want a self-contained Traefik just for OTLP. This variant uses a file provider config that mirrors the Docker labels — pick one, not both.
+
+1. Set the same env vars as C1 (plus `DASHBOARD_DOMAIN` is not used here; the rule is in the file provider).
+
+2. Start with the Traefik OTLP overlay:
+
+   ```bash
+   docker compose -f docker/docker-compose.yml -f docker/docker-compose.traefik-otlp.yml up -d
+   ```
+
+3. Configure each Beyla exporter:
+
+   ```env
+   OTEL_EXPORTER_OTLP_ENDPOINT=https://dashboard.example.com/api/traces/otlp
+   OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+   OTEL_EXPORTER_OTLP_HEADERS=X-API-Key=your-secret-api-key-here
+   ```
+
+Repository assets for this variant:
 - `docker/docker-compose.traefik-otlp.yml`
 - `docker/traefik/dynamic/beyla-otlp.yml`
 
-Important:
+Before you start:
 - Replace `dashboard.example.com` in `docker/traefik/dynamic/beyla-otlp.yml`.
-- Replace default IP allow-list CIDRs with your real Beyla source networks.
+- Replace the default IP allow-list CIDRs with your real Beyla source networks.
 - Mount valid TLS certs at `docker/traefik/certs/fullchain.pem` and `docker/traefik/certs/privkey.pem`.
 
 ## Multi-Endpoint Deployment


### PR DESCRIPTION
## Summary

Restructures the eBPF trace ingestion documentation and environment configuration to clarify two distinct Traefik deployment patterns for OTLP ingest, each with different prerequisites and trade-offs. Adds comprehensive guidance on Docker label discovery (C1) vs. file-provider config (C2), and updates `.env.example` with detailed comments on `DASHBOARD_EXTERNAL_URL`, `DASHBOARD_DOMAIN`, and new rate-limit/CIDR allowlist variables.

## Key Changes

- **Documentation (docs/ebpf-trace-ingestion.md)**
  - Split "Option C: Production via Traefik on HTTPS 443" into two sub-variants:
    - **C1 (Recommended)**: Existing Traefik with Docker label discovery — leverages bundled labels on the backend container (`docker-compose.yml` lines 139–159) for a dedicated `/api/traces/otlp` route; no file-provider config needed.
    - **C2**: Dedicated OTLP-only Traefik using file-provider overlay (`docker-compose.traefik-otlp.yml`) when no existing Traefik owns port 443.
  - Added step-by-step instructions for C1 including network attachment, Traefik prerequisites, and curl verification.
  - Added C2 instructions for remote Beyla endpoint configuration.
  - Clarified that C1 supports dashboard UI deployment via eBPF Coverage → Deploy (Portainer API integration).

- **Environment Configuration (.env.example)**
  - Expanded `DASHBOARD_EXTERNAL_URL` comment with topology guidance (Traefik on 443 vs. direct backend port).
  - Added `DASHBOARD_DOMAIN` documentation: required when backend is fronted by Traefik, used in router rule matching.
  - Added new variables: `BEYLA_ALLOWED_SOURCE_CIDRS` (IP allowlist, defaults to RFC1918), `BEYLA_RATE_LIMIT_AVERAGE` (100 req/s), `BEYLA_RATE_LIMIT_BURST` (200).
  - Updated `TRACES_INGESTION_ENABLED` comment to reference Option C and Traefik label routing.

- **Docker Compose Labels (docker/docker-compose.yml)**
  - Made IP allowlist and rate-limit values environment-variable-driven via `${BEYLA_ALLOWED_SOURCE_CIDRS:-...}` and `${BEYLA_RATE_LIMIT_AVERAGE:-...}` / `${BEYLA_RATE_LIMIT_BURST:-...}`.
  - Enhanced inline comments explaining CIDR override scenarios (public IPs, VPN ranges, CDN egress) and rate-limit tuning for fleet scaling.

- **Beyla Sidecar Overlay (docker/docker-compose.beyla.yml)**
  - Clarified use case: local Beyla sidecar on dashboard host (vs. remote endpoint deployments via Portainer API).
  - Updated `OTEL_EXPORTER_OTLP_ENDPOINT` to default to `https://${DASHBOARD_DOMAIN}/api/traces/otlp` (Traefik path) with fallback to `http://backend:3051/api/traces/otlp` (internal network bypass).
  - Added `BEYLA_SERVICE_NAMESPACE` environment variable (defaults to `dashboard-host`).
  - Made `DASHBOARD_DOMAIN` optional when `BEYLA_OTLP_ENDPOINT` is explicitly set.
  - Added `restart: unless-stopped` policy.
  - Enhanced comments explaining endpoint resolution and auth flow.

## Implementation Details

- **C1 Design**: Reuses existing Traefik instance already fronting the dashboard frontend; no additional infrastructure. Requires `DASHBOARD_DOMAIN` at compose time so the backend's Docker labels can construct the router rule. Network attachment ensures Traefik can reach `backend:3051`.

- **C2 Design**: Self-contained Traefik overlay for environments without existing Traefik on port 443. Uses file-provider config (`docker/traefik/dynamic/beyla-otl

https://claude.ai/code/session_0135TCc3MKfUxmYATUkLe88p