### PR TITLE
style(ui): align pane and KPI card styling with Home page

### DIFF
--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -438,7 +438,7 @@ export default function AiMonitorPage() {
           Single pane so the filter context lives next to the query that
           drives it; removes the visual gap between the two controls. */}
       <SpotlightCard>
-        <div className="rounded-lg border bg-card p-4 shadow-sm space-y-3">
+        <div className="rounded-lg border bg-card p-6 shadow-sm space-y-3">
           {/* Search */}
           <div className="relative">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden />

--- a/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
@@ -5,6 +5,8 @@ import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
 import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+import { TiltCard } from '@/shared/components/data-display/tilt-card';
 import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
 import { cn, formatDate } from '@/shared/lib/utils';
 import {
@@ -189,34 +191,43 @@ export default function LlmObservabilityPage() {
         </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-4">
-          <KpiCard
-            label="Total Queries"
-            value={stats?.totalQueries ?? 0}
-            icon={<MessageSquare className="h-5 w-5" />}
-          />
-          <KpiCard
-            label="Total Tokens"
-            value={stats?.totalTokens ?? 0}
-            icon={<Hash className="h-5 w-5" />}
-          />
-          <KpiCard
-            label="Avg Latency"
-            value={`${Math.round(stats?.avgLatencyMs ?? 0)}ms`}
-            icon={<Zap className="h-5 w-5" />}
-          />
-          <KpiCard
-            label="Error Rate"
-            value={`${((stats?.errorRate ?? 0) * 100).toFixed(1)}%`}
-            icon={<AlertTriangle className="h-5 w-5" />}
-            trend={(stats?.errorRate ?? 0) > 0.05 ? 'down' : undefined}
-            trendValue={(stats?.errorRate ?? 0) > 0.05 ? 'Above 5%' : undefined}
-          />
+          <TiltCard>
+            <KpiCard
+              label="Total Queries"
+              value={stats?.totalQueries ?? 0}
+              icon={<MessageSquare className="h-5 w-5" />}
+            />
+          </TiltCard>
+          <TiltCard>
+            <KpiCard
+              label="Total Tokens"
+              value={stats?.totalTokens ?? 0}
+              icon={<Hash className="h-5 w-5" />}
+            />
+          </TiltCard>
+          <TiltCard>
+            <KpiCard
+              label="Avg Latency"
+              value={`${Math.round(stats?.avgLatencyMs ?? 0)}ms`}
+              icon={<Zap className="h-5 w-5" />}
+            />
+          </TiltCard>
+          <TiltCard>
+            <KpiCard
+              label="Error Rate"
+              value={`${((stats?.errorRate ?? 0) * 100).toFixed(1)}%`}
+              icon={<AlertTriangle className="h-5 w-5" />}
+              trend={(stats?.errorRate ?? 0) > 0.05 ? 'down' : undefined}
+              trendValue={(stats?.errorRate ?? 0) > 0.05 ? 'Above 5%' : undefined}
+            />
+          </TiltCard>
         </div>
       )}
 
       {/* Model Breakdown */}
       {stats && (
-        <div className="rounded-lg border bg-card p-6">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
           <h2 className="text-lg font-semibold mb-4">Model Breakdown</h2>
           {modelBreakdown.length === 0 ? (
             <p className="text-sm text-muted-foreground">No model data available.</p>
@@ -263,25 +274,30 @@ export default function LlmObservabilityPage() {
             </div>
           )}
         </div>
+        </SpotlightCard>
       )}
 
       {/* LLM Latency Breakdown (#1239) — Network vs Model split per provider */}
-      <div>
+      <SpotlightCard>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
         <div className="flex items-center gap-2 mb-4">
           <Activity className="h-5 w-5 text-primary" />
           <h2 className="text-lg font-semibold">Latency Breakdown</h2>
         </div>
         <LlmLatencyBreakdown />
       </div>
+      </SpotlightCard>
 
       {/* Recent Traces */}
-      <div>
+      <SpotlightCard>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
         <div className="flex items-center gap-2 mb-4">
           <Activity className="h-5 w-5 text-primary" />
           <h2 className="text-lg font-semibold">Recent Traces</h2>
         </div>
         <TracesTable traces={traces ?? []} isLoading={showTracesSkeleton} privacyMode={privacyMode} />
       </div>
+      </SpotlightCard>
     </div>
   );
 }

