### PR TITLE
feat(ui): migrate high-traffic pages to EmptyState + skeletons (PR 2 of 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ frontend/vite.config.d.ts
 # Screenshots dropped at the repo root — developer scratch, not assets.
 # `/` anchors to repo root only, leaving frontend/public/*.png tracked.
 /*.png
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ Premium glassmorphic dashboard: bento grids, backdrop blur cards, staggered anim
 
 **Status colors:** Green=healthy, Yellow=warning, Orange=critical, Red=error, Blue=info, Gray=inactive, Purple=AI insight.
 
+**Empty / loading / error states:** Use `<EmptyState>` (variants: `empty` / `error` / `not-configured`) and the skeleton primitives (`SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`) in `frontend/src/shared/components/feedback/`. Skeletons live inside the caller's pane chrome — they do not wrap themselves in cards. `EmptyState` is purely informational; render any retry / settings action in the parent pane's header. See `@docs/superpowers/specs/2026-05-16-empty-loading-states-design.md` for the full rationale.
+
 For detailed specs (animation durations, easing curves, glass override patterns, layout patterns), see `@docs/ai-instructions/ui-design-system.md`.
 
 ## Testing & Mocks

--- a/docs/superpowers/plans/2026-05-16-empty-loading-states-pr1-primitives.md
+++ b/docs/superpowers/plans/2026-05-16-empty-loading-states-pr1-primitives.md
@@ -1,0 +1,957 @@
+# Empty / Loading / Error States — PR 1: Primitives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `<EmptyState>` component (variants: empty / error / not-configured) and five skeleton primitives that match content shape, so subsequent PRs can migrate the ~17 ad-hoc empty-state and ~25 ad-hoc loading-state call sites to a single canonical set.
+
+**Architecture:** Replace the dead-export `EmptyState` at `frontend/src/shared/components/feedback/empty-state.tsx` with the new hybrid-chrome design from the spec. Add a sibling `frontend/src/shared/components/feedback/skeleton.tsx` module exporting `SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`. Leave the existing `LoadingSkeleton` and `SkeletonCard` in `loading-skeleton.tsx` untouched — they have 73 active call sites and get retired in PR 3. Validate end-to-end by migrating one low-traffic page (`webhooks.tsx`) as a demo, which exercises both the empty state and a loading skeleton.
+
+**Tech Stack:** React 19, TypeScript strict, Vite, Tailwind v4 (custom theme via CSS vars), Vitest + jsdom + `@testing-library/react`, `lucide-react` for icons, existing `cn` util at `@/shared/lib/utils`, existing `SpotlightCard` at `@/shared/components/data-display/spotlight-card`.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-empty-loading-states-design.md`
+
+**Scope:** PR 1 only. Migrations of other call sites (high-traffic in PR 2, long-tail in PR 3) are out of scope here.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `frontend/src/shared/components/feedback/empty-state.tsx` | **Replace** | Single `<EmptyState>` component, three variants (empty / error / not-configured), no action slot, canonical card chrome with iconchip. |
+| `frontend/src/shared/components/feedback/empty-state.test.tsx` | **Create** | Vitest tests covering variant tints, default variant, optional description, custom className. |
+| `frontend/src/shared/components/feedback/skeleton.tsx` | **Create** | Five skeleton primitives: `SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`. No card chrome — callers wrap. |
+| `frontend/src/shared/components/feedback/skeleton.test.tsx` | **Create** | Vitest tests asserting row counts, prop defaults, role="status" accessibility. |
+| `frontend/src/features/core/pages/webhooks.tsx` | **Modify** | Demo migration — replace one ad-hoc loading block (~line 215) and one ad-hoc empty block (~line 220) with the new primitives. |
+
+`LoadingSkeleton`, `SkeletonCard`, and any other file are **not touched** in this PR.
+
+---
+
+## Conventions to follow
+
+- **Branch:** `feature/ui-empty-loading-primitives` off `dev`. PR target: `dev`.
+- **Commits:** One commit per task (Task 1, Task 2, …). Conventional commit prefixes: `feat`, `test`, `refactor`, `style`, `docs`. Subject ≤ 72 chars. No `--no-verify`.
+- **Tests:** TDD throughout — failing test first, then implementation, then green. Tests live next to the component (`*.test.tsx`).
+- **Imports:** Use `@/shared/...` path alias (already configured). Lucide icons named-imported: `import { Activity } from 'lucide-react'`.
+- **Styling:** Tailwind utility classes only. Use `cn()` from `@/shared/lib/utils` to merge. Match existing primitive style: `'rounded-lg'`, `'border'`, `'bg-card'`, `'shadow-sm'`, `'text-muted-foreground'`, `'animate-pulse'`, `'bg-muted/40'`.
+- **No comments unless non-obvious why.** Don't restate what JSX already says.
+- **No `action` prop, no `children` slot on `EmptyState`.** Spec decision: state component is purely informational.
+
+---
+
+## Task 1: Replace EmptyState — write the failing tests
+
+**Files:**
+- Create: `frontend/src/shared/components/feedback/empty-state.test.tsx`
+
+The existing `empty-state.tsx` is a dead export (zero callers — verified via `grep -rn "<EmptyState" frontend/src --include="*.tsx"` returns 0). We rewrite both the component and the tests from scratch. Tests first.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+// frontend/src/shared/components/feedback/empty-state.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Activity, AlertTriangle, Settings } from 'lucide-react';
+import { vi } from 'vitest';
+import { EmptyState } from './empty-state';
+
+vi.mock('@/stores/ui-store', () => ({
+  useUiStore: (selector: (s: { potatoMode: boolean }) => boolean) =>
+    selector({ potatoMode: false }),
+}));
+
+describe('EmptyState', () => {
+  it('renders the title', () => {
+    render(<EmptyState icon={Activity} title="No traces yet" />);
+    expect(screen.getByText('No traces yet')).toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    render(
+      <EmptyState
+        icon={Activity}
+        title="No traces yet"
+        description="Run a workload to start capturing distributed traces."
+      />,
+    );
+    expect(
+      screen.getByText('Run a workload to start capturing distributed traces.'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits description paragraph when not provided', () => {
+    const { container } = render(<EmptyState icon={Activity} title="Empty" />);
+    // Only one <p> — the title sits in a <p>, no description <p> follows.
+    expect(container.querySelectorAll('p')).toHaveLength(1);
+  });
+
+  it('uses neutral muted tint for default (empty) variant', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    const iconEl = container.querySelector('svg');
+    expect(iconEl).toHaveClass('text-muted-foreground');
+  });
+
+  it('uses destructive tint for error variant', () => {
+    const { container } = render(
+      <EmptyState variant="error" icon={AlertTriangle} title="Failed" />,
+    );
+    const iconEl = container.querySelector('svg');
+    expect(iconEl?.className).toContain('text-destructive');
+  });
+
+  it('uses amber tint for not-configured variant', () => {
+    const { container } = render(
+      <EmptyState variant="not-configured" icon={Settings} title="Not set up" />,
+    );
+    const iconEl = container.querySelector('svg');
+    expect(iconEl?.className).toContain('text-amber-500');
+  });
+
+  it('renders the canonical pane chrome (border + bg-card + shadow-sm + rounded-lg)', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    // SpotlightCard is the outer wrapper; the inner div carries the chrome classes.
+    const inner = container.querySelector('.spotlight-card > div');
+    expect(inner).toHaveClass('rounded-lg');
+    expect(inner).toHaveClass('border');
+    expect(inner).toHaveClass('bg-card');
+    expect(inner).toHaveClass('shadow-sm');
+  });
+
+  it('applies a custom className to the outer card', () => {
+    const { container } = render(
+      <EmptyState icon={Activity} title="t" className="h-64" />,
+    );
+    expect(container.firstChild).toHaveClass('h-64');
+  });
+
+  it('renders a circular iconchip around the icon', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    const chip = container.querySelector('.rounded-full');
+    expect(chip).toBeInTheDocument();
+    expect(chip?.querySelector('svg')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/empty-state.test.tsx
+```
+
+Expected: tests fail because the old `EmptyState` doesn't accept `icon: LucideIcon`, doesn't have the new variant names, and has the old dashed-border chrome.
+
+---
+
+## Task 2: Replace EmptyState — implement the new component
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/empty-state.tsx` (full rewrite)
+
+- [ ] **Step 1: Rewrite the component**
+
+Replace the entire file contents with:
+
+```tsx
+// frontend/src/shared/components/feedback/empty-state.tsx
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+
+export type EmptyStateVariant = 'empty' | 'error' | 'not-configured';
+
+export interface EmptyStateProps {
+  variant?: EmptyStateVariant;
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  className?: string;
+}
+
+const iconTintByVariant: Record<EmptyStateVariant, string> = {
+  empty: 'text-muted-foreground',
+  error: 'text-destructive/80',
+  'not-configured': 'text-amber-500/80',
+};
+
+export function EmptyState({
+  variant = 'empty',
+  icon: Icon,
+  title,
+  description,
+  className,
+}: EmptyStateProps) {
+  return (
+    <SpotlightCard className={className}>
+      <div className="flex flex-col items-center justify-center rounded-lg border bg-card p-8 text-center shadow-sm">
+        <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-muted/40">
+          <Icon className={cn('h-6 w-6', iconTintByVariant[variant])} />
+        </div>
+        <p className="text-sm font-semibold text-foreground/80">{title}</p>
+        {description && (
+          <p className="mt-1 max-w-sm text-xs text-muted-foreground">{description}</p>
+        )}
+      </div>
+    </SpotlightCard>
+  );
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/empty-state.test.tsx
+```
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 3: Run typecheck and lint to verify no regressions**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit && npm run lint
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/empty-state.tsx \
+        frontend/src/shared/components/feedback/empty-state.test.tsx
+git commit -m "feat(ui): rebuild EmptyState with canonical chrome + variants"
+```
+
+---
+
+## Task 3: Add SkeletonText primitive
+
+**Files:**
+- Create: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Create: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+`SkeletonText` is the simplest primitive — N pulsing lines, last line shorter. We create the new `skeleton.tsx` file with `SkeletonText` and grow it with each subsequent task.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/shared/components/feedback/skeleton.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SkeletonText } from './skeleton';
+
+describe('SkeletonText', () => {
+  it('renders the default number of lines (3)', () => {
+    const { container } = render(<SkeletonText />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('renders the requested number of lines', () => {
+    const { container } = render(<SkeletonText lines={6} />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(6);
+  });
+
+  it('marks the last line narrower than the others', () => {
+    const { container } = render(<SkeletonText lines={4} />);
+    const lines = container.querySelectorAll('.animate-pulse');
+    expect(lines[lines.length - 1]).toHaveClass('w-2/3');
+  });
+
+  it('exposes a status role with a loading label', () => {
+    render(<SkeletonText />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className to the wrapper', () => {
+    const { container } = render(<SkeletonText className="mt-4" />);
+    expect(container.firstChild).toHaveClass('mt-4');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: fails — module `./skeleton` not found.
+
+- [ ] **Step 3: Implement SkeletonText**
+
+Create `frontend/src/shared/components/feedback/skeleton.tsx`:
+
+```tsx
+// frontend/src/shared/components/feedback/skeleton.tsx
+import { cn } from '@/shared/lib/utils';
+
+const PULSE = 'animate-pulse rounded bg-muted/40';
+
+export interface SkeletonTextProps {
+  lines?: number;
+  className?: string;
+}
+
+export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
+  return (
+    <div
+      className={cn('space-y-2', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: lines }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(PULSE, 'h-3', i === lines - 1 ? 'w-2/3' : 'w-full')}
+        />
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonText primitive"
+```
+
+---
+
+## Task 4: Add SkeletonKpi primitive
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Modify: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+`SkeletonKpi` mimics the internal shape of `KpiCard`: small label row + big number + optional sublabel. It does not include card chrome (caller wraps in `<TiltCard>` or pane).
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `skeleton.test.tsx`:
+
+```tsx
+import { SkeletonKpi } from './skeleton';
+
+describe('SkeletonKpi', () => {
+  it('renders three stacked bars (label, big number, sublabel)', () => {
+    const { container } = render(<SkeletonKpi />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('renders the big number bar taller than the label bar', () => {
+    const { container } = render(<SkeletonKpi />);
+    const bars = container.querySelectorAll('.animate-pulse');
+    // bars[0] = label, bars[1] = big number, bars[2] = sublabel
+    expect(bars[1]).toHaveClass('h-8');
+    expect(bars[0]).toHaveClass('h-3');
+  });
+
+  it('exposes status role with loading label', () => {
+    render(<SkeletonKpi />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(<SkeletonKpi className="h-full" />);
+    expect(container.firstChild).toHaveClass('h-full');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx -t SkeletonKpi
+```
+
+Expected: fails — `SkeletonKpi` is not exported.
+
+- [ ] **Step 3: Implement SkeletonKpi**
+
+Append to `skeleton.tsx`:
+
+```tsx
+export interface SkeletonKpiProps {
+  className?: string;
+}
+
+export function SkeletonKpi({ className }: SkeletonKpiProps) {
+  return (
+    <div className={cn('space-y-3', className)} role="status" aria-label="Loading">
+      <div className={cn(PULSE, 'h-3 w-1/3')} />
+      <div className={cn(PULSE, 'h-8 w-1/2')} />
+      <div className={cn(PULSE, 'h-3 w-2/5')} />
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: all SkeletonText + SkeletonKpi tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonKpi primitive"
+```
+
+---
+
+## Task 5: Add SkeletonTableRow primitive
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Modify: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+One table row with N cells, intended to be rendered inside an actual `<TableBody>` so the cell widths track the real table. Renders a `<tr>` with N `<td>`s, each containing a pulsing bar.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `skeleton.test.tsx`:
+
+```tsx
+import { SkeletonTableRow } from './skeleton';
+
+describe('SkeletonTableRow', () => {
+  it('renders the requested number of cells', () => {
+    // Render inside a <table><tbody> so the <tr> is valid HTML.
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow columns={5} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('tr > td')).toHaveLength(5);
+  });
+
+  it('puts a pulsing bar inside each cell', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow columns={3} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('td > .animate-pulse')).toHaveLength(3);
+  });
+
+  it('defaults to 4 columns when no count is provided', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx -t SkeletonTableRow
+```
+
+Expected: fails — `SkeletonTableRow` is not exported.
+
+- [ ] **Step 3: Implement SkeletonTableRow**
+
+Append to `skeleton.tsx`:
+
+```tsx
+export interface SkeletonTableRowProps {
+  columns?: number;
+  className?: string;
+}
+
+export function SkeletonTableRow({ columns = 4, className }: SkeletonTableRowProps) {
+  return (
+    <tr className={className}>
+      {Array.from({ length: columns }).map((_, i) => (
+        <td key={i} className="px-3 py-2">
+          <div className={cn(PULSE, 'h-3 w-full')} />
+        </td>
+      ))}
+    </tr>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: all skeleton tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonTableRow primitive"
+```
+
+---
+
+## Task 6: Add SkeletonChart primitive
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Modify: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+A rectangular pulsing block sized to fit a chart slot. Two heights: `md` (192px / `h-48`) for sparkline/area-chart panes, `lg` (320px / `h-80`) for full chart panes.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `skeleton.test.tsx`:
+
+```tsx
+import { SkeletonChart } from './skeleton';
+
+describe('SkeletonChart', () => {
+  it('renders a single pulsing block', () => {
+    const { container } = render(<SkeletonChart />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('defaults to medium height (h-48)', () => {
+    const { container } = render(<SkeletonChart />);
+    expect(container.firstChild).toHaveClass('h-48');
+  });
+
+  it('uses h-80 for large size', () => {
+    const { container } = render(<SkeletonChart size="lg" />);
+    expect(container.firstChild).toHaveClass('h-80');
+  });
+
+  it('exposes status role with loading label', () => {
+    render(<SkeletonChart />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(<SkeletonChart className="mt-2" />);
+    expect(container.firstChild).toHaveClass('mt-2');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx -t SkeletonChart
+```
+
+Expected: fails — `SkeletonChart` is not exported.
+
+- [ ] **Step 3: Implement SkeletonChart**
+
+Append to `skeleton.tsx`:
+
+```tsx
+export interface SkeletonChartProps {
+  size?: 'md' | 'lg';
+  className?: string;
+}
+
+export function SkeletonChart({ size = 'md', className }: SkeletonChartProps) {
+  return (
+    <div
+      className={cn(PULSE, 'w-full', size === 'lg' ? 'h-80' : 'h-48', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: all skeleton tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonChart primitive"
+```
+
+---
+
+## Task 7: Add SkeletonList primitive
+
+**Files:**
+- Modify: `frontend/src/shared/components/feedback/skeleton.tsx`
+- Modify: `frontend/src/shared/components/feedback/skeleton.test.tsx`
+
+N list rows, each with a circular avatar/icon placeholder on the left and two stacked text bars on the right. Used for log lists, audit lists, edge-agent lists.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `skeleton.test.tsx`:
+
+```tsx
+import { SkeletonList } from './skeleton';
+
+describe('SkeletonList', () => {
+  it('renders the default number of rows (4)', () => {
+    const { container } = render(<SkeletonList />);
+    expect(container.querySelectorAll('[data-skeleton-row]')).toHaveLength(4);
+  });
+
+  it('renders the requested number of rows', () => {
+    const { container } = render(<SkeletonList rows={7} />);
+    expect(container.querySelectorAll('[data-skeleton-row]')).toHaveLength(7);
+  });
+
+  it('renders an avatar circle plus two text bars per row', () => {
+    const { container } = render(<SkeletonList rows={1} />);
+    const row = container.querySelector('[data-skeleton-row]');
+    expect(row?.querySelector('.rounded-full')).toBeInTheDocument();
+    expect(row?.querySelectorAll('.animate-pulse')).toHaveLength(3); // 1 avatar + 2 text bars
+  });
+
+  it('exposes a status role with loading label', () => {
+    render(<SkeletonList />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx -t SkeletonList
+```
+
+Expected: fails — `SkeletonList` is not exported.
+
+- [ ] **Step 3: Implement SkeletonList**
+
+Append to `skeleton.tsx`:
+
+```tsx
+export interface SkeletonListProps {
+  rows?: number;
+  className?: string;
+}
+
+export function SkeletonList({ rows = 4, className }: SkeletonListProps) {
+  return (
+    <div
+      className={cn('space-y-3', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} data-skeleton-row className="flex items-center gap-3">
+          <div className={cn(PULSE, 'h-8 w-8 rounded-full')} />
+          <div className="flex-1 space-y-2">
+            <div className={cn(PULSE, 'h-3 w-1/2')} />
+            <div className={cn(PULSE, 'h-3 w-1/3')} />
+          </div>
+        </div>
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/shared/components/feedback/skeleton.test.tsx
+```
+
+Expected: all skeleton tests pass (SkeletonText + SkeletonKpi + SkeletonTableRow + SkeletonChart + SkeletonList).
+
+- [ ] **Step 5: Run lint + typecheck on the whole frontend**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit && npm run lint
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/shared/components/feedback/skeleton.tsx \
+        frontend/src/shared/components/feedback/skeleton.test.tsx
+git commit -m "feat(ui): add SkeletonList primitive"
+```
+
+---
+
+## Task 8: Demo migration — webhooks.tsx
+
+**Files:**
+- Modify: `frontend/src/features/core/pages/webhooks.tsx` (around lines 213–223 and 415–419)
+
+This proves the primitives work end-to-end on a real page. We pick `webhooks.tsx` because it has both an ad-hoc loading skeleton (two `h-10 animate-pulse` bars) and two ad-hoc dashed-border empty states, in a low-traffic page where any visual issue is easy to catch.
+
+- [ ] **Step 1: Find the exact current state**
+
+Run:
+```bash
+grep -n "No webhooks configured yet\|No deliveries recorded yet\|h-10 animate-pulse" frontend/src/features/core/pages/webhooks.tsx
+```
+
+Expected output (line numbers may have shifted slightly):
+```
+216:              <div className="h-10 animate-pulse rounded bg-muted" />
+217:              <div className="h-10 animate-pulse rounded bg-muted" />
+220:              No webhooks configured yet.
+417:                <p className="mt-2 text-xs text-muted-foreground">No deliveries recorded yet.</p>
+```
+
+- [ ] **Step 2: Add the imports**
+
+Open `frontend/src/features/core/pages/webhooks.tsx`. Near the existing `lucide-react` import, add:
+
+```tsx
+import { Webhook, Inbox } from 'lucide-react';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonList } from '@/shared/components/feedback/skeleton';
+```
+
+(If `Webhook` or `Inbox` is already imported from `lucide-react`, don't duplicate — just add the missing names to the existing import line. If `lucide-react` isn't yet imported, add the full line.)
+
+- [ ] **Step 3: Replace the ad-hoc loading skeleton**
+
+Find this block (around line 213–218):
+
+```tsx
+{isLoading ? (
+  <div className="space-y-2">
+    <div className="h-10 animate-pulse rounded bg-muted" />
+    <div className="h-10 animate-pulse rounded bg-muted" />
+  </div>
+) : filteredWebhooks.length === 0 ? (
+```
+
+Replace with:
+
+```tsx
+{isLoading ? (
+  <SkeletonList rows={3} />
+) : filteredWebhooks.length === 0 ? (
+```
+
+- [ ] **Step 4: Replace the first dashed-border empty state**
+
+Find this block (around line 219–222):
+
+```tsx
+) : filteredWebhooks.length === 0 ? (
+  <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+    No webhooks configured yet.
+  </div>
+) : (
+```
+
+Replace with:
+
+```tsx
+) : filteredWebhooks.length === 0 ? (
+  <EmptyState
+    icon={Webhook}
+    title="No webhooks configured yet"
+    description="Create a webhook to receive events for this dashboard."
+  />
+) : (
+```
+
+- [ ] **Step 5: Replace the second empty state**
+
+Find this block (around line 415–419):
+
+```tsx
+<p className="mt-2 text-xs text-muted-foreground">No deliveries recorded yet.</p>
+```
+
+(Inspect the surrounding context first — read 8 lines above and below to understand whether this `<p>` lives alone or inside a wrapper. If it's a small caption inside a panel header rather than a full empty-state slot, **do not migrate it** — leave it as the panel's normal subtitle. Only migrate it if the surrounding markup is acting as an empty-state slot, e.g., it's the entire content of the panel body when there are no deliveries.)
+
+If migrating, replace the surrounding block with:
+
+```tsx
+<EmptyState
+  icon={Inbox}
+  title="No deliveries recorded yet"
+  description="Deliveries for this webhook will appear here after the first event fires."
+/>
+```
+
+If not migrating, document why in the commit message.
+
+- [ ] **Step 6: Run the page's existing tests (if any) and the full frontend test suite**
+
+Run:
+```bash
+cd frontend && npx vitest run --reporter=dot 2>&1 | tail -20
+```
+
+Expected: all tests pass. If `webhooks.tsx` has a test file that asserted on the old ad-hoc markup (`.border-dashed`, "No webhooks configured yet" inside specific markup), update those assertions to match the new component output.
+
+- [ ] **Step 7: Visual smoke check**
+
+Start the dev server and verify the page renders correctly:
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:5173` (or whichever port Vite picks), log in, navigate to `/webhooks`. Confirm:
+- With no webhooks: the empty state shows a circular muted iconchip, the bold title "No webhooks configured yet", and the description below.
+- The empty state lives inside the same outer pane card as the rest of the panel — no shape jump.
+- While the page is loading, the skeleton list shows 3 placeholder rows with a circle and two text bars each.
+
+Stop the dev server with Ctrl+C when done.
+
+- [ ] **Step 8: Run lint and typecheck**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit && npm run lint
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/features/core/pages/webhooks.tsx
+git commit -m "refactor(ui): migrate webhooks page to new EmptyState + SkeletonList"
+```
+
+---
+
+## Task 9: Update CLAUDE.md guidance + spec link
+
+**Files:**
+- Modify: `CLAUDE.md` (root) — add a one-liner under "UI/UX Design" pointing at the new primitives.
+
+The project CLAUDE.md should tell future agents that empty/loading/error states have canonical primitives now. One sentence is enough; the spec doc holds the rest.
+
+- [ ] **Step 1: Find the "UI/UX Design" section**
+
+Run:
+```bash
+grep -n "## UI/UX Design" CLAUDE.md
+```
+
+Expected: one line, near the middle of the file.
+
+- [ ] **Step 2: Append a sentence to the UI/UX paragraph**
+
+Open `CLAUDE.md`. In the UI/UX Design section, append to the paragraph (after the "Status colors" line):
+
+```markdown
+**Empty / loading / error states:** Use `<EmptyState>` (variants: `empty` / `error` / `not-configured`) and the skeleton primitives (`SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`) in `frontend/src/shared/components/feedback/`. Skeletons live inside the caller's pane chrome — they do not wrap themselves in cards. EmptyState is purely informational; render any retry / settings action in the parent pane's header. See `docs/superpowers/specs/2026-05-16-empty-loading-states-design.md` for the full rationale.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: note new EmptyState + skeleton primitives in CLAUDE.md"
+```
+
+---
+
+## Task 10: Open the pull request
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin feature/ui-empty-loading-primitives
+```
+
+If the pre-push hook (Husky) runs the test suite and fails on an unrelated flaky test, re-run the push once. Do not use `--no-verify`.
+
+- [ ] **Step 2: Create the PR**
+
+Run:
+```bash
+gh pr create --base dev --title "feat(ui): empty-state + skeleton primitives (PR 1 of 3)" --body "$(cat <<'EOF'
+## Summary
+- Rebuilds the previously-dead `<EmptyState>` export with the hybrid canonical-card chrome from the design spec — variants `empty` / `error` / `not-configured`, no action slot.
+- Adds five skeleton primitives (`SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`) at `frontend/src/shared/components/feedback/skeleton.tsx`. Each matches the shape of the content it stands in for; none wraps itself in card chrome (callers do that).
+- Demo-migrates the webhooks page so the new primitives are exercised in a real page.
+- Existing `LoadingSkeleton` and `SkeletonCard` are untouched — they have 73 active call sites and will be retired in PR 3.
+
+## Out of scope
+- The ~17 ad-hoc empty-state and ~25 ad-hoc loading-state call sites scattered across the app. Those migrate in PR 2 (high-traffic pages) and PR 3 (long tail + legacy cleanup).
+
+## Test plan
+- [x] `cd frontend && npx vitest run src/shared/components/feedback/` — all new tests pass
+- [x] `cd frontend && npx tsc --noEmit` — clean
+- [x] `cd frontend && npm run lint` — clean
+- [x] Visual check on `/webhooks` — empty state renders with iconchip + canonical chrome; loading state renders three skeleton rows; no layout shift when data arrives.
+
+Design spec: `docs/superpowers/specs/2026-05-16-empty-loading-states-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: the command returns a PR URL. Open it to confirm the description rendered correctly.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** All four spec decisions are implemented — hybrid chrome (Task 2), single component with variants (Task 2), skeleton primitives matching content shape (Tasks 3–7), no action slot (Task 2 component signature). The migration sequence is staged across PR 1/2/3 as the spec called for; this plan is PR 1.
+- **Placeholder scan:** No "TBD" / "TODO" / "implement later" steps. Every code-changing step includes the exact code or the exact `grep`/`find` command. Step 5 of Task 8 has a conditional ("inspect surrounding context") — that's a deliberate judgment point, not a placeholder, because the line in question may be a caption rather than an empty-state slot.
+- **Type consistency:** `EmptyStateVariant` matches between the type export, the `iconTintByVariant` record key, and all test assertions. `SkeletonKpi` / `SkeletonText` / `SkeletonTableRow` / `SkeletonChart` / `SkeletonList` names match between definitions, tests, the demo migration, and the CLAUDE.md note.
+- **Spec items not in plan:** "ESLint custom rule or grep-based CI check to flag re-introduction of ad-hoc empty/loading markup" — spec marks this optional and defer-able. Not in PR 1. Revisit after PR 3.

--- a/docs/superpowers/plans/2026-05-16-empty-loading-states-pr2-high-traffic.md
+++ b/docs/superpowers/plans/2026-05-16-empty-loading-states-pr2-high-traffic.md
@@ -1,0 +1,632 @@
+# Empty / Loading / Error States — PR 2: High-Traffic Page Migrations
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate every ad-hoc empty / loading / error state on the seven highest-traffic pages to the primitives shipped in PR 1, so the canonical look becomes the default visible across the app.
+
+**Architecture:** One commit per page, in order of growing complexity, so reviewer load stays bounded. No new components are introduced — all work consumes the existing `<EmptyState>`, `<SkeletonText>`, `<SkeletonKpi>`, `<SkeletonTableRow>`, `<SkeletonChart>`, `<SkeletonList>` exported from `frontend/src/shared/components/feedback/`. Legacy `SkeletonCard` usages on these seven pages are *also* migrated (they are loading states the spec asks PR 2 to convert); legacy `SkeletonCard` usages on long-tail pages stay until PR 3.
+
+**Tech Stack:** React 19, TypeScript strict, Tailwind v4, Vitest + jsdom + `@testing-library/react`, `lucide-react`.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-empty-loading-states-design.md`
+**Predecessor:** PR 1 (`docs/superpowers/plans/2026-05-16-empty-loading-states-pr1-primitives.md`) — the primitives live in the branch this one is chained off.
+
+**Scope (this PR):** Seven pages. Audited count: 13 empty states, 18 loading states, 8 error states, 2 not-configured states = **41 migrations**.
+
+| # | Page | Empty | Loading | Error | Not-configured | Total |
+|---|---|---|---|---|---|---|
+| 1 | `home.tsx` | 0 | 3 | 1 | 0 | 4 |
+| 2 | `workload-explorer.tsx` | 1 | 2 | 1 | 0 | 4 |
+| 3 | `trace-explorer.tsx` | 1 | 1 | 1 | 0 | 3 |
+| 4 | `llm-observability.tsx` | 2 | 2 | 0 | 0 | 4 |
+| 5 | `ai-monitor.tsx` | 1 | 2 | 1 | 0 | 4 |
+| 6 | `fleet-overview.tsx` | 3 | 3 | 1 | 1 | 8 |
+| 7 | `metrics-dashboard.tsx` | 5 | 5 | 3 | 1 | 14 |
+
+Order is light → heavy so reviewers warm up on simpler pages first.
+
+**Out of scope:**
+- Long-tail page migrations (PR 3).
+- Removing the legacy `LoadingSkeleton` / `SkeletonCard` exports themselves (PR 3 — still 73 callers across the rest of the app even after this PR lands).
+- Normalizing the `Loading…` vs `Loading...` sr-only text mismatch (PR 3).
+- Aligning `bg-muted/40` vs `bg-muted/50` skeleton tint (PR 3).
+- Any non-loading / non-empty / non-error UX changes on these pages.
+
+---
+
+## Conventions
+
+- **Branch:** `feature/ui-empty-loading-pr2-high-traffic` off `feature/ui-empty-loading-primitives` (chain). When PR 1 merges, this branch rebases onto the new `dev`.
+- **Commits:** One per task (= one per page). Prefix `refactor(ui):`. Subject ≤ 72 chars.
+- **Imports:** Add `EmptyState` / skeleton primitives as needed. Remove now-dead imports (`LoadingSkeleton`, `SkeletonCard`, ad-hoc shimmer helpers) if they leave the file with zero uses.
+- **Lucide icons:** Use the icon already imported on the page where possible. If a new icon is needed, add it to the existing `lucide-react` import line; if the page imports a Lucide identifier that clashes with another local name, alias with the `XxxIcon` suffix (e.g. `Webhook as WebhookIcon`) — matches the codebase pattern.
+- **Tests:** After each migration, run the page's existing test file and update any assertions that depended on the old markup (e.g. asserting `.border-dashed` or `Loading...` text). Where a test gap is created (e.g. a new empty branch with no test), add a focused test using `useXxxMock` patterns where applicable; do not over-invest in interaction tests for Radix controls.
+- **Skip list:** Captions below tables, status pills, count badges, pane subtitles, fleet-summary sub-components, and button spinners are **not** migrated.
+- **No `--no-verify`, no `--amend` of previously-pushed commits.**
+
+---
+
+## Task 1 — home.tsx (4 migrations)
+
+**Files:**
+- Modify: `frontend/src/features/core/pages/home.tsx`
+- Test: `frontend/src/features/core/pages/home.test.tsx` (update if assertions break)
+
+### Migrations
+
+**1.1 — KPI grid loading (line ~149–154)**
+
+Replace:
+```tsx
+{Array.from({ length: 5 }).map((_, i) => (
+  <SkeletonCard key={i} />
+))}
+```
+With:
+```tsx
+{Array.from({ length: 5 }).map((_, i) => (
+  <SkeletonKpi key={i} />
+))}
+```
+
+**1.2 — Endpoint health pane loading (line ~270–271)**
+
+Replace:
+```tsx
+<SkeletonCard className="h-[300px]" />
+```
+With:
+```tsx
+<SkeletonChart size="lg" />
+```
+
+**1.3 — Workloads + Fleet Summary grid loading (line ~288–292)**
+
+Replace each of the two `<SkeletonCard className="h-[XXXpx]" />` blocks with `<SkeletonChart size="lg" />`.
+
+**1.4 — Top-level error (line ~106–129)**
+
+Replace the `<div>` containing `AlertTriangle` + "Failed to load dashboard" + retry button with:
+```tsx
+<EmptyState
+  variant="error"
+  icon={AlertTriangle}
+  title="Failed to load dashboard"
+  description={errorMessage}
+/>
+```
+The retry button is the existing `refetch()` action — keep it visible by leaving it OUTSIDE the `<EmptyState>` (e.g., in the section header or as a sibling block). If the current layout wraps retry inside the error block, move it to a sibling position in the same flex/grid container.
+
+### Steps
+
+- [ ] **1.a** Read the current file fully; confirm the four locations match the audit (line numbers may have drifted ±5).
+- [ ] **1.b** Add imports: `EmptyState`, `SkeletonKpi`, `SkeletonChart` from their feedback paths. Confirm `AlertTriangle` is already imported (it is, per the audit).
+- [ ] **1.c** Apply the four replacements in order 1.1 → 1.4. Drop the `SkeletonCard` import if no longer used; same for any imports left dangling.
+- [ ] **1.d** Run the page tests:
+  ```bash
+  cd frontend && npx vitest run src/features/core/pages/home.test.tsx
+  ```
+  Fix any assertions that depend on the old markup (most likely none — assertions usually target visible text).
+- [ ] **1.e** Run typecheck + lint:
+  ```bash
+  cd frontend && npx tsc --noEmit && npm run lint
+  ```
+- [ ] **1.f** Commit:
+  ```bash
+  git add frontend/src/features/core/pages/home.tsx frontend/src/features/core/pages/home.test.tsx
+  git commit -m "refactor(ui): migrate home page to EmptyState + skeleton primitives"
+  ```
+
+---
+
+## Task 2 — workload-explorer.tsx (4 migrations)
+
+**Files:**
+- Modify: `frontend/src/features/containers/pages/workload-explorer.tsx`
+- Test: `frontend/src/features/containers/pages/workload-explorer.test.tsx`
+
+### Migrations
+
+**2.1 — Compare-mode empty (line ~678–689)**
+
+Replace the dashed-border block ("No containers to compare" + "Back to list" button) with:
+```tsx
+<EmptyState
+  icon={Boxes}
+  title="No containers to compare"
+  description="Pick at least 2 containers from Workload Explorer to compare them."
+/>
+```
+Move the "Back to list" button to a sibling position next to or above the EmptyState (it's an action, EmptyState is informational).
+
+**2.2 — Compare-mode loading (line ~668)**
+
+Replace `<SkeletonCard className="h-[300px]" />` with `<SkeletonChart size="md" />`.
+
+**2.3 — Table pane loading (line ~803–804)**
+
+Replace `<SkeletonCard className="h-[500px]" />` with `<SkeletonChart size="lg" />`.
+
+**2.4 — Top-level error (line ~578–601)**
+
+Replace the `<div>` containing `AlertTriangle` + "Failed to load containers" + retry button with:
+```tsx
+<EmptyState
+  variant="error"
+  icon={AlertTriangle}
+  title="Failed to load containers"
+  description={errorMessage}
+/>
+```
+Keep the existing retry button outside the EmptyState.
+
+### Steps
+
+- [ ] **2.a** Verify the four locations match the audit.
+- [ ] **2.b** Add imports (`EmptyState`, `SkeletonChart`); check `Boxes` icon — if not imported, add to the lucide line.
+- [ ] **2.c** Apply migrations 2.1 → 2.4. Drop dead imports.
+- [ ] **2.d** Run tests; fix assertions if any break.
+- [ ] **2.e** Typecheck + lint clean.
+- [ ] **2.f** Commit:
+  ```bash
+  git commit -m "refactor(ui): migrate workload-explorer to EmptyState + skeleton primitives"
+  ```
+
+---
+
+## Task 3 — trace-explorer.tsx (3 migrations)
+
+**Files:**
+- Modify: `frontend/src/features/observability/pages/trace-explorer.tsx`
+- Test: `frontend/src/features/observability/pages/trace-explorer.test.tsx`
+
+### Migrations
+
+**3.1 — Traces list empty (line ~1417–1425)**
+
+Replace dashed-border "No traces found" block with:
+```tsx
+<EmptyState
+  icon={GitBranch}
+  title="No traces found"
+  description={traces.length === 0 ? 'Run a workload to start capturing distributed traces.' : 'Adjust your filters to surface more spans.'}
+/>
+```
+(Use whatever the existing conditional message variable is; inline ternary above is illustrative.)
+
+**3.2 — Right-pane (trace detail) loading (line ~1409–1415)**
+
+Replace the right-pane `<SkeletonCard className="h-[600px]" />` with `<SkeletonChart size="lg" />`. Leave the left pane skeleton as-is in this task — it's the list pane, see 3.2b.
+
+**3.2b — Left-pane (traces list) loading** (same line range, the second `<SkeletonCard>`)
+
+Replace the left-pane `<SkeletonCard ...>` with `<SkeletonList rows={4} />`.
+
+**3.3 — Top-level error (line ~791–812)**
+
+Replace dashed/red-bordered "Failed to load traces" + `AlertTriangle` + retry with:
+```tsx
+<EmptyState
+  variant="error"
+  icon={AlertTriangle}
+  title="Failed to load traces"
+  description={errorMessage}
+/>
+```
+Keep retry button as a sibling.
+
+### Steps
+
+- [ ] **3.a** Verify locations.
+- [ ] **3.b** Add imports (`EmptyState`, `SkeletonChart`, `SkeletonList`); `GitBranch` and `AlertTriangle` already imported per audit.
+- [ ] **3.c** Apply 3.1 → 3.3 (covering both 3.2 and 3.2b).
+- [ ] **3.d** Tests, typecheck, lint.
+- [ ] **3.e** Commit:
+  ```bash
+  git commit -m "refactor(ui): migrate trace-explorer to EmptyState + skeleton primitives"
+  ```
+
+---
+
+## Task 4 — llm-observability.tsx (4 migrations)
+
+**Files:**
+- Modify: `frontend/src/features/ai-intelligence/pages/llm-observability.tsx`
+- Test: `frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx`
+
+### Migrations
+
+**4.1 — Traces table empty (line ~57–66)**
+
+Replace dashed-border "No LLM traces yet" block with:
+```tsx
+<EmptyState
+  icon={MessageSquare}
+  title="No LLM traces yet"
+  description="LLM interactions will appear here once the assistant is used."
+/>
+```
+
+**4.2 — Model breakdown table empty (line ~232–233)**
+
+If the existing `"No model data available."` is wrapped in pane chrome (`<SpotlightCard>` or a panel `<section>`), migrate to:
+```tsx
+<EmptyState
+  icon={BarChart3}
+  title="No model data available"
+  description="Once the assistant runs, per-model usage breakdowns will appear here."
+/>
+```
+If it's a small inline caption (a single `<p>` inside an existing card with other content), **do not migrate** — leave it as a caption. Inspect the surrounding 10 lines before deciding.
+
+**4.3 — KPI cards loading (line ~185–191)**
+
+Replace `Array.from({ length: 4 }).map(...) => <SkeletonCard />` with `<SkeletonKpi />`.
+
+**4.4 — Traces table loading (line ~47–54)**
+
+Replace the 2-`SkeletonCard` grid loading state with:
+```tsx
+<SkeletonList rows={4} />
+```
+
+### Steps
+
+- [ ] **4.a** Verify locations.
+- [ ] **4.b** Add imports as needed (`EmptyState`, `SkeletonKpi`, `SkeletonList`). Confirm `MessageSquare`, `BarChart3` in lucide imports.
+- [ ] **4.c** Apply 4.1 → 4.4. For 4.2, inspect the surrounding context and skip if it's a caption.
+- [ ] **4.d** Tests, typecheck, lint.
+- [ ] **4.e** Commit:
+  ```bash
+  git commit -m "refactor(ui): migrate llm-observability to EmptyState + skeleton primitives"
+  ```
+
+---
+
+## Task 5 — ai-monitor.tsx (4 migrations)
+
+**Files:**
+- Modify: `frontend/src/features/ai-intelligence/pages/ai-monitor.tsx`
+- Test: `frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx`
+
+### Migrations
+
+**5.1 — Insights feed empty (line ~612–623)**
+
+Replace dashed-border "No insights" block with:
+```tsx
+<EmptyState
+  icon={Activity}
+  title="No insights"
+  description={
+    /* preserve the existing conditional message logic — e.g.,
+       hasActiveFilters ? 'Adjust filters to surface more insights.' : 'AI-generated insights will appear here as your fleet runs.'
+    */
+  }
+/>
+```
+
+**5.2 — Correlated anomalies grid loading (line ~564–569)**
+
+Replace `Array.from({ length: 3 }).map(...) => <SkeletonCard className="h-[180px]" />` with `<SkeletonChart size="md" />`.
+
+**5.3 — Insights feed loading (line ~610–611)**
+
+Replace `<SkeletonCard className="h-[400px]" />` with `<SkeletonList rows={6} />`.
+
+**5.4 — Top-level error (line ~381–404)**
+
+Replace dashed "Failed to load insights" + retry with:
+```tsx
+<EmptyState
+  variant="error"
+  icon={AlertTriangle}
+  title="Failed to load insights"
+  description={errorMessage}
+/>
+```
+Keep retry as sibling.
+
+### Steps
+
+- [ ] **5.a** Verify locations.
+- [ ] **5.b** Add imports (`EmptyState`, `SkeletonChart`, `SkeletonList`). Confirm `Activity`, `AlertTriangle` imports.
+- [ ] **5.c** Apply 5.1 → 5.4.
+- [ ] **5.d** Tests, typecheck, lint.
+- [ ] **5.e** Commit:
+  ```bash
+  git commit -m "refactor(ui): migrate ai-monitor to EmptyState + skeleton primitives"
+  ```
+
+---
+
+## Task 6 — fleet-overview.tsx (8 migrations)
+
+**Files:**
+- Modify: `frontend/src/features/containers/pages/fleet-overview.tsx`
+- Test: `frontend/src/features/containers/pages/fleet-overview.test.tsx`
+
+### Migrations
+
+**6.1 — Endpoints filter-empty (line ~980–989)**
+
+Replace dashed-border "No endpoints match filters" with:
+```tsx
+<EmptyState
+  icon={Server}
+  title="No endpoints match filters"
+  description="Adjust your filters to see endpoints."
+/>
+```
+
+**6.2 — Endpoints search-empty (line ~992–1001)**
+
+Replace dashed-border "No endpoints match your search" with:
+```tsx
+<EmptyState
+  icon={Search}
+  title="No endpoints match your search"
+  description="Try a different query or clear the search."
+/>
+```
+
+**6.3 — Stacks empty (line ~1163–1200, multi-branch)**
+
+This block currently renders one of several messages via inline conditionals (filtered, searched, not configured on a specific endpoint). Split into one of:
+```tsx
+{stacksFilteredOnly ? (
+  <EmptyState icon={Layers} title="No stacks match filters" description="Adjust your filters to see stacks." />
+) : stacksSearchOnly ? (
+  <EmptyState icon={Search} title="No stacks match your search" description="Try a different query or clear the search." />
+) : (
+  <EmptyState
+    variant="not-configured"
+    icon={Layers}
+    title="No stacks or compose projects detected"
+    description="There are no Docker Stacks or Compose projects deployed across your endpoints."
+  />
+)}
+```
+Preserve the exact condition variable names from the existing code.
+
+**6.4 — Top-level error (line ~852–865)**
+
+Replace dashed "Failed to load infrastructure data" + retry with:
+```tsx
+<EmptyState
+  variant="error"
+  icon={AlertTriangle}
+  title="Failed to load infrastructure data"
+  description={errorMessage}
+/>
+```
+
+**6.5 — Endpoints grid loading (line ~974–979)**
+
+Replace `Array.from({ length: 6 }).map(...) => <SkeletonCard className="h-[120px]" />` with `<SkeletonText lines={2} />` (six instances inside the grid).
+
+**6.6 — Stacks grid loading (line ~1157–1162)**
+
+Replace 6× `<SkeletonCard className="h-[100px]" />` with 6× `<SkeletonText lines={1} />`.
+
+**6.7 — Kubernetes pods loading (line ~1258–1263)**
+
+Replace 6× `<SkeletonCard />` with 6× `<SkeletonChart size="md" />`.
+
+**6.8 — Same as 6.3's not-configured branch** — already covered in 6.3, no separate work.
+
+### Steps
+
+- [ ] **6.a** Verify locations (line drift expected on this file).
+- [ ] **6.b** Add imports (`EmptyState`, `SkeletonText`, `SkeletonChart`). Confirm `Server`, `Search`, `Layers`, `AlertTriangle` in lucide imports.
+- [ ] **6.c** Apply 6.1 → 6.7 in order.
+- [ ] **6.d** Tests, typecheck, lint.
+- [ ] **6.e** Commit:
+  ```bash
+  git commit -m "refactor(ui): migrate fleet-overview to EmptyState + skeleton primitives"
+  ```
+
+---
+
+## Task 7 — metrics-dashboard.tsx (14 migrations)
+
+**Files:**
+- Modify: `frontend/src/features/observability/pages/metrics-dashboard.tsx`
+- Test: `frontend/src/features/observability/pages/metrics-dashboard.test.tsx`
+
+This is the heaviest page. The audit identified 14 distinct migrations. If during execution this commit becomes unwieldy, the implementer is authorized to split it into two commits along the boundary of "empty/error/not-configured states" vs "loading skeletons" — but only if a single commit feels unreviewable. Default is one commit.
+
+### Migrations — empty / error / not-configured
+
+**7.1 — No selection empty (line ~579–587)**
+
+Replace dashed "Select a Container" block with:
+```tsx
+<EmptyState
+  icon={Server}
+  title="Select a container"
+  description="Choose an endpoint and container to view metrics."
+/>
+```
+
+**7.2 — Network data empty (line ~521–529)**
+
+Replace dashed "No connected networks found for this container" with:
+```tsx
+<EmptyState
+  icon={Network}
+  title="No connected networks found"
+  description="Select a different container or check container network attachments."
+/>
+```
+
+**7.3 — Metrics empty in time range (line ~654–670)**
+
+Replace dashed "No Metrics Data Available" + bullet-list explanation with:
+```tsx
+<EmptyState
+  icon={Clock}
+  title="No metrics data available"
+  description="No metrics have been recorded for this container in the selected time range. Containers record metrics every 60 seconds — try a wider time range or wait for collection."
+/>
+```
+
+**7.4 — Forecast collecting (line ~791–803)**
+
+Replace "Collecting Metrics Data" block with:
+```tsx
+<EmptyState
+  variant="not-configured"
+  icon={Clock}
+  title="Collecting metrics data"
+  description="Capacity forecasts require at least 5 minutes of metrics history. For higher confidence predictions, keep the container running for 20+ minutes."
+/>
+```
+(Use `not-configured` variant — this is a "waiting for setup completion" state.)
+
+**7.5 — Forecast overview empty (line ~878–884)**
+
+Replace dashed "No forecast data available" with:
+```tsx
+<EmptyState
+  icon={Clock}
+  title="No forecast data available"
+  description="Keep metrics collection running to build cross-container forecast insights."
+/>
+```
+
+**7.6 — CPU metrics error (line ~698–703)**
+
+Audit reports this is an inline red alert sized to be a small pane state. Replace with:
+```tsx
+<EmptyState
+  variant="error"
+  icon={AlertTriangle}
+  title="Failed to load CPU metrics"
+  description={cpuError?.message ?? 'Try refreshing the dashboard.'}
+/>
+```
+Use the existing error variable name from the file. If the block is genuinely tiny (e.g., a single `<p>` overlay), leave as caption.
+
+**7.7 — Memory metrics error (line ~732–737)**
+
+Same pattern as 7.6 with "Failed to load memory metrics".
+
+**7.8 — Forecast overview error (line ~871–877)**
+
+Replace dashed/destructive-bg "Failed to load forecast overview" block with:
+```tsx
+<EmptyState
+  variant="error"
+  icon={AlertTriangle}
+  title="Failed to load forecast overview"
+  description={forecastError?.message ?? 'Try again in a moment.'}
+/>
+```
+
+### Migrations — loading
+
+**7.9 — Top-level loading (line ~571–576)**
+
+Replace two `<SkeletonCard className="h-[350px]" />` with two `<SkeletonChart size="lg" />`.
+
+**7.10 — AI summary pane loading (line ~637–646)**
+
+Replace `<SkeletonCard className="h-[120px]" />` with `<SkeletonText lines={2} />`.
+
+**7.11 — Metrics charts loading (line ~649–653)**
+
+Replace two `<SkeletonCard className="h-[350px]" />` with two `<SkeletonChart size="lg" />`.
+
+**7.12 — Correlation insights loading (line ~836–840)**
+
+Replace `<SkeletonCard className="h-[260px]" />` with `<SkeletonChart size="md" />`.
+
+**7.13 — Forecast overview table loading (line ~865–870)**
+
+Replace three ad-hoc `<div className="h-10 animate-pulse rounded bg-muted" />` rows with three `<SkeletonTableRow columns={8} />` placed inside the existing `<tbody>`. Confirm the actual column count from the rendered table header and adjust `columns={N}` to match.
+
+### Steps
+
+- [ ] **7.a** Verify locations — this file is the longest of the seven; expect ±10 line drift.
+- [ ] **7.b** Add imports (`EmptyState`, `SkeletonText`, `SkeletonChart`, `SkeletonTableRow`). Confirm `Server`, `Network`, `Clock`, `AlertTriangle` in lucide imports.
+- [ ] **7.c** Apply 7.1 → 7.13. Recommended order: empties first (7.1–7.5), errors (7.6–7.8), not-configured (7.4), then loadings (7.9–7.13).
+- [ ] **7.d** Run the page test file. This page has the most assertions on visible text and structure — expect some test changes.
+- [ ] **7.e** Run typecheck + lint clean.
+- [ ] **7.f** Commit:
+  ```bash
+  git commit -m "refactor(ui): migrate metrics-dashboard to EmptyState + skeleton primitives"
+  ```
+
+---
+
+## Task 8 — Final pass + visual smoke + PR
+
+- [ ] **8.a** Confirm no legacy `SkeletonCard` or ad-hoc `border-dashed` / `Loader2.*Loading` patterns remain on these seven files:
+  ```bash
+  grep -nE 'SkeletonCard|border-dashed|Loading\.\.\.' \
+    frontend/src/features/core/pages/home.tsx \
+    frontend/src/features/containers/pages/workload-explorer.tsx \
+    frontend/src/features/containers/pages/fleet-overview.tsx \
+    frontend/src/features/observability/pages/metrics-dashboard.tsx \
+    frontend/src/features/observability/pages/trace-explorer.tsx \
+    frontend/src/features/ai-intelligence/pages/llm-observability.tsx \
+    frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+  ```
+  Expected: empty output (or only well-justified hits documented inline).
+
+- [ ] **8.b** Run the full frontend test suite:
+  ```bash
+  cd frontend && npx vitest run
+  ```
+  All 1912+ tests must pass.
+
+- [ ] **8.c** Start the dev server and visually check each of the seven pages renders correctly in at least:
+  - Default state (data loaded)
+  - Empty state (where reachable without complex setup — at minimum: log out / freshly cleared DB / new endpoint with no resources)
+  - Loading state (briefly visible on first navigation)
+  
+  Spend less than 60s per page. The goal is "no obvious visual regression" — not exhaustive QA.
+
+- [ ] **8.d** Push the branch:
+  ```bash
+  git push -u origin feature/ui-empty-loading-pr2-high-traffic
+  ```
+
+- [ ] **8.e** Open the PR. If PR 1 has merged by now, base is `dev`; otherwise base is `feature/ui-empty-loading-primitives` and the PR description notes that this stacks on PR 1.
+  ```bash
+  gh pr create --base <dev|feature/ui-empty-loading-primitives> --title "feat(ui): migrate high-traffic pages to EmptyState + skeletons (PR 2 of 3)" --body "$(cat <<'EOF'
+  ## Summary
+  Migrates every ad-hoc empty / loading / error state on the seven highest-traffic pages to the primitives shipped in PR 1:
+  - home, workload-explorer, trace-explorer, llm-observability, ai-monitor — light-touch pages
+  - fleet-overview — endpoints / stacks / k8s state branches
+  - metrics-dashboard — heaviest page, 14 migrations across empties / errors / loadings / forecast not-configured
+  
+  Net effect: zero ad-hoc `border-dashed bg-muted/20` empty states and zero raw `<SkeletonCard>` calls on these seven pages.
+  
+  ## Out of scope
+  - Long-tail migrations (~15 pages remaining) — PR 3.
+  - Removing the `LoadingSkeleton` / `SkeletonCard` exports themselves — PR 3, after all callers are gone.
+  
+  ## Test plan
+  - [x] Frontend test suite green (1912+ tests).
+  - [x] `tsc --noEmit` clean.
+  - [x] `npm run lint` clean.
+  - [ ] Manual smoke pass on each page — please verify the empty / loading / error states render with canonical chrome and no layout shift.
+  
+  Spec: `docs/superpowers/specs/2026-05-16-empty-loading-states-design.md`
+  Plan: `docs/superpowers/plans/2026-05-16-empty-loading-states-pr2-high-traffic.md`
+  
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  EOF
+  )"
+  ```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** All 41 audited migrations are mapped to tasks 1–7. The skip rules from the spec (captions stay; primitives don't carry chrome; no action slots) are preserved.
+- **Type/identifier consistency:** Component names match PR 1 exports verbatim (`EmptyState`, `SkeletonText`, `SkeletonKpi`, `SkeletonTableRow`, `SkeletonChart`, `SkeletonList`). Variant strings (`'empty'`, `'error'`, `'not-configured'`) match the union exported from PR 1.
+- **Open question deferred to execution:** The exact condition variables for branched empty states (especially 6.3 fleet-stacks and 5.1 ai-monitor insights) need to be read directly from the source — the audit captured the locations but not the exact variable names. Implementer reads the current code, preserves the conditions, swaps only the rendered output.
+- **Risk areas:** `metrics-dashboard.tsx` is large enough that a single commit is borderline reviewable. The task allows splitting it in two if the implementer judges it necessary, with a documented rationale in the second commit message.

--- a/docs/superpowers/specs/2026-05-16-empty-loading-states-design.md
+++ b/docs/superpowers/specs/2026-05-16-empty-loading-states-design.md
@@ -1,0 +1,250 @@
+# Empty / Loading / Error States — Design Spec
+
+**Date:** 2026-05-16
+**Scope:** Sub-project #1 of the UI consistency program. Standardize the three "non-data" states (empty, error, not-configured) and the loading state that precedes them.
+**Status:** Design — ready for implementation planning.
+
+## Problem
+
+Audit of `frontend/src/` found:
+
+- **17+ empty-state variants** — dashed borders, solid cards, plain text, centered icon+text, three-line CTA blocks. No two pages render "no data yet" the same way.
+- **25+ loading-state files** — `Loader2` spinners, `<p>Loading...</p>` text, ad-hoc skeleton boxes, no skeletons at all (blank pane until data arrives).
+- **15+ error-state variants** — red borders, alert icons, raw error strings, toast-only.
+
+The result: every page negotiates its own "what does nothing-here look like" decision, and the answers conflict visually. This sub-project gives every page one set of primitives so the chrome is decided once.
+
+## Decisions
+
+Selected via brainstorming session 2026-05-16:
+
+1. **Empty-state chrome — Hybrid** (canonical card + iconchip + muted text). Same outer shell as a populated data pane (`bg-card`, `border`, `shadow-sm`, `rounded-lg`), so the pane does not change shape when data arrives. Distinguished only by content: a circular muted iconchip, slightly reduced text opacity, no chart/table inside.
+2. **Component structure — Single `<EmptyState>` with variants.** One component, `variant="empty" | "error" | "not-configured"`. One place to change chrome; variant prop drives the (small) differences in iconchip tint and default copy color.
+3. **Loading — skeletons matching content shape.** No spinners inside panes. Skeleton primitives mimic the eventual content (KPI tile shape, table rows, chart bars, list rows). No layout shift when data arrives.
+4. **No action affordances inside `<EmptyState>`.** The component is purely informational — chrome + iconchip + title + body. Any retry buttons, settings links, or other CTAs are the caller's responsibility and live outside the component (typically in the parent pane's header).
+
+## Component API
+
+### `<EmptyState>`
+
+Lives at `frontend/src/shared/components/feedback/empty-state.tsx`.
+
+```tsx
+import type { LucideIcon } from 'lucide-react';
+
+export interface EmptyStateProps {
+  /** Visual variant — drives iconchip tint and minor color shifts. */
+  variant?: 'empty' | 'error' | 'not-configured';
+  /** Lucide icon rendered inside the muted circular chip. */
+  icon: LucideIcon;
+  /** Primary line — short, sentence case. e.g. "No traces yet". */
+  title: string;
+  /** Optional supporting copy. One sentence, ends with a period. */
+  description?: string;
+  /** Optional extra Tailwind classes on the outer card. */
+  className?: string;
+}
+```
+
+Renders:
+
+```tsx
+<SpotlightCard className={className}>
+  <div className="flex flex-col items-center justify-center rounded-lg border bg-card p-8 shadow-sm text-center">
+    <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-muted/40">
+      <Icon className={cn('h-6 w-6', iconColorFor(variant))} />
+    </div>
+    <p className="text-sm font-semibold text-foreground/80">{title}</p>
+    {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+  </div>
+</SpotlightCard>
+```
+
+Variant tints (`iconColorFor`):
+
+| Variant | Icon tint | Rationale |
+|---|---|---|
+| `empty` (default) | `text-muted-foreground` | Neutral — "nothing yet" is not a problem. |
+| `error` | `text-destructive/80` | Subdued red — visible without alarming. |
+| `not-configured` | `text-amber-500/80` | Amber — "action needed, not broken". |
+
+No action slot. No `children`. If a page needs a retry button, it renders the button in its pane header alongside the title — not inside the state component.
+
+### Skeleton primitives
+
+Live at `frontend/src/shared/components/feedback/skeleton.tsx` (extends the existing pattern if any). All use a single shared pulse animation (`animate-pulse bg-muted/40 rounded`).
+
+| Primitive | Use for |
+|---|---|
+| `<SkeletonText lines={n} />` | Body copy, descriptions, multi-line content. Lines vary slightly in width for natural feel. |
+| `<SkeletonKpi />` | A single KPI tile's label + big-number + sublabel. Matches `KpiCard` internal shape. |
+| `<SkeletonTableRow columns={n} />` | One table row with `n` cells. Caller renders N of them inside the real `<TableBody>`. |
+| `<SkeletonChart height="md" \| "lg" />` | Block matching a chart's footprint. Caller wraps in their own pane chrome. |
+| `<SkeletonList rows={n} />` | List of rows (avatar + text), e.g. for log lists, audit lists. |
+
+**Important:** skeletons do **not** wrap themselves in pane chrome. The caller renders skeletons inside the same `<SpotlightCard><div className="rounded-lg border bg-card p-6 shadow-sm">…</div></SpotlightCard>` shell it would use for real content. This is what makes the transition seamless.
+
+Example KPI loading row:
+
+```tsx
+{isLoading ? (
+  <>
+    <TiltCard><SkeletonKpi /></TiltCard>
+    <TiltCard><SkeletonKpi /></TiltCard>
+    <TiltCard><SkeletonKpi /></TiltCard>
+    <TiltCard><SkeletonKpi /></TiltCard>
+  </>
+) : (
+  <>
+    <TiltCard><KpiCard ... /></TiltCard>
+    ...
+  </>
+)}
+```
+
+## Usage patterns
+
+### Pane with no data
+
+```tsx
+<SpotlightCard>
+  <div className="rounded-lg border bg-card p-6 shadow-sm">
+    <h3 className="mb-4 text-sm font-medium text-muted-foreground">Recent traces</h3>
+    {traces.length === 0 ? (
+      <EmptyState
+        icon={Activity}
+        title="No traces yet"
+        description="Run a workload to start capturing distributed traces."
+      />
+    ) : (
+      <TracesTable rows={traces} />
+    )}
+  </div>
+</SpotlightCard>
+```
+
+Note: `<EmptyState>` here is nested inside the pane — it renders its own inner card, and the visual effect is intentional. The outer pane keeps its title row; the inner card displays the empty marker centered. If the pane has no title row, `<EmptyState>` can stand alone as the pane content.
+
+### Standalone empty pane
+
+```tsx
+{cards.length === 0 ? (
+  <EmptyState icon={Inbox} title="Nothing here yet" />
+) : (
+  <CardGrid cards={cards} />
+)}
+```
+
+### Error state (fetch failed)
+
+```tsx
+{error ? (
+  <EmptyState
+    variant="error"
+    icon={AlertTriangle}
+    title="Couldn't load metrics"
+    description={error.message}
+  />
+) : ...}
+```
+
+If a retry control is needed:
+
+```tsx
+<SpotlightCard>
+  <div className="rounded-lg border bg-card p-6 shadow-sm">
+    <div className="mb-4 flex items-center justify-between">
+      <h3 className="text-sm font-medium text-muted-foreground">Metrics</h3>
+      {error && <Button size="sm" variant="ghost" onClick={refetch}>Retry</Button>}
+    </div>
+    {error ? <EmptyState variant="error" icon={AlertTriangle} title="Couldn't load metrics" /> : <Chart .../>}
+  </div>
+</SpotlightCard>
+```
+
+### Not-configured state
+
+```tsx
+<EmptyState
+  variant="not-configured"
+  icon={Settings}
+  title="Harbor isn't configured"
+  description="Add Harbor credentials in Settings to surface registry vulnerabilities here."
+/>
+```
+
+The "open settings" link, if any, lives in the pane's header — not inside the state component.
+
+### Loading state
+
+```tsx
+<SpotlightCard>
+  <div className="rounded-lg border bg-card p-6 shadow-sm">
+    <h3 className="mb-4 text-sm font-medium text-muted-foreground">Recent traces</h3>
+    {isLoading ? (
+      <SkeletonList rows={6} />
+    ) : traces.length === 0 ? (
+      <EmptyState icon={Activity} title="No traces yet" description="Run a workload to start capturing distributed traces." />
+    ) : (
+      <TracesTable rows={traces} />
+    )}
+  </div>
+</SpotlightCard>
+```
+
+## Copy guidelines
+
+Each state component instance must include:
+
+- **Title** — short, sentence case, no period. ≤ 6 words. "No traces yet", not "No traces have been captured yet."
+- **Description** (optional) — one sentence, ends with a period. Tells the user what action would change the state. "Run a workload to start capturing distributed traces." not "Empty list."
+
+Anti-patterns to remove during migration:
+
+- "Loading…" / "Loading..." text → replace with skeletons.
+- "Error: <raw stack trace>" → replace with `<EmptyState variant="error">` and a user-readable message; raw error goes to console + telemetry.
+- Plain centered `<p className="text-muted-foreground">No data</p>` → replace with `<EmptyState>`.
+
+## Migration plan
+
+The full sweep across 17+ empty-state and 25+ loading-state sites is large. Implement in three sequenced PRs to keep reviews tractable:
+
+**PR 1 — Primitives + tests**
+- Build `<EmptyState>` and the five skeleton primitives in `shared/components/feedback/`.
+- Write Vitest tests covering each variant's tint, missing-description fallback, and skeleton row counts.
+- Storybook-style smoke usage in a single page (pick a low-traffic page, e.g. `webhooks.tsx`) to validate visually.
+- No other call-site migrations.
+
+**PR 2 — High-traffic page migrations**
+- Convert empty + loading + error states on: `home.tsx`, `workload-explorer.tsx`, `fleet-overview.tsx`, `metrics-dashboard.tsx`, `trace-explorer.tsx`, `llm-observability.tsx`, `ai-monitor.tsx`.
+- Delete now-dead ad-hoc empty/loading components encountered along the way.
+- Update existing tests that asserted the old markup.
+
+**PR 3 — Long-tail migrations + cleanup**
+- Remaining pages (audit, settings, users, webhooks already covered, packet-capture, edge-agent-logs, harbor, ebpf, status, log-viewer, reports, etc.).
+- Run a `grep` pass for `Loading...`, dashed borders, `Loader2` inside panes, and `text-muted-foreground.*No ` patterns to catch stragglers.
+- Add an ESLint custom rule or simple grep-based CI check to flag re-introduction of ad-hoc empty/loading markup (optional, defer if time-bound).
+
+## Out of scope
+
+- Skeleton design for animations (e.g., shimmer gradient) — deferred. Use plain pulse for now; revisit if it feels flat.
+- Toast / inline error banners — separate concern from per-pane error states. Not touched here.
+- Modal / dialog empty states — same `<EmptyState>` works inside dialogs but the migration sweep targets pages only.
+- Mobile-specific layout adjustments — current breakpoints carry through; no responsive variants planned for the primitives.
+
+## Open questions for plan phase
+
+- Should we ship the primitives behind a feature flag? (Default: no — pure visual, low risk.)
+- Snapshot tests for the primitives — useful or noise? Recommend: per-variant render assertion (icon present, title text, correct variant class), no DOM snapshots.
+- Does `<EmptyState>` need a `size="sm" | "md"` prop for in-row vs full-pane use? (Default: no — start with one size, add later if a need surfaces.)
+
+## Acceptance criteria
+
+Sub-project #1 is complete when:
+
+1. `<EmptyState>` and the five skeleton primitives exist in `shared/components/feedback/` with passing Vitest tests.
+2. All 17 audited empty-state call sites use `<EmptyState>`.
+3. All loading states inside pane chromes use skeleton primitives (spinners only remain in non-pane contexts like button loading states).
+4. All error states inside pane chromes use `<EmptyState variant="error">`.
+5. `grep -r "Loading\\.\\.\\." frontend/src --include="*.tsx"` returns no matches inside pane bodies.
+6. No regression in existing UI tests; new tests cover the primitives.

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -11,7 +11,8 @@ import { useForceRefresh } from '@/shared/hooks/use-force-refresh';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
 import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
-import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonChart, SkeletonList } from '@/shared/components/feedback/skeleton';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { cn } from '@/shared/lib/utils';
 import {
@@ -387,19 +388,18 @@ export default function AiMonitorPage() {
             Fleet health analysis and real-time AI-powered insights
           </p>
         </div>
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
-          <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
-          <p className="mt-4 font-medium text-destructive">Failed to load insights</p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {error instanceof Error ? error.message : 'An unexpected error occurred'}
-          </p>
-          <button
-            onClick={() => refetch()}
-            className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-          >
-            Try again
-          </button>
-        </div>
+        <EmptyState
+          variant="error"
+          icon={AlertTriangle}
+          title="Failed to load insights"
+          description={error instanceof Error ? error.message : 'An unexpected error occurred'}
+        />
+        <button
+          onClick={() => refetch()}
+          className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+        >
+          Try again
+        </button>
       </div>
     );
   }
@@ -563,9 +563,9 @@ export default function AiMonitorPage() {
           </div>
           {correlatedLoading ? (
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              <SkeletonCard className="h-[180px]" />
-              <SkeletonCard className="h-[180px]" />
-              <SkeletonCard className="h-[180px]" />
+              <SkeletonChart size="md" />
+              <SkeletonChart size="md" />
+              <SkeletonChart size="md" />
             </div>
           ) : (
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -608,19 +608,19 @@ export default function AiMonitorPage() {
       <SpotlightCard>
         <div className="rounded-lg border bg-card p-6 shadow-sm">
         {isLoading ? (
-          <SkeletonCard className="h-[400px]" />
+          <SkeletonList rows={6} />
         ) : filteredInsights.length === 0 ? (
-          <div className="rounded-lg border border-dashed bg-muted/20 p-12 text-center">
-            <Activity className="mx-auto h-12 w-12 text-muted-foreground" />
-            <h3 className="mt-4 text-lg font-semibold">No insights</h3>
-            <p className="mt-2 text-sm text-muted-foreground">
-              {acknowledgementFilter === 'unacknowledged'
+          <EmptyState
+            icon={Activity}
+            title="No insights"
+            description={
+              acknowledgementFilter === 'unacknowledged'
                 ? 'No unacknowledged insights match the current filters.'
                 : severityFilter === 'all'
                   ? 'AI monitoring has not generated any insights yet. Check back soon.'
-                  : `No ${severityFilter} insights found. Try a different filter.`}
-            </p>
-          </div>
+                  : `No ${severityFilter} insights found. Try a different filter.`
+            }
+          />
         ) : (
           <div className="space-y-3">
             {filteredInsights.map((insight) => (

--- a/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
@@ -7,7 +7,8 @@ import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { TiltCard } from '@/shared/components/data-display/tilt-card';
-import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
+import { SkeletonKpi, SkeletonList } from '@/shared/components/feedback/skeleton';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { cn, formatDate } from '@/shared/lib/utils';
 import {
   Activity,
@@ -46,23 +47,16 @@ function StatusBadge({ status }: { status: string }) {
 
 function TracesTable({ traces, isLoading, privacyMode }: { traces: LlmTrace[]; isLoading: boolean; privacyMode: boolean }) {
   if (isLoading) {
-    return (
-      <div className="grid gap-4 md:grid-cols-2">
-        <SkeletonCard />
-        <SkeletonCard />
-      </div>
-    );
+    return <SkeletonList rows={4} />;
   }
 
   if (traces.length === 0) {
     return (
-      <div className="rounded-lg border border-dashed bg-muted/20 p-12 text-center">
-        <MessageSquare className="mx-auto h-12 w-12 text-muted-foreground" />
-        <h3 className="mt-4 text-lg font-semibold">No LLM traces yet</h3>
-        <p className="mt-2 text-sm text-muted-foreground">
-          LLM interactions will appear here once the assistant is used.
-        </p>
-      </div>
+      <EmptyState
+        icon={MessageSquare}
+        title="No LLM traces yet"
+        description="LLM interactions will appear here once the assistant is used."
+      />
     );
   }
 
@@ -184,10 +178,10 @@ export default function LlmObservabilityPage() {
       {/* KPI Cards */}
       {showStatsSkeleton ? (
         <div className="grid gap-4 md:grid-cols-4">
-          <SkeletonCard />
-          <SkeletonCard />
-          <SkeletonCard />
-          <SkeletonCard />
+          <SkeletonKpi />
+          <SkeletonKpi />
+          <SkeletonKpi />
+          <SkeletonKpi />
         </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-4">

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -15,7 +15,8 @@ import { DataTable } from '@/shared/components/tables/data-table';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
-import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonText, SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { FilterChipBar, type FilterChip } from '@/shared/components/ui/filter-chip-bar';
 import { useUiStore } from '@/stores/ui-store';
@@ -851,17 +852,20 @@ export default function InfrastructurePage() {
 
       {/* Error state */}
       {hasError && (
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
-          <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
-          <p className="mt-4 font-medium text-destructive">Failed to load infrastructure data</p>
-          <p className="mt-1 text-sm text-muted-foreground">{errorMessage}</p>
+        <>
+          <EmptyState
+            variant="error"
+            icon={AlertTriangle}
+            title="Failed to load infrastructure data"
+            description={errorMessage}
+          />
           <button
             onClick={handleRefresh}
             className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
           >
             Try again
           </button>
-        </div>
+        </>
       )}
 
       {/* Tabbed sections */}
@@ -974,31 +978,23 @@ export default function InfrastructurePage() {
         {isLoading ? (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <SkeletonCard key={i} className="h-[120px]" />
+              <SkeletonText key={i} lines={2} />
             ))}
           </div>
         ) : filteredEndpoints.length === 0 && endpoints && endpoints.length > 0 ? (
-          <SpotlightCard>
-          <div className="rounded-lg border bg-card p-6 shadow-sm text-center">
-            <Server className="mx-auto h-10 w-10 text-muted-foreground" />
-            <p className="mt-4 font-medium">No endpoints match filters</p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Adjust your filters to see endpoints
-            </p>
-          </div>
-          </SpotlightCard>
+          <EmptyState
+            icon={Server}
+            title="No endpoints match filters"
+            description="Adjust your filters to see endpoints."
+          />
         ) : fleetViewMode === 'grid' ? (
           <>
             {paginatedEndpoints.length === 0 && endpointSearchQuery ? (
-              <SpotlightCard>
-              <div className="rounded-lg border bg-card p-6 shadow-sm text-center">
-                <Search className="mx-auto h-10 w-10 text-muted-foreground" />
-                <p className="mt-4 font-medium">No endpoints match your search</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Try a different query or clear the search
-                </p>
-              </div>
-              </SpotlightCard>
+              <EmptyState
+                icon={Search}
+                title="No endpoints match your search"
+                description="Try a different query or clear the search."
+              />
             ) : (
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                 {paginatedEndpoints.map((endpoint) => (
@@ -1157,28 +1153,24 @@ export default function InfrastructurePage() {
         {isLoading ? (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <SkeletonCard key={i} className="h-[100px]" />
+              <SkeletonText key={i} lines={1} />
             ))}
           </div>
         ) : filteredStacks.length === 0 ? (
-          <SpotlightCard>
-          <div className="rounded-lg border bg-card p-6 shadow-sm text-center">
-            <Layers className="mx-auto h-10 w-10 text-muted-foreground" />
+          <>
             {stackSearchQuery ? (
-              <>
-                <p className="mt-4 font-medium">No stacks match your search</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Try a different query or clear the search
-                </p>
-              </>
+              <EmptyState icon={Search} title="No stacks match your search" description="Try a different query or clear the search." />
             ) : hasActiveStackFilter ? (
               <>
-                <p className="mt-4 font-medium">No stacks match filters</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {stackEndpointFilterParam !== ALL_FILTER
-                    ? 'The selected endpoint has no Docker Stacks or Compose projects'
-                    : 'Adjust your filters to see stacks'}
-                </p>
+                <EmptyState
+                  icon={Layers}
+                  title="No stacks match filters"
+                  description={
+                    stackEndpointFilterParam !== ALL_FILTER
+                      ? 'The selected endpoint has no Docker Stacks or Compose projects'
+                      : 'Adjust your filters to see stacks'
+                  }
+                />
                 <button
                   onClick={() => {
                     setFleetFilters(endpointStatusFilter, endpointTypeFilter, ALL_FILTER, ALL_FILTER);
@@ -1189,15 +1181,14 @@ export default function InfrastructurePage() {
                 </button>
               </>
             ) : (
-              <>
-                <p className="mt-4 font-medium">No stacks or compose projects detected</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  There are no Docker Stacks or Compose projects deployed across your endpoints
-                </p>
-              </>
+              <EmptyState
+                variant="not-configured"
+                icon={Layers}
+                title="No stacks or compose projects detected"
+                description="There are no Docker Stacks or Compose projects deployed across your endpoints."
+              />
             )}
-          </div>
-          </SpotlightCard>
+          </>
         ) : stacksViewMode === 'grid' ? (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {filteredStacks.map((stack) => (
@@ -1258,7 +1249,7 @@ export default function InfrastructurePage() {
         {k8sPodsLoading ? (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <SkeletonCard key={i} />
+              <SkeletonChart key={i} size="md" />
             ))}
           </div>
         ) : (

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useCallback } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { type ColumnDef, type RowSelectionState } from '@tanstack/react-table';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import { AlertTriangle, Eye, GitCompareArrows, ScrollText, X } from 'lucide-react';
+import { AlertTriangle, Boxes, Eye, GitCompareArrows, ScrollText, X } from 'lucide-react';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { useContainers, type Container } from '@/features/containers/hooks/use-containers';
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
@@ -15,7 +15,8 @@ import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
 import { useForceRefresh } from '@/shared/hooks/use-force-refresh';
 import { FavoriteButton } from '@/shared/components/ui/favorite-button';
-import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { resolveContainerStackName } from '@/features/containers/lib/container-stack-grouping';
 import { exportToCsv } from '@/shared/lib/csv-export';
 import { getContainerGroup, getContainerGroupLabel, type ContainerGroup } from '@/features/containers/lib/system-container-grouping';
@@ -584,19 +585,18 @@ export default function WorkloadExplorerPage() {
             Browse and manage containers across all endpoints
           </p>
         </div>
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
-          <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
-          <p className="mt-4 font-medium text-destructive">Failed to load containers</p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {error instanceof Error ? error.message : 'An unexpected error occurred'}
-          </p>
-          <button
-            onClick={() => refetch()}
-            className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-          >
-            Try again
-          </button>
-        </div>
+        <EmptyState
+          variant="error"
+          icon={AlertTriangle}
+          title="Failed to load containers"
+          description={error instanceof Error ? error.message : 'An unexpected error occurred'}
+        />
+        <button
+          onClick={() => refetch()}
+          className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+        >
+          Try again
+        </button>
       </div>
     );
   }
@@ -665,7 +665,7 @@ export default function WorkloadExplorerPage() {
                 containers?.find((c) => c.id === containerId && c.endpointId === endpointId))
               .filter((c): c is Container => c !== undefined);
 
-            if (isLoading) return <SkeletonCard className="h-[300px]" />;
+            if (isLoading) return <SkeletonChart size="md" />;
 
             if (compared.length < 2) {
               const heading = compared.length === 0
@@ -675,9 +675,12 @@ export default function WorkloadExplorerPage() {
                 ? 'Pick at least 2 containers from Workload Explorer to compare them.'
                 : 'Add another container from Workload Explorer to compare.';
               return (
-                <div className="rounded-lg border border-dashed bg-muted/20 p-12 text-center">
-                  <h2 className="text-lg font-semibold">{heading}</h2>
-                  <p className="mt-2 text-sm text-muted-foreground">{body}</p>
+                <>
+                  <EmptyState
+                    icon={Boxes}
+                    title={heading}
+                    description={body}
+                  />
                   <button
                     type="button"
                     onClick={exitCompareMode}
@@ -685,7 +688,7 @@ export default function WorkloadExplorerPage() {
                   >
                     ← Back to list
                   </button>
-                </div>
+                </>
               );
             }
 
@@ -801,7 +804,7 @@ export default function WorkloadExplorerPage() {
 
           {/* Table pane: filter chips + search + table */}
           {isLoading ? (
-            <SkeletonCard className="h-[500px]" />
+            <SkeletonChart size="lg" />
           ) : filteredContainers ? (
             <SpotlightCard>
             <div className="rounded-lg border bg-card p-6 shadow-sm space-y-4">

--- a/frontend/src/features/core/pages/home.tsx
+++ b/frontend/src/features/core/pages/home.tsx
@@ -6,7 +6,8 @@ import { useFavoriteContainers } from '@/features/containers/hooks/use-container
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
-import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonKpi, SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
 import { useForceRefresh } from '@/shared/hooks/use-force-refresh';
@@ -112,19 +113,18 @@ export default function HomePage() {
             Dashboard overview with KPIs and charts
           </p>
         </div>
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
-          <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
-          <p className="mt-4 font-medium text-destructive">Failed to load dashboard</p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {error instanceof Error ? error.message : 'An unexpected error occurred'}
-          </p>
-          <button
-            onClick={() => refetch()}
-            className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-          >
-            Try again
-          </button>
-        </div>
+        <EmptyState
+          variant="error"
+          icon={AlertTriangle}
+          title="Failed to load dashboard"
+          description={error instanceof Error ? error.message : 'An unexpected error occurred'}
+        />
+        <button
+          onClick={() => refetch()}
+          className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+        >
+          Try again
+        </button>
       </MotionPage>
     );
   }
@@ -149,7 +149,7 @@ export default function HomePage() {
       {isLoading ? (
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-5">
           {Array.from({ length: 5 }).map((_, i) => (
-            <SkeletonCard key={i} />
+            <SkeletonKpi key={i} />
           ))}
         </div>
       ) : data ? (
@@ -268,7 +268,7 @@ export default function HomePage() {
 
       {/* Endpoint Health — full width, dynamic height */}
       {isLoading ? (
-        <SkeletonCard className="h-[300px]" />
+        <SkeletonChart size="lg" />
       ) : data ? (
         <MotionReveal>
           <SpotlightCard>
@@ -287,8 +287,8 @@ export default function HomePage() {
       {/* Top Workloads + Fleet Summary */}
       {isLoading || isLoadingResources ? (
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-          <SkeletonCard className="h-[520px] lg:col-span-2" />
-          <SkeletonCard className="h-[520px]" />
+          <SkeletonChart size="lg" className="lg:col-span-2" />
+          <SkeletonChart size="lg" />
         </div>
       ) : data && resourcesData ? (
         <MotionStagger className="grid grid-cols-1 gap-4 lg:grid-cols-3" stagger={0.05}>

--- a/frontend/src/features/core/pages/webhooks.test.tsx
+++ b/frontend/src/features/core/pages/webhooks.test.tsx
@@ -7,24 +7,22 @@ const mockDelete = vi.fn();
 const mockTest = vi.fn();
 const mockRefetch = vi.fn();
 
+const { useWebhooksMock } = vi.hoisted(() => ({ useWebhooksMock: vi.fn() }));
+
+const defaultWebhook = {
+  id: 'wh-1',
+  name: 'Alerts Hook',
+  url: 'https://hooks.example.com/alerts',
+  secret: 'abcd1234...',
+  events: ['insight.created'],
+  enabled: 1,
+  description: null,
+  created_at: '2026-02-06T10:00:00Z',
+  updated_at: '2026-02-06T10:00:00Z',
+};
+
 vi.mock('@/features/core/hooks/use-webhooks', () => ({
-  useWebhooks: () => ({
-    data: [
-      {
-        id: 'wh-1',
-        name: 'Alerts Hook',
-        url: 'https://hooks.example.com/alerts',
-        secret: 'abcd1234...',
-        events: ['insight.created'],
-        enabled: 1,
-        description: null,
-        created_at: '2026-02-06T10:00:00Z',
-        updated_at: '2026-02-06T10:00:00Z',
-      },
-    ],
-    isLoading: false,
-    refetch: mockRefetch,
-  }),
+  useWebhooks: useWebhooksMock,
   useWebhookEventTypes: () => ({
     data: [
       { type: '*', description: 'All events' },
@@ -65,6 +63,19 @@ import { WebhooksPanel } from './webhooks';
 describe('WebhooksPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useWebhooksMock.mockReturnValue({
+      data: [defaultWebhook],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+  });
+
+  it('shows the empty state when no webhooks exist', () => {
+    useWebhooksMock.mockReturnValue({ data: [], isLoading: false, refetch: mockRefetch });
+    render(<WebhooksPanel />);
+    expect(screen.getByText('No webhooks configured yet')).toBeInTheDocument();
+    expect(screen.getByTestId('empty-state-card')).toBeInTheDocument();
+    expect(screen.queryByText('No webhooks match the current filter.')).not.toBeInTheDocument();
   });
 
   it('renders webhook list, delivery monitor, and add button', () => {

--- a/frontend/src/features/core/pages/webhooks.tsx
+++ b/frontend/src/features/core/pages/webhooks.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Loader2, PlugZap, Plus, TestTube2, Trash2, Activity, Radio, RefreshCw } from 'lucide-react';
+import { Loader2, PlugZap, Plus, TestTube2, Trash2, Activity, Radio, RefreshCw, Webhook as WebhookIcon } from 'lucide-react';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonText } from '@/shared/components/feedback/skeleton';
 import {
   useCreateWebhook,
   useDeleteWebhook,
@@ -212,14 +214,13 @@ export function WebhooksPanel() {
           </div>
 
           {webhooksQuery.isLoading ? (
-            <div className="space-y-2">
-              <div className="h-10 animate-pulse rounded bg-muted" />
-              <div className="h-10 animate-pulse rounded bg-muted" />
-            </div>
+            <SkeletonText lines={3} />
           ) : filteredWebhooks.length === 0 ? (
-            <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
-              No webhooks configured yet.
-            </div>
+            <EmptyState
+              icon={WebhookIcon}
+              title="No webhooks configured yet"
+              description="Create a webhook to receive events for this dashboard."
+            />
           ) : (
             <div className="space-y-2">
               {filteredWebhooks.map((webhook) => (

--- a/frontend/src/features/core/pages/webhooks.tsx
+++ b/frontend/src/features/core/pages/webhooks.tsx
@@ -215,12 +215,16 @@ export function WebhooksPanel() {
 
           {webhooksQuery.isLoading ? (
             <SkeletonText lines={3} />
-          ) : filteredWebhooks.length === 0 ? (
+          ) : (webhooksQuery.data?.length ?? 0) === 0 ? (
             <EmptyState
               icon={WebhookIcon}
               title="No webhooks configured yet"
               description="Create a webhook to receive events for this dashboard."
             />
+          ) : filteredWebhooks.length === 0 ? (
+            <p className="rounded-md p-6 text-center text-sm text-muted-foreground">
+              No webhooks match the current filter.
+            </p>
           ) : (
             <div className="space-y-2">
               {filteredWebhooks.map((webhook) => (

--- a/frontend/src/features/observability/pages/metrics-dashboard.test.tsx
+++ b/frontend/src/features/observability/pages/metrics-dashboard.test.tsx
@@ -197,7 +197,7 @@ describe('MetricsDashboardPage', () => {
 
   it('shows select container prompt when no selection', () => {
     renderPage();
-    expect(screen.getByText('Select a Container')).toBeTruthy();
+    expect(screen.getByText('Select a container')).toBeTruthy();
   });
 
   it('renders endpoint selector', () => {

--- a/frontend/src/features/observability/pages/metrics-dashboard.tsx
+++ b/frontend/src/features/observability/pages/metrics-dashboard.tsx
@@ -10,7 +10,6 @@ import {
   Clock,
   Server,
   Box,
-  RefreshCw,
   ZoomIn,
   ZoomOut,
   TrendingUp,
@@ -30,7 +29,8 @@ import { AnomalySparkline } from '@/shared/components/charts/anomaly-sparkline';
 import { NetworkTrafficTooltip } from '@/shared/components/charts/network-traffic-tooltip';
 import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
-import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonText, SkeletonChart, SkeletonTableRow } from '@/shared/components/feedback/skeleton';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { InlineChatPanel } from '@/features/ai-intelligence/components/metrics/inline-chat-panel';
 import { useLlmModels } from '@/features/ai-intelligence/hooks/use-llm-models';
@@ -519,14 +519,11 @@ export default function MetricsDashboardPage() {
           </div>
 
           {networkTrafficData.length === 0 ? (
-            <div className="flex h-[320px] items-center justify-center rounded-lg border border-dashed bg-muted/20 p-8 text-center">
-              <div>
-                <p className="font-medium">No connected networks found for this container</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Select a different container or check container network attachments.
-                </p>
-              </div>
-            </div>
+            <EmptyState
+              icon={Network}
+              title="No connected networks found"
+              description="Select a different container or check container network attachments."
+            />
           ) : (
             <div className="space-y-3">
               <div className="h-[320px]">
@@ -570,20 +567,18 @@ export default function MetricsDashboardPage() {
       {/* Loading State */}
       {isLoading && (
         <div className="space-y-4">
-          <SkeletonCard className="h-[350px]" />
-          <SkeletonCard className="h-[350px]" />
+          <SkeletonChart size="lg" />
+          <SkeletonChart size="lg" />
         </div>
       )}
 
       {/* No Selection State */}
       {!isLoading && !hasSelection && (
-        <div className="rounded-lg border border-dashed bg-muted/20 p-12 text-center">
-          <Server className="mx-auto h-12 w-12 text-muted-foreground" />
-          <h3 className="mt-4 text-lg font-semibold">Select a Container</h3>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Choose an endpoint and container to view metrics
-          </p>
-        </div>
+        <EmptyState
+          icon={Server}
+          title="Select a container"
+          description="Choose an endpoint and container to view metrics."
+        />
       )}
 
       {/* Metrics Content */}
@@ -634,7 +629,7 @@ export default function MetricsDashboardPage() {
 
           {/* AI Summary */}
           {showSecondaryPanels ? (
-            <Suspense fallback={<SkeletonCard className="h-[120px]" />}>
+            <Suspense fallback={<SkeletonText lines={2} />}>
               <LazyAiMetricsSummary
                 endpointId={selectedEndpoint ?? undefined}
                 containerId={selectedContainer ?? undefined}
@@ -642,32 +637,21 @@ export default function MetricsDashboardPage() {
               />
             </Suspense>
           ) : (
-            <SkeletonCard className="h-[120px]" />
+            <SkeletonText lines={2} />
           )}
 
           {/* Charts */}
           {metricsLoading ? (
             <div className="space-y-4">
-              <SkeletonCard className="h-[350px]" />
-              <SkeletonCard className="h-[350px]" />
+              <SkeletonChart size="lg" />
+              <SkeletonChart size="lg" />
             </div>
           ) : allMetricsEmpty ? (
-            <div className="rounded-lg border border-dashed bg-muted/20 p-8 text-center">
-              <Clock className="mx-auto h-10 w-10 text-muted-foreground" />
-              <h4 className="mt-3 font-semibold">No Metrics Data Available</h4>
-              <p className="mt-2 text-sm text-muted-foreground max-w-lg mx-auto">
-                No metrics have been recorded for this container in the selected time range.
-                This can happen when:
-              </p>
-              <ul className="mt-3 text-sm text-muted-foreground space-y-1 max-w-md mx-auto text-left list-disc list-inside">
-                <li>The container was recently started and metrics collection hasn&apos;t run yet (runs every 60 seconds)</li>
-                <li>The container is stopped or paused</li>
-                <li>The selected time range doesn&apos;t overlap with when the container was running</li>
-              </ul>
-              <p className="mt-4 text-xs text-muted-foreground">
-                Try selecting a wider time range or wait for the next collection cycle.
-              </p>
-            </div>
+            <EmptyState
+              icon={Clock}
+              title="No metrics data available"
+              description="No metrics have been recorded for this container in the selected time range. Containers record metrics every 60 seconds — try a wider time range or wait for collection."
+            />
           ) : (
             <div className="space-y-6">
               {/* CPU Chart */}
@@ -788,18 +772,12 @@ export default function MetricsDashboardPage() {
                 )}
               </div>
             ) : (
-              <div className="rounded-lg border border-dashed bg-muted/20 p-8 text-center">
-                <Clock className="mx-auto h-10 w-10 text-muted-foreground" />
-                <h4 className="mt-3 font-semibold">Collecting Metrics Data</h4>
-                <p className="mt-2 text-sm text-muted-foreground max-w-md mx-auto">
-                  Capacity forecasts require at least <span className="font-medium text-foreground">5 minutes</span> of
-                  metrics history. For higher confidence predictions, keep the container running
-                  for <span className="font-medium text-foreground">20+ minutes</span>.
-                </p>
-                <p className="mt-3 text-xs text-muted-foreground">
-                  Metrics are collected every 60 seconds. The longer the container runs, the more accurate the forecast.
-                </p>
-              </div>
+              <EmptyState
+                variant="not-configured"
+                icon={Clock}
+                title="Collecting metrics data"
+                description="Capacity forecasts require at least 5 minutes of metrics history. For higher confidence predictions, keep the container running for 20+ minutes."
+              />
             )}
           </div>
 
@@ -832,11 +810,11 @@ export default function MetricsDashboardPage() {
 
       {/* Cross-Container Correlation Insights */}
       {showSecondaryPanels ? (
-        <Suspense fallback={<SkeletonCard className="h-[260px]" />}>
+        <Suspense fallback={<SkeletonChart size="md" />}>
           <LazyCorrelationInsightsPanel llmAvailable={llmAvailable} hours={24} selectedContainerId={selectedContainer} />
         </Suspense>
       ) : (
-        <SkeletonCard className="h-[260px]" />
+        <SkeletonChart size="md" />
       )}
 
       {/* Forecast Overview */}
@@ -863,25 +841,28 @@ export default function MetricsDashboardPage() {
         </div>
 
         {forecastOverviewQuery.isLoading ? (
-          <div className="mt-4 space-y-2">
-            <div className="h-10 animate-pulse rounded bg-muted" />
-            <div className="h-10 animate-pulse rounded bg-muted" />
-            <div className="h-10 animate-pulse rounded bg-muted" />
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full min-w-[880px] text-sm">
+              <tbody>
+                <SkeletonTableRow columns={8} />
+                <SkeletonTableRow columns={8} />
+                <SkeletonTableRow columns={8} />
+              </tbody>
+            </table>
           </div>
         ) : forecastOverviewQuery.error ? (
-          <div className="mt-4 rounded-md border border-destructive/40 bg-destructive/10 p-4">
-            <p className="font-medium text-destructive">Failed to load forecast overview</p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              {forecastOverviewQuery.error instanceof Error ? forecastOverviewQuery.error.message : 'Unexpected error'}
-            </p>
-          </div>
+          <EmptyState
+            variant="error"
+            icon={AlertTriangle}
+            title="Failed to load forecast overview"
+            description={forecastOverviewQuery.error instanceof Error ? forecastOverviewQuery.error.message : 'Try again in a moment.'}
+          />
         ) : rankedForecasts.length === 0 ? (
-          <div className="mt-4 rounded-md border border-dashed bg-muted/20 p-6 text-center">
-            <p className="font-medium">No forecast data available</p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Keep metrics collection running to build cross-container forecast insights.
-            </p>
-          </div>
+          <EmptyState
+            icon={Clock}
+            title="No forecast data available"
+            description="Keep metrics collection running to build cross-container forecast insights."
+          />
         ) : (
           <div className="mt-4 overflow-x-auto">
             <table className="w-full min-w-[880px] text-sm">

--- a/frontend/src/features/observability/pages/trace-explorer.tsx
+++ b/frontend/src/features/observability/pages/trace-explorer.tsx
@@ -19,7 +19,8 @@ import { ServiceMap } from '@/shared/components/charts/service-map';
 import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
-import { SkeletonCard } from '@/shared/components/feedback/loading-skeleton';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { SkeletonChart, SkeletonList } from '@/shared/components/feedback/skeleton';
 import { cn, formatDate } from '@/shared/lib/utils';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
@@ -795,19 +796,18 @@ export default function TraceExplorerPage() {
           <h1 className="text-3xl font-bold tracking-tight">Trace Explorer</h1>
           <p className="text-muted-foreground">Distributed trace visualization with service map</p>
         </div>
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
-          <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
-          <p className="mt-4 font-medium text-destructive">Failed to load traces</p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {error instanceof Error ? error.message : 'An unexpected error occurred'}
-          </p>
-          <button
-            onClick={() => refetch()}
-            className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-          >
-            Try again
-          </button>
-        </div>
+        <EmptyState
+          variant="error"
+          icon={AlertTriangle}
+          title="Failed to load traces"
+          description={error instanceof Error ? error.message : 'An unexpected error occurred'}
+        />
+        <button
+          onClick={() => refetch()}
+          className="mt-4 inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+        >
+          Try again
+        </button>
       </div>
     );
   }
@@ -1408,21 +1408,21 @@ export default function TraceExplorerPage() {
 
       {isLoading ? (
         <div className="grid gap-6 lg:grid-cols-3">
-          <SkeletonCard className="h-[600px]" />
+          <SkeletonList rows={4} className="h-[600px]" />
           <div className="lg:col-span-2">
-            <SkeletonCard className="h-[600px]" />
+            <SkeletonChart size="lg" className="h-[600px]" />
           </div>
         </div>
       ) : filteredTraces.length === 0 ? (
-        <div className="rounded-lg border border-dashed bg-muted/20 p-12 text-center">
-          <GitBranch className="mx-auto h-12 w-12 text-muted-foreground" />
-          <h3 className="mt-4 text-lg font-semibold">No traces found</h3>
-          <p className="mt-2 text-sm text-muted-foreground">
-            {searchQuery || serviceFilter || sourceFilter || hasAdvancedFiltersApplied
+        <EmptyState
+          icon={GitBranch}
+          title="No traces found"
+          description={
+            searchQuery || serviceFilter || sourceFilter || hasAdvancedFiltersApplied
               ? 'Try adjusting your search or filter criteria.'
-              : 'No distributed traces have been collected yet.'}
-          </p>
-        </div>
+              : 'No distributed traces have been collected yet.'
+          }
+        />
       ) : (
         <div className="grid gap-6 lg:grid-cols-3">
           <div className="max-h-[600px] space-y-3 overflow-y-auto pr-2">

--- a/frontend/src/features/observability/pages/trace-explorer.tsx
+++ b/frontend/src/features/observability/pages/trace-explorer.tsx
@@ -1698,12 +1698,12 @@ export default function TraceExplorerPage() {
               </div>
               </SpotlightCard>
             ) : (
-              <div className="flex h-[600px] items-center justify-center rounded-lg border border-dashed bg-muted/20">
-                <div className="text-center">
-                  <ChevronRight className="mx-auto h-8 w-8 text-muted-foreground" />
-                  <p className="mt-2 text-sm text-muted-foreground">Select a trace to view details</p>
-                </div>
-              </div>
+              <EmptyState
+                icon={ChevronRight}
+                title="Select a trace to view details"
+                description="Pick a trace from the list to inspect its spans, timing, and metadata."
+                className="h-[600px] justify-center"
+              />
             )}
           </div>
         </div>

--- a/frontend/src/shared/components/feedback/empty-state.test.tsx
+++ b/frontend/src/shared/components/feedback/empty-state.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Activity, AlertTriangle, Settings } from 'lucide-react';
+import { EmptyState } from './empty-state';
+
+vi.mock('@/stores/ui-store', () => ({
+  useUiStore: (selector: (s: { potatoMode: boolean }) => boolean) =>
+    selector({ potatoMode: false }),
+}));
+
+describe('EmptyState', () => {
+  it('renders the title', () => {
+    render(<EmptyState icon={Activity} title="No traces yet" />);
+    expect(screen.getByText('No traces yet')).toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    render(
+      <EmptyState
+        icon={Activity}
+        title="No traces yet"
+        description="Run a workload to start capturing distributed traces."
+      />,
+    );
+    expect(
+      screen.getByText('Run a workload to start capturing distributed traces.'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits description paragraph when not provided', () => {
+    const { container } = render(<EmptyState icon={Activity} title="Empty" />);
+    expect(container.querySelectorAll('p')).toHaveLength(0);
+  });
+
+  it('uses neutral muted tint for default (empty) variant', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    const iconEl = container.querySelector('svg');
+    expect(iconEl).toHaveClass('text-muted-foreground');
+  });
+
+  it('uses destructive tint for error variant', () => {
+    const { container } = render(
+      <EmptyState variant="error" icon={AlertTriangle} title="Failed" />,
+    );
+    const iconEl = container.querySelector('svg');
+    expect(iconEl).toHaveClass('text-destructive/80');
+  });
+
+  it('uses amber tint for not-configured variant', () => {
+    const { container } = render(
+      <EmptyState variant="not-configured" icon={Settings} title="Not set up" />,
+    );
+    const iconEl = container.querySelector('svg');
+    expect(iconEl).toHaveClass('text-amber-500/80');
+  });
+
+  it('renders the canonical pane chrome (border + bg-card + shadow-sm + rounded-lg)', () => {
+    render(<EmptyState icon={Activity} title="t" />);
+    const card = screen.getByTestId('empty-state-card');
+    expect(card).toHaveClass('rounded-lg', 'border', 'bg-card', 'shadow-sm');
+  });
+
+  it('applies a custom className to the inner card', () => {
+    render(<EmptyState icon={Activity} title="t" className="h-64" />);
+    expect(screen.getByTestId('empty-state-card')).toHaveClass('h-64');
+  });
+
+  it('renders a circular icon chip around the icon', () => {
+    const { container } = render(<EmptyState icon={Activity} title="t" />);
+    const chip = container.querySelector('.rounded-full');
+    expect(chip).toBeInTheDocument();
+    expect(chip?.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/feedback/empty-state.tsx
+++ b/frontend/src/shared/components/feedback/empty-state.tsx
@@ -1,64 +1,47 @@
+import type { LucideIcon } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
-import { Inbox, Search, AlertCircle, FileQuestion } from 'lucide-react';
+import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
-type EmptyStateVariant = 'default' | 'search' | 'error' | 'no-data';
+export type EmptyStateVariant = 'empty' | 'error' | 'not-configured';
 
-const variantIcons = {
-  default: Inbox,
-  search: Search,
-  error: AlertCircle,
-  'no-data': FileQuestion,
-};
-
-const variantColors = {
-  default: 'text-muted-foreground',
-  search: 'text-blue-500',
-  error: 'text-destructive',
-  'no-data': 'text-amber-500',
-};
-
-interface EmptyStateProps {
+export interface EmptyStateProps {
+  variant?: EmptyStateVariant;
+  icon: LucideIcon;
   title: string;
   description?: string;
-  variant?: EmptyStateVariant;
-  icon?: React.ReactNode;
-  action?: React.ReactNode;
   className?: string;
 }
 
+const iconTintByVariant: Record<EmptyStateVariant, string> = {
+  empty: 'text-muted-foreground',
+  error: 'text-destructive/80',
+  'not-configured': 'text-amber-500/80',
+};
+
 export function EmptyState({
+  variant = 'empty',
+  icon: Icon,
   title,
   description,
-  variant = 'default',
-  icon,
-  action,
   className,
 }: EmptyStateProps) {
-  const Icon = variantIcons[variant];
-  const iconColor = variantColors[variant];
-
   return (
-    <div
-      className={cn(
-        'flex flex-col items-center justify-center rounded-lg border border-dashed bg-muted/20 p-12 text-center',
-        className
-      )}
-    >
+    <SpotlightCard>
       <div
+        data-testid="empty-state-card"
         className={cn(
-          'flex h-16 w-16 items-center justify-center rounded-full bg-muted/50',
-          iconColor
+          'flex flex-col items-center justify-center rounded-lg border bg-card p-8 text-center shadow-sm',
+          className,
         )}
       >
-        {icon || <Icon className="h-8 w-8" />}
+        <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-muted/40">
+          <Icon className={cn('h-6 w-6', iconTintByVariant[variant])} />
+        </div>
+        <h3 className="text-sm font-semibold text-foreground/80">{title}</h3>
+        {description && (
+          <p className="mt-1 max-w-sm text-xs text-muted-foreground">{description}</p>
+        )}
       </div>
-      <h3 className="mt-4 text-lg font-semibold">{title}</h3>
-      {description && (
-        <p className="mt-2 max-w-sm text-sm text-muted-foreground">
-          {description}
-        </p>
-      )}
-      {action && <div className="mt-6">{action}</div>}
-    </div>
+    </SpotlightCard>
   );
 }

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -59,3 +59,38 @@ describe('SkeletonKpi', () => {
     expect(container.firstChild).toHaveClass('h-full');
   });
 });
+
+describe('SkeletonTableRow', () => {
+  it('renders the requested number of cells', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow columns={5} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('tr > td')).toHaveLength(5);
+  });
+
+  it('puts a pulsing bar inside each cell', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow columns={3} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('td > .animate-pulse')).toHaveLength(3);
+  });
+
+  it('defaults to 4 columns when no count is provided', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SkeletonTableRow />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  SkeletonText,
+  SkeletonKpi,
+  SkeletonTableRow,
+  SkeletonChart,
+  SkeletonList,
+} from './skeleton';
+
+describe('SkeletonText', () => {
+  it('renders the default number of lines (3)', () => {
+    const { container } = render(<SkeletonText />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('renders the requested number of lines', () => {
+    const { container } = render(<SkeletonText lines={6} />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(6);
+  });
+
+  it('marks the last line narrower than the others', () => {
+    const { container } = render(<SkeletonText lines={4} />);
+    const lines = container.querySelectorAll('.animate-pulse');
+    expect(lines[lines.length - 1]).toHaveClass('w-2/3');
+  });
+
+  it('exposes a status role with a loading label', () => {
+    render(<SkeletonText />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className to the wrapper', () => {
+    const { container } = render(<SkeletonText className="mt-4" />);
+    expect(container.firstChild).toHaveClass('mt-4');
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -14,6 +14,17 @@ describe('SkeletonText', () => {
     expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
   });
 
+  it('disables the pulse animation under prefers-reduced-motion', () => {
+    // The `motion-reduce:animate-none` Tailwind utility maps to a class that
+    // resolves to `animation: none` inside `@media (prefers-reduced-motion:
+    // reduce)`. jsdom can't evaluate the media query, so we assert the class
+    // is present on each pulsing bar; the CSS handles the rest.
+    const { container } = render(<SkeletonText />);
+    const bars = container.querySelectorAll('.animate-pulse');
+    expect(bars.length).toBeGreaterThan(0);
+    bars.forEach((bar) => expect(bar).toHaveClass('motion-reduce:animate-none'));
+  });
+
   it('renders the requested number of lines', () => {
     const { container } = render(<SkeletonText lines={6} />);
     expect(container.querySelectorAll('.animate-pulse')).toHaveLength(6);

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -35,3 +35,27 @@ describe('SkeletonText', () => {
     expect(container.firstChild).toHaveClass('mt-4');
   });
 });
