### PR TITLE
feat(ui): empty-state + skeleton primitives (PR 1 of 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ frontend/vite.config.d.ts
 # Screenshots dropped at the repo root — developer scratch, not assets.
 # `/` anchors to repo root only, leaving frontend/public/*.png tracked.
 /*.png
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ Premium glassmorphic dashboard: bento grids, backdrop blur cards, staggered anim
 
 **Status colors:** Green=healthy, Yellow=warning, Orange=critical, Red=error, Blue=info, Gray=inactive, Purple=AI insight.
 
+**Empty / loading / error states:** Use `<EmptyState>` (variants: `empty` / `error` / `not-configured`) and the skeleton primitives (`SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`) in `frontend/src/shared/components/feedback/`. Skeletons live inside the caller's pane chrome — they do not wrap themselves in cards. `EmptyState` is purely informational; render any retry / settings action in the parent pane's header. See `@docs/superpowers/specs/2026-05-16-empty-loading-states-design.md` for the full rationale.
+
 For detailed specs (animation durations, easing curves, glass override patterns, layout patterns), see `@docs/ai-instructions/ui-design-system.md`.
 
 ## Testing & Mocks

--- a/docs/superpowers/plans/2026-05-16-empty-loading-states-pr1-primitives.md
+++ b/docs/superpowers/plans/2026-05-16-empty-loading-states-pr1-primitives.md
@@ -1,0 +1,957 @@
+# Empty / Loading / Error States — PR 1: Primitives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `<EmptyState>` component (variants: empty / error / not-configured) and five skeleton primitives that match content shape, so subsequent PRs can migrate the ~17 ad-hoc empty-state and ~25 ad-hoc loading-state call sites to a single canonical set.
+
+**Architecture:** Replace the dead-export `EmptyState` at `frontend/src/shared/components/feedback/empty-state.tsx` with the new hybrid-chrome design from the spec. Add a sibling `frontend/src/shared/components/feedback/skeleton.tsx` module exporting `SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`. Leave the existing `LoadingSkeleton` and `SkeletonCard` in `loading-skeleton.tsx` untouched — they have 73 active call sites and get retired in PR 3. Validate end-to-end by migrating one low-traffic page (`webhooks.tsx`) as a demo, which exercises both the empty state and a loading skeleton.
+
+**Tech Stack:** React 19, TypeScript strict, Vite, Tailwind v4 (custom theme via CSS vars), Vitest + jsdom + `@testing-library/react`, `lucide-react` for icons, existing `cn` util at `@/shared/lib/utils`, existing `SpotlightCard` at `@/shared/components/data-display/spotlight-card`.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-empty-loading-states-design.md`
+
+**Scope:** PR 1 only. Migrations of other call sites (high-traffic in PR 2, long-tail in PR 3) are out of scope here.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `frontend/src/shared/components/feedback/empty-state.tsx` | **Replace** | Single `<EmptyState>` component, three variants (empty / error / not-configured), no action slot, canonical card chrome with iconchip. |
+| `frontend/src/shared/components/feedback/empty-state.test.tsx` | **Create** | Vitest tests covering variant tints, default variant, optional description, custom className. |
+| `frontend/src/shared/components/feedback/skeleton.tsx` | **Create** | Five skeleton primitives: `SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`. No card chrome — callers wrap. |
+| `frontend/src/shared/components/feedback/skeleton.test.tsx` | **Create** | Vitest tests asserting row counts, prop defaults, role="status" accessibility. |
+| `frontend/src/features/core/pages/webhooks.tsx` | **Modify** | Demo migration — replace one ad-hoc loading block (~line 215) and one ad-hoc empty block (~line 220) with the new primitives. |
+
+`LoadingSkeleton`, `SkeletonCard`, and any other file are **not touched** in this PR.
+
+---
+
+## Conventions to follow
+
+- **Branch:** `feature/ui-empty-loading-primitives` off `dev`. PR target: `dev`.
+- **Commits:** One commit per task (Task 1, Task 2, …). Conventional commit prefixes: `feat`, `test`, `refactor`, `style`, `docs`. Subject ≤ 72 chars. No `--no-verify`.
+- **Tests:** TDD throughout — failing test first, then implementation, then green. Tests live next to the component (`*.test.tsx`).
+- **Imports:** Use `@/shared/...` path alias (already configured). Lucide icons named-imported: `import { Activity } from 'lucide-react'`.
+- **Styling:** Tailwind utility classes only. Use `cn()` from `@/shared/lib/utils` to merge. Match existing primitive style: `'rounded-lg'`, `'border'`, `'bg-card'`, `'shadow-sm'`, `'text-muted-foreground'`, `'animate-pulse'`, `'bg-muted/40'`.
+- **No comments unless non-obvious why.** Don't restate what JSX already says.
+- **No `action` prop, no `children` slot on `EmptyState`.** Spec decision: state component is purely informational.
+
+---
+
+## Task 1: Replace EmptyState — write the failing tests
+
+**Files:**
+- Create: `frontend/src/shared/components/feedback/empty-state.test.tsx`
+
+The existing `empty-state.tsx` is a dead export (zero callers — verified via `grep -rn "<EmptyState" frontend/src --include="*.tsx"` returns 0). We rewrite both the component and the tests from scratch. Tests first.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+// frontend/src/shared/components/feedback/empty-state.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Activity, AlertTriangle, Settings } from 'lucide-react';
+import { vi } from 'vitest';
+import { EmptyState } from './empty-state';
+
+vi.mock('@/stores/ui-store', () => ({
+  useUiStore: (selector: (s: { potatoMode: boolean }) => boolean) =>
+    selector({ potatoMode: false }),
+}));
+
+describe('EmptyState', () => {
+  it('renders the title', () => {
+    render(<EmptyState icon={Activity} title="No traces yet" />);
+    expect(screen.getByText('No traces yet')).toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    render(
+      <EmptyState
+        icon={Activity}
+        title="No traces yet"
+        description="Run a workload to start capturing distributed traces."
+      />,
+    );
+    expect(
+      screen.getByText('Run a workload to start capturing distributed traces.'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits description paragraph when not provided', () => {
+    const { container } = render(<EmptyState icon={Activity} title="Empty" />);
+    // Only one <p> — the title sits in a <p>, no description <p> follows.
+    expect(container.querySelectorAll('p')).toHaveLength(1);
+  });
+
+  it('uses neutral muted tint for default (empty) variant', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    const iconEl = container.querySelector('svg');
+    expect(iconEl).toHaveClass('text-muted-foreground');
+  });
+
+  it('uses destructive tint for error variant', () => {
+    const { container } = render(
+      <EmptyState variant="error" icon={AlertTriangle} title="Failed" />,
+    );
+    const iconEl = container.querySelector('svg');
+    expect(iconEl?.className).toContain('text-destructive');
+  });
+
+  it('uses amber tint for not-configured variant', () => {
+    const { container } = render(
+      <EmptyState variant="not-configured" icon={Settings} title="Not set up" />,
+    );
+    const iconEl = container.querySelector('svg');
+    expect(iconEl?.className).toContain('text-amber-500');
+  });
+
+  it('renders the canonical pane chrome (border + bg-card + shadow-sm + rounded-lg)', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    // SpotlightCard is the outer wrapper; the inner div carries the chrome classes.
+    const inner = container.querySelector('.spotlight-card > div');
+    expect(inner).toHaveClass('rounded-lg');
+    expect(inner).toHaveClass('border');
+    expect(inner).toHaveClass('bg-card');
+    expect(inner).toHaveClass('shadow-sm');
+  });
+
+  it('applies a custom className to the outer card', () => {
+    const { container } = render(
+      <EmptyState icon={Activity} title="t" className="h-64" />,
+    );
+    expect(container.firstChild).toHaveClass('h-64');
+  });
+
+  it('renders a circular iconchip around the icon', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    const chip = container.querySelector('.rounded-full');
+    expect(chip).toBeInTheDocument();
+    expect(chip?.querySelector('svg')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/empty-state.test.tsx
+```
+
+Expected: tests fail because the old `EmptyState` doesn't accept `icon: LucideIcon`, doesn't have the new variant names, and has the old dashed-border chrome.
+
+---
+
+## Task 2: Replace EmptyState — implement the new component
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/empty-state.tsx` (full rewrite)
+
+- [ ] **Step 1: Rewrite the component**
+
+Replace the entire file contents with:
+
+```tsx
+// frontend/src/shared/components/feedback/empty-state.tsx
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+
+export type EmptyStateVariant = 'empty' | 'error' | 'not-configured';
+
+export interface EmptyStateProps {
+  variant?: EmptyStateVariant;
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  className?: string;
+}
+
+const iconTintByVariant: Record<EmptyStateVariant, string> = {
+  empty: 'text-muted-foreground',
+  error: 'text-destructive/80',
+  'not-configured': 'text-amber-500/80',
+};
+
+export function EmptyState({
+  variant = 'empty',
+  icon: Icon,
+  title,
+  description,
+  className,
+}: EmptyStateProps) {
+  return (
+    <SpotlightCard className={className}>
+      <div className="flex flex-col items-center justify-center rounded-lg border bg-card p-8 text-center shadow-sm">
+        <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-muted/40">
+          <Icon className={cn('h-6 w-6', iconTintByVariant[variant])} />
+        </div>
+        <p className="text-sm font-semibold text-foreground/80">{title}</p>
+        {description && (
+          <p className="mt-1 max-w-sm text-xs text-muted-foreground">{description}</p>
+        )}
+      </div>
+    </SpotlightCard>
+  );
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/empty-state.test.tsx
+```
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 3: Run typecheck and lint to verify no regressions**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit && npm run lint
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/empty-state.tsx \
+        frontend/src/shared/components/feedback/empty-state.test.tsx
+git commit -m "feat(ui): rebuild EmptyState with canonical chrome + variants"
+```
+
+---
+
+## Task 3: Add SkeletonText primitive
+
+**Files:**
+- Create: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Create: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+`SkeletonText` is the simplest primitive — N pulsing lines, last line shorter. We create the new `skeleton.tsx` file with `SkeletonText` and grow it with each subsequent task.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/shared/components/feedback/skeleton.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SkeletonText } from './skeleton';
+
+describe('SkeletonText', () => {
+  it('renders the default number of lines (3)', () => {
+    const { container } = render(<SkeletonText />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('renders the requested number of lines', () => {
+    const { container } = render(<SkeletonText lines={6} />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(6);
+  });
+
+  it('marks the last line narrower than the others', () => {
+    const { container } = render(<SkeletonText lines={4} />);
+    const lines = container.querySelectorAll('.animate-pulse');
+    expect(lines[lines.length - 1]).toHaveClass('w-2/3');
+  });
+
+  it('exposes a status role with a loading label', () => {
+    render(<SkeletonText />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className to the wrapper', () => {
+    const { container } = render(<SkeletonText className="mt-4" />);
+    expect(container.firstChild).toHaveClass('mt-4');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: fails — module `./skeleton` not found.
+
+- [ ] **Step 3: Implement SkeletonText**
+
+Create `frontend/src/shared/components/feedback/skeleton.tsx`:
+
+```tsx
+// frontend/src/shared/components/feedback/skeleton.tsx
+import { cn } from '@/shared/lib/utils';
+
+const PULSE = 'animate-pulse rounded bg-muted/40';
+
+export interface SkeletonTextProps {
+  lines?: number;
+  className?: string;
+}
+
+export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
+  return (
+    <div
+      className={cn('space-y-2', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: lines }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(PULSE, 'h-3', i === lines - 1 ? 'w-2/3' : 'w-full')}
+        />
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonText primitive"
+```
+
+---
+
+## Task 4: Add SkeletonKpi primitive
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Modify: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+`SkeletonKpi` mimics the internal shape of `KpiCard`: small label row + big number + optional sublabel. It does not include card chrome (caller wraps in `<TiltCard>` or pane).
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `skeleton.test.tsx`:
+
+```tsx
+import { SkeletonKpi } from './skeleton';
+
+describe('SkeletonKpi', () => {
+  it('renders three stacked bars (label, big number, sublabel)', () => {
+    const { container } = render(<SkeletonKpi />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('renders the big number bar taller than the label bar', () => {
+    const { container } = render(<SkeletonKpi />);
+    const bars = container.querySelectorAll('.animate-pulse');
+    // bars[0] = label, bars[1] = big number, bars[2] = sublabel
+    expect(bars[1]).toHaveClass('h-8');
+    expect(bars[0]).toHaveClass('h-3');
+  });
+
+  it('exposes status role with loading label', () => {
+    render(<SkeletonKpi />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(<SkeletonKpi className="h-full" />);
+    expect(container.firstChild).toHaveClass('h-full');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx -t SkeletonKpi
+```
+
+Expected: fails — `SkeletonKpi` is not exported.
+
+- [ ] **Step 3: Implement SkeletonKpi**
+
+Append to `skeleton.tsx`:
+
+```tsx
+export interface SkeletonKpiProps {
+  className?: string;
+}
+
+export function SkeletonKpi({ className }: SkeletonKpiProps) {
+  return (
+    <div className={cn('space-y-3', className)} role="status" aria-label="Loading">
+      <div className={cn(PULSE, 'h-3 w-1/3')} />
+      <div className={cn(PULSE, 'h-8 w-1/2')} />
+      <div className={cn(PULSE, 'h-3 w-2/5')} />
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: all SkeletonText + SkeletonKpi tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonKpi primitive"
+```
+
+---
+
+## Task 5: Add SkeletonTableRow primitive
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Modify: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+One table row with N cells, intended to be rendered inside an actual `<TableBody>` so the cell widths track the real table. Renders a `<tr>` with N `<td>`s, each containing a pulsing bar.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `skeleton.test.tsx`:
+
+```tsx
+import { SkeletonTableRow } from './skeleton';
+
+describe('SkeletonTableRow', () => {
+  it('renders the requested number of cells', () => {
+    // Render inside a <table><tbody> so the <tr> is valid HTML.
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow columns={5} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('tr > td')).toHaveLength(5);
+  });
+
+  it('puts a pulsing bar inside each cell', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow columns={3} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('td > .animate-pulse')).toHaveLength(3);
+  });
+
+  it('defaults to 4 columns when no count is provided', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx -t SkeletonTableRow
+```
+
+Expected: fails — `SkeletonTableRow` is not exported.
+
+- [ ] **Step 3: Implement SkeletonTableRow**
+
+Append to `skeleton.tsx`:
+
+```tsx
+export interface SkeletonTableRowProps {
+  columns?: number;
+  className?: string;
+}
+
+export function SkeletonTableRow({ columns = 4, className }: SkeletonTableRowProps) {
+  return (
+    <tr className={className}>
+      {Array.from({ length: columns }).map((_, i) => (
+        <td key={i} className="px-3 py-2">
+          <div className={cn(PULSE, 'h-3 w-full')} />
+        </td>
+      ))}
+    </tr>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: all skeleton tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonTableRow primitive"
+```
+
+---
+
+## Task 6: Add SkeletonChart primitive
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Modify: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+A rectangular pulsing block sized to fit a chart slot. Two heights: `md` (192px / `h-48`) for sparkline/area-chart panes, `lg` (320px / `h-80`) for full chart panes.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `skeleton.test.tsx`:
+
+```tsx
+import { SkeletonChart } from './skeleton';
+
+describe('SkeletonChart', () => {
+  it('renders a single pulsing block', () => {
+    const { container } = render(<SkeletonChart />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('defaults to medium height (h-48)', () => {
+    const { container } = render(<SkeletonChart />);
+    expect(container.firstChild).toHaveClass('h-48');
+  });
+
+  it('uses h-80 for large size', () => {
+    const { container } = render(<SkeletonChart size="lg" />);
+    expect(container.firstChild).toHaveClass('h-80');
+  });
+
+  it('exposes status role with loading label', () => {
+    render(<SkeletonChart />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(<SkeletonChart className="mt-2" />);
+    expect(container.firstChild).toHaveClass('mt-2');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx -t SkeletonChart
+```
+
+Expected: fails — `SkeletonChart` is not exported.
+
+- [ ] **Step 3: Implement SkeletonChart**
+
+Append to `skeleton.tsx`:
+
+```tsx
+export interface SkeletonChartProps {
+  size?: 'md' | 'lg';
+  className?: string;
+}
+
+export function SkeletonChart({ size = 'md', className }: SkeletonChartProps) {
+  return (
+    <div
+      className={cn(PULSE, 'w-full', size === 'lg' ? 'h-80' : 'h-48', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: all skeleton tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonChart primitive"
+```
+
+---
+
+## Task 7: Add SkeletonList primitive
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Modify: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+N list rows, each with a circular avatar/icon placeholder on the left and two stacked text bars on the right. Used for log lists, audit lists, edge-agent lists.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `skeleton.test.tsx`:
+
+```tsx
+import { SkeletonList } from './skeleton';
+
+describe('SkeletonList', () => {
+  it('renders the default number of rows (4)', () => {
+    const { container } = render(<SkeletonList />);
+    expect(container.querySelectorAll('[data-skeleton-row]')).toHaveLength(4);
+  });
+
+  it('renders the requested number of rows', () => {
+    const { container } = render(<SkeletonList rows={7} />);
+    expect(container.querySelectorAll('[data-skeleton-row]')).toHaveLength(7);
+  });
+
+  it('renders an avatar circle plus two text bars per row', () => {
+    const { container } = render(<SkeletonList rows={1} />);
+    const row = container.querySelector('[data-skeleton-row]');
+    expect(row?.querySelector('.rounded-full')).toBeInTheDocument();
+    expect(row?.querySelectorAll('.animate-pulse')).toHaveLength(3); // 1 avatar + 2 text bars
+  });
+
+  it('exposes a status role with loading label', () => {
+    render(<SkeletonList />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx -t SkeletonList
+```
+
+Expected: fails — `SkeletonList` is not exported.
+
+- [ ] **Step 3: Implement SkeletonList**
+
+Append to `skeleton.tsx`:
+
+```tsx
+export interface SkeletonListProps {
+  rows?: number;
+  className?: string;
+}
+
+export function SkeletonList({ rows = 4, className }: SkeletonListProps) {
+  return (
+    <div
+      className={cn('space-y-3', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} data-skeleton-row className="flex items-center gap-3">
+          <div className={cn(PULSE, 'h-8 w-8 rounded-full')} />
+          <div className="flex-1 space-y-2">
+            <div className={cn(PULSE, 'h-3 w-1/2')} />
+            <div className={cn(PULSE, 'h-3 w-1/3')} />
+          </div>
+        </div>
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: all skeleton tests pass (SkeletonText + SkeletonKpi + SkeletonTableRow + SkeletonChart + SkeletonList).
+
+- [ ] **Step 5: Run lint + typecheck on the whole frontend**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit && npm run lint
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonList primitive"
+```
+
+---
+
+## Task 8: Demo migration — webhooks.tsx
+
+**Files:**
+- Modify: `frontend/src/features/core/pages/webhooks.tsx` (around lines 213–223 and 415–419)
+
+This proves the primitives work end-to-end on a real page. We pick `webhooks.tsx` because it has both an ad-hoc loading skeleton (two `h-10 animate-pulse` bars) and two ad-hoc dashed-border empty states, in a low-traffic page where any visual issue is easy to catch.
+
+- [ ] **Step 1: Find the exact current state**
+
+Run:
+```bash
+grep -n "No webhooks configured yet\|No deliveries recorded yet\|h-10 animate-pulse" frontend/src/features/core/pages/webhooks.tsx
+```
+
+Expected output (line numbers may have shifted slightly):
+```
+216:              <div className="h-10 animate-pulse rounded bg-muted" />
+217:              <div className="h-10 animate-pulse rounded bg-muted" />
+220:              No webhooks configured yet.
+417:                <p className="mt-2 text-xs text-muted-foreground">No deliveries recorded yet.</p>
+```
+
+- [ ] **Step 2: Add the imports**
+
+Open `frontend/src/features/core/pages/webhooks.tsx`. Near the existing `lucide-react` import, add:
+
+```tsx
+import { Webhook, Inbox } from 'lucide-react';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonList } from '@/shared/components/feedback/skeleton';
+```
+
+(If `Webhook` or `Inbox` is already imported from `lucide-react`, don't duplicate — just add the missing names to the existing import line. If `lucide-react` isn't yet imported, add the full line.)
+
+- [ ] **Step 3: Replace the ad-hoc loading skeleton**
+
+Find this block (around line 213–218):
+
+```tsx
+{isLoading ? (
+  <div className="space-y-2">
+    <div className="h-10 animate-pulse rounded bg-muted" />
+    <div className="h-10 animate-pulse rounded bg-muted" />
+  </div>
+) : filteredWebhooks.length === 0 ? (
+```
+
+Replace with:
+
+```tsx
+{isLoading ? (
+  <SkeletonList rows={3} />
+) : filteredWebhooks.length === 0 ? (
+```
+
+- [ ] **Step 4: Replace the first dashed-border empty state**
+
+Find this block (around line 219–222):
+
+```tsx
+) : filteredWebhooks.length === 0 ? (
+  <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+    No webhooks configured yet.
+  </div>
+) : (
+```
+
+Replace with:
+
+```tsx
+) : filteredWebhooks.length === 0 ? (
+  <EmptyState
+    icon={Webhook}
+    title="No webhooks configured yet"
+    description="Create a webhook to receive events for this dashboard."
+  />
+) : (
+```
+
+- [ ] **Step 5: Replace the second empty state**
+
+Find this block (around line 415–419):
+
+```tsx
+<p className="mt-2 text-xs text-muted-foreground">No deliveries recorded yet.</p>
+```
+
+(Inspect the surrounding context first — read 8 lines above and below to understand whether this `<p>` lives alone or inside a wrapper. If it's a small caption inside a panel header rather than a full empty-state slot, **do not migrate it** — leave it as the panel's normal subtitle. Only migrate it if the surrounding markup is acting as an empty-state slot, e.g., it's the entire content of the panel body when there are no deliveries.)
+
+If migrating, replace the surrounding block with:
+
+```tsx
+<EmptyState
+  icon={Inbox}
+  title="No deliveries recorded yet"
+  description="Deliveries for this webhook will appear here after the first event fires."
+/>
+```
+
+If not migrating, document why in the commit message.
+
+- [ ] **Step 6: Run the page's existing tests (if any) and the full frontend test suite**
+
+Run:
+```bash
+cd frontend && npx vitest run --reporter=dot 2>&1 | tail -20
+```
+
+Expected: all tests pass. If `webhooks.tsx` has a test file that asserted on the old ad-hoc markup (`.border-dashed`, "No webhooks configured yet" inside specific markup), update those assertions to match the new component output.
+
+- [ ] **Step 7: Visual smoke check**
+
+Start the dev server and verify the page renders correctly:
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:5173` (or whichever port Vite picks), log in, navigate to `/webhooks`. Confirm:
+- With no webhooks: the empty state shows a circular muted iconchip, the bold title "No webhooks configured yet", and the description below.
+- The empty state lives inside the same outer pane card as the rest of the panel — no shape jump.
+- While the page is loading, the skeleton list shows 3 placeholder rows with a circle and two text bars each.
+
+Stop the dev server with Ctrl+C when done.
+
+- [ ] **Step 8: Run lint and typecheck**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit && npm run lint
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/features/core/pages/webhooks.tsx
+git commit -m "refactor(ui): migrate webhooks page to new EmptyState + SkeletonList"
+```
+
+---
+
+## Task 9: Update CLAUDE.md guidance + spec link
+
+**Files:**
+- Modify: `CLAUDE.md` (root) — add a one-liner under "UI/UX Design" pointing at the new primitives.
+
+The project CLAUDE.md should tell future agents that empty/loading/error states have canonical primitives now. One sentence is enough; the spec doc holds the rest.
+
+- [ ] **Step 1: Find the "UI/UX Design" section**
+
+Run:
+```bash
+grep -n "## UI/UX Design" CLAUDE.md
+```
+
+Expected: one line, near the middle of the file.
+
+- [ ] **Step 2: Append a sentence to the UI/UX paragraph**
+
+Open `CLAUDE.md`. In the UI/UX Design section, append to the paragraph (after the "Status colors" line):
+
+```markdown
+**Empty / loading / error states:** Use `<EmptyState>` (variants: `empty` / `error` / `not-configured`) and the skeleton primitives (`SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`) in `frontend/src/shared/components/feedback/`. Skeletons live inside the caller's pane chrome — they do not wrap themselves in cards. EmptyState is purely informational; render any retry / settings action in the parent pane's header. See `docs/superpowers/specs/2026-05-16-empty-loading-states-design.md` for the full rationale.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: note new EmptyState + skeleton primitives in CLAUDE.md"
+```
+
+---
+
+## Task 10: Open the pull request
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin feature/ui-empty-loading-primitives
+```
+
+If the pre-push hook (Husky) runs the test suite and fails on an unrelated flaky test, re-run the push once. Do not use `--no-verify`.
+
+- [ ] **Step 2: Create the PR**
+
+Run:
+```bash
+gh pr create --base dev --title "feat(ui): empty-state + skeleton primitives (PR 1 of 3)" --body "$(cat <<'EOF'
+## Summary
+- Rebuilds the previously-dead `<EmptyState>` export with the hybrid canonical-card chrome from the design spec — variants `empty` / `error` / `not-configured`, no action slot.
+- Adds five skeleton primitives (`SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`) at `frontend/src/shared/components/feedback/skeleton.tsx`. Each matches the shape of the content it stands in for; none wraps itself in card chrome (callers do that).
+- Demo-migrates the webhooks page so the new primitives are exercised in a real page.
+- Existing `LoadingSkeleton` and `SkeletonCard` are untouched — they have 73 active call sites and will be retired in PR 3.
+
+## Out of scope
+- The ~17 ad-hoc empty-state and ~25 ad-hoc loading-state call sites scattered across the app. Those migrate in PR 2 (high-traffic pages) and PR 3 (long tail + legacy cleanup).
+
+## Test plan
+- [x] `cd frontend && npx vitest run src/shared/components/feedback/` — all new tests pass
+- [x] `cd frontend && npx tsc --noEmit` — clean
+- [x] `cd frontend && npm run lint` — clean
+- [x] Visual check on `/webhooks` — empty state renders with iconchip + canonical chrome; loading state renders three skeleton rows; no layout shift when data arrives.
+
+Design spec: `docs/superpowers/specs/2026-05-16-empty-loading-states-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: the command returns a PR URL. Open it to confirm the description rendered correctly.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** All four spec decisions are implemented — hybrid chrome (Task 2), single component with variants (Task 2), skeleton primitives matching content shape (Tasks 3–7), no action slot (Task 2 component signature). The migration sequence is staged across PR 1/2/3 as the spec called for; this plan is PR 1.
+- **Placeholder scan:** No "TBD" / "TODO" / "implement later" steps. Every code-changing step includes the exact code or the exact `grep`/`find` command. Step 5 of Task 8 has a conditional ("inspect surrounding context") — that's a deliberate judgment point, not a placeholder, because the line in question may be a caption rather than an empty-state slot.
+- **Type consistency:** `EmptyStateVariant` matches between the type export, the `iconTintByVariant` record key, and all test assertions. `SkeletonKpi` / `SkeletonText` / `SkeletonTableRow` / `SkeletonChart` / `SkeletonList` names match between definitions, tests, the demo migration, and the CLAUDE.md note.
+- **Spec items not in plan:** "ESLint custom rule or grep-based CI check to flag re-introduction of ad-hoc empty/loading markup" — spec marks this optional and defer-able. Not in PR 1. Revisit after PR 3.

--- a/docs/superpowers/specs/2026-05-16-empty-loading-states-design.md
+++ b/docs/superpowers/specs/2026-05-16-empty-loading-states-design.md
@@ -1,0 +1,250 @@
+# Empty / Loading / Error States — Design Spec
+
+**Date:** 2026-05-16
+**Scope:** Sub-project #1 of the UI consistency program. Standardize the three "non-data" states (empty, error, not-configured) and the loading state that precedes them.
+**Status:** Design — ready for implementation planning.
+
+## Problem
+
+Audit of `frontend/src/` found:
+
+- **17+ empty-state variants** — dashed borders, solid cards, plain text, centered icon+text, three-line CTA blocks. No two pages render "no data yet" the same way.
+- **25+ loading-state files** — `Loader2` spinners, `<p>Loading...</p>` text, ad-hoc skeleton boxes, no skeletons at all (blank pane until data arrives).
+- **15+ error-state variants** — red borders, alert icons, raw error strings, toast-only.
+
+The result: every page negotiates its own "what does nothing-here look like" decision, and the answers conflict visually. This sub-project gives every page one set of primitives so the chrome is decided once.
+
+## Decisions
+
+Selected via brainstorming session 2026-05-16:
+
+1. **Empty-state chrome — Hybrid** (canonical card + iconchip + muted text). Same outer shell as a populated data pane (`bg-card`, `border`, `shadow-sm`, `rounded-lg`), so the pane does not change shape when data arrives. Distinguished only by content: a circular muted iconchip, slightly reduced text opacity, no chart/table inside.
+2. **Component structure — Single `<EmptyState>` with variants.** One component, `variant="empty" | "error" | "not-configured"`. One place to change chrome; variant prop drives the (small) differences in iconchip tint and default copy color.
+3. **Loading — skeletons matching content shape.** No spinners inside panes. Skeleton primitives mimic the eventual content (KPI tile shape, table rows, chart bars, list rows). No layout shift when data arrives.
+4. **No action affordances inside `<EmptyState>`.** The component is purely informational — chrome + iconchip + title + body. Any retry buttons, settings links, or other CTAs are the caller's responsibility and live outside the component (typically in the parent pane's header).
+
+## Component API
+
+### `<EmptyState>`
+
+Lives at `frontend/src/shared/components/feedback/empty-state.tsx`.
+
+```tsx
+import type { LucideIcon } from 'lucide-react';
+
+export interface EmptyStateProps {
+  /** Visual variant — drives iconchip tint and minor color shifts. */
+  variant?: 'empty' | 'error' | 'not-configured';
+  /** Lucide icon rendered inside the muted circular chip. */
+  icon: LucideIcon;
+  /** Primary line — short, sentence case. e.g. "No traces yet". */
+  title: string;
+  /** Optional supporting copy. One sentence, ends with a period. */
+  description?: string;
+  /** Optional extra Tailwind classes on the outer card. */
+  className?: string;
+}
+```
+
+Renders:
+
+```tsx
+<SpotlightCard className={className}>
+  <div className="flex flex-col items-center justify-center rounded-lg border bg-card p-8 shadow-sm text-center">
+    <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-muted/40">
+      <Icon className={cn('h-6 w-6', iconColorFor(variant))} />
+    </div>
+    <p className="text-sm font-semibold text-foreground/80">{title}</p>
+    {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+  </div>
+</SpotlightCard>
+```
+
+Variant tints (`iconColorFor`):
+
+| Variant | Icon tint | Rationale |
+|---|---|---|
+| `empty` (default) | `text-muted-foreground` | Neutral — "nothing yet" is not a problem. |
+| `error` | `text-destructive/80` | Subdued red — visible without alarming. |
+| `not-configured` | `text-amber-500/80` | Amber — "action needed, not broken". |
+
+No action slot. No `children`. If a page needs a retry button, it renders the button in its pane header alongside the title — not inside the state component.
+
+### Skeleton primitives
+
+Live at `frontend/src/shared/components/feedback/skeleton.tsx` (extends the existing pattern if any). All use a single shared pulse animation (`animate-pulse bg-muted/40 rounded`).
+
+| Primitive | Use for |
+|---|---|
+| `<SkeletonText lines={n} />` | Body copy, descriptions, multi-line content. Lines vary slightly in width for natural feel. |
+| `<SkeletonKpi />` | A single KPI tile's label + big-number + sublabel. Matches `KpiCard` internal shape. |
+| `<SkeletonTableRow columns={n} />` | One table row with `n` cells. Caller renders N of them inside the real `<TableBody>`. |
+| `<SkeletonChart height="md" \| "lg" />` | Block matching a chart's footprint. Caller wraps in their own pane chrome. |
+| `<SkeletonList rows={n} />` | List of rows (avatar + text), e.g. for log lists, audit lists. |
+
+**Important:** skeletons do **not** wrap themselves in pane chrome. The caller renders skeletons inside the same `<SpotlightCard><div className="rounded-lg border bg-card p-6 shadow-sm">…</div></SpotlightCard>` shell it would use for real content. This is what makes the transition seamless.
+
+Example KPI loading row:
+
+```tsx
+{isLoading ? (
+  <>
+    <TiltCard><SkeletonKpi /></TiltCard>
+    <TiltCard><SkeletonKpi /></TiltCard>
+    <TiltCard><SkeletonKpi /></TiltCard>
+    <TiltCard><SkeletonKpi /></TiltCard>
+  </>
+) : (
+  <>
+    <TiltCard><KpiCard ... /></TiltCard>
+    ...
+  </>
+)}
+```
+
+## Usage patterns
+
+### Pane with no data
+
+```tsx
+<SpotlightCard>
+  <div className="rounded-lg border bg-card p-6 shadow-sm">
+    <h3 className="mb-4 text-sm font-medium text-muted-foreground">Recent traces</h3>
+    {traces.length === 0 ? (
+      <EmptyState
+        icon={Activity}
+        title="No traces yet"
+        description="Run a workload to start capturing distributed traces."
+      />
+    ) : (
+      <TracesTable rows={traces} />
+    )}
+  </div>
+</SpotlightCard>
+```
+
+Note: `<EmptyState>` here is nested inside the pane — it renders its own inner card, and the visual effect is intentional. The outer pane keeps its title row; the inner card displays the empty marker centered. If the pane has no title row, `<EmptyState>` can stand alone as the pane content.
+
+### Standalone empty pane
+
+```tsx
+{cards.length === 0 ? (
+  <EmptyState icon={Inbox} title="Nothing here yet" />
+) : (
+  <CardGrid cards={cards} />
+)}
+```
+
+### Error state (fetch failed)
+
+```tsx
+{error ? (
+  <EmptyState
+    variant="error"
+    icon={AlertTriangle}
+    title="Couldn't load metrics"
+    description={error.message}
+  />
+) : ...}
+```
+
+If a retry control is needed:
+
+```tsx
+<SpotlightCard>
+  <div className="rounded-lg border bg-card p-6 shadow-sm">
+    <div className="mb-4 flex items-center justify-between">
+      <h3 className="text-sm font-medium text-muted-foreground">Metrics</h3>
+      {error && <Button size="sm" variant="ghost" onClick={refetch}>Retry</Button>}
+    </div>
+    {error ? <EmptyState variant="error" icon={AlertTriangle} title="Couldn't load metrics" /> : <Chart .../>}
+  </div>
+</SpotlightCard>
+```
+
+### Not-configured state
+
+```tsx
+<EmptyState
+  variant="not-configured"
+  icon={Settings}
+  title="Harbor isn't configured"
+  description="Add Harbor credentials in Settings to surface registry vulnerabilities here."
+/>
+```
+
+The "open settings" link, if any, lives in the pane's header — not inside the state component.
+
+### Loading state
+
+```tsx
+<SpotlightCard>
+  <div className="rounded-lg border bg-card p-6 shadow-sm">
+    <h3 className="mb-4 text-sm font-medium text-muted-foreground">Recent traces</h3>
+    {isLoading ? (
+      <SkeletonList rows={6} />
+    ) : traces.length === 0 ? (
+      <EmptyState icon={Activity} title="No traces yet" description="Run a workload to start capturing distributed traces." />
+    ) : (
+      <TracesTable rows={traces} />
+    )}
+  </div>
+</SpotlightCard>
+```
+
+## Copy guidelines
+
+Each state component instance must include:
+
+- **Title** — short, sentence case, no period. ≤ 6 words. "No traces yet", not "No traces have been captured yet."
+- **Description** (optional) — one sentence, ends with a period. Tells the user what action would change the state. "Run a workload to start capturing distributed traces." not "Empty list."
+
+Anti-patterns to remove during migration:
+
+- "Loading…" / "Loading..." text → replace with skeletons.
+- "Error: <raw stack trace>" → replace with `<EmptyState variant="error">` and a user-readable message; raw error goes to console + telemetry.
+- Plain centered `<p className="text-muted-foreground">No data</p>` → replace with `<EmptyState>`.
+
+## Migration plan
+
+The full sweep across 17+ empty-state and 25+ loading-state sites is large. Implement in three sequenced PRs to keep reviews tractable:
+
+**PR 1 — Primitives + tests**
+- Build `<EmptyState>` and the five skeleton primitives in `shared/components/feedback/`.
+- Write Vitest tests covering each variant's tint, missing-description fallback, and skeleton row counts.
+- Storybook-style smoke usage in a single page (pick a low-traffic page, e.g. `webhooks.tsx`) to validate visually.
+- No other call-site migrations.
+
+**PR 2 — High-traffic page migrations**
+- Convert empty + loading + error states on: `home.tsx`, `workload-explorer.tsx`, `fleet-overview.tsx`, `metrics-dashboard.tsx`, `trace-explorer.tsx`, `llm-observability.tsx`, `ai-monitor.tsx`.
+- Delete now-dead ad-hoc empty/loading components encountered along the way.
+- Update existing tests that asserted the old markup.
+
+**PR 3 — Long-tail migrations + cleanup**
+- Remaining pages (audit, settings, users, webhooks already covered, packet-capture, edge-agent-logs, harbor, ebpf, status, log-viewer, reports, etc.).
+- Run a `grep` pass for `Loading...`, dashed borders, `Loader2` inside panes, and `text-muted-foreground.*No ` patterns to catch stragglers.
+- Add an ESLint custom rule or simple grep-based CI check to flag re-introduction of ad-hoc empty/loading markup (optional, defer if time-bound).
+
+## Out of scope
+
+- Skeleton design for animations (e.g., shimmer gradient) — deferred. Use plain pulse for now; revisit if it feels flat.
+- Toast / inline error banners — separate concern from per-pane error states. Not touched here.
+- Modal / dialog empty states — same `<EmptyState>` works inside dialogs but the migration sweep targets pages only.
+- Mobile-specific layout adjustments — current breakpoints carry through; no responsive variants planned for the primitives.
+
+## Open questions for plan phase
+
+- Should we ship the primitives behind a feature flag? (Default: no — pure visual, low risk.)
+- Snapshot tests for the primitives — useful or noise? Recommend: per-variant render assertion (icon present, title text, correct variant class), no DOM snapshots.
+- Does `<EmptyState>` need a `size="sm" | "md"` prop for in-row vs full-pane use? (Default: no — start with one size, add later if a need surfaces.)
+
+## Acceptance criteria
+
+Sub-project #1 is complete when:
+
+1. `<EmptyState>` and the five skeleton primitives exist in `shared/components/feedback/` with passing Vitest tests.
+2. All 17 audited empty-state call sites use `<EmptyState>`.
+3. All loading states inside pane chromes use skeleton primitives (spinners only remain in non-pane contexts like button loading states).
+4. All error states inside pane chromes use `<EmptyState variant="error">`.
+5. `grep -r "Loading\\.\\.\\." frontend/src --include="*.tsx"` returns no matches inside pane bodies.
+6. No regression in existing UI tests; new tests cover the primitives.

--- a/frontend/src/features/core/pages/webhooks.test.tsx
+++ b/frontend/src/features/core/pages/webhooks.test.tsx
@@ -7,24 +7,22 @@ const mockDelete = vi.fn();
 const mockTest = vi.fn();
 const mockRefetch = vi.fn();
 
+const { useWebhooksMock } = vi.hoisted(() => ({ useWebhooksMock: vi.fn() }));
+
+const defaultWebhook = {
+  id: 'wh-1',
+  name: 'Alerts Hook',
+  url: 'https://hooks.example.com/alerts',
+  secret: 'abcd1234...',
+  events: ['insight.created'],
+  enabled: 1,
+  description: null,
+  created_at: '2026-02-06T10:00:00Z',
+  updated_at: '2026-02-06T10:00:00Z',
+};
+
 vi.mock('@/features/core/hooks/use-webhooks', () => ({
-  useWebhooks: () => ({
-    data: [
-      {
-        id: 'wh-1',
-        name: 'Alerts Hook',
-        url: 'https://hooks.example.com/alerts',
-        secret: 'abcd1234...',
-        events: ['insight.created'],
-        enabled: 1,
-        description: null,
-        created_at: '2026-02-06T10:00:00Z',
-        updated_at: '2026-02-06T10:00:00Z',
-      },
-    ],
-    isLoading: false,
-    refetch: mockRefetch,
-  }),
+  useWebhooks: useWebhooksMock,
   useWebhookEventTypes: () => ({
     data: [
       { type: '*', description: 'All events' },
@@ -65,6 +63,19 @@ import { WebhooksPanel } from './webhooks';
 describe('WebhooksPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useWebhooksMock.mockReturnValue({
+      data: [defaultWebhook],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+  });
+
+  it('shows the empty state when no webhooks exist', () => {
+    useWebhooksMock.mockReturnValue({ data: [], isLoading: false, refetch: mockRefetch });
+    render(<WebhooksPanel />);
+    expect(screen.getByText('No webhooks configured yet')).toBeInTheDocument();
+    expect(screen.getByTestId('empty-state-card')).toBeInTheDocument();
+    expect(screen.queryByText('No webhooks match the current filter.')).not.toBeInTheDocument();
   });
 
   it('renders webhook list, delivery monitor, and add button', () => {

--- a/frontend/src/features/core/pages/webhooks.tsx
+++ b/frontend/src/features/core/pages/webhooks.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Loader2, PlugZap, Plus, TestTube2, Trash2, Activity, Radio, RefreshCw } from 'lucide-react';
+import { Loader2, PlugZap, Plus, TestTube2, Trash2, Activity, Radio, RefreshCw, Webhook as WebhookIcon } from 'lucide-react';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonText } from '@/shared/components/feedback/skeleton';
 import {
   useCreateWebhook,
   useDeleteWebhook,
@@ -212,14 +214,13 @@ export function WebhooksPanel() {
           </div>
 
           {webhooksQuery.isLoading ? (
-            <div className="space-y-2">
-              <div className="h-10 animate-pulse rounded bg-muted" />
-              <div className="h-10 animate-pulse rounded bg-muted" />
-            </div>
+            <SkeletonText lines={3} />
           ) : filteredWebhooks.length === 0 ? (
-            <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
-              No webhooks configured yet.
-            </div>
+            <EmptyState
+              icon={WebhookIcon}
+              title="No webhooks configured yet"
+              description="Create a webhook to receive events for this dashboard."
+            />
           ) : (
             <div className="space-y-2">
               {filteredWebhooks.map((webhook) => (

--- a/frontend/src/features/core/pages/webhooks.tsx
+++ b/frontend/src/features/core/pages/webhooks.tsx
@@ -215,12 +215,16 @@ export function WebhooksPanel() {
 
           {webhooksQuery.isLoading ? (
             <SkeletonText lines={3} />
-          ) : filteredWebhooks.length === 0 ? (
+          ) : (webhooksQuery.data?.length ?? 0) === 0 ? (
             <EmptyState
               icon={WebhookIcon}
               title="No webhooks configured yet"
               description="Create a webhook to receive events for this dashboard."
             />
+          ) : filteredWebhooks.length === 0 ? (
+            <p className="rounded-md p-6 text-center text-sm text-muted-foreground">
+              No webhooks match the current filter.
+            </p>
           ) : (
             <div className="space-y-2">
               {filteredWebhooks.map((webhook) => (

--- a/frontend/src/shared/components/feedback/empty-state.test.tsx
+++ b/frontend/src/shared/components/feedback/empty-state.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Activity, AlertTriangle, Settings } from 'lucide-react';
+import { EmptyState } from './empty-state';
+
+vi.mock('@/stores/ui-store', () => ({
+  useUiStore: (selector: (s: { potatoMode: boolean }) => boolean) =>
+    selector({ potatoMode: false }),
+}));
+
+describe('EmptyState', () => {
+  it('renders the title', () => {
+    render(<EmptyState icon={Activity} title="No traces yet" />);
+    expect(screen.getByText('No traces yet')).toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    render(
+      <EmptyState
+        icon={Activity}
+        title="No traces yet"
+        description="Run a workload to start capturing distributed traces."
+      />,
+    );
+    expect(
+      screen.getByText('Run a workload to start capturing distributed traces.'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits description paragraph when not provided', () => {
+    const { container } = render(<EmptyState icon={Activity} title="Empty" />);
+    expect(container.querySelectorAll('p')).toHaveLength(0);
+  });
+
+  it('uses neutral muted tint for default (empty) variant', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    const iconEl = container.querySelector('svg');
+    expect(iconEl).toHaveClass('text-muted-foreground');
+  });
+
+  it('uses destructive tint for error variant', () => {
+    const { container } = render(
+      <EmptyState variant="error" icon={AlertTriangle} title="Failed" />,
+    );
+    const iconEl = container.querySelector('svg');
+    expect(iconEl).toHaveClass('text-destructive/80');
+  });
+
+  it('uses amber tint for not-configured variant', () => {
+    const { container } = render(
+      <EmptyState variant="not-configured" icon={Settings} title="Not set up" />,
+    );
+    const iconEl = container.querySelector('svg');
+    expect(iconEl).toHaveClass('text-amber-500/80');
+  });
+
+  it('renders the canonical pane chrome (border + bg-card + shadow-sm + rounded-lg)', () => {
+    render(<EmptyState icon={Activity} title="t" />);
+    const card = screen.getByTestId('empty-state-card');
+    expect(card).toHaveClass('rounded-lg', 'border', 'bg-card', 'shadow-sm');
+  });
+
+  it('applies a custom className to the inner card', () => {
+    render(<EmptyState icon={Activity} title="t" className="h-64" />);
+    expect(screen.getByTestId('empty-state-card')).toHaveClass('h-64');
+  });
+
+  it('renders a circular icon chip around the icon', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    const chip = container.querySelector('.rounded-full');
+    expect(chip).toBeInTheDocument();
+    expect(chip?.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/feedback/empty-state.tsx
+++ b/frontend/src/shared/components/feedback/empty-state.tsx
@@ -1,64 +1,47 @@
+import type { LucideIcon } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
-import { Inbox, Search, AlertCircle, FileQuestion } from 'lucide-react';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
-type EmptyStateVariant = 'default' | 'search' | 'error' | 'no-data';
+export type EmptyStateVariant = 'empty' | 'error' | 'not-configured';
 
-const variantIcons = {
-  default: Inbox,
-  search: Search,
-  error: AlertCircle,
-  'no-data': FileQuestion,
-};
-
-const variantColors = {
-  default: 'text-muted-foreground',
-  search: 'text-blue-500',
-  error: 'text-destructive',
-  'no-data': 'text-amber-500',
-};
-
-interface EmptyStateProps {
+export interface EmptyStateProps {
+  variant?: EmptyStateVariant;
+  icon: LucideIcon;
   title: string;
   description?: string;
-  variant?: EmptyStateVariant;
-  icon?: React.ReactNode;
-  action?: React.ReactNode;
   className?: string;
 }
 
+const iconTintByVariant: Record<EmptyStateVariant, string> = {
+  empty: 'text-muted-foreground',
+  error: 'text-destructive/80',
+  'not-configured': 'text-amber-500/80',
+};
+
 export function EmptyState({
+  variant = 'empty',
+  icon: Icon,
   title,
   description,
-  variant = 'default',
-  icon,
-  action,
   className,
 }: EmptyStateProps) {
-  const Icon = variantIcons[variant];
-  const iconColor = variantColors[variant];
-
   return (
-    <div
-      className={cn(
-        'flex flex-col items-center justify-center rounded-lg border border-dashed bg-muted/20 p-12 text-center',
-        className
-      )}
-    >
+    <SpotlightCard>
       <div
+        data-testid="empty-state-card"
         className={cn(
-          'flex h-16 w-16 items-center justify-center rounded-full bg-muted/50',
-          iconColor
+          'flex flex-col items-center justify-center rounded-lg border bg-card p-8 text-center shadow-sm',
+          className,
         )}
       >
-        {icon || <Icon className="h-8 w-8" />}
+        <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-muted/40">
+          <Icon className={cn('h-6 w-6', iconTintByVariant[variant])} />
+        </div>
+        <h3 className="text-sm font-semibold text-foreground/80">{title}</h3>
+        {description && (
+          <p className="mt-1 max-w-sm text-xs text-muted-foreground">{description}</p>
+        )}
       </div>
-      <h3 className="mt-4 text-lg font-semibold">{title}</h3>
-      {description && (
-        <p className="mt-2 max-w-sm text-sm text-muted-foreground">
-          {description}
-        </p>
-      )}
-      {action && <div className="mt-6">{action}</div>}
-    </div>
+    </SpotlightCard>
   );
 }

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -59,3 +59,38 @@ describe('SkeletonKpi', () => {
     expect(container.firstChild).toHaveClass('h-full');
   });
 });
+
+describe('SkeletonTableRow', () => {
+  it('renders the requested number of cells', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow columns={5} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('tr > td')).toHaveLength(5);
+  });
+
+  it('puts a pulsing bar inside each cell', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow columns={3} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('td > .animate-pulse')).toHaveLength(3);
+  });
+
+  it('defaults to 4 columns when no count is provided', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  SkeletonText,
+  SkeletonKpi,
+  SkeletonTableRow,
+  SkeletonChart,
+  SkeletonList,
+} from './skeleton';
+
+describe('SkeletonText', () => {
+  it('renders the default number of lines (3)', () => {
+    const { container } = render(<SkeletonText />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('renders the requested number of lines', () => {
+    const { container } = render(<SkeletonText lines={6} />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(6);
+  });
+
+  it('marks the last line narrower than the others', () => {
+    const { container } = render(<SkeletonText lines={4} />);
+    const lines = container.querySelectorAll('.animate-pulse');
+    expect(lines[lines.length - 1]).toHaveClass('w-2/3');
+  });
+
+  it('exposes a status role with a loading label', () => {
+    render(<SkeletonText />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className to the wrapper', () => {
+    const { container } = render(<SkeletonText className="mt-4" />);
+    expect(container.firstChild).toHaveClass('mt-4');
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -35,3 +35,27 @@ describe('SkeletonText', () => {
     expect(container.firstChild).toHaveClass('mt-4');
   });
 });
+
+describe('SkeletonKpi', () => {
+  it('renders three stacked bars (label, big number, sublabel)', () => {
+    const { container } = render(<SkeletonKpi />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('renders the big number bar taller than the label bar', () => {
+    const { container } = render(<SkeletonKpi />);
+    const bars = container.querySelectorAll('.animate-pulse');
+    expect(bars[1]).toHaveClass('h-8');
+    expect(bars[0]).toHaveClass('h-3');
+  });
+
+  it('exposes status role with loading label', () => {
+    render(<SkeletonKpi />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(<SkeletonKpi className="h-full" />);
+    expect(container.firstChild).toHaveClass('h-full');
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -93,6 +93,13 @@ describe('SkeletonTableRow', () => {
     );
     expect(container.querySelectorAll('td')).toHaveLength(4);
   });
+
+  it('applies a custom className to the tr', () => {
+    const { container } = render(
+      <table><tbody><SkeletonTableRow className="bg-muted" /></tbody></table>,
+    );
+    expect(container.querySelector('tr')).toHaveClass('bg-muted');
+  });
 });
 
 describe('SkeletonChart', () => {
@@ -143,5 +150,10 @@ describe('SkeletonList', () => {
   it('exposes a status role with loading label', () => {
     render(<SkeletonList />);
     expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className to the wrapper', () => {
+    const { container } = render(<SkeletonList className="p-4" />);
+    expect(container.firstChild).toHaveClass('p-4');
   });
 });

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -94,3 +94,30 @@ describe('SkeletonTableRow', () => {
     expect(container.querySelectorAll('td')).toHaveLength(4);
   });
 });
+
+describe('SkeletonChart', () => {
+  it('renders a single pulsing block', () => {
+    const { container } = render(<SkeletonChart />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('defaults to medium height (h-48)', () => {
+    const { container } = render(<SkeletonChart />);
+    expect(container.firstChild).toHaveClass('h-48');
+  });
+
+  it('uses h-80 for large size', () => {
+    const { container } = render(<SkeletonChart size="lg" />);
+    expect(container.firstChild).toHaveClass('h-80');
+  });
+
+  it('exposes status role with loading label', () => {
+    render(<SkeletonChart />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(<SkeletonChart className="mt-2" />);
+    expect(container.firstChild).toHaveClass('mt-2');
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -121,3 +121,27 @@ describe('SkeletonChart', () => {
     expect(container.firstChild).toHaveClass('mt-2');
   });
 });
+
+describe('SkeletonList', () => {
+  it('renders the default number of rows (4)', () => {
+    const { container } = render(<SkeletonList />);
+    expect(container.querySelectorAll('[data-skeleton-row]')).toHaveLength(4);
+  });
+
+  it('renders the requested number of rows', () => {
+    const { container } = render(<SkeletonList rows={7} />);
+    expect(container.querySelectorAll('[data-skeleton-row]')).toHaveLength(7);
+  });
+
+  it('renders an avatar circle plus two text bars per row', () => {
+    const { container } = render(<SkeletonList rows={1} />);
+    const row = container.querySelector('[data-skeleton-row]');
+    expect(row?.querySelector('.rounded-full')).toBeInTheDocument();
+    expect(row?.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('exposes a status role with loading label', () => {
+    render(<SkeletonList />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -24,3 +24,18 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
     </div>
   );
 }
+
+export interface SkeletonKpiProps {
+  className?: string;
+}
+
+export function SkeletonKpi({ className }: SkeletonKpiProps) {
+  return (
+    <div className={cn('space-y-3', className)} role="status" aria-label="Loading">
+      <div className={cn(PULSE, 'h-3 w-1/3')} />
+      <div className={cn(PULSE, 'h-8 w-1/2')} />
+      <div className={cn(PULSE, 'h-3 w-2/5')} />
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -25,44 +25,16 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
   );
 }
 
-export interface SkeletonListProps {
-  rows?: number;
+export interface SkeletonKpiProps {
   className?: string;
 }
 
-export function SkeletonList({ rows = 4, className }: SkeletonListProps) {
+export function SkeletonKpi({ className }: SkeletonKpiProps) {
   return (
-    <div
-      className={cn('space-y-3', className)}
-      role="status"
-      aria-label="Loading"
-    >
-      {Array.from({ length: rows }).map((_, i) => (
-        <div key={i} data-skeleton-row className="flex items-center gap-3">
-          <div className={cn(PULSE, 'h-8 w-8 rounded-full')} />
-          <div className="flex-1 space-y-2">
-            <div className={cn(PULSE, 'h-3 w-1/2')} />
-            <div className={cn(PULSE, 'h-3 w-1/3')} />
-          </div>
-        </div>
-      ))}
-      <span className="sr-only">Loading…</span>
-    </div>
-  );
-}
-
-export interface SkeletonChartProps {
-  size?: 'md' | 'lg';
-  className?: string;
-}
-
-export function SkeletonChart({ size = 'md', className }: SkeletonChartProps) {
-  return (
-    <div
-      className={cn(PULSE, 'w-full', size === 'lg' ? 'h-80' : 'h-48', className)}
-      role="status"
-      aria-label="Loading"
-    >
+    <div className={cn('space-y-3', className)} role="status" aria-label="Loading">
+      <div className={cn(PULSE, 'h-3 w-1/3')} />
+      <div className={cn(PULSE, 'h-8 w-1/2')} />
+      <div className={cn(PULSE, 'h-3 w-2/5')} />
       <span className="sr-only">Loading…</span>
     </div>
   );
@@ -85,16 +57,45 @@ export function SkeletonTableRow({ columns = 4, className }: SkeletonTableRowPro
   );
 }
 
-export interface SkeletonKpiProps {
+export interface SkeletonChartProps {
+  size?: 'md' | 'lg';
   className?: string;
 }
 
-export function SkeletonKpi({ className }: SkeletonKpiProps) {
+export function SkeletonChart({ size = 'md', className }: SkeletonChartProps) {
   return (
-    <div className={cn('space-y-3', className)} role="status" aria-label="Loading">
-      <div className={cn(PULSE, 'h-3 w-1/3')} />
-      <div className={cn(PULSE, 'h-8 w-1/2')} />
-      <div className={cn(PULSE, 'h-3 w-2/5')} />
+    <div
+      className={cn('w-full', size === 'lg' ? 'h-80' : 'h-48', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      <div className={cn(PULSE, 'h-full w-full')} />
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
+export interface SkeletonListProps {
+  rows?: number;
+  className?: string;
+}
+
+export function SkeletonList({ rows = 4, className }: SkeletonListProps) {
+  return (
+    <div
+      className={cn('space-y-3', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} data-skeleton-row className="flex items-center gap-3">
+          <div className={cn(PULSE, 'h-8 w-8 rounded-full')} />
+          <div className="flex-1 space-y-2">
+            <div className={cn(PULSE, 'h-3 w-1/2')} />
+            <div className={cn(PULSE, 'h-3 w-1/3')} />
+          </div>
+        </div>
+      ))}
       <span className="sr-only">Loading…</span>
     </div>
   );

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -25,6 +25,23 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
   );
 }
 
+export interface SkeletonTableRowProps {
+  columns?: number;
+  className?: string;
+}
+
+export function SkeletonTableRow({ columns = 4, className }: SkeletonTableRowProps) {
+  return (
+    <tr className={className}>
+      {Array.from({ length: columns }).map((_, i) => (
+        <td key={i} className="px-3 py-2">
+          <div className={cn(PULSE, 'h-3 w-full')} />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
 export interface SkeletonKpiProps {
   className?: string;
 }

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -25,6 +25,23 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
   );
 }
 
+export interface SkeletonChartProps {
+  size?: 'md' | 'lg';
+  className?: string;
+}
+
+export function SkeletonChart({ size = 'md', className }: SkeletonChartProps) {
+  return (
+    <div
+      className={cn(PULSE, 'w-full', size === 'lg' ? 'h-80' : 'h-48', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
 export interface SkeletonTableRowProps {
   columns?: number;
   className?: string;

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -25,6 +25,32 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
   );
 }
 
+export interface SkeletonListProps {
+  rows?: number;
+  className?: string;
+}
+
+export function SkeletonList({ rows = 4, className }: SkeletonListProps) {
+  return (
+    <div
+      className={cn('space-y-3', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} data-skeleton-row className="flex items-center gap-3">
+          <div className={cn(PULSE, 'h-8 w-8 rounded-full')} />
+          <div className="flex-1 space-y-2">
+            <div className={cn(PULSE, 'h-3 w-1/2')} />
+            <div className={cn(PULSE, 'h-3 w-1/3')} />
+          </div>
+        </div>
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
 export interface SkeletonChartProps {
   size?: 'md' | 'lg';
   className?: string;

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/shared/lib/utils';
+
+const PULSE = 'animate-pulse rounded bg-muted/40';
+
+export interface SkeletonTextProps {
+  lines?: number;
+  className?: string;
+}
+
+export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
+  return (
+    <div
+      className={cn('space-y-2', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: lines }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(PULSE, 'h-3', i === lines - 1 ? 'w-2/3' : 'w-full')}
+        />
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Builds the foundation for the empty/loading/error-state consistency sweep:

- **Rebuilds `<EmptyState>`** with the hybrid canonical-card chrome from the design spec. Variants: `empty` / `error` / `not-configured`. No action slot (purely informational; retry / settings actions belong in the parent pane's header). The previous `EmptyState` export had 0 callers, so the rewrite is a clean break.
- **Adds five skeleton primitives** at `frontend/src/shared/components/feedback/skeleton.tsx`: `SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`. Each matches the shape of the eventual content. None wraps itself in card chrome — callers do that, so there's no shape jump when data arrives.
- **Demo migration on the webhooks page** (`frontend/src/features/core/pages/webhooks.tsx`) exercising both `<EmptyState>` and `<SkeletonText>` in a real page.
- **CLAUDE.md** now points future agents at the new primitives and the design spec.

## Out of scope (deliberate)

- The ~17 ad-hoc empty-state and ~25 ad-hoc loading-state call sites scattered across the app. They migrate in **PR 2** (high-traffic pages) and **PR 3** (long-tail + legacy cleanup).
- The existing `LoadingSkeleton` and `SkeletonCard` in `loading-skeleton.tsx` are untouched here — 73 active callers. They retire in PR 3.
- One **pre-existing UX bug** surfaced during review on `webhooks.tsx`: when a user filters webhooks to "Enabled" or "Disabled" with no matches, the empty state currently reads "No webhooks configured yet — Create a webhook…", which is misleading. The condition (`filteredWebhooks.length === 0`) is the same as before; this PR only swaps the visual. Distinguishing data-empty from filter-empty stays as a follow-up.

## Design spec & plan

- Spec: `docs/superpowers/specs/2026-05-16-empty-loading-states-design.md`
- Plan: `docs/superpowers/plans/2026-05-16-empty-loading-states-pr1-primitives.md`

## Test plan

- [x] `npx vitest run src/shared/components/feedback/` — 32 unit tests pass (9 EmptyState + 23 skeleton primitives)
- [x] `npx vitest run src/features/core/pages/webhooks.test.tsx` — 3/3 pass
- [x] Full frontend suite — 1911/1911 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [ ] Visual smoke on `/webhooks` — please verify the empty state renders with iconchip + canonical chrome, and the loading state shows 3 text bars; no layout shift when data arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)