--- a/frontend/src/features/containers/pages/image-footprint.tsx
+++ b/frontend/src/features/containers/pages/image-footprint.tsx
@@ -18,6 +18,7 @@ import { DataTable } from '@/shared/components/tables/data-table';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
 import { MotionPage, MotionReveal, MotionStagger } from '@/shared/components/layout/motion-page';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+import { TiltCard } from '@/shared/components/data-display/tilt-card';
 import { spring } from '@/shared/lib/motion-tokens';
 import { formatBytes, truncate } from '@/shared/lib/utils';
 
@@ -263,29 +264,35 @@ export default function ImageFootprintPage() {
       {stalenessData && stalenessData.summary.total > 0 && (
         <MotionStagger className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3" stagger={0.05}>
           <MotionReveal className="h-full">
-            <KpiCard
-              label="Checked"
-              value={stalenessData.summary.total}
-              icon={<Layers className="h-5 w-5" />}
-            />
+            <TiltCard>
+              <KpiCard
+                label="Checked"
+                value={stalenessData.summary.total}
+                icon={<Layers className="h-5 w-5" />}
+              />
+            </TiltCard>
           </MotionReveal>
           <MotionReveal className="h-full">
-            <KpiCard
-              label="Up to Date"
-              value={stalenessData.summary.upToDate}
-              icon={<CheckCircle2 className="h-5 w-5" />}
-              trend="up"
-              trendValue={`of ${stalenessData.summary.total} checked`}
-            />
+            <TiltCard>
+              <KpiCard
+                label="Up to Date"
+                value={stalenessData.summary.upToDate}
+                icon={<CheckCircle2 className="h-5 w-5" />}
+                trend="up"
+                trendValue={`of ${stalenessData.summary.total} checked`}
+              />
+            </TiltCard>
           </MotionReveal>
           <MotionReveal className="h-full">
-            <KpiCard
-              label="Stale"
-              value={stalenessData.summary.stale}
-              icon={<AlertTriangle className="h-5 w-5" />}
-              trend={stalenessData.summary.stale > 0 ? 'down' : 'neutral'}
-              trendValue={stalenessData.summary.stale > 0 ? `${stalenessData.summary.stale} outdated` : 'none'}
-            />
+            <TiltCard>
+              <KpiCard
+                label="Stale"
+                value={stalenessData.summary.stale}
+                icon={<AlertTriangle className="h-5 w-5" />}
+                trend={stalenessData.summary.stale > 0 ? 'down' : 'neutral'}
+                trendValue={stalenessData.summary.stale > 0 ? `${stalenessData.summary.stale} outdated` : 'none'}
+              />
+            </TiltCard>
           </MotionReveal>
         </MotionStagger>
       )}

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -706,7 +706,7 @@ export default function WorkloadExplorerPage() {
         <>
           {/* Filter pane: dropdowns + status summary */}
           <SpotlightCard>
-          <div className="rounded-lg border bg-card p-4 shadow-sm space-y-3">
+          <div className="rounded-lg border bg-card p-6 shadow-sm space-y-3">
             <div className="flex items-center gap-4 flex-wrap">
               <div className="flex items-center gap-2">
                 <label htmlFor="endpoint-select" className="text-sm font-medium">

--- a/frontend/src/features/observability/pages/metrics-dashboard.tsx
+++ b/frontend/src/features/observability/pages/metrics-dashboard.tsx
@@ -31,6 +31,7 @@ import { NetworkTrafficTooltip } from '@/shared/components/charts/network-traffi
 import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
 import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { InlineChatPanel } from '@/features/ai-intelligence/components/metrics/inline-chat-panel';
 import { useLlmModels } from '@/features/ai-intelligence/hooks/use-llm-models';
 import { cn } from '@/shared/lib/utils';
@@ -496,7 +497,8 @@ export default function MetricsDashboardPage() {
       </div>
 
       {hasSelection && (
-        <div className="rounded-lg border bg-card p-4 md:p-5">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
           <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-2">
               <Network className="h-5 w-5 text-blue-500" />
@@ -562,6 +564,7 @@ export default function MetricsDashboardPage() {
             </div>
           )}
         </div>
+        </SpotlightCard>
       )}
 
       {/* Loading State */}
@@ -589,35 +592,43 @@ export default function MetricsDashboardPage() {
           {/* Container Info & Stats */}
           {selectedContainerData && (
             <div className="grid gap-4 md:grid-cols-4">
-              <div className="rounded-lg border bg-card p-4">
-                <p className="text-sm text-muted-foreground">Container</p>
-                <p className="text-lg font-semibold truncate">{selectedContainerData.name}</p>
-              </div>
-              <div className="rounded-lg border bg-card p-4">
-                <p className="text-sm text-muted-foreground">Avg CPU</p>
-                <p className="text-lg font-semibold">{stats.cpu.avg.toFixed(1)}%</p>
-                <AnomalySparkline
-                  values={cpuData.map((d) => d.value)}
-                  anomalyIndices={cpuAnomalyIndices}
-                  className="mt-2"
-                />
-              </div>
-              <div className="rounded-lg border bg-card p-4">
-                <p className="text-sm text-muted-foreground">Avg Memory</p>
-                <p className="text-lg font-semibold">{stats.memory.avg.toFixed(1)}%</p>
-                <AnomalySparkline
-                  values={memoryData.map((d) => d.value)}
-                  anomalyIndices={memoryAnomalyIndices}
-                  className="mt-2"
-                />
-              </div>
-              <div className="rounded-lg border bg-card p-4">
-                <p className="text-sm text-muted-foreground">Peak Memory</p>
-                <p className="text-lg font-semibold">{stats.memoryBytes.max.toFixed(1)} MB</p>
-                <p className="text-xs text-muted-foreground mt-1">
-                  Min: {stats.memoryBytes.min.toFixed(1)} MB
-                </p>
-              </div>
+              <SpotlightCard>
+                <div className="rounded-lg border bg-card p-6 shadow-sm">
+                  <p className="text-sm font-medium text-muted-foreground">Container</p>
+                  <p className="mt-2 text-3xl font-bold tracking-tight truncate">{selectedContainerData.name}</p>
+                </div>
+              </SpotlightCard>
+              <SpotlightCard>
+                <div className="rounded-lg border bg-card p-6 shadow-sm">
+                  <p className="text-sm font-medium text-muted-foreground">Avg CPU</p>
+                  <p className="mt-2 text-3xl font-bold tracking-tight">{stats.cpu.avg.toFixed(1)}%</p>
+                  <AnomalySparkline
+                    values={cpuData.map((d) => d.value)}
+                    anomalyIndices={cpuAnomalyIndices}
+                    className="mt-2"
+                  />
+                </div>
+              </SpotlightCard>
+              <SpotlightCard>
+                <div className="rounded-lg border bg-card p-6 shadow-sm">
+                  <p className="text-sm font-medium text-muted-foreground">Avg Memory</p>
+                  <p className="mt-2 text-3xl font-bold tracking-tight">{stats.memory.avg.toFixed(1)}%</p>
+                  <AnomalySparkline
+                    values={memoryData.map((d) => d.value)}
+                    anomalyIndices={memoryAnomalyIndices}
+                    className="mt-2"
+                  />
+                </div>
+              </SpotlightCard>
+              <SpotlightCard>
+                <div className="rounded-lg border bg-card p-6 shadow-sm">
+                  <p className="text-sm font-medium text-muted-foreground">Peak Memory</p>
+                  <p className="mt-2 text-3xl font-bold tracking-tight">{stats.memoryBytes.max.toFixed(1)} MB</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Min: {stats.memoryBytes.min.toFixed(1)} MB
+                  </p>
+                </div>
+              </SpotlightCard>
             </div>
           )}
 
@@ -660,7 +671,8 @@ export default function MetricsDashboardPage() {
           ) : (
             <div className="space-y-6">
               {/* CPU Chart */}
-              <div className="rounded-lg border bg-card p-6">
+              <SpotlightCard>
+              <div className="rounded-lg border bg-card p-6 shadow-sm">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-2">
                     <Cpu className="h-5 w-5 text-blue-500" />
@@ -690,9 +702,11 @@ export default function MetricsDashboardPage() {
                   </div>
                 )}
               </div>
+              </SpotlightCard>
 
               {/* Memory Chart */}
-              <div className="rounded-lg border bg-card p-6">
+              <SpotlightCard>
+              <div className="rounded-lg border bg-card p-6 shadow-sm">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-2">
                     <MemoryStick className="h-5 w-5 text-purple-500" />
@@ -722,9 +736,11 @@ export default function MetricsDashboardPage() {
                   </div>
                 )}
               </div>
+              </SpotlightCard>
 
               {/* Memory Bytes Chart */}
-              <div className="rounded-lg border bg-card p-6">
+              <SpotlightCard>
+              <div className="rounded-lg border bg-card p-6 shadow-sm">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-2">
                     <MemoryStick className="h-5 w-5 text-cyan-500" />
@@ -750,6 +766,7 @@ export default function MetricsDashboardPage() {
                   height={300 * zoomLevel}
                 />
               </div>
+              </SpotlightCard>
             </div>
           )}
 
@@ -788,7 +805,8 @@ export default function MetricsDashboardPage() {
 
           {/* Anomaly Summary */}
           {anomaliesData && (
-            <div className="rounded-lg border bg-card p-6">
+            <SpotlightCard>
+            <div className="rounded-lg border bg-card p-6 shadow-sm">
               <div className="flex items-center gap-2 mb-4">
                 <AlertTriangle className="h-5 w-5 text-amber-500" />
                 <h3 className="text-lg font-semibold">Recent Anomalies</h3>
@@ -807,6 +825,7 @@ export default function MetricsDashboardPage() {
                 </div>
               </div>
             </div>
+            </SpotlightCard>
           )}
         </>
       )}
@@ -821,7 +840,8 @@ export default function MetricsDashboardPage() {
       )}
 
       {/* Forecast Overview */}
