### PR TITLE
style(ui): full sweep — normalize remaining panes and KPI tiles

### DIFF
--- a/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.tsx
+++ b/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.tsx
@@ -150,7 +150,7 @@ export function LlmLatencyBreakdown({ peers, fromIso, toIso }: LlmLatencyBreakdo
   }
 
   return (
-    <section className="rounded-xl border bg-card/75 p-4 backdrop-blur" data-testid="llm-latency-breakdown">
+    <section data-testid="llm-latency-breakdown">
       <h3 className="text-base font-semibold tracking-tight">LLM latency breakdown</h3>
       <p className="text-sm text-muted-foreground">
         Network roundtrip vs estimated model latency per upstream provider, last 1h.

--- a/frontend/src/features/ai-intelligence/components/metrics/ai-metrics-summary.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/ai-metrics-summary.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { Bot, RefreshCw, AlertCircle } from 'lucide-react';
 import { useAiMetricsSummary } from '@/features/ai-intelligence/hooks/use-ai-metrics-summary';
 import { cn } from '@/shared/lib/utils';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 interface AiMetricsSummaryProps {
   endpointId: number | undefined;
@@ -23,7 +24,8 @@ export const AiMetricsSummary = memo(function AiMetricsSummary({ endpointId, con
   if (!endpointId || !containerId) return null;
 
   return (
-    <div className="rounded-lg border bg-card p-4">
+    <SpotlightCard>
+    <div className="rounded-lg border bg-card p-6 shadow-sm">
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
           <Bot className="h-4 w-4 text-purple-500" />
@@ -66,5 +68,6 @@ export const AiMetricsSummary = memo(function AiMetricsSummary({ endpointId, con
         </p>
       )}
     </div>
+    </SpotlightCard>
   );
 });

--- a/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react';
 import { Link2, Bot, ArrowUpDown, TrendingUp, TrendingDown } from 'lucide-react';
 import { useCorrelations, useCorrelationInsights, type CorrelationPair } from '@/features/observability/hooks/use-correlations';
 import { cn } from '@/shared/lib/utils';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 interface CorrelationInsightsPanelProps {
   llmAvailable: boolean;
@@ -146,7 +147,8 @@ export const CorrelationInsightsPanel = memo(function CorrelationInsightsPanel({
 
   if (pairsLoading) {
     return (
-      <div className="rounded-lg border bg-card p-6">
+      <SpotlightCard>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
         <div className="flex items-center gap-2 mb-4">
           <Link2 className="h-5 w-5 text-blue-500" />
           <h3 className="text-lg font-semibold">Cross-Container Correlation Insights</h3>
@@ -156,11 +158,13 @@ export const CorrelationInsightsPanel = memo(function CorrelationInsightsPanel({
           <div className="h-16 animate-pulse rounded bg-muted" />
         </div>
       </div>
+      </SpotlightCard>
     );
   }
 
   return (
-    <div className="rounded-lg border bg-card p-6">
+    <SpotlightCard>
+    <div className="rounded-lg border bg-card p-6 shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
         <div className="flex items-center gap-2">
           <Link2 className="h-5 w-5 text-blue-500" />
@@ -269,5 +273,6 @@ export const CorrelationInsightsPanel = memo(function CorrelationInsightsPanel({
         </div>
       )}
     </div>
+    </SpotlightCard>
   );
 });

--- a/frontend/src/features/ai-intelligence/pages/investigation-detail.tsx
+++ b/frontend/src/features/ai-intelligence/pages/investigation-detail.tsx
@@ -7,6 +7,8 @@ import {
   type RecommendedAction,
 } from '@/features/ai-intelligence/hooks/use-investigations';
 import { formatDate } from '@/shared/lib/utils';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+import { TiltCard } from '@/shared/components/data-display/tilt-card';
 
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
@@ -96,42 +98,51 @@ export default function InvestigationDetailPage() {
       </div>
 
       <div className="grid gap-4 md:grid-cols-4">
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center justify-between text-muted-foreground">
-            <span className="text-sm">Created</span>
-            <Clock className="h-4 w-4" />
+        <TiltCard>
+          <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-muted-foreground">Created</p>
+              <Clock className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <p className="mt-2 text-sm font-medium">{formatDate(investigation.created_at)}</p>
           </div>
-          <p className="mt-2 text-sm font-medium">{formatDate(investigation.created_at)}</p>
-        </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center justify-between text-muted-foreground">
-            <span className="text-sm">Confidence</span>
-            <Brain className="h-4 w-4" />
+        </TiltCard>
+        <TiltCard>
+          <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-muted-foreground">Confidence</p>
+              <Brain className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <p className="mt-2 text-3xl font-bold tracking-tight">
+              {investigation.confidence_score != null ? `${Math.round(investigation.confidence_score * 100)}%` : 'N/A'}
+            </p>
           </div>
-          <p className="mt-2 text-lg font-semibold">
-            {investigation.confidence_score != null ? `${Math.round(investigation.confidence_score * 100)}%` : 'N/A'}
-          </p>
-        </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center justify-between text-muted-foreground">
-            <span className="text-sm">Duration</span>
-            <Loader2 className="h-4 w-4" />
+        </TiltCard>
+        <TiltCard>
+          <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-muted-foreground">Duration</p>
+              <Loader2 className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <p className="mt-2 text-3xl font-bold tracking-tight">
+              {investigation.analysis_duration_ms != null ? `${(investigation.analysis_duration_ms / 1000).toFixed(1)}s` : 'N/A'}
+            </p>
           </div>
-          <p className="mt-2 text-lg font-semibold">
-            {investigation.analysis_duration_ms != null ? `${(investigation.analysis_duration_ms / 1000).toFixed(1)}s` : 'N/A'}
-          </p>
-        </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center justify-between text-muted-foreground">
-            <span className="text-sm">Model</span>
-            <Database className="h-4 w-4" />
+        </TiltCard>
+        <TiltCard>
+          <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-muted-foreground">Model</p>
+              <Database className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <p className="mt-2 text-sm font-medium">{investigation.llm_model ?? 'Unknown'}</p>
           </div>
-          <p className="mt-2 text-sm font-medium">{investigation.llm_model ?? 'Unknown'}</p>
-        </div>
+        </TiltCard>
       </div>
 
       <div className="grid gap-4 lg:grid-cols-2">
-        <div className="rounded-lg border bg-card p-5">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
           <h2 className="text-lg font-semibold">Timeline</h2>
           <div className="mt-4 space-y-3">
             {timeline.map((item, index) => (
@@ -146,8 +157,10 @@ export default function InvestigationDetailPage() {
             ))}
           </div>
         </div>
+        </SpotlightCard>
 
-        <div className="rounded-lg border bg-card p-5">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
           <h2 className="text-lg font-semibold">Related Artifacts</h2>
           <div className="mt-4 space-y-2 text-sm">
             <div className="flex items-center gap-2">
@@ -178,9 +191,11 @@ export default function InvestigationDetailPage() {
             )}
           </div>
         </div>
+        </SpotlightCard>
       </div>
 
-      <div className="rounded-lg border bg-card p-5">
+      <SpotlightCard>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
         <h2 className="text-lg font-semibold">Findings</h2>
         <div className="mt-4 space-y-4">
           {investigation.root_cause && (
@@ -221,6 +236,7 @@ export default function InvestigationDetailPage() {
           )}
         </div>
       </div>
+      </SpotlightCard>
     </div>
   );
 }

--- a/frontend/src/features/ai-intelligence/pages/investigation-detail.tsx
+++ b/frontend/src/features/ai-intelligence/pages/investigation-detail.tsx
@@ -10,6 +10,32 @@ import { formatDate } from '@/shared/lib/utils';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { TiltCard } from '@/shared/components/data-display/tilt-card';
 
+function StatTile({
+  label,
+  icon: Icon,
+  value,
+  variant = 'numeric',
+}: {
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  value: string;
+  variant?: 'numeric' | 'text';
+}) {
+  return (
+    <TiltCard>
+      <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
+          <Icon className="h-5 w-5 text-muted-foreground" />
+        </div>
+        <p className={variant === 'numeric' ? 'mt-2 text-3xl font-bold tracking-tight' : 'mt-2 text-sm font-medium'}>
+          {value}
+        </p>
+      </div>
+    </TiltCard>
+  );
+}
+
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
     pending: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
@@ -98,46 +124,18 @@ export default function InvestigationDetailPage() {
       </div>
 
       <div className="grid gap-4 md:grid-cols-4">
-        <TiltCard>
-          <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-muted-foreground">Created</p>
-              <Clock className="h-5 w-5 text-muted-foreground" />
-            </div>
-            <p className="mt-2 text-sm font-medium">{formatDate(investigation.created_at)}</p>
-          </div>
-        </TiltCard>
-        <TiltCard>
-          <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-muted-foreground">Confidence</p>
-              <Brain className="h-5 w-5 text-muted-foreground" />
-            </div>
-            <p className="mt-2 text-3xl font-bold tracking-tight">
-              {investigation.confidence_score != null ? `${Math.round(investigation.confidence_score * 100)}%` : 'N/A'}
-            </p>
-          </div>
-        </TiltCard>
-        <TiltCard>
-          <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-muted-foreground">Duration</p>
-              <Loader2 className="h-5 w-5 text-muted-foreground" />
-            </div>
-            <p className="mt-2 text-3xl font-bold tracking-tight">
-              {investigation.analysis_duration_ms != null ? `${(investigation.analysis_duration_ms / 1000).toFixed(1)}s` : 'N/A'}
-            </p>
-          </div>
-        </TiltCard>
-        <TiltCard>
-          <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-muted-foreground">Model</p>
-              <Database className="h-5 w-5 text-muted-foreground" />
-            </div>
-            <p className="mt-2 text-sm font-medium">{investigation.llm_model ?? 'Unknown'}</p>
-          </div>
-        </TiltCard>
+        <StatTile label="Created" icon={Clock} value={formatDate(investigation.created_at)} variant="text" />
+        <StatTile
+          label="Confidence"
+          icon={Brain}
+          value={investigation.confidence_score != null ? `${Math.round(investigation.confidence_score * 100)}%` : 'N/A'}
+        />
+        <StatTile
+          label="Duration"
+          icon={Loader2}
+          value={investigation.analysis_duration_ms != null ? `${(investigation.analysis_duration_ms / 1000).toFixed(1)}s` : 'N/A'}
+        />
+        <StatTile label="Model" icon={Database} value={investigation.llm_model ?? 'Unknown'} variant="text" />
       </div>
 
       <div className="grid gap-4 lg:grid-cols-2">

--- a/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
@@ -280,10 +280,6 @@ export default function LlmObservabilityPage() {
       {/* LLM Latency Breakdown (#1239) — Network vs Model split per provider */}
       <SpotlightCard>
       <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <div className="flex items-center gap-2 mb-4">
-          <Activity className="h-5 w-5 text-primary" />
-          <h2 className="text-lg font-semibold">Latency Breakdown</h2>
-        </div>
         <LlmLatencyBreakdown />
       </div>
       </SpotlightCard>

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -978,23 +978,27 @@ export default function InfrastructurePage() {
             ))}
           </div>
         ) : filteredEndpoints.length === 0 && endpoints && endpoints.length > 0 ? (
-          <div className="rounded-lg border bg-card p-8 text-center">
+          <SpotlightCard>
+          <div className="rounded-lg border bg-card p-6 shadow-sm text-center">
             <Server className="mx-auto h-10 w-10 text-muted-foreground" />
             <p className="mt-4 font-medium">No endpoints match filters</p>
             <p className="mt-1 text-sm text-muted-foreground">
               Adjust your filters to see endpoints
             </p>
           </div>
+          </SpotlightCard>
         ) : fleetViewMode === 'grid' ? (
           <>
             {paginatedEndpoints.length === 0 && endpointSearchQuery ? (
-              <div className="rounded-lg border bg-card p-8 text-center">
+              <SpotlightCard>
+              <div className="rounded-lg border bg-card p-6 shadow-sm text-center">
                 <Search className="mx-auto h-10 w-10 text-muted-foreground" />
                 <p className="mt-4 font-medium">No endpoints match your search</p>
                 <p className="mt-1 text-sm text-muted-foreground">
                   Try a different query or clear the search
                 </p>
               </div>
+              </SpotlightCard>
             ) : (
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                 {paginatedEndpoints.map((endpoint) => (
@@ -1157,7 +1161,8 @@ export default function InfrastructurePage() {
             ))}
           </div>
         ) : filteredStacks.length === 0 ? (
-          <div className="rounded-lg border bg-card p-8 text-center">
+          <SpotlightCard>
+          <div className="rounded-lg border bg-card p-6 shadow-sm text-center">
             <Layers className="mx-auto h-10 w-10 text-muted-foreground" />
             {stackSearchQuery ? (
               <>
@@ -1192,6 +1197,7 @@ export default function InfrastructurePage() {
               </>
             )}
           </div>
+          </SpotlightCard>
         ) : stacksViewMode === 'grid' ? (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {filteredStacks.map((stack) => (
@@ -1224,7 +1230,8 @@ export default function InfrastructurePage() {
         <h2 id="k8s-heading" className="sr-only">Kubernetes Resources</h2>
 
         {/* K8s summary bar */}
-        <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-card p-3 shadow-sm text-sm">
+        <SpotlightCard>
+        <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-card p-6 shadow-sm text-sm">
           <span className="font-medium">Kubernetes</span>
           <span className="text-muted-foreground">
             {k8sPods?.length ?? 0} pods
@@ -1245,6 +1252,7 @@ export default function InfrastructurePage() {
             />
           </div>
         </div>
+        </SpotlightCard>
 
         {/* Pods table */}
         {k8sPodsLoading ? (

--- a/frontend/src/features/containers/pages/network-topology.tsx
+++ b/frontend/src/features/containers/pages/network-topology.tsx
@@ -239,7 +239,7 @@ export default function NetworkTopologyPage() {
 
             {/* Side Panel */}
             {selectedNode && (
-              <div className="w-1/3 rounded-lg border bg-card p-6 space-y-4 overflow-y-auto">
+              <div className="w-1/3 rounded-lg border bg-card p-6 shadow-sm space-y-4 overflow-y-auto">
                 <div className="flex items-center justify-between">
                   <h3 className="text-lg font-semibold">
                     {selectedNode.type === 'container' ? 'Container Details' : 'Network Details'}

--- a/frontend/src/features/core/components/settings/tab-ai-llm.tsx
+++ b/frontend/src/features/core/components/settings/tab-ai-llm.tsx
@@ -805,7 +805,7 @@ function McpServersSection() {
   };
 
   return (
-    <div className="rounded-xl border border-border bg-card p-6 space-y-4">
+    <div className="rounded-lg border bg-card p-6 shadow-sm space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <Plug className="h-5 w-5 text-purple-500" />

--- a/frontend/src/features/core/pages/users.tsx
+++ b/frontend/src/features/core/pages/users.tsx
@@ -5,6 +5,7 @@ import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
 import { useCreateUser, useDeleteUser, useUpdateUser, useUsers, type UserRole } from '@/features/core/hooks/use-users';
 import { cn, formatDate } from '@/shared/lib/utils';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 interface UserForm {
   username: string;
@@ -140,7 +141,8 @@ export function UsersPanel() {
   return (
     <div className="space-y-6">
       <div className="grid gap-6 lg:grid-cols-5">
-        <section className="rounded-lg border bg-card p-4 lg:col-span-3">
+        <SpotlightCard className="lg:col-span-3">
+        <section className="rounded-lg border bg-card p-6 shadow-sm">
           <div className="mb-4 flex flex-wrap items-center gap-2">
             <input
               value={search}
@@ -222,11 +224,13 @@ export function UsersPanel() {
             </div>
           )}
         </section>
+        </SpotlightCard>
 
+        <SpotlightCard className="lg:col-span-2">
         <section
           ref={formSectionRef}
           className={cn(
-            'rounded-lg border bg-card p-4 lg:col-span-2 transition-all duration-300',
+            'rounded-lg border bg-card p-6 shadow-sm transition-all duration-300',
             editHighlight && 'ring-2 ring-primary/60 shadow-md shadow-primary/10',
           )}
         >
@@ -294,6 +298,7 @@ export function UsersPanel() {
             </div>
           </div>
         </section>
+        </SpotlightCard>
       </div>
 
       <ConfirmDialog

--- a/frontend/src/features/core/pages/webhooks.tsx
+++ b/frontend/src/features/core/pages/webhooks.tsx
@@ -14,6 +14,7 @@ import {
   type Webhook,
 } from '@/features/core/hooks/use-webhooks';
 import { formatDate } from '@/shared/lib/utils';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 interface FormState {
   name: string;
@@ -187,7 +188,8 @@ export function WebhooksPanel() {
       </div>
 
       <div className="grid gap-6 lg:grid-cols-5">
-        <section className="rounded-lg border bg-card p-4 lg:col-span-3">
+        <SpotlightCard className="lg:col-span-3">
+        <section className="rounded-lg border bg-card p-6 shadow-sm">
           <div className="mb-4 flex flex-wrap items-center gap-2">
             <label className="text-sm text-muted-foreground">Filter</label>
             <ThemedSelect
@@ -282,8 +284,10 @@ export function WebhooksPanel() {
             </div>
           )}
         </section>
+        </SpotlightCard>
 
-        <section className="rounded-lg border bg-card p-4 lg:col-span-2">
+        <SpotlightCard className="lg:col-span-2">
+        <section className="rounded-lg border bg-card p-6 shadow-sm">
           <h2 className="text-base font-semibold">{editingId ? 'Edit Webhook' : 'Create Webhook'}</h2>
           <div className="mt-3 space-y-3 text-sm">
             <label className="block">
@@ -371,10 +375,12 @@ export function WebhooksPanel() {
             </div>
           </div>
         </section>
+        </SpotlightCard>
       </div>
 
       <div className="grid gap-6 xl:grid-cols-2">
-        <section className="rounded-lg border bg-card p-4">
+        <SpotlightCard>
+        <section className="rounded-lg border bg-card p-6 shadow-sm">
           <h2 className="text-base font-semibold">Delivery Monitor</h2>
           {!selectedWebhookId ? (
             <p className="mt-3 text-sm text-muted-foreground">Select a webhook to view delivery history.</p>
@@ -413,8 +419,10 @@ export function WebhooksPanel() {
             </div>
           )}
         </section>
+        </SpotlightCard>
 
-        <section className="rounded-lg border bg-card p-4">
+        <SpotlightCard>
+        <section className="rounded-lg border bg-card p-6 shadow-sm">
           <div className="flex items-center gap-2">
             <h2 className="text-base font-semibold">Live Event Feed</h2>
             <Radio className="h-4 w-4 text-primary" />
@@ -435,6 +443,7 @@ export function WebhooksPanel() {
             )}
           </div>
         </section>
+        </SpotlightCard>
       </div>
 
       <ConfirmDialog

--- a/frontend/src/features/observability/pages/log-viewer.test.tsx
+++ b/frontend/src/features/observability/pages/log-viewer.test.tsx
@@ -97,7 +97,10 @@ describe('LogViewerPage', () => {
 
     const filterSection = container.querySelector('section.z-20');
     expect(filterSection).toBeInTheDocument();
-    expect(filterSection).toHaveClass('backdrop-blur');
+    // Canonical card pattern (no backdrop-blur) — verify the pane uses the
+    // shared rounded-lg/border/shadow-sm aesthetic instead.
+    expect(filterSection).toHaveClass('rounded-lg');
+    expect(filterSection).toHaveClass('shadow-sm');
 
     const logSection = container.querySelector('section.z-10');
     expect(logSection).toBeInTheDocument();

--- a/frontend/src/features/observability/pages/log-viewer.tsx
+++ b/frontend/src/features/observability/pages/log-viewer.tsx
@@ -13,6 +13,7 @@ import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { useUiStore } from '@/stores/ui-store';
 import { usePageVisibility } from '@/shared/hooks/use-page-visibility';
 import { useLogStream } from '@/features/observability/hooks/use-log-stream';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 const FALLBACK_POLL_INTERVAL_MS = 5000;
 const BUFFER_OPTIONS = [500, 1000, 2000] as const;
@@ -138,7 +139,7 @@ function VirtualizedLogView({
   );
 
   return (
-    <section className="relative z-10 overflow-hidden rounded-xl border bg-slate-950">
+    <section className="relative z-10 overflow-hidden rounded-lg border bg-slate-950 shadow-sm">
       {!autoScroll && (
         <button
           onClick={() => {
@@ -395,7 +396,8 @@ export default function LogViewerPage() {
         </div>
       )}
 
-      <section className="relative z-20 rounded-xl border bg-card/75 p-4 backdrop-blur">
+      <SpotlightCard>
+      <section className="relative z-20 rounded-lg border bg-card p-6 shadow-sm">
         <div className="grid gap-3 lg:grid-cols-4">
           <label className="text-sm">
             <span className="mb-1 block text-muted-foreground">Endpoint</span>
@@ -511,6 +513,7 @@ export default function LogViewerPage() {
           {filteredEntries.length} lines | {searchMatches} search matches
         </div>
       </section>
+      </SpotlightCard>
 
       <VirtualizedLogView
         scrollRef={scrollRef}

--- a/frontend/src/features/observability/pages/reports.tsx
+++ b/frontend/src/features/observability/pages/reports.tsx
@@ -29,6 +29,9 @@ import { MetricsLineChart } from '@/shared/components/charts/metrics-line-chart'
 import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
 import { cn } from '@/shared/lib/utils';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+import { TiltCard } from '@/shared/components/data-display/tilt-card';
+import { KpiCard } from '@/shared/components/data-display/kpi-card';
 import { exportToCsv } from '@/shared/lib/csv-export';
 import {
   MANAGEMENT_PDF_THEMES,
@@ -65,22 +68,24 @@ function StatCard({
   trend?: 'up' | 'down' | 'neutral';
 }) {
   return (
-    <div className="rounded-lg border bg-card p-4">
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">{label}</p>
-        <Icon className="h-4 w-4 text-muted-foreground" />
-      </div>
-      <div className="mt-2 flex items-baseline gap-1">
-        <p className="text-2xl font-bold">{value.toFixed(1)}</p>
-        <span className="text-sm text-muted-foreground">{unit}</span>
-      </div>
-      {trend && trend !== 'neutral' && (
-        <div className={cn('mt-1 flex items-center gap-1 text-xs', trend === 'up' ? 'text-red-500' : 'text-green-500')}>
-          {trend === 'up' ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
-          <span>{trend === 'up' ? 'Increasing' : 'Decreasing'}</span>
+    <SpotlightCard className="h-full">
+      <div className="h-full rounded-lg border bg-card p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
+          <Icon className="h-5 w-5 text-muted-foreground" />
         </div>
-      )}
-    </div>
+        <div className="mt-2 flex items-baseline gap-1">
+          <p className="text-3xl font-bold tracking-tight">{value.toFixed(1)}</p>
+          <span className="text-sm text-muted-foreground">{unit}</span>
+        </div>
+        {trend && trend !== 'neutral' && (
+          <div className={cn('mt-1 flex items-center gap-1 text-xs', trend === 'up' ? 'text-red-500' : 'text-green-500')}>
+            {trend === 'up' ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+            <span>{trend === 'up' ? 'Increasing' : 'Decreasing'}</span>
+          </div>
+        )}
+      </div>
+    </SpotlightCard>
   );
 }
 
@@ -207,40 +212,27 @@ export function DienststellenOverview({
     <div className="space-y-4">
       {/* Dienststellen KPIs */}
       <div className="grid gap-4 md:grid-cols-4">
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">Total Dienststellen</p>
-            <Building2 className="h-4 w-4 text-muted-foreground" />
-          </div>
-          <p className="mt-2 text-2xl font-bold">{totalDienststellen}</p>
-        </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">Total Containers</p>
-            <Box className="h-4 w-4 text-muted-foreground" />
-          </div>
-          <p className="mt-2 text-2xl font-bold">{totalContainers}</p>
-        </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">Departments</p>
-            <Tag className="h-4 w-4 text-muted-foreground" />
-          </div>
-          <p className="mt-2 text-2xl font-bold">{uniqueDepartments.size}</p>
-        </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">Avg Containers / Dienststelle</p>
-            <Server className="h-4 w-4 text-muted-foreground" />
-          </div>
-          <p className="mt-2 text-2xl font-bold">
-            {totalDienststellen > 0 ? (totalContainers / totalDienststellen).toFixed(1) : '0'}
-          </p>
-        </div>
+        <TiltCard>
+          <KpiCard label="Total Dienststellen" value={totalDienststellen} icon={<Building2 className="h-5 w-5" />} />
+        </TiltCard>
+        <TiltCard>
+          <KpiCard label="Total Containers" value={totalContainers} icon={<Box className="h-5 w-5" />} />
+        </TiltCard>
+        <TiltCard>
+          <KpiCard label="Departments" value={uniqueDepartments.size} icon={<Tag className="h-5 w-5" />} />
+        </TiltCard>
+        <TiltCard>
+          <KpiCard
+            label="Avg Containers / Dienststelle"
+            value={totalDienststellen > 0 ? (totalContainers / totalDienststellen).toFixed(1) : '0'}
+            icon={<Server className="h-5 w-5" />}
+          />
+        </TiltCard>
       </div>
 
       {/* Grouped table */}
-      <div className="rounded-lg border bg-card">
+      <SpotlightCard>
+      <div className="rounded-lg border bg-card shadow-sm">
         <div className="flex items-center justify-between p-4 border-b">
           <div className="flex items-center gap-2">
             <Building2 className="h-5 w-5" />
@@ -363,6 +355,7 @@ export function DienststellenOverview({
           })}
         </div>
       </div>
+      </SpotlightCard>
     </div>
   );
 }
@@ -731,7 +724,8 @@ export default function ReportsPage() {
       </div>
 
       {/* Controls */}
-      <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-card p-4">
+      <SpotlightCard>
+      <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-card p-6 shadow-sm">
         <div className="flex items-center gap-2">
           <Server className="h-4 w-4 text-muted-foreground" />
           <ThemedSelect
@@ -774,9 +768,11 @@ export default function ReportsPage() {
           Exclude infrastructure services
         </label>
       </div>
+      </SpotlightCard>
 
       {showPdfOptions && (
-        <div className="relative z-20 space-y-4 rounded-lg border bg-card p-4 pointer-events-auto">
+        <SpotlightCard>
+        <div className="relative z-20 space-y-4 rounded-lg border bg-card p-6 shadow-sm pointer-events-auto">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h2 className="text-base font-semibold">Management PDF Export</h2>
@@ -913,6 +909,7 @@ export default function ReportsPage() {
             )}
           </div>
         </div>
+        </SpotlightCard>
       )}
 
       {/* Dienststellen Overview */}
@@ -968,7 +965,8 @@ export default function ReportsPage() {
       {/* Trend Charts */}
       {trends && (cpuTrendData.length > 0 || memTrendData.length > 0) && (
         <div className="grid gap-6 lg:grid-cols-2">
-          <div className="rounded-lg border bg-card p-6">
+          <SpotlightCard>
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
             <div className="flex items-center gap-2 mb-4">
               <Cpu className="h-5 w-5 text-blue-500" />
               <h3 className="text-lg font-semibold">CPU Trend (Fleet Avg)</h3>
@@ -988,8 +986,10 @@ export default function ReportsPage() {
               )}
             </div>
           </div>
+          </SpotlightCard>
 
-          <div className="rounded-lg border bg-card p-6">
+          <SpotlightCard>
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
             <div className="flex items-center gap-2 mb-4">
               <MemoryStick className="h-5 w-5 text-purple-500" />
               <h3 className="text-lg font-semibold">Memory Trend (Fleet Avg)</h3>
@@ -1009,12 +1009,14 @@ export default function ReportsPage() {
               )}
             </div>
           </div>
+          </SpotlightCard>
         </div>
       )}
 
       {/* Recommendations */}
       {report && report.recommendations.length > 0 && (
-        <div className="rounded-lg border bg-card p-6">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
           <div className="flex items-center gap-2 mb-4">
             <Lightbulb className="h-5 w-5 text-amber-500" />
             <h3 className="text-lg font-semibold">Right-Sizing Recommendations</h3>
@@ -1038,12 +1040,14 @@ export default function ReportsPage() {
             ))}
           </div>
         </div>
+        </SpotlightCard>
       )}
 
       {/* Container Utilization Table */}
       {report && report.containers.length > 0 && (
         <div className="space-y-4">
-          <div className="rounded-lg border bg-card">
+          <SpotlightCard>
+          <div className="rounded-lg border bg-card shadow-sm">
             <div className="p-4 border-b">
               <h3 className="text-lg font-semibold">Application Services</h3>
             </div>
@@ -1053,14 +1057,17 @@ export default function ReportsPage() {
               <div className="p-4 text-sm text-muted-foreground">No application services for the selected scope.</div>
             )}
           </div>
+          </SpotlightCard>
 
           {infrastructureContainers.length > 0 && (
-            <div className="rounded-lg border bg-card">
+            <SpotlightCard>
+            <div className="rounded-lg border bg-card shadow-sm">
               <div className="p-4 border-b">
                 <h3 className="text-lg font-semibold">Infrastructure Services</h3>
               </div>
               {renderContainerTable(infrastructureContainers)}
             </div>
+            </SpotlightCard>
           )}
         </div>
       )}

--- a/frontend/src/features/observability/pages/status-page.test.tsx
+++ b/frontend/src/features/observability/pages/status-page.test.tsx
@@ -271,9 +271,11 @@ describe('StatusPage', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/status');
   });
 
-  it('uses glassmorphic card styling', async () => {
+  it('uses canonical card styling', async () => {
     await renderPage();
-    const cards = document.querySelectorAll('.backdrop-blur-xl');
+    // Card style normalized to canonical pattern (rounded-lg border bg-card shadow-sm)
+    // matching Home/Workload-Explorer aesthetic across the app.
+    const cards = document.querySelectorAll('.rounded-lg.border.bg-card.shadow-sm');
     expect(cards.length).toBeGreaterThan(0);
   });
 

--- a/frontend/src/features/observability/pages/status-page.tsx
+++ b/frontend/src/features/observability/pages/status-page.tsx
@@ -61,7 +61,7 @@ const PARTICLES = [
 ];
 
 const GLASS_CARD =
-  'rounded-xl border bg-card/80 backdrop-blur-xl shadow-lg transition-all duration-200 hover:shadow-xl hover:-translate-y-0.5';
+  'rounded-lg border bg-card shadow-sm transition-all duration-200 hover:shadow-md hover:-translate-y-0.5';
 
 const STATUS_CONFIG = {
   operational: {
@@ -334,7 +334,7 @@ export default function StatusPage() {
           <MotionReveal>
             <div
               className={cn(
-                'rounded-xl border p-8 text-center backdrop-blur-xl',
+                'rounded-lg border p-6 text-center shadow-sm',
                 statusConf.bg,
               )}
               data-testid="status-banner"

--- a/frontend/src/features/observability/pages/trace-explorer.tsx
+++ b/frontend/src/features/observability/pages/trace-explorer.tsx
@@ -22,6 +22,9 @@ import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
 import { cn, formatDate } from '@/shared/lib/utils';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
+import { KpiCard } from '@/shared/components/data-display/kpi-card';
+import { TiltCard } from '@/shared/components/data-display/tilt-card';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 function formatDuration(ms: number): string {
   if (ms < 1) return '<1ms';
@@ -825,22 +828,18 @@ export default function TraceExplorerPage() {
       {summary && (
         <>
           <div className="grid gap-4 md:grid-cols-4">
-            <div className="rounded-lg border bg-card p-4">
-              <p className="text-sm text-muted-foreground">Total Traces</p>
-              <p className="text-2xl font-bold">{summary.totalTraces}</p>
-            </div>
-            <div className="rounded-lg border bg-card p-4">
-              <p className="text-sm text-muted-foreground">Avg Duration</p>
-              <p className="text-2xl font-bold">{formatDuration(summary.avgDuration)}</p>
-            </div>
-            <div className="rounded-lg border bg-card p-4">
-              <p className="text-sm text-muted-foreground">Error Rate</p>
-              <p className="text-2xl font-bold">{(summary.errorRate * 100).toFixed(1)}%</p>
-            </div>
-            <div className="rounded-lg border bg-card p-4">
-              <p className="text-sm text-muted-foreground">Services</p>
-              <p className="text-2xl font-bold">{summary.services}</p>
-            </div>
+            <TiltCard>
+              <KpiCard label="Total Traces" value={summary.totalTraces} />
+            </TiltCard>
+            <TiltCard>
+              <KpiCard label="Avg Duration" value={formatDuration(summary.avgDuration)} />
+            </TiltCard>
+            <TiltCard>
+              <KpiCard label="Error Rate" value={`${(summary.errorRate * 100).toFixed(1)}%`} />
+            </TiltCard>
+            <TiltCard>
+              <KpiCard label="Services" value={summary.services} />
+            </TiltCard>
           </div>
           <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-card p-3 text-xs">
             <span className="font-medium text-muted-foreground">Source counters:</span>
@@ -853,7 +852,8 @@ export default function TraceExplorerPage() {
         </>
       )}
 
-      <div className="space-y-3 rounded-lg border bg-card p-4">
+      <SpotlightCard>
+      <div className="space-y-3 rounded-lg border bg-card p-6 shadow-sm">
         <div className="flex flex-wrap items-center gap-4">
           <div className="relative min-w-[200px] flex-1">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -1395,12 +1395,15 @@ export default function TraceExplorerPage() {
           </div>
         )}
       </div>
+      </SpotlightCard>
 
       {showServiceMap && (
-        <div className="rounded-lg border bg-card p-4">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
           <h3 className="mb-4 text-lg font-semibold">Service Dependency Map</h3>
           <ServiceMap serviceNodes={serviceMapNodes} serviceEdges={serviceMapEdges} />
         </div>
+        </SpotlightCard>
       )}
 
       {isLoading ? (
@@ -1447,7 +1450,8 @@ export default function TraceExplorerPage() {
 
           <div className="lg:col-span-2">
             {selectedTraceId && selectedTrace ? (
-              <div className="rounded-lg border bg-card">
+              <SpotlightCard>
+              <div className="rounded-lg border bg-card shadow-sm">
                 <div className="border-b p-4">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
@@ -1692,6 +1696,7 @@ export default function TraceExplorerPage() {
                   </div>
                 )}
               </div>
+              </SpotlightCard>
             ) : (
               <div className="flex h-[600px] items-center justify-center rounded-lg border border-dashed bg-muted/20">
                 <div className="text-center">

--- a/frontend/src/features/operations/pages/edge-agent-logs.tsx
+++ b/frontend/src/features/operations/pages/edge-agent-logs.tsx
@@ -27,6 +27,9 @@ import { RefreshButton } from '@/shared/components/ui/refresh-button';
 import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
 import { cn, formatDate } from '@/shared/lib/utils';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+import { TiltCard } from '@/shared/components/data-display/tilt-card';
+import { KpiCard } from '@/shared/components/data-display/kpi-card';
 
 // Log levels with colors
 const LOG_LEVELS = [
@@ -169,7 +172,8 @@ function LogRow({ log, isExpanded, onToggle }: LogRowProps) {
 
 function NotConfiguredState() {
   return (
-    <div className="rounded-lg border bg-card p-8">
+    <SpotlightCard>
+    <div className="rounded-lg border bg-card p-6 shadow-sm">
       <div className="flex flex-col items-center text-center max-w-md mx-auto">
         <div className="rounded-full bg-amber-500/10 p-4 mb-4">
           <Settings className="h-8 w-8 text-amber-500" />
@@ -219,6 +223,7 @@ function NotConfiguredState() {
         </a>
       </div>
     </div>
+    </SpotlightCard>
   );
 }
 
@@ -378,7 +383,8 @@ export default function EdgeAgentLogsPage() {
       </div>
 
       {/* Search and Filters */}
-      <div className="rounded-lg border bg-card p-4">
+      <SpotlightCard>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
         <form onSubmit={handleSearch} className="flex gap-3 flex-wrap">
           {/* Search Input */}
           <div className="relative flex-1 min-w-[300px]">
@@ -454,38 +460,43 @@ export default function EdgeAgentLogsPage() {
           )}
         </form>
       </div>
+      </SpotlightCard>
 
       {/* Stats Cards */}
       {logs.length > 0 && (
         <div className="grid gap-4 md:grid-cols-5">
-          <div className="rounded-lg border bg-card p-4">
-            <p className="text-sm text-muted-foreground">Total Logs</p>
-            <p className="text-2xl font-bold">{logsData?.total || logs.length}</p>
-          </div>
-          <div className="rounded-lg border bg-card p-4">
-            <p className="text-sm text-muted-foreground flex items-center gap-1">
-              <XCircle className="h-3 w-3 text-red-500" /> Errors
-            </p>
-            <p className="text-2xl font-bold text-red-500">{stats.error || 0}</p>
-          </div>
-          <div className="rounded-lg border bg-card p-4">
-            <p className="text-sm text-muted-foreground flex items-center gap-1">
-              <AlertCircle className="h-3 w-3 text-amber-500" /> Warnings
-            </p>
-            <p className="text-2xl font-bold text-amber-500">{(stats.warn || 0) + (stats.warning || 0)}</p>
-          </div>
-          <div className="rounded-lg border bg-card p-4">
-            <p className="text-sm text-muted-foreground flex items-center gap-1">
-              <Info className="h-3 w-3 text-blue-500" /> Info
-            </p>
-            <p className="text-2xl font-bold text-blue-500">{stats.info || 0}</p>
-          </div>
-          <div className="rounded-lg border bg-card p-4">
-            <p className="text-sm text-muted-foreground flex items-center gap-1">
-              <CheckCircle2 className="h-3 w-3 text-emerald-500" /> Debug
-            </p>
-            <p className="text-2xl font-bold text-emerald-500">{stats.debug || 0}</p>
-          </div>
+          <TiltCard>
+            <KpiCard label="Total Logs" value={logsData?.total || logs.length} />
+          </TiltCard>
+          <TiltCard>
+            <KpiCard
+              label="Errors"
+              value={stats.error || 0}
+              icon={<XCircle className="h-5 w-5 text-red-500" />}
+              trend={(stats.error || 0) > 0 ? 'down' : 'neutral'}
+            />
+          </TiltCard>
+          <TiltCard>
+            <KpiCard
+              label="Warnings"
+              value={(stats.warn || 0) + (stats.warning || 0)}
+              icon={<AlertCircle className="h-5 w-5 text-amber-500" />}
+            />
+          </TiltCard>
+          <TiltCard>
+            <KpiCard
+              label="Info"
+              value={stats.info || 0}
+              icon={<Info className="h-5 w-5 text-blue-500" />}
+            />
+          </TiltCard>
+          <TiltCard>
+            <KpiCard
+              label="Debug"
+              value={stats.debug || 0}
+              icon={<CheckCircle2 className="h-5 w-5 text-emerald-500" />}
+            />
+          </TiltCard>
         </div>
       )}
 
@@ -519,7 +530,8 @@ export default function EdgeAgentLogsPage() {
 
       {/* Empty State */}
       {!isLoading && !isError && logs.length === 0 && (
-        <div className="rounded-lg border bg-card p-8 text-center">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card p-6 shadow-sm text-center">
           <FileText className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
           <h3 className="text-lg font-semibold mb-2">No logs found</h3>
           <p className="text-muted-foreground mb-4">
@@ -536,11 +548,13 @@ export default function EdgeAgentLogsPage() {
             </ul>
           </div>
         </div>
+        </SpotlightCard>
       )}
 
       {/* Results Table */}
       {!isLoading && !isError && logs.length > 0 && (
-        <div className="rounded-lg border bg-card">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card shadow-sm">
           <div className="border-b border-border p-4 flex items-center justify-between">
             <h3 className="font-semibold">
               Log Results
@@ -563,6 +577,7 @@ export default function EdgeAgentLogsPage() {
             ))}
           </div>
         </div>
+        </SpotlightCard>
       )}
     </div>
   );

--- a/frontend/src/features/operations/pages/remediation.tsx
+++ b/frontend/src/features/operations/pages/remediation.tsx
@@ -30,6 +30,8 @@ import { RefreshButton } from '@/shared/components/ui/refresh-button';
 import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
 import { useSockets } from '@/providers/socket-provider';
 import { cn, formatDate } from '@/shared/lib/utils';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+import { TiltCard } from '@/shared/components/data-display/tilt-card';
 
 type ActionStatus = 'all' | 'pending' | 'approved' | 'rejected' | 'executing' | 'completed' | 'failed';
 
@@ -573,38 +575,47 @@ export default function RemediationPage() {
 
       {/* Stats Cards */}
       <div className="grid gap-4 md:grid-cols-4">
-        <div className="rounded-lg border bg-amber-50 dark:bg-amber-900/20 p-4">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-amber-800 dark:text-amber-200">Pending Approval</p>
-            <Clock className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+        <TiltCard>
+          <div className="h-full rounded-lg border bg-amber-50 dark:bg-amber-900/20 p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-amber-800 dark:text-amber-200">Pending Approval</p>
+              <Clock className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <p className="mt-2 text-3xl font-bold tracking-tight text-amber-900 dark:text-amber-100">{stats.pending}</p>
           </div>
-          <p className="mt-2 text-3xl font-bold text-amber-900 dark:text-amber-100">{stats.pending}</p>
-        </div>
-        <div className="rounded-lg border bg-blue-50 dark:bg-blue-900/20 p-4">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-blue-800 dark:text-blue-200">Approved</p>
-            <ThumbsUp className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+        </TiltCard>
+        <TiltCard>
+          <div className="h-full rounded-lg border bg-blue-50 dark:bg-blue-900/20 p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-blue-800 dark:text-blue-200">Approved</p>
+              <ThumbsUp className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+            </div>
+            <p className="mt-2 text-3xl font-bold tracking-tight text-blue-900 dark:text-blue-100">{stats.approved}</p>
           </div>
-          <p className="mt-2 text-3xl font-bold text-blue-900 dark:text-blue-100">{stats.approved}</p>
-        </div>
-        <div className="rounded-lg border bg-emerald-50 dark:bg-emerald-900/20 p-4">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-emerald-800 dark:text-emerald-200">Completed</p>
-            <CheckCircle2 className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+        </TiltCard>
+        <TiltCard>
+          <div className="h-full rounded-lg border bg-emerald-50 dark:bg-emerald-900/20 p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-emerald-800 dark:text-emerald-200">Completed</p>
+              <CheckCircle2 className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+            </div>
+            <p className="mt-2 text-3xl font-bold tracking-tight text-emerald-900 dark:text-emerald-100">{stats.completed}</p>
           </div>
-          <p className="mt-2 text-3xl font-bold text-emerald-900 dark:text-emerald-100">{stats.completed}</p>
-        </div>
-        <div className="rounded-lg border bg-red-50 dark:bg-red-900/20 p-4">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-red-800 dark:text-red-200">Failed</p>
-            <XCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+        </TiltCard>
+        <TiltCard>
+          <div className="h-full rounded-lg border bg-red-50 dark:bg-red-900/20 p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-red-800 dark:text-red-200">Failed</p>
+              <XCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+            </div>
+            <p className="mt-2 text-3xl font-bold tracking-tight text-red-900 dark:text-red-100">{stats.failed}</p>
           </div>
-          <p className="mt-2 text-3xl font-bold text-red-900 dark:text-red-100">{stats.failed}</p>
-        </div>
+        </TiltCard>
       </div>
 
       {/* Status Filter Tabs */}
-      <div className="flex items-center gap-1 overflow-x-auto rounded-lg border bg-card p-1">
+      <SpotlightCard>
+      <div className="flex items-center gap-1 overflow-x-auto rounded-lg border bg-card p-1 shadow-sm">
         {STATUS_TABS.map((tab) => (
           <button
             key={tab.value}
@@ -631,6 +642,7 @@ export default function RemediationPage() {
           </button>
         ))}
       </div>
+      </SpotlightCard>
 
       {/* Actions Table */}
       {isLoading ? (
@@ -646,7 +658,8 @@ export default function RemediationPage() {
           </p>
         </div>
       ) : (
-        <div className="rounded-lg border bg-card overflow-hidden">
+        <SpotlightCard>
+        <div className="rounded-lg border bg-card shadow-sm overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
@@ -678,6 +691,7 @@ export default function RemediationPage() {
             </table>
           </div>
         </div>
+        </SpotlightCard>
       )}
 
       {/* Execute Confirmation Dialog */}

--- a/frontend/src/features/security/components/observed-destinations-panel.tsx
+++ b/frontend/src/features/security/components/observed-destinations-panel.tsx
@@ -3,6 +3,7 @@ import { Globe } from 'lucide-react';
 import { api } from '@/shared/lib/api';
 import { cn } from '@/shared/lib/utils';
 import { NoTraceDataCallout } from '@/features/observability/components/no-trace-data-callout';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 export type Verdict = 'allow' | 'warn' | 'deny';
 
@@ -59,7 +60,8 @@ export function ObservedDestinationsPanel({ endpointId }: Props) {
   const destinations = data?.destinations ?? [];
 
   return (
-    <section className="rounded-xl border bg-card/75 p-4 backdrop-blur" data-testid="observed-destinations-panel">
+    <SpotlightCard>
+    <section className="rounded-lg border bg-card p-6 shadow-sm" data-testid="observed-destinations-panel">
       <div className="mb-3 flex items-center gap-2">
         <Globe className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
         <h2 className="text-lg font-semibold">Observed Destinations</h2>
@@ -126,5 +128,6 @@ export function ObservedDestinationsPanel({ endpointId }: Props) {
         </div>
       )}
     </section>
+    </SpotlightCard>
   );
 }

--- a/frontend/src/features/security/pages/ebpf-coverage.tsx
+++ b/frontend/src/features/security/pages/ebpf-coverage.tsx
@@ -401,7 +401,8 @@ export default function EbpfCoveragePage() {
       {isLoading ? (
         <SkeletonCard className="h-64" />
       ) : (
-        <div className="overflow-x-auto rounded-xl border border-border bg-card">
+        <SpotlightCard>
+        <div className="overflow-x-auto rounded-lg border bg-card shadow-sm">
           <table className="w-full text-left" data-testid="coverage-table">
             <thead>
               <tr className="border-b border-border bg-muted/50">
@@ -440,6 +441,7 @@ export default function EbpfCoveragePage() {
             </tbody>
           </table>
         </div>
+        </SpotlightCard>
       )}
     </div>
   );

--- a/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
+++ b/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
@@ -236,7 +236,7 @@ export default function HarborVulnerabilitiesPage() {
       )}
 
       {isError && (
-        <div className="rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           Failed to load vulnerability data: {error instanceof Error ? error.message : 'Unknown error'}
           <button onClick={() => refetch()} className="ml-2 underline">Retry</button>
         </div>

--- a/frontend/src/features/security/pages/packet-capture.tsx
+++ b/frontend/src/features/security/pages/packet-capture.tsx
@@ -36,6 +36,7 @@ import { api } from '@/shared/lib/api';
 import { cn } from '@/shared/lib/utils';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { buildStackGroupedContainerOptions, NO_STACK_LABEL, resolveContainerStackName } from '@/features/containers/lib/container-stack-grouping';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
@@ -164,7 +165,8 @@ export default function PacketCapture() {
       )}
 
       {/* New Capture Form */}
-      <div className="rounded-lg border bg-card p-6">
+      <SpotlightCard>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold">New Capture</h2>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {/* Endpoint */}
@@ -282,6 +284,7 @@ export default function PacketCapture() {
           </div>
         </div>
       </div>
+      </SpotlightCard>
 
       {/* Active Captures */}
       {activeCaptures.length > 0 && (
@@ -323,13 +326,16 @@ export default function PacketCapture() {
         </div>
 
         {captures.length === 0 ? (
-          <div className="rounded-lg border bg-card p-8 text-center text-muted-foreground">
+          <SpotlightCard>
+          <div className="rounded-lg border bg-card p-6 shadow-sm text-center text-muted-foreground">
             <Radio className="mx-auto mb-3 h-10 w-10 opacity-50" />
             <p className="font-medium">No captures found</p>
             <p className="text-sm">Start a new capture above to begin monitoring network traffic.</p>
           </div>
+          </SpotlightCard>
         ) : (
-          <div className="overflow-x-auto rounded-lg border">
+          <SpotlightCard>
+          <div className="overflow-x-auto rounded-lg border bg-card shadow-sm">
             <table className="w-full text-sm">
               <thead className="border-b bg-muted/50">
                 <tr>
@@ -365,6 +371,7 @@ export default function PacketCapture() {
               </tbody>
             </table>
           </div>
+          </SpotlightCard>
         )}
       </div>
     </div>
@@ -381,7 +388,8 @@ function ActiveCaptureCard({
   isStopping: boolean;
 }) {
   return (
-    <div className="rounded-lg border bg-card p-4">
+    <SpotlightCard>
+    <div className="rounded-lg border bg-card p-6 shadow-sm">
       <div className="flex items-start justify-between">
         <div>
           <p className="font-medium">{capture.container_name}</p>
@@ -411,6 +419,7 @@ function ActiveCaptureCard({
         </button>
       </div>
     </div>
+    </SpotlightCard>
   );
 }
 
@@ -486,7 +495,8 @@ function FindingCard({ finding }: { finding: PcapFinding }) {
 
 function AnalysisPanel({ analysis, onReanalyze, isAnalyzing }: { analysis: PcapAnalysisResult; onReanalyze: () => void; isAnalyzing: boolean }) {
   return (
-    <div className="space-y-3 rounded-lg border bg-card/50 p-4">
+    <SpotlightCard>
+    <div className="space-y-3 rounded-lg border bg-card p-6 shadow-sm">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <HealthBadge status={analysis.health_status} />
@@ -514,6 +524,7 @@ function AnalysisPanel({ analysis, onReanalyze, isAnalyzing }: { analysis: PcapA
         </div>
       )}
     </div>
+    </SpotlightCard>
   );
 }
 

--- a/frontend/src/shared/components/data-display/spotlight-card.tsx
+++ b/frontend/src/shared/components/data-display/spotlight-card.tsx
@@ -33,7 +33,7 @@ export function SpotlightCard({ children, className }: SpotlightCardProps) {
   return (
     <div
       ref={containerRef}
-      className={cn('spotlight-card rounded-xl', className)}
+      className={cn('spotlight-card rounded-lg', className)}
       onMouseMove={handleMouseMove}
     >
       {children}

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -10,6 +10,23 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+// Mock matchMedia for components using prefers-reduced-motion (e.g. KpiCard).
+// We return matches:true for the reduce-motion query so animated counters
+// (useCountUp) skip the rAF tween and render their target value immediately.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: query.includes('prefers-reduced-motion'),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
 // Mock scrollIntoView for jsdom (used by cmdk)
 Element.prototype.scrollIntoView = function () {};
 


### PR DESCRIPTION
## Summary

Second pass after #1251. Applies the canonical `<SpotlightCard>` wrapping `rounded-lg border bg-card p-6 shadow-sm` pattern (and `<TiltCard>` + `<KpiCard>` for stat tiles) across every remaining page and shared sub-component so every pane visually matches Home / Workload Explorer.

## Changes

### Pages
- **trace-explorer**: 4 inline stat tiles → KpiCard+TiltCard; filter pane, service-map pane and selected-trace details wrapped in SpotlightCard.
- **reports**: local `StatCard` reshaped to canonical KPI layout; 4 Dienststellen tiles use KpiCard+TiltCard; trend charts, recommendations, Application/Infrastructure tables, controls and PDF options all wrapped.
- **edge-agent-logs**: NotConfigured state, search/filters, results table, empty state wrapped in SpotlightCard; 5 stat tiles → KpiCard+TiltCard.
- **investigation-detail**: 4 summary tiles → TiltCard; Timeline / Related Artifacts / Findings panes wrapped (p-5 → p-6).
- **remediation**: 4 colored status tiles → p-6 + shadow-sm + TiltCard; status tabs and actions table wrapped.
- **users / webhooks**: list + form sections (p-4 → p-6 + shadow-sm) wrapped.
- **packet-capture**: New Capture form, captures table, empty state, ActiveCaptureCard and AnalysisPanel wrapped (p-4 / p-8 / bg-card/50 → canonical p-6 + shadow-sm).
- **log-viewer**: filter pane `rounded-xl bg-card/75 backdrop-blur` → canonical pattern; log terminal radius normalized.
- **status-page**: `GLASS_CARD` constant + status banner swap glassmorphic styling for canonical pattern.
- **fleet-overview**: empty states (p-8 → p-6) and Kubernetes summary bar wrapped.
- **network-topology**: side panel adds `shadow-sm`.

### Shared components
- **ai-metrics-summary**: wrapped (p-4 → p-6 + shadow-sm).
- **correlation-insights-panel**: loading + loaded states wrapped.
- **llm-latency-breakdown**: drop self-applied `rounded-xl/backdrop-blur` since parent pane provides it.
- **observed-destinations-panel**: `rounded-xl/backdrop-blur` → canonical pattern.

### Other
- **ebpf-coverage**: coverage table wrapper normalized.
- **harbor-vulnerabilities**: error banner `rounded-xl` → `rounded-lg`.
- **settings/tab-ai-llm**: MCP Servers pane normalized.

### Tests / setup
- `vitest.setup.ts`: mock `window.matchMedia` (`matches:true` for `prefers-reduced-motion`) so `KpiCard` / `useCountUp` render their target value synchronously in jsdom — needed because several test files now render `KpiCard` for the first time.
- `status-page.test.tsx`: assertion updated from `.backdrop-blur-xl` → canonical `.rounded-lg.border.bg-card.shadow-sm`.
- `log-viewer.test.tsx`: assertion updated from `backdrop-blur` → canonical `rounded-lg` + `shadow-sm` (z-index ordering still verified).

## Test plan

- [x] `npx tsc --noEmit -p frontend` — clean
- [x] `npx eslint frontend/src` — clean
- [x] `npx vitest run` — 1879/1879 passing
- [ ] Reviewer: spot-check pages with live Portainer data

🤖 Generated with [Claude Code](https://claude.com/claude-code)