### PR TITLE
fix(k8s): convert querystring schemas to Zod

### DIFF
--- a/backend/src/routes/kubernetes.test.ts
+++ b/backend/src/routes/kubernetes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
 import Fastify from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
 import { kubernetesRoutes } from '@dashboard/foundation';
 vi.mock('@dashboard/core/portainer/portainer-client.js', async (importOriginal) => await importOriginal());
 import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
@@ -16,6 +17,10 @@ afterAll(async () => {
 
 function buildApp() {
   const app = Fastify();
+  // Match production wiring: routes use Zod schemas via fastify-type-provider-zod.
+  // Without this, Fastify's default ajv validator can't parse Zod objects and
+  // route registration fails with "schema is invalid: data/required must be array".
+  app.setValidatorCompiler(validatorCompiler);
   app.decorate('authenticate', async () => undefined);
   app.register(kubernetesRoutes);
   return app;

--- a/packages/foundation/src/__tests__/kubernetes-route.test.ts
+++ b/packages/foundation/src/__tests__/kubernetes-route.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { validatorCompiler } from 'fastify-type-provider-zod';
+import { kubernetesRoutes } from '../routes/kubernetes.js';
+
+// Passthrough mock: keep real client module writable so individual functions can be spied.
+vi.mock('@dashboard/core/portainer/portainer-client.js', async (importOriginal) => await importOriginal());
+// Bypass caching so each test exercises a fresh upstream call.
+vi.mock('@dashboard/core/portainer/portainer-cache.js', async (importOriginal) => {
+  const real = await importOriginal() as typeof import('@dashboard/core/portainer/portainer-cache.js');
+  return {
+    ...real,
+    cachedFetch: <T>(_key: string, _ttl: number, fn: () => Promise<T>) => fn(),
+    cachedFetchSWR: <T>(_key: string, _ttl: number, fn: () => Promise<T>) => fn(),
+  };
+});
+
+import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
+
+const k8sEndpoint = (id: number, name: string) => ({
+  Id: id,
+  Name: name,
+  Type: 5, // Kubernetes Local
+  Status: 1, // up
+  Snapshots: [],
+  EdgeID: null,
+  LastCheckInDate: null,
+  EdgeCheckinInterval: null,
+});
+
+describe('Kubernetes Routes - querystring validation (regression for #1231)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', () => async () => undefined);
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'admin', sessionId: 's1', role: 'admin' as const };
+    });
+    await app.register(kubernetesRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+      k8sEndpoint(1, 'k8s-prod'),
+    ] as any);
+    vi.spyOn(portainerClient, 'getPods').mockResolvedValue([]);
+    vi.spyOn(portainerClient, 'getDeployments').mockResolvedValue([]);
+    vi.spyOn(portainerClient, 'getServices').mockResolvedValue([]);
+    vi.spyOn(portainerClient, 'getNamespaces').mockResolvedValue([]);
+  });
+
+  // The bug: querystrings were defined as raw JSON Schema, which the
+  // fastify-type-provider-zod validator could not parse — every request
+  // returned 500 with `Cannot read properties of undefined (reading 'run')`.
+  // These tests assert validation succeeds and the route runs.
+
+  describe('GET /api/kubernetes/pods', () => {
+    it('accepts empty querystring without 500', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/kubernetes/pods' });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body).toHaveProperty('pods');
+      expect(body).toHaveProperty('errors');
+    });
+
+    it('accepts namespace and coerces endpointId from string', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/pods?namespace=default&endpointId=1',
+      });
+      expect(res.statusCode).toBe(200);
+      // Confirms endpointId coercion: filter should keep endpoint 1.
+      expect(portainerClient.getPods).toHaveBeenCalledWith(1, 'default');
+    });
+
+    it('rejects non-numeric endpointId with 400 (not 500)', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/pods?endpointId=not-a-number',
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('GET /api/kubernetes/deployments', () => {
+    it('accepts empty querystring without 500', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/kubernetes/deployments' });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('accepts valid querystring', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/deployments?namespace=kube-system&endpointId=1',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(portainerClient.getDeployments).toHaveBeenCalledWith(1, 'kube-system');
+    });
+  });
+
+  describe('GET /api/kubernetes/services', () => {
+    it('accepts empty querystring without 500', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/kubernetes/services' });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('accepts valid querystring', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/services?namespace=default&endpointId=1',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(portainerClient.getServices).toHaveBeenCalledWith(1, 'default');
+    });
+  });
+
+  describe('GET /api/kubernetes/namespaces', () => {
+    it('accepts empty querystring without 500', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/kubernetes/namespaces' });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('accepts endpointId querystring', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/namespaces?endpointId=1',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(portainerClient.getNamespaces).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('GET /api/kubernetes/pods/:endpointId/:namespace/:podName/logs', () => {
+    it('accepts empty querystring (defaults applied)', async () => {
+      vi.spyOn(portainerClient, 'getPodLogs').mockResolvedValue('hello');
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/pods/1/default/my-pod/logs',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(portainerClient.getPodLogs).toHaveBeenCalledWith(
+        1,
+        'default',
+        'my-pod',
+        expect.objectContaining({ tail: 100, timestamps: true }),
+      );
+    });
+
+    it('accepts full querystring with coerced types', async () => {
+      vi.spyOn(portainerClient, 'getPodLogs').mockResolvedValue('hello');
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/kubernetes/pods/1/default/my-pod/logs?tail=50&sinceSeconds=60&timestamps=false&container=app',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(portainerClient.getPodLogs).toHaveBeenCalledWith(
+        1,
+        'default',
+        'my-pod',
+        { tail: 50, sinceSeconds: 60, timestamps: false, container: 'app' },
+      );
+    });
+  });
+});