+
+describe('SkeletonKpi', () => {
+  it('renders three stacked bars (label, big number, sublabel)', () => {
+    const { container } = render(<SkeletonKpi />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('renders the big number bar taller than the label bar', () => {
+    const { container } = render(<SkeletonKpi />);
+    const bars = container.querySelectorAll('.animate-pulse');
+    expect(bars[1]).toHaveClass('h-8');
+    expect(bars[0]).toHaveClass('h-3');
+  });
+
+  it('exposes status role with loading label', () => {
+    render(<SkeletonKpi />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(<SkeletonKpi className="h-full" />);
+    expect(container.firstChild).toHaveClass('h-full');
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -93,6 +93,13 @@ describe('SkeletonTableRow', () => {
     );
     expect(container.querySelectorAll('td')).toHaveLength(4);
   });
+
+  it('applies a custom className to the tr', () => {
+    const { container } = render(
+      <table><tbody><SkeletonTableRow className="bg-muted" /></tbody></table>,
+    );
+    expect(container.querySelector('tr')).toHaveClass('bg-muted');
+  });
 });
 
 describe('SkeletonChart', () => {
@@ -143,5 +150,10 @@ describe('SkeletonList', () => {
   it('exposes a status role with loading label', () => {
     render(<SkeletonList />);
     expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className to the wrapper', () => {
+    const { container } = render(<SkeletonList className="p-4" />);
+    expect(container.firstChild).toHaveClass('p-4');
   });
 });

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -94,3 +94,30 @@ describe('SkeletonTableRow', () => {
     expect(container.querySelectorAll('td')).toHaveLength(4);
   });
 });
+
+describe('SkeletonChart', () => {
+  it('renders a single pulsing block', () => {
+    const { container } = render(<SkeletonChart />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('defaults to medium height (h-48)', () => {
+    const { container } = render(<SkeletonChart />);
+    expect(container.firstChild).toHaveClass('h-48');
+  });
+
+  it('uses h-80 for large size', () => {
+    const { container } = render(<SkeletonChart size="lg" />);
+    expect(container.firstChild).toHaveClass('h-80');
+  });
+
+  it('exposes status role with loading label', () => {
+    render(<SkeletonChart />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(<SkeletonChart className="mt-2" />);
+    expect(container.firstChild).toHaveClass('mt-2');
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.test.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.test.tsx
@@ -121,3 +121,27 @@ describe('SkeletonChart', () => {
     expect(container.firstChild).toHaveClass('mt-2');
   });
 });
+
+describe('SkeletonList', () => {
+  it('renders the default number of rows (4)', () => {
+    const { container } = render(<SkeletonList />);
+    expect(container.querySelectorAll('[data-skeleton-row]')).toHaveLength(4);
+  });
+
+  it('renders the requested number of rows', () => {
+    const { container } = render(<SkeletonList rows={7} />);
+    expect(container.querySelectorAll('[data-skeleton-row]')).toHaveLength(7);
+  });
+
+  it('renders an avatar circle plus two text bars per row', () => {
+    const { container } = render(<SkeletonList rows={1} />);
+    const row = container.querySelector('[data-skeleton-row]');
+    expect(row?.querySelector('.rounded-full')).toBeInTheDocument();
+    expect(row?.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('exposes a status role with loading label', () => {
+    render(<SkeletonList />);
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -24,3 +24,18 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
     </div>
   );
 }
+
+export interface SkeletonKpiProps {
+  className?: string;
+}
+
+export function SkeletonKpi({ className }: SkeletonKpiProps) {
+  return (
+    <div className={cn('space-y-3', className)} role="status" aria-label="Loading">
+      <div className={cn(PULSE, 'h-3 w-1/3')} />
+      <div className={cn(PULSE, 'h-8 w-1/2')} />
+      <div className={cn(PULSE, 'h-3 w-2/5')} />
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -25,44 +25,16 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
   );
 }
 
-export interface SkeletonListProps {
-  rows?: number;
+export interface SkeletonKpiProps {
   className?: string;
 }
 
-export function SkeletonList({ rows = 4, className }: SkeletonListProps) {
+export function SkeletonKpi({ className }: SkeletonKpiProps) {
   return (
-    <div
-      className={cn('space-y-3', className)}
-      role="status"
-      aria-label="Loading"
-    >
-      {Array.from({ length: rows }).map((_, i) => (
-        <div key={i} data-skeleton-row className="flex items-center gap-3">
-          <div className={cn(PULSE, 'h-8 w-8 rounded-full')} />
-          <div className="flex-1 space-y-2">
-            <div className={cn(PULSE, 'h-3 w-1/2')} />
-            <div className={cn(PULSE, 'h-3 w-1/3')} />
-          </div>
-        </div>
-      ))}
-      <span className="sr-only">Loading…</span>
-    </div>
-  );
-}
-
-export interface SkeletonChartProps {
-  size?: 'md' | 'lg';
-  className?: string;
-}
-
-export function SkeletonChart({ size = 'md', className }: SkeletonChartProps) {
-  return (
-    <div
-      className={cn(PULSE, 'w-full', size === 'lg' ? 'h-80' : 'h-48', className)}
-      role="status"
-      aria-label="Loading"
-    >
+    <div className={cn('space-y-3', className)} role="status" aria-label="Loading">
+      <div className={cn(PULSE, 'h-3 w-1/3')} />
+      <div className={cn(PULSE, 'h-8 w-1/2')} />
+      <div className={cn(PULSE, 'h-3 w-2/5')} />
       <span className="sr-only">Loading…</span>
     </div>
   );
@@ -85,16 +57,45 @@ export function SkeletonTableRow({ columns = 4, className }: SkeletonTableRowPro
   );
 }
 
-export interface SkeletonKpiProps {
+export interface SkeletonChartProps {
+  size?: 'md' | 'lg';
   className?: string;
 }
 
-export function SkeletonKpi({ className }: SkeletonKpiProps) {
+export function SkeletonChart({ size = 'md', className }: SkeletonChartProps) {
   return (
-    <div className={cn('space-y-3', className)} role="status" aria-label="Loading">
-      <div className={cn(PULSE, 'h-3 w-1/3')} />
-      <div className={cn(PULSE, 'h-8 w-1/2')} />
-      <div className={cn(PULSE, 'h-3 w-2/5')} />
+    <div
+      className={cn('w-full', size === 'lg' ? 'h-80' : 'h-48', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      <div className={cn(PULSE, 'h-full w-full')} />
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
+export interface SkeletonListProps {
+  rows?: number;
+  className?: string;
+}
+
+export function SkeletonList({ rows = 4, className }: SkeletonListProps) {
+  return (
+    <div
+      className={cn('space-y-3', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} data-skeleton-row className="flex items-center gap-3">
+          <div className={cn(PULSE, 'h-8 w-8 rounded-full')} />
+          <div className="flex-1 space-y-2">
+            <div className={cn(PULSE, 'h-3 w-1/2')} />
+            <div className={cn(PULSE, 'h-3 w-1/3')} />
+          </div>
+        </div>
+      ))}
       <span className="sr-only">Loading…</span>
     </div>
   );

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/shared/lib/utils';
 
-const PULSE = 'animate-pulse rounded bg-muted/40';
+const PULSE = 'animate-pulse motion-reduce:animate-none rounded bg-muted/40';
 
 export interface SkeletonTextProps {
   lines?: number;

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -25,6 +25,23 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
   );
 }
 
+export interface SkeletonTableRowProps {
+  columns?: number;
+  className?: string;
+}
+
+export function SkeletonTableRow({ columns = 4, className }: SkeletonTableRowProps) {
+  return (
+    <tr className={className}>
+      {Array.from({ length: columns }).map((_, i) => (
+        <td key={i} className="px-3 py-2">
+          <div className={cn(PULSE, 'h-3 w-full')} />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
 export interface SkeletonKpiProps {
   className?: string;
 }

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -25,6 +25,23 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
   );
 }
 
+export interface SkeletonChartProps {
+  size?: 'md' | 'lg';
+  className?: string;
+}
+
+export function SkeletonChart({ size = 'md', className }: SkeletonChartProps) {
+  return (
+    <div
+      className={cn(PULSE, 'w-full', size === 'lg' ? 'h-80' : 'h-48', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
 export interface SkeletonTableRowProps {
   columns?: number;
   className?: string;

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -25,6 +25,32 @@ export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
   );
 }
 
+export interface SkeletonListProps {
+  rows?: number;
+  className?: string;
+}
+
+export function SkeletonList({ rows = 4, className }: SkeletonListProps) {
+  return (
+    <div
+      className={cn('space-y-3', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} data-skeleton-row className="flex items-center gap-3">
+          <div className={cn(PULSE, 'h-8 w-8 rounded-full')} />
+          <div className="flex-1 space-y-2">
+            <div className={cn(PULSE, 'h-3 w-1/2')} />
+            <div className={cn(PULSE, 'h-3 w-1/3')} />
+          </div>
+        </div>
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
 export interface SkeletonChartProps {
   size?: 'md' | 'lg';
   className?: string;

--- a/frontend/src/shared/components/feedback/skeleton.tsx
+++ b/frontend/src/shared/components/feedback/skeleton.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/shared/lib/utils';
+
+const PULSE = 'animate-pulse rounded bg-muted/40';
+
+export interface SkeletonTextProps {
+  lines?: number;
+  className?: string;
+}
+
+export function SkeletonText({ lines = 3, className }: SkeletonTextProps) {
+  return (
+    <div
+      className={cn('space-y-2', className)}
+      role="status"
+      aria-label="Loading"
+    >
+      {Array.from({ length: lines }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(PULSE, 'h-3', i === lines - 1 ? 'w-2/3' : 'w-full')}
+        />
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Migrates every ad-hoc empty / loading / error state on the seven highest-traffic pages to the primitives shipped in PR 1:

- `home`, `workload-explorer`, `trace-explorer`, `llm-observability`, `ai-monitor` — light-touch pages
- `fleet-overview` — endpoints / stacks / k8s state branches
- `metrics-dashboard` — heaviest page, 14 migrations across empties / errors / loadings / forecast not-configured

Net effect: zero ad-hoc `border-dashed bg-muted/20` empty states and zero raw `<SkeletonCard>` calls on these seven pages.

A small follow-up commit also covers the trace-explorer right-pane "Select a trace to view details" placeholder that was missed in the first trace-explorer migration commit.

## Out of scope

- Long-tail migrations (~15 pages remaining) — PR 3.
- Removing the `LoadingSkeleton` / `SkeletonCard` exports themselves — PR 3, after all callers are gone.

## Test plan

- [x] Frontend test suite green (1912/1912 tests).
- [x] \`tsc --noEmit\` clean.
- [x] \`npm run lint\` clean.
- [x] \`grep -nE 'SkeletonCard|border-dashed|Loading\.\.\.'\` on the seven pages: empty output.
- [ ] Manual smoke pass on each page — verify empty / loading / error states render with canonical chrome and no layout shift.

Spec: \`docs/superpowers/specs/2026-05-16-empty-loading-states-design.md\`
Plan: \`docs/superpowers/plans/2026-05-16-empty-loading-states-pr2-high-traffic.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)