-      <div className="rounded-lg border bg-card p-6">
+      <SpotlightCard>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 className="text-xl font-semibold">Forecast Overview (Next 24h)</h2>
@@ -918,6 +938,7 @@ export default function MetricsDashboardPage() {
           </div>
         )}
       </div>
+      </SpotlightCard>
 
       {/* Inline Chat Panel */}
       {selectedContainerData && selectedEndpoint && (
@@ -999,7 +1020,8 @@ function ForecastCard({
   const projectionStartIdx = chartData.findIndex((d) => d.isProjected);
 
   return (
-    <div className="rounded-lg border bg-card p-5 shadow-sm">
+    <SpotlightCard>
+    <div className="rounded-lg border bg-card p-6 shadow-sm">
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
@@ -1120,5 +1142,6 @@ function ForecastCard({
         </div>
       )}
     </div>
+    </SpotlightCard>
   );
 }

--- a/frontend/src/features/security/pages/ebpf-coverage.tsx
+++ b/frontend/src/features/security/pages/ebpf-coverage.tsx
@@ -27,6 +27,7 @@ import {
 import type { CoverageRecord } from '@/features/security/hooks/use-ebpf-coverage';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { formatDate } from '@/shared/lib/utils';
 
 /** Human-readable labels for coverage statuses */
@@ -79,9 +80,10 @@ function SummaryBar() {
   const missing = summary.total - summary.deployed;
 
   return (
+    <SpotlightCard>
     <div
       data-testid="coverage-summary"
-      className="flex flex-wrap items-center gap-4 rounded-xl border border-border bg-card p-4"
+      className="flex flex-wrap items-center gap-4 rounded-lg border bg-card p-6 shadow-sm"
     >
       <div className="flex items-center gap-2">
         <Radio className="h-5 w-5 text-primary" />
@@ -118,6 +120,7 @@ function SummaryBar() {
         </>
       )}
     </div>
+    </SpotlightCard>
   );
 }
 

--- a/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
+++ b/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import {
   useHarborStatus,
   useHarborVulnerabilities,
@@ -103,7 +104,8 @@ export default function HarborVulnerabilitiesPage() {
           <h1 className="text-3xl font-bold tracking-tight">Vulnerability Management</h1>
           <p className="text-muted-foreground">Harbor Registry integration for image vulnerability tracking.</p>
         </div>
-        <div className="rounded-xl border bg-card/75 p-8 backdrop-blur text-center">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card p-6 shadow-sm text-center">
           <ShieldAlert className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
           <h2 className="text-xl font-semibold mb-2">Harbor Not Configured</h2>
           <p className="text-muted-foreground max-w-md mx-auto">
@@ -113,6 +115,7 @@ export default function HarborVulnerabilitiesPage() {
             variables to connect to your Harbor registry.
           </p>
         </div>
+        </SpotlightCard>
       </div>
     );
   }
@@ -182,7 +185,8 @@ export default function HarborVulnerabilitiesPage() {
       )}
 
       {/* Filters */}
-      <section className="rounded-xl border bg-card/75 p-4 backdrop-blur">
+      <SpotlightCard>
+      <section className="rounded-lg border bg-card p-6 shadow-sm">
         <div className="relative mb-3">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <input
@@ -214,6 +218,7 @@ export default function HarborVulnerabilitiesPage() {
           </label>
         </div>
       </section>
+      </SpotlightCard>
 
       {/* Connection error banner */}
       {status && !status.connected && status.configured && (
@@ -239,7 +244,8 @@ export default function HarborVulnerabilitiesPage() {
 
       {/* Vulnerability table */}
       {!isLoading && !isError && (
-        <section className="rounded-xl border bg-card/75 backdrop-blur overflow-hidden">
+        <SpotlightCard>
+        <section className="rounded-lg border bg-card shadow-sm overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
@@ -281,6 +287,7 @@ export default function HarborVulnerabilitiesPage() {
             </div>
           )}
         </section>
+        </SpotlightCard>
       )}
     </div>
   );
@@ -306,25 +313,27 @@ function SummaryCard({
   gif?: string;
 }) {
   return (
-    <div
-      className={cn(
-        'rounded-xl border bg-card/75 p-4 backdrop-blur',
-        highlight && 'border-red-500/30 bg-red-500/5',
-      )}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex-1">
-          <div className="flex items-center gap-2">
-            <Icon className={cn('h-4 w-4', className)} />
-            <span className="text-xs text-muted-foreground">{label}</span>
-          </div>
-          <div className={cn('mt-1 text-2xl font-bold', className)}>{value.toLocaleString()}</div>
-        </div>
-        {gif && (
-          <img src={gif} alt="" aria-hidden="true" className="h-12 w-12 rounded object-cover shrink-0" />
+    <SpotlightCard className="h-full">
+      <div
+        className={cn(
+          'h-full rounded-lg border bg-card p-6 shadow-sm transition-all duration-200 hover:shadow-md hover:-translate-y-0.5 hover:border-primary/20',
+          highlight && 'border-red-500/30 bg-red-500/5',
         )}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-muted-foreground">{label}</p>
+              <Icon className={cn('h-5 w-5', className)} />
+            </div>
+            <p className={cn('mt-2 text-3xl font-bold tracking-tight', className)}>{value.toLocaleString()}</p>
+          </div>
+          {gif && (
+            <img src={gif} alt="" aria-hidden="true" className="h-12 w-12 rounded object-cover shrink-0" />
+          )}
+        </div>
       </div>
-    </div>
+    </SpotlightCard>
   );
 }
 

--- a/frontend/src/features/security/pages/security-audit.tsx
+++ b/frontend/src/features/security/pages/security-audit.tsx
@@ -5,6 +5,7 @@ import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { cn } from '@/shared/lib/utils';
 import { ObservedDestinationsPanel } from '@/features/security/components/observed-destinations-panel';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 const severityOptions = [
   { value: 'all', label: 'All Severities' },
@@ -105,7 +106,8 @@ export default function SecurityAuditPage() {
         <p className="text-muted-foreground">Container capability posture across endpoints with ignore-list visibility.</p>
       </div>
 
-      <section className="rounded-xl border bg-card/75 p-4 backdrop-blur">
+      <SpotlightCard>
+      <section className="rounded-lg border bg-card p-6 shadow-sm">
         <div className="relative mb-3">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <input
@@ -161,6 +163,7 @@ export default function SecurityAuditPage() {
           </label>
         </div>
       </section>
+      </SpotlightCard>
 
       {isError && (
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6">
@@ -175,7 +178,8 @@ export default function SecurityAuditPage() {
         </div>
       )}
 
-      <section className="rounded-xl border bg-card/75 p-4 backdrop-blur">
+      <SpotlightCard>
+      <section className="rounded-lg border bg-card p-6 shadow-sm">
         <div className="mb-3 text-sm text-muted-foreground">
           {filteredEntries.length} containers shown ({entries.filter((entry) => entry.findings.length > 0).length} with findings total)
         </div>
@@ -270,6 +274,7 @@ export default function SecurityAuditPage() {
           </div>
         )}
       </section>
+      </SpotlightCard>
 
       {/* Observed Destinations (#1240) — outbound traffic captured by Beyla */}
       <ObservedDestinationsPanel


### PR DESCRIPTION
## Summary

Normalize panes and KPI tiles across dashboard pages to use the canonical Home pattern: `<SpotlightCard>` wrapping `rounded-lg border bg-card p-6 shadow-sm`, with KPI cards wrapped in `<TiltCard>` for consistent hover behavior.

## Changes

- **metrics-dashboard**: wrap Network/CPU/Memory/Anomaly/Forecast panes in `SpotlightCard`; normalize 4 inline stat tiles (p-4 → p-6 + SpotlightCard); `ForecastCard` matches canonical pattern (p-5 → p-6).
- **llm-observability**: `TiltCard` around 4 KPI cards; `SpotlightCard` around Model Breakdown, Latency Breakdown, and Recent Traces panes.
- **image-footprint**: `TiltCard` wrappers around the 3 staleness KPI cards.
- **ai-monitor** & **workload-explorer**: filter pane padding p-4 → p-6.
- **security-audit** & **harbor-vulnerabilities**: replace `rounded-xl bg-card/75 backdrop-blur` with the canonical pattern. Harbor `SummaryCard` reshaped to match `KpiCard` layout (label + 3xl bold value).
- **ebpf-coverage**: summary bar uses canonical pane styling.

## Test plan

- [x] `npx tsc --noEmit -p frontend` — clean
- [x] `npx vitest run` — 1873/1873 passing
- [x] Visual verification with Playwright on `/llm-observability`, `/security/audit`, `/security/vulnerabilities`, `/ebpf-coverage` — cards/panes now match Home aesthetic
- [ ] Reviewer: spot-check pages with live Portainer data (couldn't verify in this env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)