### PR TITLE
feat(edge): live Docker-info fallback for Edge Standard endpoints (#1249)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -41,6 +41,14 @@ PORTAINER_VERIFY_SSL=true
 # Circuit breaker — trips on 5xx/network errors, ignores 4xx
 # PORTAINER_CB_FAILURE_THRESHOLD=5    # failures before opening circuit
 # PORTAINER_CB_RESET_TIMEOUT_MS=30000 # ms before retrying (HALF_OPEN probe)
+# Edge Standard live-fetch (issue #1249) — fills container counts for Edge Agent
+# Standard endpoints whose Portainer Snapshots[] never gets populated. Cached via
+# stale-while-revalidate and rate-limited with a dedicated concurrency budget so
+# large fleets don't stampede Portainer's chisel tunnel.
+# EDGE_LIVE_QUERY_ENABLED=true              # master toggle (set false to disable live fallback)
+# EDGE_LIVE_QUERY_CONCURRENCY=2             # max parallel live /docker/info calls (1-20)
+# EDGE_LIVE_QUERY_INTERVAL_SECONDS=60       # cache TTL per endpoint (15-3600)
+# EDGE_LIVE_QUERY_TIMEOUT_MS=5000           # per-call timeout (1000-30000)
 
 # LLM Integration (OpenAI-compatible API: OpenAI, LM Studio, vLLM, LiteLLM, OpenWebUI, etc.)
 # Bare base URL is fine — /v1/chat/completions is appended automatically.

--- a/frontend/src/features/containers/hooks/use-endpoints.ts
+++ b/frontend/src/features/containers/hooks/use-endpoints.ts
@@ -29,6 +29,17 @@ export interface Endpoint {
   capabilities: EdgeCapabilities;
   agentVersion?: string;
   lastCheckIn?: number;
+  /**
+   * Where container counts came from (issue #1249).
+   * `'snapshot'` is the default Portainer-cached path. `'live'` means we filled
+   * the counts via a live `/docker/info` call through the chisel tunnel (Edge
+   * Standard endpoints whose Snapshots[] never gets populated). `'unavailable'`
+   * means the live fallback was attempted but failed — UI should label this
+   * distinctly from a genuinely empty endpoint.
+   */
+  snapshotSource: 'snapshot' | 'live' | 'unavailable';
+  /** Epoch millis of the last live refresh. Set when `snapshotSource === 'live'`. */
+  snapshotFetchedAt?: number;
 }
 
 export function useEndpoints() {

--- a/frontend/src/features/core/components/settings/shared.tsx
+++ b/frontend/src/features/core/components/settings/shared.tsx
@@ -138,6 +138,13 @@ export const DEFAULT_SETTINGS = {
   edgeAgent: [
     { key: 'edge.staleness_threshold_minutes', label: 'Staleness Threshold', description: 'Minutes since last Edge Agent check-in before data is marked stale', type: 'number', defaultValue: '5', min: 1, max: 60 },
     { key: 'edge.checkin_warning_multiplier', label: 'Check-in Warning Multiplier', description: 'Show warning when time since last check-in exceeds this multiple of the check-in interval', type: 'number', defaultValue: '3', min: 2, max: 10 },
+    // Live Docker-info fallback (issue #1249) — Portainer EE doesn't persist
+    // Snapshots[] for Edge Standard endpoints, so we fall back to live tunnel
+    // queries. Tunable so large fleets don't hammer Portainer's chisel tunnel.
+    { key: 'edge.live_query_enabled', label: 'Live Container Counts Fallback', description: 'Fetch live Docker info via the chisel tunnel when an Edge Standard endpoint has no snapshot (#1249). Disable to keep the legacy behavior (0/0/0 counts).', type: 'boolean', defaultValue: 'true' },
+    { key: 'edge.live_query_concurrency', label: 'Live Fetch Concurrency', description: 'Max parallel live /docker/info calls across Edge endpoints. Keep low (1–3) for large fleets to avoid stampeding Portainer.', type: 'number', defaultValue: '2', min: 1, max: 20 },
+    { key: 'edge.live_query_interval_seconds', label: 'Live Fetch Interval (seconds)', description: 'Cache TTL per endpoint. The dashboard returns stale data instantly while refreshing in the background.', type: 'number', defaultValue: '60', min: 15, max: 3600 },
+    { key: 'edge.live_query_timeout_ms', label: 'Live Fetch Timeout (ms)', description: 'Per-call timeout — a slow agent never blocks the dashboard.', type: 'number', defaultValue: '5000', min: 1000, max: 30000 },
   ],
   harbor: [
     { key: 'harbor.enabled', label: 'Enable Harbor Integration', description: 'Enable vulnerability management via Harbor Registry', type: 'boolean', defaultValue: 'false' },

--- a/frontend/src/features/core/pages/home.tsx
+++ b/frontend/src/features/core/pages/home.tsx
@@ -49,6 +49,9 @@ export default function HomePage() {
       running: ep.containersRunning,
       stopped: ep.containersStopped,
       total: ep.totalContainers,
+      status: ep.status,
+      snapshotSource: ep.snapshotSource,
+      snapshotFetchedAt: ep.snapshotFetchedAt,
     }));
   }, [endpoints]);
 

