### PR TITLE
fix(portainer): treat Docker 304 from start/stop as success, not failure

### DIFF
--- a/packages/core/src/portainer/portainer-client.test.ts
+++ b/packages/core/src/portainer/portainer-client.test.ts
@@ -1,6 +1,37 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { decodeDockerLogPayload, sanitizeContainerLabels, _resetClientState, getCircuitBreakerStats, buildApiUrl, buildApiHeaders, pruneStaleBreakers, startBreakerPruning, stopBreakerPruning, isEdgeTunnelNotActive, EDGE_TUNNEL_NOT_ACTIVE_TOKEN } from './portainer-client.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Kept: undici mock — external dependency. Lets us assert behavior of
+// startContainer / stopContainer against fabricated Docker responses.
+vi.mock('undici', () => ({
+  Agent: vi.fn(function () { return { close: vi.fn().mockResolvedValue(undefined) }; }),
+  fetch: vi.fn(),
+}));
+
+// Kept: trace-context mock — side-effect isolation. withSpan would otherwise
+// require an active trace context for portainerFetch to nest under.
+vi.mock('../tracing/trace-context.js', () => ({
+  withSpan: (_name: string, _service: string, _kind: string, fn: () => unknown) => fn(),
+}));
+
+import { fetch as undiciFetch } from 'undici';
+import {
+  decodeDockerLogPayload,
+  sanitizeContainerLabels,
+  _resetClientState,
+  getCircuitBreakerStats,
+  buildApiUrl,
+  buildApiHeaders,
+  pruneStaleBreakers,
+  startBreakerPruning,
+  stopBreakerPruning,
+  startContainer,
+  stopContainer,
+  isEdgeTunnelNotActive,
+  EDGE_TUNNEL_NOT_ACTIVE_TOKEN,
+} from './portainer-client.js';
 import pLimit from 'p-limit';
+
+const mockFetch = vi.mocked(undiciFetch);
 
 describe('isEdgeTunnelNotActive', () => {
   // SNAPSHOT: this is the exact substring our predicate matches against
@@ -212,5 +243,80 @@ describe('circuit breaker pruning (#547)', () => {
     expect(() => stopBreakerPruning()).not.toThrow();
     // Calling stop again should be idempotent
     expect(() => stopBreakerPruning()).not.toThrow();
+  });
+});
+
+// =====================================================================
+//  Docker idempotent lifecycle endpoints (start / stop) — #1230
+//
+//  Docker's /containers/{id}/start and /stop return HTTP 304 Not Modified
+//  when the container is already in the requested state. Without this
+//  guard, the just-created container was actually running, but
+//  startContainer's phantom 304 failure triggered the orphan-rollback
+//  path in deployBeyla and removed the working container on every retry.
+// =====================================================================
+
+function buildResponse({
+  status,
+  statusText,
+  body = {},
+}: { status: number; statusText: string; body?: unknown }) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+describe('startContainer / stopContainer — 304 idempotency (#1230)', () => {
+  beforeEach(() => {
+    _resetClientState();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    _resetClientState();
+  });
+
+  it('startContainer resolves when Docker returns 304 (already running)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      buildResponse({ status: 304, statusText: 'Not Modified' }),
+    );
+    await expect(startContainer(1, 'abc123')).resolves.toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('stopContainer resolves when Docker returns 304 (already stopped)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      buildResponse({ status: 304, statusText: 'Not Modified' }),
+    );
+    await expect(stopContainer(1, 'abc123')).resolves.toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('startContainer resolves on 204 No Content (Docker happy path)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      buildResponse({ status: 204, statusText: 'No Content' }),
+    );
+    await expect(startContainer(1, 'abc123')).resolves.toBeUndefined();
+  });
+
+  it('startContainer rethrows other non-2xx errors (e.g. 404, 500)', async () => {
+    // 404: container not found. This must NOT be swallowed by the 304 guard.
+    mockFetch.mockResolvedValue(
+      buildResponse({ status: 404, statusText: 'Not Found' }),
+    );
+    await expect(startContainer(1, 'missing')).rejects.toThrow(/HTTP 404/);
+  });
+
+  it('stopContainer rethrows server errors (e.g. 500)', async () => {
+    // 500: actual server failure. Retries (3) and then surfaces the error.
+    mockFetch.mockResolvedValue(
+      buildResponse({ status: 500, statusText: 'Internal Server Error' }),
+    );
+    await expect(stopContainer(1, 'abc123')).rejects.toThrow(/HTTP 500/);
   });
 });