--- a/packages/foundation/src/routes/kubernetes.ts
+++ b/packages/foundation/src/routes/kubernetes.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from 'fastify';
+import { z } from 'zod/v4';
 import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import {
@@ -33,13 +34,10 @@ export async function kubernetesRoutes(fastify: FastifyInstance) {
       tags: ['Kubernetes'],
       summary: 'List pods across all Kubernetes endpoints',
       security: [{ bearerAuth: [] }],
-      querystring: {
-        type: 'object',
-        properties: {
-          namespace: { type: 'string' },
-          endpointId: { type: 'number' },
-        },
-      },
+      querystring: z.object({
+        namespace: z.string().optional(),
+        endpointId: z.coerce.number().int().positive().optional(),
+      }),
     },
     preHandler: [fastify.authenticate],
   }, async (request) => {
@@ -80,13 +78,10 @@ export async function kubernetesRoutes(fastify: FastifyInstance) {
       tags: ['Kubernetes'],
       summary: 'List deployments across all Kubernetes endpoints',
       security: [{ bearerAuth: [] }],
-      querystring: {
-        type: 'object',
-        properties: {
-          namespace: { type: 'string' },
-          endpointId: { type: 'number' },
-        },
-      },
+      querystring: z.object({
+        namespace: z.string().optional(),
+        endpointId: z.coerce.number().int().positive().optional(),
+      }),
     },
     preHandler: [fastify.authenticate],
   }, async (request) => {
@@ -127,13 +122,10 @@ export async function kubernetesRoutes(fastify: FastifyInstance) {
       tags: ['Kubernetes'],
       summary: 'List services across all Kubernetes endpoints',
       security: [{ bearerAuth: [] }],
-      querystring: {
-        type: 'object',
-        properties: {
-          namespace: { type: 'string' },
-          endpointId: { type: 'number' },
-        },
-      },
+      querystring: z.object({
+        namespace: z.string().optional(),
+        endpointId: z.coerce.number().int().positive().optional(),
+      }),
     },
     preHandler: [fastify.authenticate],
   }, async (request) => {
@@ -174,12 +166,9 @@ export async function kubernetesRoutes(fastify: FastifyInstance) {
       tags: ['Kubernetes'],
       summary: 'List namespaces across all Kubernetes endpoints',
       security: [{ bearerAuth: [] }],
-      querystring: {
-        type: 'object',
-        properties: {
-          endpointId: { type: 'number' },
-        },
-      },
+      querystring: z.object({
+        endpointId: z.coerce.number().int().positive().optional(),
+      }),
     },
     preHandler: [fastify.authenticate],
   }, async (request) => {
@@ -220,24 +209,24 @@ export async function kubernetesRoutes(fastify: FastifyInstance) {
       tags: ['Kubernetes'],
       summary: 'Get pod logs (read-only)',
       security: [{ bearerAuth: [] }],
-      params: {
-        type: 'object',
-        required: ['endpointId', 'namespace', 'podName'],
-        properties: {
-          endpointId: { type: 'number' },
-          namespace: { type: 'string' },
-          podName: { type: 'string' },
-        },
-      },
-      querystring: {
-        type: 'object',
-        properties: {
-          tail: { type: 'number', default: 100 },
-          sinceSeconds: { type: 'number' },
-          timestamps: { type: 'boolean', default: true },
-          container: { type: 'string' },
-        },
-      },
+      params: z.object({
+        endpointId: z.coerce.number().int().positive(),
+        namespace: z.string().min(1),
+        podName: z.string().min(1),
+      }),
+      querystring: z.object({
+        tail: z.coerce.number().int().positive().optional().default(100),
+        sinceSeconds: z.coerce.number().int().positive().optional(),
+        timestamps: z
+          .union([z.boolean(), z.string()])
+          .optional()
+          .default(true)
+          .transform((value) => {
+            if (typeof value === 'boolean') return value;
+            return value !== 'false' && value !== '0';
+          }),
+        container: z.string().optional(),
+      }),
     },
     preHandler: [fastify.authenticate],
   }, async (request, reply) => {

--- a/packages/foundation/src/routes/kubernetes.ts
+++ b/packages/foundation/src/routes/kubernetes.ts
@@ -215,11 +215,10 @@ export async function kubernetesRoutes(fastify: FastifyInstance) {
         podName: z.string().min(1),
       }),
       querystring: z.object({
-        tail: z.coerce.number().int().positive().optional().default(100),
+        tail: z.coerce.number().int().positive().default(100),
         sinceSeconds: z.coerce.number().int().positive().optional(),
         timestamps: z
           .union([z.boolean(), z.string()])
-          .optional()
           .default(true)
           .transform((value) => {
             if (typeof value === 'boolean') return value;


### PR DESCRIPTION
## Summary

Fixes #1231 — every `/api/kubernetes/*` request was returning HTTP 500 with `TypeError: Cannot read properties of undefined (reading 'run')`.

## Root cause

`packages/foundation/src/routes/kubernetes.ts` defined route querystrings (and the pod-logs `params`) as **raw JSON Schema** (`{ type: 'object', properties: {...} }`). The app is wired with `fastify-type-provider-zod`'s validator compiler, which expects **Zod schemas** — handing it a plain JSON-Schema object means `schema._zod` is undefined and `.run()` blows up at request-validation time.

## Fix

Converted the five affected route blocks to Zod:

- `GET /api/kubernetes/pods` — querystring
- `GET /api/kubernetes/deployments` — querystring
- `GET /api/kubernetes/services` — querystring
- `GET /api/kubernetes/namespaces` — querystring
- `GET /api/kubernetes/pods/:endpointId/:namespace/:podName/logs` — params + querystring

Used `z.coerce.number().int().positive()` for numerics (querystrings arrive as strings) and a union+transform for `timestamps` so `"false"` correctly maps to `false` rather than coercing to truthy. All previously-optional fields stay optional.

## Test coverage

New regression test at `packages/foundation/src/__tests__/kubernetes-route.test.ts` (11 cases):

- Each of the 5 endpoints exercised with empty querystring AND valid querystring — asserts status is not 500 / `FST_ERR_VALIDATION`.
- Coercion verified (string `"1"` → number `1`).
- Pod-logs full querystring asserts `timestamps=false` is honored as boolean `false`.
- Invalid `endpointId=not-a-number` returns 400 (validation), not 500.

Test pattern mirrors `packages/foundation/src/__tests__/endpoints-route.test.ts`: passthrough `vi.mock` on the Portainer client + cache, then `vi.spyOn` to stub individual upstream functions. Auth is decorated via `app.decorate('authenticate', ...)` per project convention.

## Verification

- `npx vitest run src/__tests__/kubernetes-route.test.ts` — 11/11 pass
- `npm run typecheck` — clean
- `npm run lint` — clean
- Pre-push hook ran the full 1873-test suite — all green

Closes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)