--- a/frontend/src/shared/components/charts/endpoint-health-octagons.test.tsx
+++ b/frontend/src/shared/components/charts/endpoint-health-octagons.test.tsx
@@ -62,7 +62,38 @@ describe('EndpointHealthOctagons', () => {
     renderWithWidth(<EndpointHealthOctagons endpoints={ENDPOINTS} />);
     expect(screen.getByText('Production')).toBeInTheDocument();
     expect(screen.getByText('9/10 running')).toBeInTheDocument();
-    expect(screen.getByText('No containers')).toBeInTheDocument();
+    // The Empty endpoint (total=0) now reads "Awaiting snapshot" instead of "No containers" —
+    // it's the same gray hexagon but the label distinguishes "we haven't seen data yet"
+    // from "we tried and failed" (issue #1249).
+    expect(screen.getByText('Awaiting snapshot')).toBeInTheDocument();
+  });
+
+  it('renders "Offline" inside the hexagon when status=down', () => {
+    const down = [{ id: 9, name: 'DeadNode', running: 0, stopped: 0, total: 0, status: 'down' as const }];
+    renderWithWidth(<EndpointHealthOctagons endpoints={down} />);
+    const hex = screen.getByTestId('octagon-DeadNode');
+    expect(hex.textContent).toContain('Offline');
+  });
+
+  it('renders "Data unavailable" when snapshotSource=unavailable (issue #1249)', () => {
+    const unavail = [{ id: 10, name: 'EdgeStandard', running: 0, stopped: 0, total: 0, status: 'up' as const, snapshotSource: 'unavailable' as const }];
+    renderWithWidth(<EndpointHealthOctagons endpoints={unavail} />);
+    const hex = screen.getByTestId('octagon-EdgeStandard');
+    expect(hex.textContent).toContain('Data unavailable');
+    expect(hex.textContent).not.toContain('Awaiting snapshot');
+  });
+
+  it('shows live counts and includes refresh age in the tooltip when snapshotSource=live', () => {
+    const tenSecondsAgo = Date.now() - 10_000;
+    const live = [{
+      id: 11, name: 'LiveEdge', running: 4, stopped: 1, total: 5,
+      status: 'up' as const, snapshotSource: 'live' as const, snapshotFetchedAt: tenSecondsAgo,
+    }];
+    renderWithWidth(<EndpointHealthOctagons endpoints={live} />);
+    const hex = screen.getByTestId('octagon-LiveEdge');
+    expect(hex.textContent).toContain('4/5 running');
+    // Tooltip lives on the title attribute — surfaced to screen readers via aria-label.
+    expect(hex.getAttribute('title')).toMatch(/live, refreshed \d+s ago/);
   });
 
   it('handles empty endpoints array', () => {
@@ -116,5 +147,20 @@ describe('getHealthLevel', () => {
 
   it('returns empty when total is 0', () => {
     expect(getHealthLevel_testable(0, 0)).toBe('empty');
+  });
+
+  it('returns offline when status is down regardless of counts (issue #1249)', () => {
+    expect(getHealthLevel_testable(0, 0, 'down')).toBe('offline');
+    expect(getHealthLevel_testable(5, 10, 'down')).toBe('offline');
+    expect(getHealthLevel_testable(10, 10, 'down')).toBe('offline');
+  });
+
+  it('returns unavailable when snapshotSource is unavailable (issue #1249)', () => {
+    expect(getHealthLevel_testable(0, 0, 'up', 'unavailable')).toBe('unavailable');
+  });
+
+  it('uses container ratio when status=up and snapshotSource=live', () => {
+    expect(getHealthLevel_testable(9, 10, 'up', 'live')).toBe('good');
+    expect(getHealthLevel_testable(0, 0, 'up', 'live')).toBe('empty');
   });
 });

--- a/frontend/src/shared/components/charts/endpoint-health-octagons.tsx
+++ b/frontend/src/shared/components/charts/endpoint-health-octagons.tsx
@@ -28,7 +28,7 @@ export interface EndpointHealthOctagonsProps {
 const HEALTH_COLORS = {
   good: { fill: 'rgba(16,185,129,0.85)', stroke: 'rgba(52,211,153,0.4)', text: 'text-white', shadow: 'rgba(16,185,129,0.35)' },
   warning: { fill: 'rgba(245,158,11,0.85)', stroke: 'rgba(251,191,36,0.4)', text: 'text-white', shadow: 'rgba(245,158,11,0.35)' },
-  critical: { fill: 'rgba(239,68,68,0.85)', stroke: 'rgba(248,113,113,0.4)', text: 'text-white', shadow: 'rgba(248,113,113,0.4)', shadowExt: 'rgba(239,68,68,0.35)' },
+  critical: { fill: 'rgba(239,68,68,0.85)', stroke: 'rgba(248,113,113,0.4)', text: 'text-white', shadow: 'rgba(239,68,68,0.35)' },
   offline: { fill: 'rgba(100,116,139,0.85)', stroke: 'rgba(148,163,184,0.5)', text: 'text-white', shadow: 'rgba(100,116,139,0.35)' },
   unavailable: { fill: 'rgba(120,113,108,0.7)', stroke: 'rgba(168,162,158,0.5)', text: 'text-white', shadow: 'rgba(120,113,108,0.3)' },
   empty: { fill: 'rgba(148,163,184,0.6)', stroke: 'rgba(203,213,225,0.3)', text: 'text-white', shadow: 'rgba(148,163,184,0.2)' },

--- a/frontend/src/shared/components/charts/endpoint-health-octagons.tsx
+++ b/frontend/src/shared/components/charts/endpoint-health-octagons.tsx
@@ -11,6 +11,16 @@ export interface EndpointHealthOctagonsProps {
     running: number;
     stopped: number;
     total: number;
+    /** Endpoint connectivity status — `'down'` flips the hexagon to slate "Offline". */
+    status?: 'up' | 'down';
+    /**
+     * Where the counts came from (issue #1249). `'unavailable'` renders distinctly
+     * from "no containers" so an operator can tell whether Portainer is just empty
+     * vs the live-fallback fetch failed.
+     */
+    snapshotSource?: 'snapshot' | 'live' | 'unavailable';
+    /** Epoch millis of last live refresh (only set when source === 'live'). */
+    snapshotFetchedAt?: number;
   }>;
   isLoading?: boolean;
 }
@@ -18,13 +28,33 @@ export interface EndpointHealthOctagonsProps {
 const HEALTH_COLORS = {
   good: { fill: 'rgba(16,185,129,0.85)', stroke: 'rgba(52,211,153,0.4)', text: 'text-white', shadow: 'rgba(16,185,129,0.35)' },
   warning: { fill: 'rgba(245,158,11,0.85)', stroke: 'rgba(251,191,36,0.4)', text: 'text-white', shadow: 'rgba(245,158,11,0.35)' },
-  critical: { fill: 'rgba(239,68,68,0.85)', stroke: 'rgba(248,113,113,0.4)', text: 'text-white', shadow: 'rgba(239,68,68,0.35)' },
+  critical: { fill: 'rgba(239,68,68,0.85)', stroke: 'rgba(248,113,113,0.4)', text: 'text-white', shadow: 'rgba(248,113,113,0.4)', shadowExt: 'rgba(239,68,68,0.35)' },
+  offline: { fill: 'rgba(100,116,139,0.85)', stroke: 'rgba(148,163,184,0.5)', text: 'text-white', shadow: 'rgba(100,116,139,0.35)' },
+  unavailable: { fill: 'rgba(120,113,108,0.7)', stroke: 'rgba(168,162,158,0.5)', text: 'text-white', shadow: 'rgba(120,113,108,0.3)' },
   empty: { fill: 'rgba(148,163,184,0.6)', stroke: 'rgba(203,213,225,0.3)', text: 'text-white', shadow: 'rgba(148,163,184,0.2)' },
 } as const;
 
 type HealthLevel = keyof typeof HEALTH_COLORS;
 
-function getHealthLevel(running: number, total: number): HealthLevel {
+/**
+ * Map endpoint state to a hexagon color level.
+ *
+ * Precedence (top wins):
+ * 1. `status === 'down'` → `offline` (slate) regardless of counts.
+ * 2. `snapshotSource === 'unavailable'` → `unavailable` (stone) — live fallback
+ *    was attempted but failed; distinct from an empty endpoint.
+ * 3. `total === 0` → `empty` (gray) — endpoint is up with no containers yet,
+ *    or snapshot data hasn't arrived yet.
+ * 4. Otherwise, ratio buckets: >80% good, 50-80% warning, <50% critical.
+ */
+function getHealthLevel(
+  running: number,
+  total: number,
+  status?: 'up' | 'down',
+  snapshotSource?: 'snapshot' | 'live' | 'unavailable',
+): HealthLevel {
+  if (status === 'down') return 'offline';
+  if (snapshotSource === 'unavailable') return 'unavailable';
   if (total === 0) return 'empty';
   const ratio = running / total;
   if (ratio > 0.8) return 'good';
@@ -118,13 +148,62 @@ interface HexagonCardProps {
   running: number;
   total: number;
   level: HealthLevel;
+  snapshotSource?: 'snapshot' | 'live' | 'unavailable';
+  snapshotFetchedAt?: number;
   onClick: () => void;
   index: number;
 }
 
-function HexagonCard({ name, running, total, level, onClick }: HexagonCardProps) {
+/** Inner label shown under the endpoint name. */
+function getStatusLabel(
+  level: HealthLevel,
+  running: number,
+  total: number,
+): string {
+  if (level === 'offline') return 'Offline';
+  if (level === 'unavailable') return 'Data unavailable';
+  if (level === 'empty') return 'Awaiting snapshot';
+  return `${running}/${total} running`;
+}
+
+/** Hover/aria title — same string for screen readers and tooltip. */
+function getCardTitle(
+  name: string,
+  level: HealthLevel,
+  running: number,
+  total: number,
+  snapshotSource?: 'snapshot' | 'live' | 'unavailable',
+  snapshotFetchedAt?: number,
+): string {
+  if (level === 'offline') {
+    return `${name} — offline`;
+  }
+  if (level === 'unavailable') {
+    return `${name} — data unavailable (live fetch failed)`;
+  }
+  if (level === 'empty') {
+    return `${name} — awaiting snapshot`;
+  }
+  const counts = `${running}/${total} running`;
+  if (snapshotSource === 'live' && snapshotFetchedAt) {
+    const seconds = Math.max(0, Math.round((Date.now() - snapshotFetchedAt) / 1000));
+    return `${name} — ${counts} (live, refreshed ${seconds}s ago)`;
+  }
+  return `${name} — ${counts}`;
+}
+
+function HexagonCard({
+  name,
+  running,
+  total,
+  level,
+  snapshotSource,
+  snapshotFetchedAt,
+  onClick,
+}: HexagonCardProps) {
   const colors = HEALTH_COLORS[level];
   const blurId = `hex-blur-${level}`;
+  const title = getCardTitle(name, level, running, total, snapshotSource, snapshotFetchedAt);
 
   return (
     <motion.div
@@ -133,7 +212,8 @@ function HexagonCard({ name, running, total, level, onClick }: HexagonCardProps)
       onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onClick()}
       role="button"
       tabIndex={0}
-      aria-label={`${name} endpoint - ${running}/${total} running`}
+      title={title}
+      aria-label={title}
       className="octagon-button absolute focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 cursor-pointer select-none [-webkit-user-select:none] [-webkit-tap-highlight-color:transparent] hover:!bg-transparent"
       data-testid={`octagon-${name}`}
       style={{
@@ -189,7 +269,7 @@ function HexagonCard({ name, running, total, level, onClick }: HexagonCardProps)
             {name}
           </span>
           <span className="text-[10px] mt-0.5 opacity-80 font-medium">
-            {total > 0 ? `${running}/${total} running` : 'No containers'}
+            {getStatusLabel(level, running, total)}
           </span>
         </div>
       </div>
@@ -266,7 +346,7 @@ export const EndpointHealthOctagons = memo(function EndpointHealthOctagons({
   const items = useMemo(() => {
     return endpoints.map((ep) => ({
       ...ep,
-      level: getHealthLevel(ep.running, ep.total),
+      level: getHealthLevel(ep.running, ep.total, ep.status, ep.snapshotSource),
     }));
   }, [endpoints]);
 
@@ -326,6 +406,8 @@ export const EndpointHealthOctagons = memo(function EndpointHealthOctagons({
                   running={ep.running}
                   total={ep.total}
                   level={ep.level}
+                  snapshotSource={ep.snapshotSource}
+                  snapshotFetchedAt={ep.snapshotFetchedAt}
                   onClick={handleClick}
                   index={i}
                 />
@@ -336,7 +418,7 @@ export const EndpointHealthOctagons = memo(function EndpointHealthOctagons({
       </div>
 
       {/* Legend */}
-      <div className="flex justify-center gap-5 pt-3 shrink-0">
+      <div className="flex justify-center gap-5 pt-3 shrink-0 flex-wrap">
         <div className="flex items-center gap-1.5">
           <div className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
           <span className="text-xs text-muted-foreground">&gt;80% healthy</span>
@@ -348,6 +430,18 @@ export const EndpointHealthOctagons = memo(function EndpointHealthOctagons({
         <div className="flex items-center gap-1.5">
           <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
           <span className="text-xs text-muted-foreground">&lt;50%</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full bg-slate-500" />
+          <span className="text-xs text-muted-foreground">Offline</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full bg-stone-500" />
+          <span className="text-xs text-muted-foreground">Unavailable</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full bg-slate-400" />
+          <span className="text-xs text-muted-foreground">No data</span>
         </div>
       </div>
     </div>

--- a/packages/core/src/config/env.schema.ts
+++ b/packages/core/src/config/env.schema.ts
@@ -42,6 +42,13 @@ export const envSchema = z.object({
   PORTAINER_MAX_CONNECTIONS: z.coerce.number().int().min(1).max(100).default(20),
   PORTAINER_CB_FAILURE_THRESHOLD: z.coerce.number().int().min(1).max(50).default(5),
   PORTAINER_CB_RESET_TIMEOUT_MS: z.coerce.number().int().min(1000).max(300000).default(30000),
+
+  // Edge Standard live-fetch fallback (issue #1249) — fills container counts for
+  // Edge Agent Standard endpoints whose Portainer Snapshots[] never gets populated.
+  EDGE_LIVE_QUERY_ENABLED: z.string().default('true').transform((v) => v === 'true' || v === '1'),
+  EDGE_LIVE_QUERY_CONCURRENCY: z.coerce.number().int().min(1).max(20).default(2),
+  EDGE_LIVE_QUERY_INTERVAL_SECONDS: z.coerce.number().int().min(15).max(3600).default(60),
+  EDGE_LIVE_QUERY_TIMEOUT_MS: z.coerce.number().int().min(1000).max(30000).default(5000),
   // Public/external dashboard URL used by remote agents/endpoints to call back into the API.
   DASHBOARD_EXTERNAL_URL: optionalUrl,
 

--- a/packages/core/src/portainer/edge-live-query.test.ts
+++ b/packages/core/src/portainer/edge-live-query.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock undici fetch — the only external boundary this module crosses.
+vi.mock('undici', () => ({
+  fetch: vi.fn(),
+}));
+
+import { fetch as undiciFetch } from 'undici';
+import {
+  fetchEdgeLiveDockerInfo,
+  edgeLiveQueryCacheKey,
+  getEdgeLiveQueryConfigFromEnv,
+  _resetEdgeLiveQueryState,
+  type EdgeLiveQueryConfig,
+} from './edge-live-query.js';
+import { resetConfig, setConfigForTest } from '../config/index.js';
+
+const mockFetch = vi.mocked(undiciFetch);
+
+function mockJsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Awaited<ReturnType<typeof undiciFetch>>;
+}
+
+beforeEach(() => {
+  resetConfig();
+  // Disable the SWR cache layer so each test exercises the real fetch path —
+  // cache behavior is already covered by portainer-cache.test.ts and caching
+  // would hide call-count assertions here.
+  setConfigForTest({ CACHE_ENABLED: false, PORTAINER_API_URL: 'http://test.local' });
+  _resetEdgeLiveQueryState();
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  resetConfig();
+});
+
+function cfg(overrides: Partial<EdgeLiveQueryConfig> = {}): EdgeLiveQueryConfig {
+  return { enabled: true, concurrency: 2, intervalSeconds: 60, timeoutMs: 5000, ...overrides };
+}
+
+describe('fetchEdgeLiveDockerInfo', () => {
+  it('returns null when disabled and never touches the network', async () => {
+    const result = await fetchEdgeLiveDockerInfo(7, cfg({ enabled: false }));
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('maps Docker /info response into the EdgeDockerInfo shape', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockJsonResponse({ Containers: 7, ContainersRunning: 5, ContainersStopped: 2, ContainersPaused: 0 }),
+    );
+    const result = await fetchEdgeLiveDockerInfo(7, cfg());
+
+    expect(result).toMatchObject({
+      containers: 7,
+      containersRunning: 5,
+      containersStopped: 2,
+      containersPaused: 0,
+    });
+    expect(typeof result?.fetchedAt).toBe('number');
+    // /docker/info path is the contract — keep this assertion explicit.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = String(mockFetch.mock.calls[0][0]);
+    expect(url).toContain('/api/endpoints/7/docker/info');
+  });
+
+  it('falls back to summing running+stopped+paused when Containers field is missing', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockJsonResponse({ ContainersRunning: 3, ContainersStopped: 1, ContainersPaused: 1 }),
+    );
+    const result = await fetchEdgeLiveDockerInfo(7, cfg());
+    expect(result?.containers).toBe(5);
+  });
+
+  it('treats missing count fields as zero rather than NaN/undefined', async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse({}));
+    const result = await fetchEdgeLiveDockerInfo(7, cfg());
+    expect(result).toMatchObject({
+      containers: 0,
+      containersRunning: 0,
+      containersStopped: 0,
+      containersPaused: 0,
+    });
+  });
+
+  it('returns null on non-2xx response and logs (no throw)', async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse({}, 502));
+    const result = await fetchEdgeLiveDockerInfo(7, cfg());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the fetch itself rejects (network / abort)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('AbortError'));
+    const result = await fetchEdgeLiveDockerInfo(7, cfg());
+    expect(result).toBeNull();
+  });
+
+  it('passes an AbortController signal so timeouts can cancel the request', async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse({ Containers: 0 }));
+    await fetchEdgeLiveDockerInfo(7, cfg({ timeoutMs: 1234 }));
+    const opts = mockFetch.mock.calls[0][1] as { signal?: AbortSignal };
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('respects the concurrency limit — at most N fetches in flight simultaneously', async () => {
+    // Each fetch settles after a tiny delay. With concurrency=2 and 5 tasks,
+    // the limiter must serialize batches so peak inflight never exceeds 2.
+    let inFlight = 0;
+    let peak = 0;
+    mockFetch.mockImplementation(() => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          inFlight--;
+          resolve(mockJsonResponse({ Containers: 0 }));
+        }, 20);
+      });
+    });
+
+    const config = cfg({ concurrency: 2 });
+    const tasks = [1, 2, 3, 4, 5].map((id) => fetchEdgeLiveDockerInfo(id, config));
+    await Promise.all(tasks);
+
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(peak).toBeLessThanOrEqual(2);
+    expect(peak).toBeGreaterThan(0);
+  });
+
+  it('rebuilds the limiter when concurrency changes between calls', async () => {
+    mockFetch.mockResolvedValue(mockJsonResponse({ Containers: 0 }));
+    await fetchEdgeLiveDockerInfo(1, cfg({ concurrency: 2 }));
+    // After this call the cached limiter has concurrency=2.
+    // Calling with concurrency=5 should rebuild it without throwing.
+    await fetchEdgeLiveDockerInfo(2, cfg({ concurrency: 5 }));
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('edgeLiveQueryCacheKey', () => {
+  it('produces a stable, unambiguous key per endpoint id', () => {
+    expect(edgeLiveQueryCacheKey(7)).toBe('edge-live-info:7');
+    expect(edgeLiveQueryCacheKey(123)).toBe('edge-live-info:123');
+  });
+});
+
+describe('getEdgeLiveQueryConfigFromEnv', () => {
+  it('reads defaults from getConfig()', () => {
+    const c = getEdgeLiveQueryConfigFromEnv();
+    expect(c.enabled).toBeTypeOf('boolean');
+    expect(c.concurrency).toBeGreaterThanOrEqual(1);
+    expect(c.intervalSeconds).toBeGreaterThanOrEqual(15);
+    expect(c.timeoutMs).toBeGreaterThanOrEqual(1000);
+  });
+});

--- a/packages/core/src/portainer/edge-live-query.ts
+++ b/packages/core/src/portainer/edge-live-query.ts
@@ -1,0 +1,170 @@
+/**
+ * Edge Standard live Docker-info fallback (issue #1249).
+ *
+ * Portainer EE 2.39 does not write persistent `Snapshots[]` entries for Edge
+ * Agent Standard endpoints (Type=4, AsyncMode=false). As a result, the
+ * normalizer reports 0/0/0 container counts for those endpoints even when the
+ * agent is fully connected and reachable via the chisel tunnel.
+ *
+ * This module fills that gap: when an Edge Standard endpoint has empty
+ * `Snapshots[]`, the route layer can call `fetchEdgeLiveDockerInfo(id)` to
+ * pull a live `/docker/info` summary through Portainer's tunnel proxy.
+ *
+ * Constraints (per issue #1249):
+ *
+ * - **Dedicated concurrency budget.** Separate `p-limit` so that a fleet of
+ *   dozens of edge nodes never fans out simultaneously and stampedes the
+ *   chisel tunnel. Sized by `EDGE_LIVE_QUERY_CONCURRENCY` (default 2).
+ * - **SWR caching.** Wrapped in `cachedFetchSWR` keyed per endpoint, so the
+ *   dashboard returns stale data instantly and revalidates in the background.
+ *   TTL controlled by `EDGE_LIVE_QUERY_INTERVAL_SECONDS` (default 60s).
+ * - **Per-call timeout.** A slow agent must never block the dashboard.
+ *   Bounded by `EDGE_LIVE_QUERY_TIMEOUT_MS` (default 5000ms).
+ * - **Graceful degradation.** On failure or when disabled, returns `null` so
+ *   the caller can mark the endpoint as `snapshotSource: 'unavailable'`.
+ *
+ * Defaults are tunable at runtime via the Settings UI (see
+ * `getEffectiveEdgeLiveQueryConfig` in `services/settings-store.ts`), which
+ * lets operators dial concurrency/interval down without a backend restart.
+ */
+import pLimit from 'p-limit';
+import { fetch as undiciFetch } from 'undici';
+import { getConfig } from '../config/index.js';
+import { createChildLogger } from '../utils/logger.js';
+import { cachedFetchSWR, getCacheKey } from './portainer-cache.js';
+import { buildApiUrl, buildApiHeaders } from './portainer-client.js';
+
+const log = createChildLogger('edge-live-query');
+
+/** Minimal slice of Docker `/info` that we actually use. */
+export interface EdgeDockerInfo {
+  containers: number;
+  containersRunning: number;
+  containersStopped: number;
+  /** Optional — Docker rarely has paused containers, and the normalizer doesn't use it today. */
+  containersPaused?: number;
+  fetchedAt: number;
+}
+
+/** Effective runtime config. Mirrors env vars but is intended to be overridden by Settings UI. */
+export interface EdgeLiveQueryConfig {
+  enabled: boolean;
+  concurrency: number;
+  intervalSeconds: number;
+  timeoutMs: number;
+}
+
+let limiter: ReturnType<typeof pLimit> | undefined;
+let limiterConcurrency: number | undefined;
+
+/**
+ * Get the live-query limiter, rebuilding when the concurrency value changes.
+ * This allows the Settings UI to adjust concurrency at runtime without a restart.
+ */
+function getLimiter(concurrency: number): ReturnType<typeof pLimit> {
+  if (!limiter || limiterConcurrency !== concurrency) {
+    limiter = pLimit(concurrency);
+    limiterConcurrency = concurrency;
+  }
+  return limiter;
+}
+
+/** Reset cached limiter state — for tests. */
+export function _resetEdgeLiveQueryState(): void {
+  limiter = undefined;
+  limiterConcurrency = undefined;
+}
+
+/**
+ * Build a runtime config from env. The settings-store may later override this
+ * before each request. Kept here so callers without a DB still get sensible
+ * behavior (e.g. unit tests, CLI scripts).
+ */
+export function getEdgeLiveQueryConfigFromEnv(): EdgeLiveQueryConfig {
+  const cfg = getConfig();
+  return {
+    enabled: cfg.EDGE_LIVE_QUERY_ENABLED,
+    concurrency: cfg.EDGE_LIVE_QUERY_CONCURRENCY,
+    intervalSeconds: cfg.EDGE_LIVE_QUERY_INTERVAL_SECONDS,
+    timeoutMs: cfg.EDGE_LIVE_QUERY_TIMEOUT_MS,
+  };
+}
+
+/** Cache key used both internally and exposed for invalidation in tests/diagnostics. */
+export function edgeLiveQueryCacheKey(endpointId: number): string {
+  return getCacheKey('edge-live-info', endpointId);
+}
+
+interface PortainerDockerInfoResponse {
+  Containers?: number;
+  ContainersRunning?: number;
+  ContainersStopped?: number;
+  ContainersPaused?: number;
+}
+
+/**
+ * Issue a single `/docker/info` call through Portainer's tunnel proxy.
+ * Intentionally bypasses the main `portainerFetch` helper because we want a
+ * tighter timeout, a separate concurrency budget, and no retry storm — a slow
+ * or unreachable edge agent should fail fast and let the dashboard render.
+ */
+async function fetchDockerInfoOnce(endpointId: number, timeoutMs: number): Promise<EdgeDockerInfo> {
+  const url = buildApiUrl(`/api/endpoints/${endpointId}/docker/info`);
+  const headers = buildApiHeaders(false);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await undiciFetch(url, { headers, signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    }
+    const body = (await res.json()) as PortainerDockerInfoResponse;
+    const running = body.ContainersRunning ?? 0;
+    const stopped = body.ContainersStopped ?? 0;
+    const paused = body.ContainersPaused ?? 0;
+    // Docker's `Containers` is the canonical total (running + stopped + paused);
+    // fall back to a sum if the field is missing.
+    const total = body.Containers ?? running + stopped + paused;
+    return {
+      containers: total,
+      containersRunning: running,
+      containersStopped: stopped,
+      containersPaused: paused,
+      fetchedAt: Date.now(),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetch live Docker info for an Edge Standard endpoint, going through the
+ * dedicated concurrency limiter and SWR cache.
+ *
+ * Returns `null` when the live-query feature is disabled, or when the fetch
+ * fails / times out. Callers should treat `null` as
+ * `snapshotSource: 'unavailable'`.
+ *
+ * @param endpointId Portainer endpoint id
+ * @param cfg Effective runtime config (env merged with Settings overrides)
+ */
+export async function fetchEdgeLiveDockerInfo(
+  endpointId: number,
+  cfg: EdgeLiveQueryConfig = getEdgeLiveQueryConfigFromEnv(),
+): Promise<EdgeDockerInfo | null> {
+  if (!cfg.enabled) return null;
+
+  const limit = getLimiter(cfg.concurrency);
+
+  try {
+    return await cachedFetchSWR<EdgeDockerInfo>(
+      edgeLiveQueryCacheKey(endpointId),
+      cfg.intervalSeconds,
+      () => limit(() => fetchDockerInfoOnce(endpointId, cfg.timeoutMs)),
+    );
+  } catch (err) {
+    log.warn({ endpointId, err }, 'Edge live Docker-info fetch failed');
+    return null;
+  }
+}

--- a/packages/core/src/portainer/portainer-normalizers-edge.test.ts
+++ b/packages/core/src/portainer/portainer-normalizers-edge.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { normalizeEndpoint } from './portainer-normalizers.js';
+import {
+  normalizeEndpoint,
+  endpointNeedsLiveFallback,
+  applyLiveDockerInfo,
+  markLiveUnavailable,
+} from './portainer-normalizers.js';
 import type { Endpoint } from '../models/portainer.js';
 
 function makeEndpoint(overrides: Partial<Endpoint> = {}): Endpoint {
@@ -266,6 +271,117 @@ describe('normalizeEndpoint — Edge Agent fields', () => {
 
       const down = makeEndpoint({ Type: 1, Status: 2 });
       expect(normalizeEndpoint(down).status).toBe('down');
+    });
+  });
+
+  // Issue #1249 — live Docker-info fallback for Edge Standard endpoints whose
+  // Portainer Snapshots[] is permanently empty.
+  describe('Live fallback helpers (issue #1249)', () => {
+    it('normalizeEndpoint defaults snapshotSource to "snapshot"', () => {
+      const result = normalizeEndpoint(makeEndpoint());
+      expect(result.snapshotSource).toBe('snapshot');
+      expect(result.snapshotFetchedAt).toBeUndefined();
+    });
+
+    it('endpointNeedsLiveFallback returns true for Edge Standard with empty counts', () => {
+      // Edge Standard up, with no Snapshots → normalizer yields 0/0/0 counts.
+      const ep = makeEndpoint({
+        Type: 4,
+        EdgeID: 'edge-empty',
+        Status: 1,
+        Snapshots: [],
+      });
+      const normalized = normalizeEndpoint(ep);
+      expect(normalized.totalContainers).toBe(0);
+      expect(endpointNeedsLiveFallback(normalized)).toBe(true);
+    });
+
+    it('endpointNeedsLiveFallback returns false for Edge Standard that has snapshot data', () => {
+      const ep = makeEndpoint({
+        Type: 4,
+        EdgeID: 'edge-with-snapshot',
+        Status: 1,
+      });
+      const normalized = normalizeEndpoint(ep);
+      // makeEndpoint provides a populated Snapshots[] by default → counts > 0
+      expect(endpointNeedsLiveFallback(normalized)).toBe(false);
+    });
+
+    it('endpointNeedsLiveFallback returns false for non-Edge endpoints regardless of counts', () => {
+      const ep = makeEndpoint({ Type: 1, Snapshots: [] });
+      const normalized = normalizeEndpoint(ep);
+      expect(normalized.isEdge).toBe(false);
+      expect(endpointNeedsLiveFallback(normalized)).toBe(false);
+    });
+
+    it('endpointNeedsLiveFallback returns false when endpoint is down', () => {
+      const ep = makeEndpoint({
+        Type: 4,
+        EdgeID: 'edge-down',
+        Status: 2,
+        Snapshots: [],
+        // no LastCheckInDate → normalizer marks status='down'
+      });
+      const normalized = normalizeEndpoint(ep);
+      expect(normalized.status).toBe('down');
+      expect(endpointNeedsLiveFallback(normalized)).toBe(false);
+    });
+
+    it('endpointNeedsLiveFallback returns false for Async Edge (only Standard uses this fallback)', () => {
+      // Async edge agents push their own snapshots — Portainer never proxies
+      // through a tunnel for them, so the live /docker/info path would fail.
+      const ep = makeEndpoint({
+        Type: 7,
+        EdgeID: 'edge-async',
+        Status: 1,
+        Snapshots: [],
+      });
+      const normalized = normalizeEndpoint(ep);
+      expect(normalized.edgeMode).toBe('async');
+      expect(endpointNeedsLiveFallback(normalized)).toBe(false);
+    });
+
+    it('applyLiveDockerInfo overrides counts and flips snapshotSource to "live"', () => {
+      const ep = makeEndpoint({
+        Type: 4,
+        EdgeID: 'edge-merge',
+        Status: 1,
+        Snapshots: [],
+      });
+      const normalized = normalizeEndpoint(ep);
+      const fetchedAt = Date.now();
+
+      const result = applyLiveDockerInfo(normalized, {
+        containers: 5,
+        containersRunning: 4,
+        containersStopped: 1,
+        fetchedAt,
+      });
+
+      expect(result.containersRunning).toBe(4);
+      expect(result.containersStopped).toBe(1);
+      expect(result.totalContainers).toBe(5);
+      expect(result.snapshotSource).toBe('live');
+      expect(result.snapshotFetchedAt).toBe(fetchedAt);
+      // Same reference (mutated in place — caller owns it after .map())
+      expect(result).toBe(normalized);
+    });
+
+    it('markLiveUnavailable flips snapshotSource without changing counts', () => {
+      const ep = makeEndpoint({
+        Type: 4,
+        EdgeID: 'edge-unavailable',
+        Status: 1,
+        Snapshots: [],
+      });
+      const normalized = normalizeEndpoint(ep);
+      const before = { ...normalized };
+
+      const result = markLiveUnavailable(normalized);
+      expect(result.snapshotSource).toBe('unavailable');
+      expect(result.containersRunning).toBe(before.containersRunning);
+      expect(result.containersStopped).toBe(before.containersStopped);
+      expect(result.totalContainers).toBe(before.totalContainers);
     });
   });
 });

--- a/packages/core/src/portainer/portainer-normalizers.ts
+++ b/packages/core/src/portainer/portainer-normalizers.ts
@@ -32,6 +32,17 @@ export interface NormalizedEndpoint {
   capabilities: EdgeCapabilities;
   agentVersion?: string;
   lastCheckIn?: number;
+  /**
+   * Where the container counts came from (issue #1249).
+   * - `snapshot`: read from Portainer's persisted `Snapshots[0]` (the normal path).
+   * - `live`: fetched live via `/docker/info` through the chisel tunnel — used for
+   *   Edge Standard endpoints whose Snapshots[] never gets populated.
+   * - `unavailable`: live-fetch was attempted but failed/timed out. Counts are 0/0/0
+   *   and the UI should label this distinctly from a genuinely empty endpoint.
+   */
+  snapshotSource: 'snapshot' | 'live' | 'unavailable';
+  /** Epoch millis of when the counts were last refreshed. Set when `snapshotSource` is `live`. */
+  snapshotFetchedAt?: number;
 }
 
 export interface NormalizedContainer {
@@ -167,7 +178,64 @@ export function normalizeEndpoint(ep: Endpoint): NormalizedEndpoint {
     capabilities: buildCapabilities(edgeMode),
     agentVersion: ep.Agent?.Version,
     lastCheckIn: ep.LastCheckInDate,
+    // Without a live merge, the source is whatever the snapshot lookup yielded.
+    // `applyLiveDockerInfo` / `markLiveUnavailable` flip this for Edge endpoints
+    // whose Snapshots[] is empty.
+    snapshotSource: 'snapshot',
   };
+}
+
+/**
+ * True when the normalizer produced 0/0/0 because Portainer has no snapshot
+ * (the Edge Standard case from issue #1249). Use this to decide whether a
+ * live `/docker/info` fallback should be attempted.
+ */
+export function endpointNeedsLiveFallback(ep: NormalizedEndpoint): boolean {
+  return (
+    ep.isEdge &&
+    ep.edgeMode === 'standard' &&
+    ep.status === 'up' &&
+    ep.totalContainers === 0 &&
+    ep.containersRunning === 0 &&
+    ep.containersStopped === 0
+  );
+}
+
+/** Live `/docker/info` payload shape — narrow enough to keep this file zero-dependency. */
+export interface LiveDockerInfoCounts {
+  containers: number;
+  containersRunning: number;
+  containersStopped: number;
+  containersPaused?: number;
+  fetchedAt: number;
+}
+
+/**
+ * Overlay live Docker-info counts onto a normalized endpoint and mark the
+ * snapshot source as `live`. Returns the updated endpoint (mutated in place,
+ * since the caller owns it from `endpoints.map(normalizeEndpoint)`).
+ */
+export function applyLiveDockerInfo(
+  ep: NormalizedEndpoint,
+  info: LiveDockerInfoCounts,
+): NormalizedEndpoint {
+  ep.containersRunning = info.containersRunning;
+  ep.containersStopped = info.containersStopped;
+  ep.totalContainers = info.containers;
+  ep.snapshotSource = 'live';
+  ep.snapshotFetchedAt = info.fetchedAt;
+  return ep;
+}
+
+/**
+ * Mark a normalized endpoint as `unavailable` — used when the live-fetch
+ * fallback was attempted but failed/timed out. Counts stay 0/0/0; the
+ * frontend uses the marker to render a distinct "data unavailable" state
+ * instead of a misleading "no containers".
+ */
+export function markLiveUnavailable(ep: NormalizedEndpoint): NormalizedEndpoint {
+  ep.snapshotSource = 'unavailable';
+  return ep;
 }
 
 /** Extract Docker health check status from the Status string (e.g. "Up 2 hours (healthy)"). */

--- a/packages/core/src/services/settings-store.ts
+++ b/packages/core/src/services/settings-store.ts
@@ -82,6 +82,47 @@ export async function getEffectiveHarborConfig() {
   return { enabled, apiUrl, robotName, robotSecret, verifySsl, syncIntervalMinutes };
 }
 
+/**
+ * Edge Standard live-fetch fallback (issue #1249).
+ *
+ * Read at the top of each endpoints/dashboard request so operators can dial
+ * concurrency / interval / timeout from the Settings UI without restarting.
+ * DB values override env defaults; clamped on read so a bad DB value never
+ * crashes the request path.
+ */
+export interface EdgeLiveQueryConfig {
+  enabled: boolean;
+  concurrency: number;
+  intervalSeconds: number;
+  timeoutMs: number;
+}
+
+function clampInt(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
+export async function getEffectiveEdgeLiveQueryConfig(): Promise<EdgeLiveQueryConfig> {
+  const cfg = getConfig();
+  const enabledRow = await getSetting('edge.live_query_enabled');
+  const enabled = enabledRow ? enabledRow.value === 'true' : cfg.EDGE_LIVE_QUERY_ENABLED;
+
+  const concurrency = clampInt(
+    parseInt((await getSetting('edge.live_query_concurrency'))?.value || '', 10) || cfg.EDGE_LIVE_QUERY_CONCURRENCY,
+    1, 20, cfg.EDGE_LIVE_QUERY_CONCURRENCY,
+  );
+  const intervalSeconds = clampInt(
+    parseInt((await getSetting('edge.live_query_interval_seconds'))?.value || '', 10) || cfg.EDGE_LIVE_QUERY_INTERVAL_SECONDS,
+    15, 3600, cfg.EDGE_LIVE_QUERY_INTERVAL_SECONDS,
+  );
+  const timeoutMs = clampInt(
+    parseInt((await getSetting('edge.live_query_timeout_ms'))?.value || '', 10) || cfg.EDGE_LIVE_QUERY_TIMEOUT_MS,
+    1000, 30000, cfg.EDGE_LIVE_QUERY_TIMEOUT_MS,
+  );
+
+  return { enabled, concurrency, intervalSeconds, timeoutMs };
+}
+
 // ── Monitoring scheduler config ──────────────────────────────────────────────
 
 /**

--- a/packages/foundation/src/__tests__/edge-live-enrichment.test.ts
+++ b/packages/foundation/src/__tests__/edge-live-enrichment.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocked at the module boundary — we want to assert the orchestration logic in
+// edge-live-enrichment.ts (which endpoints get queried, what the failure path
+// does, that disabled config short-circuits) without exercising the real
+// network / cache / settings DB.
+vi.mock('@dashboard/core/portainer/edge-live-query.js', () => ({
+  fetchEdgeLiveDockerInfo: vi.fn(),
+}));
+vi.mock('@dashboard/core/services/settings-store.js', () => ({
+  getEffectiveEdgeLiveQueryConfig: vi.fn(),
+}));
+
+import { enrichEdgeStandardWithLiveInfo } from '../services/edge-live-enrichment.js';
+import { fetchEdgeLiveDockerInfo } from '@dashboard/core/portainer/edge-live-query.js';
+import { getEffectiveEdgeLiveQueryConfig } from '@dashboard/core/services/settings-store.js';
+import type { NormalizedEndpoint } from '@dashboard/core/portainer/portainer-normalizers.js';
+
+const mockFetch = vi.mocked(fetchEdgeLiveDockerInfo);
+const mockGetConfig = vi.mocked(getEffectiveEdgeLiveQueryConfig);
+
+function makeEndpoint(overrides: Partial<NormalizedEndpoint>): NormalizedEndpoint {
+  return {
+    id: 1,
+    name: 'ep',
+    type: 4,
+    url: 'http://edge.local:9000',
+    status: 'up',
+    containersRunning: 0,
+    containersStopped: 0,
+    containersHealthy: 0,
+    containersUnhealthy: 0,
+    totalContainers: 0,
+    stackCount: 0,
+    totalCpu: 0,
+    totalMemory: 0,
+    isEdge: true,
+    edgeMode: 'standard',
+    snapshotAge: null,
+    checkInInterval: null,
+    capabilities: { exec: true, realtimeLogs: true, liveStats: true, immediateActions: true },
+    snapshotSource: 'snapshot',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockGetConfig.mockReset();
+  mockGetConfig.mockResolvedValue({ enabled: true, concurrency: 2, intervalSeconds: 60, timeoutMs: 5000 });
+});
+
+describe('enrichEdgeStandardWithLiveInfo', () => {
+  it('returns the input unchanged when the feature is disabled', async () => {
+    mockGetConfig.mockResolvedValueOnce({ enabled: false, concurrency: 2, intervalSeconds: 60, timeoutMs: 5000 });
+    const eps = [makeEndpoint({ id: 1 })];
+
+    const result = await enrichEdgeStandardWithLiveInfo(eps);
+
+    expect(result).toBe(eps);
+    expect(result[0].snapshotSource).toBe('snapshot');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('skips endpoints that do not need a live fallback', async () => {
+    // Non-edge, with healthy snapshot — must not be touched.
+    const eps = [makeEndpoint({ id: 1, isEdge: false, edgeMode: null, containersRunning: 5, totalContainers: 5 })];
+    await enrichEdgeStandardWithLiveInfo(eps);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(eps[0].snapshotSource).toBe('snapshot');
+  });
+
+  it('queries only Edge Standard endpoints with empty counts', async () => {
+    mockFetch.mockResolvedValue({ containers: 3, containersRunning: 2, containersStopped: 1, containersPaused: 0, fetchedAt: 1234567 });
+
+    const eps = [
+      // Will be queried — Edge Standard with empty counts.
+      makeEndpoint({ id: 1, name: 'edge-empty' }),
+      // Skipped — Edge Standard but already has data.
+      makeEndpoint({ id: 2, name: 'edge-with-data', containersRunning: 4, totalContainers: 4 }),
+      // Skipped — non-edge.
+      makeEndpoint({ id: 3, name: 'local', isEdge: false, edgeMode: null }),
+      // Skipped — Edge Async.
+      makeEndpoint({ id: 4, name: 'edge-async', edgeMode: 'async' }),
+      // Skipped — Edge Standard but DOWN.
+      makeEndpoint({ id: 5, name: 'edge-down', status: 'down' }),
+    ];
+
+    await enrichEdgeStandardWithLiveInfo(eps);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(1, expect.objectContaining({ enabled: true }));
+    expect(eps[0].snapshotSource).toBe('live');
+    expect(eps[0].containersRunning).toBe(2);
+    expect(eps[0].totalContainers).toBe(3);
+    // Untouched endpoints keep their original snapshotSource.
+    expect(eps[1].snapshotSource).toBe('snapshot');
+    expect(eps[2].snapshotSource).toBe('snapshot');
+    expect(eps[3].snapshotSource).toBe('snapshot');
+    expect(eps[4].snapshotSource).toBe('snapshot');
+  });
+
+  it('marks endpoint unavailable when the live fetcher returns null', async () => {
+    mockFetch.mockResolvedValue(null);
+    const eps = [makeEndpoint({ id: 7 })];
+
+    await enrichEdgeStandardWithLiveInfo(eps);
+
+    expect(eps[0].snapshotSource).toBe('unavailable');
+    expect(eps[0].containersRunning).toBe(0);
+    expect(eps[0].totalContainers).toBe(0);
+  });
+
+  it('isolates failure: one rejected fetch does not poison the others', async () => {
+    // Endpoint 1 fails outright (rejection escapes — should not happen in
+    // practice since fetcher catches, but allSettled keeps us safe), endpoint
+    // 2 succeeds. The dashboard must still get data for the healthy node.
+    mockFetch
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ containers: 5, containersRunning: 5, containersStopped: 0, fetchedAt: 1 });
+
+    const eps = [
+      makeEndpoint({ id: 1, name: 'bad' }),
+      makeEndpoint({ id: 2, name: 'good' }),
+    ];
+
+    await enrichEdgeStandardWithLiveInfo(eps);
+
+    expect(eps[0].snapshotSource).toBe('unavailable');
+    expect(eps[1].snapshotSource).toBe('live');
+    expect(eps[1].containersRunning).toBe(5);
+  });
+});

--- a/packages/foundation/src/__tests__/endpoints-route.test.ts
+++ b/packages/foundation/src/__tests__/endpoints-route.test.ts
@@ -14,8 +14,21 @@ vi.mock('@dashboard/core/portainer/portainer-cache.js', async (importOriginal) =
     cachedFetchSWR: <T>(_key: string, _ttl: number, fn: () => Promise<T>) => fn(),
   };
 });
+// Stub the edge live-query boundary so the route test can drive enrichment
+// outcomes without a real Portainer tunnel (issue #1249). The settings-store
+// is also stubbed so getEffectiveEdgeLiveQueryConfig doesn't try to hit the DB.
+vi.mock('@dashboard/core/portainer/edge-live-query.js', () => ({
+  fetchEdgeLiveDockerInfo: vi.fn(),
+}));
+vi.mock('@dashboard/core/services/settings-store.js', () => ({
+  getEffectiveEdgeLiveQueryConfig: vi.fn().mockResolvedValue({
+    enabled: true, concurrency: 2, intervalSeconds: 60, timeoutMs: 5000,
+  }),
+}));
 
 import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
+import { fetchEdgeLiveDockerInfo } from '@dashboard/core/portainer/edge-live-query.js';
+const mockEdgeFetch = vi.mocked(fetchEdgeLiveDockerInfo);
 
 const fakeEndpoint = (id: number, name: string, type = 1, status = 1) => ({
   Id: id,
@@ -50,6 +63,7 @@ describe('Endpoints Routes', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockEdgeFetch.mockReset();
   });
 
   describe('GET /api/endpoints', () => {
@@ -122,6 +136,82 @@ describe('Endpoints Routes', () => {
       });
 
       expect(response.statusCode).toBe(502);
+    });
+
+    // Issue #1249 — end-to-end: an Edge Standard endpoint with empty Snapshots[]
+    // must surface live counts via the enrichment path, not 0/0/0.
+    it('enriches Edge Standard endpoints with empty Snapshots[] via the live fallback', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        {
+          Id: 7,
+          Name: 'srv-edge-01',
+          Type: 4,
+          Status: 1,
+          Snapshots: [],
+          EdgeID: 'edge-abc',
+          // Recent check-in keeps the normalizer's heartbeat check happy
+          LastCheckInDate: Math.floor(Date.now() / 1000) - 5,
+          EdgeCheckinInterval: 5,
+        } as any,
+      ]);
+      mockEdgeFetch.mockResolvedValueOnce({
+        containers: 12, containersRunning: 9, containersStopped: 3, fetchedAt: 1_700_000_000_000,
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/endpoints',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveLength(1);
+      expect(body[0].id).toBe(7);
+      expect(body[0].snapshotSource).toBe('live');
+      expect(body[0].containersRunning).toBe(9);
+      expect(body[0].containersStopped).toBe(3);
+      expect(body[0].totalContainers).toBe(12);
+      expect(body[0].snapshotFetchedAt).toBe(1_700_000_000_000);
+      expect(mockEdgeFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks an Edge Standard endpoint as unavailable when live fetch returns null', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        {
+          Id: 8, Name: 'srv-edge-broken', Type: 4, Status: 1, Snapshots: [],
+          EdgeID: 'edge-broken',
+          LastCheckInDate: Math.floor(Date.now() / 1000) - 5,
+          EdgeCheckinInterval: 5,
+        } as any,
+      ]);
+      mockEdgeFetch.mockResolvedValueOnce(null);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/endpoints',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body[0].snapshotSource).toBe('unavailable');
+      expect(body[0].containersRunning).toBe(0);
+      expect(body[0].totalContainers).toBe(0);
+    });
+
+    it('does not call the live fetcher for non-Edge endpoints', async () => {
+      vi.spyOn(portainerClient, 'getEndpoints').mockResolvedValue([
+        { Id: 1, Name: 'local', Type: 1, Status: 1, Snapshots: [], EdgeID: null } as any,
+      ]);
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/endpoints',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(mockEdgeFetch).not.toHaveBeenCalled();
     });
 
     it('requires authentication', async () => {

--- a/packages/foundation/src/routes/dashboard.ts
+++ b/packages/foundation/src/routes/dashboard.ts
@@ -4,6 +4,7 @@ import pLimit from 'p-limit';
 import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { normalizeEndpoint, normalizeContainer } from '@dashboard/core/portainer/portainer-normalizers.js';
+import { enrichEdgeStandardWithLiveInfo } from '../services/edge-live-enrichment.js';
 import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { getKpiHistory, getLatestMetricsBatch } from '@dashboard/observability';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
@@ -60,6 +61,9 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
     }
 
     const normalized = endpoints.map(normalizeEndpoint);
+    // Fill Edge Standard endpoints with live counts before the totals reduce
+    // (issue #1249) — otherwise KPI cards under-report running container totals.
+    await enrichEdgeStandardWithLiveInfo(normalized);
 
     const totals = normalized.reduce(
       (acc, ep) => ({
@@ -154,6 +158,8 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
     }
 
     const normalized = endpoints.map(normalizeEndpoint);
+    // Live-fetch for Edge Standard endpoints with empty Snapshots[] (issue #1249).
+    await enrichEdgeStandardWithLiveInfo(normalized);
     const upEndpoints = normalized.filter((e) => e.status === 'up');
     // Only fetch Docker containers — K8s pods are served by /api/kubernetes/ routes
     const upDockerEndpoints = upEndpoints.filter((e) => isDockerEndpoint(e.type));
@@ -355,6 +361,9 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
     rawEndpoints = endpointTiming.result;
 
     const normalized = rawEndpoints.map(normalizeEndpoint);
+    // Live-fetch for Edge Standard endpoints with empty Snapshots[] (issue #1249).
+    // Run before container fan-out so totals/KPIs reflect live container counts.
+    await timed('edge-live', () => enrichEdgeStandardWithLiveInfo(normalized));
     const upEndpoints = normalized.filter((e) => e.status === 'up');
     // Only fetch Docker containers — K8s pods are served by /api/kubernetes/ routes
     const upDockerEndpoints = upEndpoints.filter((e) => isDockerEndpoint(e.type));

--- a/packages/foundation/src/routes/endpoints.ts
+++ b/packages/foundation/src/routes/endpoints.ts
@@ -4,6 +4,7 @@ import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portain
 import { normalizeEndpoint } from '@dashboard/core/portainer/portainer-normalizers.js';
 import { EndpointIdParamsSchema } from '@dashboard/core/models/api-schemas.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
+import { enrichEdgeStandardWithLiveInfo } from '../services/edge-live-enrichment.js';
 
 const log = createChildLogger('route:endpoints');
 
@@ -27,7 +28,10 @@ export async function endpointsRoutes(fastify: FastifyInstance) {
         TTL.ENDPOINTS,
         () => portainer.getEndpoints(),
       );
-      return endpoints.map(normalizeEndpoint);
+      const normalized = endpoints.map(normalizeEndpoint);
+      // Fill in live container counts for Edge Standard endpoints whose
+      // Portainer Snapshots[] never gets populated (issue #1249).
+      return await enrichEdgeStandardWithLiveInfo(normalized);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
       log.error({ err }, 'Failed to fetch endpoints from Portainer');

--- a/packages/foundation/src/services/edge-live-enrichment.ts
+++ b/packages/foundation/src/services/edge-live-enrichment.ts
@@ -1,0 +1,85 @@
+/**
+ * Enrich Edge Standard endpoints with live `/docker/info` counts (issue #1249).
+ *
+ * Portainer EE doesn't write persistent Snapshots[] for Edge Agent Standard
+ * endpoints, so the normalizer reports 0/0/0 container counts. This helper
+ * runs after `endpoints.map(normalizeEndpoint)` and, for each endpoint that
+ * matches `endpointNeedsLiveFallback`, fetches a live Docker info summary
+ * through the chisel tunnel and merges the counts in.
+ *
+ * All concurrency, caching, and timeout behavior is owned by
+ * `fetchEdgeLiveDockerInfo` — this layer is just the route-side glue.
+ *
+ * Errors from individual endpoints are swallowed (logged once, marked
+ * `snapshotSource: 'unavailable'`) so one bad agent never breaks the
+ * dashboard for the rest of the fleet.
+ */
+import {
+  fetchEdgeLiveDockerInfo,
+  type EdgeLiveQueryConfig as _EdgeLiveQueryConfig,
+} from '@dashboard/core/portainer/edge-live-query.js';
+import {
+  applyLiveDockerInfo,
+  endpointNeedsLiveFallback,
+  markLiveUnavailable,
+  type NormalizedEndpoint,
+} from '@dashboard/core/portainer/portainer-normalizers.js';
+import { getEffectiveEdgeLiveQueryConfig } from '@dashboard/core/services/settings-store.js';
+import { createChildLogger } from '@dashboard/core/utils/logger.js';
+
+const log = createChildLogger('edge-live-enrichment');
+
+/**
+ * Walk a list of already-normalized endpoints and fill in live counts for
+ * any Edge Standard endpoint whose snapshot is empty. Mutates the input
+ * array in place (the caller owns it) and returns the same reference so
+ * callers can chain.
+ *
+ * Safe to call on every dashboard request — the underlying fetcher is
+ * SWR-cached so the cost amortizes to one HTTP call per endpoint per
+ * `EDGE_LIVE_QUERY_INTERVAL_SECONDS` window.
+ */
+export async function enrichEdgeStandardWithLiveInfo(
+  normalized: NormalizedEndpoint[],
+): Promise<NormalizedEndpoint[]> {
+  // Defensive: if the settings DB is unavailable (e.g. early boot, isolated
+  // unit tests, broken migration), don't crash the route — just skip
+  // enrichment. The route still returns Portainer's snapshot data, which is
+  // the same behavior as before this feature existed.
+  let cfg;
+  try {
+    cfg = await getEffectiveEdgeLiveQueryConfig();
+  } catch (err) {
+    log.warn({ err }, 'Edge live-query config unavailable — skipping enrichment');
+    return normalized;
+  }
+  if (!cfg.enabled) return normalized;
+
+  const targets = normalized.filter(endpointNeedsLiveFallback);
+  if (targets.length === 0) return normalized;
+
+  // Fan out via Promise.allSettled — fetchEdgeLiveDockerInfo already
+  // enforces its own dedicated p-limit, so we don't double-cap here.
+  // allSettled guarantees one slow/failed agent never poisons the others.
+  const results = await Promise.allSettled(
+    targets.map((ep) => fetchEdgeLiveDockerInfo(ep.id, cfg)),
+  );
+
+  for (let i = 0; i < targets.length; i++) {
+    const ep = targets[i];
+    const r = results[i];
+    if (r.status === 'fulfilled' && r.value) {
+      applyLiveDockerInfo(ep, r.value);
+    } else {
+      if (r.status === 'rejected') {
+        // fetchEdgeLiveDockerInfo already logs on failure, but allSettled
+        // rejection here would indicate something escaped its catch — log
+        // at debug so we have a breadcrumb without being noisy.
+        log.debug({ endpointId: ep.id, err: r.reason }, 'Edge live enrichment rejected');
+      }
+      markLiveUnavailable(ep);
+    }
+  }
+
+  return normalized;
+}

--- a/packages/foundation/src/services/edge-live-enrichment.ts
+++ b/packages/foundation/src/services/edge-live-enrichment.ts
@@ -14,10 +14,7 @@
  * `snapshotSource: 'unavailable'`) so one bad agent never breaks the
  * dashboard for the rest of the fleet.
  */
-import {
-  fetchEdgeLiveDockerInfo,
-  type EdgeLiveQueryConfig as _EdgeLiveQueryConfig,
-} from '@dashboard/core/portainer/edge-live-query.js';
+import { fetchEdgeLiveDockerInfo } from '@dashboard/core/portainer/edge-live-query.js';
 import {
   applyLiveDockerInfo,
   endpointNeedsLiveFallback,


### PR DESCRIPTION
## Summary

- Portainer EE 2.39 doesn't persist `Snapshots[]` for Edge Agent Standard endpoints — the dashboard normalizer therefore reports 0/0/0 container counts for them and the **Endpoint Health** hexagon renders them as gray "no containers", indistinguishable from a truly empty or offline node. Investigated against a live `srv-edge-01` endpoint in [#1249](https://github.com/kenhaesler/ai-portainer-dashboard/issues/1249).
- This PR fills that gap: when an Edge Standard endpoint has empty `Snapshots[]` and `Status=1`, the route layer fetches live `/docker/info` through Portainer's chisel tunnel and merges the counts in. A new `snapshotSource` field (`'snapshot' | 'live' | 'unavailable'`) propagates to the frontend so the hexagon can distinguish live data, snapshot data, and "live fetch failed".

## Safety properties (designed for large fleets)

| Concern | Mitigation |
|---|---|
| Stampeding Portainer's chisel tunnel | Dedicated `p-limit` (`EDGE_LIVE_QUERY_CONCURRENCY`, default **2**) — separate from `PORTAINER_CONCURRENCY` so edge load is isolated |
| Repeated fetches on every page load | `cachedFetchSWR` keyed per endpoint (`EDGE_LIVE_QUERY_INTERVAL_SECONDS`, default **60s**) — stale data returns instantly, refresh runs in background |
| One slow agent stalling the dashboard | `AbortController` per call (`EDGE_LIVE_QUERY_TIMEOUT_MS`, default **5000ms**) |
| One bad agent poisoning the others | `Promise.allSettled` + per-call `try/catch` → endpoint marked `snapshotSource: 'unavailable'`, fleet keeps rendering |
| Emergency disable | `EDGE_LIVE_QUERY_ENABLED=false` (env) or Settings UI toggle → zero new traffic |
| Settings DB unavailable | Enrichment swallows config-load errors and returns the input — same behavior as before the feature existed |
| Operators tuning without restart | `getEffectiveEdgeLiveQueryConfig` reads DB on every request; limiter rebuilds when concurrency value changes |

## Files changed

| Layer | File | Note |
|---|---|---|
| Config | `packages/core/src/config/env.schema.ts` | 4 new env vars, bounded ranges |
| Config | `docker/.env.example` | Documented |
| Core | `packages/core/src/portainer/edge-live-query.ts` (new) | Live fetcher with limit + SWR + timeout |
| Core | `packages/core/src/portainer/portainer-normalizers.ts` | `snapshotSource` field + 3 helpers (`endpointNeedsLiveFallback`, `applyLiveDockerInfo`, `markLiveUnavailable`) |
| Core | `packages/core/src/services/settings-store.ts` | `getEffectiveEdgeLiveQueryConfig` mirrors Harbor pattern, clamps to schema bounds |
| Foundation | `packages/foundation/src/services/edge-live-enrichment.ts` (new) | Route-level glue |
| Foundation | `routes/endpoints.ts`, `routes/dashboard.ts` | Calls enrichment after `normalizeEndpoint` at all 4 sites |
| Frontend | `components/settings/shared.tsx` | 4 new entries in `edgeAgent` Settings category |
| Frontend | `hooks/use-endpoints.ts` | `Endpoint` TS type extended |
| Frontend | `pages/home.tsx` | Threads new fields into `endpointChartData` |
| Frontend | `charts/endpoint-health-octagons.tsx` | 6-level color matrix (good/warning/critical/offline/unavailable/empty) + tooltip ("live, refreshed Ns ago") + expanded legend |

## Test plan

- [x] `packages/core` — 11 tests for `edge-live-query` (disabled, mapping, missing fields, errors, AbortController, concurrency cap, limiter rebuild, cache key, env config)
- [x] `packages/core` — 8 new tests for normalizer helpers (`endpointNeedsLiveFallback` matrix incl. non-Edge / Async / down; `applyLiveDockerInfo` / `markLiveUnavailable`)
- [x] `packages/foundation` — 5 tests for `enrichEdgeStandardWithLiveInfo` (disabled, target filtering, success, unavailable, failure isolation)
- [x] `frontend` — 7 new tests for hexagon (Offline rendering, Data unavailable rendering, live tooltip with age, `getHealthLevel` precedence)
- [x] `npm run typecheck` clean
- [x] `npm run lint -w frontend` clean
- [ ] Manual verification on live srv-edge-01: hexagon should turn from gray "Awaiting snapshot" to green "N/M running" once live data lands (within `EDGE_LIVE_QUERY_INTERVAL_SECONDS`)
- [ ] Stress test: dial `EDGE_LIVE_QUERY_CONCURRENCY=1` on a fleet to confirm serialization holds

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)