--- a/packages/core/src/portainer/portainer-client.ts
+++ b/packages/core/src/portainer/portainer-client.ts
@@ -546,16 +546,35 @@ export async function getContainerHostConfig(endpointId: number, containerId: st
   return raw.HostConfig ?? {};
 }
 
+/**
+ * Docker's lifecycle endpoints (start/stop) are idempotent: they return 304
+ * Not Modified when the container is already in the requested state. That's
+ * a success signal, not a failure — translate by swallowing the 304.
+ */
+function isAlreadyInTargetStateError(err: unknown): boolean {
+  return err instanceof PortainerError && err.status === 304;
+}
+
 export async function startContainer(endpointId: number, containerId: string): Promise<void> {
-  await portainerFetch(`/api/endpoints/${endpointId}/docker/containers/${containerId}/start`, {
-    method: 'POST',
-  });
+  try {
+    await portainerFetch(`/api/endpoints/${endpointId}/docker/containers/${containerId}/start`, {
+      method: 'POST',
+    });
+  } catch (err) {
+    if (isAlreadyInTargetStateError(err)) return; // already running
+    throw err;
+  }
 }
 
 export async function stopContainer(endpointId: number, containerId: string): Promise<void> {
-  await portainerFetch(`/api/endpoints/${endpointId}/docker/containers/${containerId}/stop`, {
-    method: 'POST',
-  });
+  try {
+    await portainerFetch(`/api/endpoints/${endpointId}/docker/containers/${containerId}/stop`, {
+      method: 'POST',
+    });
+  } catch (err) {
+    if (isAlreadyInTargetStateError(err)) return; // already stopped
+    throw err;
+  }
 }
 
 export async function restartContainer(endpointId: number, containerId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Docker's `/containers/{id}/start` and `/stop` endpoints are idempotent and return **HTTP 304 Not Modified** when the container is already in the requested state. `portainerFetchInner` treats every non-2xx response as an error, so `startContainer` threw `PortainerError(status=304)` in a perfectly normal case — for example when Docker auto-starts a container immediately after create, or `stopContainer` is called on an already-stopped container.

In the Beyla eBPF deploy flow this was destructive: the just-created container was actually running, but `startContainer`'s phantom 304 failure triggered the orphan-rollback path (#1228) which removed the working container. Every retry killed the previously-running Beyla.

Found by exercising the deploy against a real Edge Agent — observed the `removing just-created container to avoid orphan` log line firing immediately after a successful create, with `err: "HTTP 304: Not Modified"` from Docker.

## Change

`startContainer` and `stopContainer` now catch the 304 case via a small helper `isAlreadyInTargetStateError` and return normally — the function contract was "ensure the container is in this state," and a 304 means it already is.

Other Docker idempotent endpoints (`/pause`, `/unpause`, `/restart`, `/kill`) return 204 on success, not 304, so they're unaffected.

## Test plan

- [x] Existing 64 core tests pass.
- [x] All 76 security tests pass (deploy flow integration).
- [x] Verified end-to-end against a real Edge Agent (Type 4) — Beyla `/beyla-7` deploys cleanly to `srv-edge-01` and starts emitting OTLP traces to the configured endpoint.

## Note for reviewer

This was originally bundled into #1228 but is logically a separate Docker-API quirk fix, so it's been split into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)