### PR TITLE
feat(monitoring): dedup-engine telemetry + research-question decisions (#1200)

### DIFF
--- a/docs/superpowers/specs/2026-05-16-1200-dedup-telemetry-design.md
+++ b/docs/superpowers/specs/2026-05-16-1200-dedup-telemetry-design.md
@@ -1,0 +1,179 @@
+# Incident-engine dedup telemetry + research-question decisions (#1200)
+
+**Status:** Design — drives the implementation in this PR.
+**Author:** simon
+**Date:** 2026-05-16
+**Closes:** #1200
+**Follows:** #1195 (architectural context), #1199 (code-level dedup fixes shipped 2026-05-07)
+
+## Goals
+
+1. **Telemetry**: emit per-signature aggregate ratios so the next round of engine work is data-driven instead of guessed.
+2. **Decisions**: document a position on each of the five research questions and the Confirmed Issue 2 (non-anomaly correlation) decision from #1195.
+
+The PR ships the telemetry and the runnable analysis script. The decisions are recommendations grounded in the synthetic-data analysis below — they're explicit so the next engine PR has somewhere to start, not a final ruling.
+
+## Findings
+
+> **Synthetic data caveat.** Dev has been running monitoring for 22h since #1199 merged but has produced **zero** insights/incidents (no anomalies have fired). The numbers below were generated from a 7-day synthetic seed at `/tmp/seed-1200-analysis.sql` (320 insights, 15 incidents, 8 containers, 8 signatures). They are **illustrative of the shape** of expected production data, not real measurements. Run `scripts/analyze-dedup-engine.sql` against prod once data has accrued, then revise this doc.
+
+### Q1 — alerts_per_container ratio per derived signature
+
+| signature | total_insights | distinct_containers | alerts_per_container |
+|---|---|---|---|
+| `anomaly:threshold:cpu` | 144 | 8 | **18.00** |
+| `anomaly:ml-anomaly:memory` | 48 | 8 | 6.00 |
+| `log:pattern` | 40 | 8 | 5.00 |
+| `ai:analysis` | 32 | 8 | 4.00 |
+| `security:scan` | 24 | 8 | 3.00 |
+| `predictive:prediction:memory` | 16 | 8 | 2.00 |
+| `anomaly:threshold:disk` | 8 | 8 | 1.00 |
+| `predictive:prediction:disk` | 8 | 8 | 1.00 |
+
+The threshold-CPU detector dominates emissions ~3× the next-loudest signature. In prod this is the first place to tighten cooldowns.
+
+### Q2 — insights_per_incident per signature
+
+| signature | total_incidents | avg_insights_per_incident |
+|---|---|---|
+| `anomaly:ml-anomaly:memory` | 5 | 6.00 |
+| `predictive:prediction:memory` | 5 | 2.00 |
+| `anomaly:threshold:cpu` | 5 | **18.00** |
+
+Correlation is doing its job for the anomaly category — 18 raw CPU insights collapse into 1 incident per container. The LLM summarizer downstream sees ~5–6× compression on average.
+
+### Q3 — emission share by category
+
+| category | total | pct |
+|---|---|---|
+| anomaly | 200 | 62.5 |
+| log-analysis | 40 | 12.5 |
+| ai-analysis | 32 | 10.0 |
+| security | 24 | 7.5 |
+| predictive | 24 | 7.5 |
+
+**37.5%** of all emissions today bypass `correlateInsights()` entirely (only `category === 'anomaly'` enters correlation, per `incident-correlator.ts:56`).
+
+### Q4 — dedup headroom for non-anomaly categories
+
+| category | insights | would_be_deduped | pct_deduped |
+|---|---|---|---|
+| log-analysis | 40 | 32 | 80.0% |
+| ai-analysis | 32 | 24 | 75.0% |
+| security | 24 | 16 | 66.7% |
+| predictive | 24 | 8 | 33.3% |
+
+Log, AI-analysis, and security categories would shed 67–80% of their volume if grouped by `(signature, container_name)`. Predictive only sheds ~33% — predictions are mostly naturally distinct (different time horizons, different metrics).
+
+## Decisions
+
+### RQ1 — Should non-anomaly insights form / join incidents?
+
+**Yes for `security`, `log-analysis`, `ai-analysis`. Yes for `predictive` but with a longer dedup window. Implementation deferred to a follow-up PR.**
+
+| Category | Eligible for `correlateInsights()` | Rationale |
+|---|---|---|
+| anomaly | ✓ (today) | Already wired |
+| security | ✓ (proposed) | Q4: 67% dedup headroom; signature is stable (`security:scan`) |
+| log-analysis | ✓ (proposed) | Q4: 80% headroom; same log pattern fires every poll until resolved |
+| ai-analysis | ✓ (proposed) | Q4: 75% headroom; LLM re-runs produce duplicate findings |
+| predictive | ✓ (proposed, separate TTL) | Q4: 33% headroom; predictions inherently span longer horizons (see RQ2) |
+| config / other | ✗ | Volume too low; correlation overhead exceeds win |
+
+**Dedup key:** `(signature, container_name)` — same shape as the current anomaly path, no new key derivation needed. `signature` is already populated for incidents and derivable for insights via `deriveSignature()`.
+
+**Why this isn't shipped in this PR:** it changes `correlateInsights()` semantics and would conflate analysis with implementation. We need this PR to ship the telemetry so a future PR can A/B the change against real ratios. Once `monitoring_dedup_metrics` rows accrue for a week post-merge, the follow-up PR has a baseline to compare against.
+
+### RQ2 — Right dedup TTL for predictions
+
+**Per-category TTL, default 60min, overrides as below.**
+
+| Category | TTL | Why |
+|---|---|---|
+| anomaly | 60 min (current) | Matches metric collection cadence; anomalies often re-resolve within the hour |
+| security | 6 h | Scan results don't change minute-to-minute |
+| log-analysis | 30 min | Logs are continuous; tighter window prevents spam from a single noisy pattern |
+| ai-analysis | 2 h | LLM re-runs are paced; 2h matches the analysis interval |
+| predictive | **24 h** | A "memory exhaustion in 24 hours" prediction should not re-fire 24 times before the window elapses |
+
+**Implementation hook:** add `getDedupWindowMs(category)` returning per-category milliseconds, called from `insights-store.ts` where `DEDUP_WINDOW_MINUTES` is used today. The constant becomes a function. Deferred to the same follow-up PR as RQ1.
+
+### RQ3 — Do the three dedup layers conflict?
+
+**Yes, they key on different shapes. Recommendation: keep three layers but unify the key as `signature`.**
+
+| Layer | File | Key today | Recommended key |
+|---|---|---|---|
+| 1. Detection cooldown | `monitoring-service.ts:58` (`anomalyCooldowns` Map) | `${containerId}:${metricType}` | `${containerId}:${signature}` |
+| 2. Insertion dedup | `insights-store.ts:8` (`DEDUP_WINDOW_MINUTES`) | structured fields OR title slug | `signature` |
+| 3. Incident correlation | `incident-correlator.ts:206` (`groupByContainerAndMetric`) | `(container_id, metric_type)` | `(container_id, signature)` |
+
+Why three layers, not one: they fire at different points in the pipeline (pre-detection / pre-insert / post-insert) and serve different purposes (CPU savings vs DB pressure vs UX rollup). Collapsing them into one would lose the CPU savings of layer 1.
+
+Why unify the key: today's keys overlap partially. `metricType` ≠ `signature` because two detectors on the same metric (e.g. threshold vs ML-anomaly) collide on layer 1 but split on layer 3. After unification, the layers agree on what "the same event" means.
+
+**Implementation hook:** introduce a single `dedupKey(insight) → signature` helper in `signature.ts`. Replace the three call-site key derivations with calls to that helper. Deferred follow-up.
+
+### RQ4 — Actual emission distribution
+
+**Top offender: `anomaly:threshold:cpu`** (illustrative — 3× the next-loudest signature in the synthetic data; expected to be similar in prod).
+
+**Engine targets, in priority order:**
+
+1. Tighten `anomaly:threshold:cpu` cooldown (longest cooldown of any signature)
+2. Audit `anomaly:ml-anomaly:memory` for whether the ML detector is re-firing on the same anomaly band
+3. Once non-anomaly categories enter correlation, re-measure — log/ai/security shouldn't sit in the top emitters anymore
+
+The new `monitoring_dedup_metrics` table this PR adds is the long-term source for this list — operators can `SELECT * FROM monitoring_dedup_metrics ORDER BY collected_at DESC, alerts_per_container DESC` to see the current top emitters at any point.
+
+### RQ5 — Should the LLM summarizer take the deduped incident or the raw insight stream?
+
+**Deduped incident (current behaviour). Keep.**
+
+Q2 shows the correlation engine produces ~6× compression on average (18 insights → 1 incident for high-volume signatures). If we tightened dedup further by adopting the RQ1+RQ2 changes, compression rises. Feeding raw insights would waste prompt budget and lose the human-meaningful grouping.
+
+**No code change required.** Documented here so the follow-up PRs don't accidentally route raw streams to the LLM.
+
+### Confirmed Issue 2 (from #1195) — non-anomaly insights joining `correlateInsights()`
+
+Covered by RQ1 above. **Yes** for security / log-analysis / ai-analysis / predictive, with `(signature, container_name)` as the dedup key and per-category TTL (RQ2). Deferred to the follow-up PR.
+
+## What this PR ships
+
+### Telemetry
+
+- **Migration 033** (`packages/core/src/db/postgres-migrations/033_monitoring_dedup_metrics.sql`): new `monitoring_dedup_metrics` table with one row per `(signature, collected_at)` and columns for the four metrics from Q1/Q2 plus a window-length tag.
+- **Service** (`packages/ai-intelligence/src/services/dedup-telemetry.ts`):
+  - `collectDedupMetrics({ db })` — runs the four aggregation queries, returns rows for insertion.
+  - `runDedupTelemetryCycle({ db })` — the scheduler-callable wrapper that collects + inserts + logs.
+- **Store** (`packages/ai-intelligence/src/services/dedup-telemetry-store.ts`): `insertDedupMetrics(rows)`, `getLatestDedupMetrics(limit)`.
+- **Scheduler hook** (`packages/server/src/scheduler.ts`): registers the new job at **1-hour cadence**. Rationale: the underlying SQL is cheap (indexed on `signature`, `created_at`); hourly captures intraday variance without flooding the table; the new table grows ~24 rows per signature per day.
+- **Route** (`packages/ai-intelligence/src/routes/dedup-telemetry.ts`): `GET /api/dedup-telemetry` returning the latest snapshot. **Admin-only** via `fastify.requireRole('admin')` (sensitive: exposes signature-level emission rates that could inform an attacker about detection coverage).
+- **Tests** (`packages/ai-intelligence/src/__tests__/dedup-telemetry.test.ts`): real-Postgres integration tests covering the four query shapes, the per-signature rollup, the route auth gate, and idempotency under repeated cycles.
+
+### Runnable analysis script
+
+`scripts/analyze-dedup-engine.sql` — the four queries above, runnable against any environment. Drop into prod psql once data has accumulated.
+
+## What this PR does NOT ship
+
+- The RQ1 / RQ2 / RQ3 code changes themselves. Those are the next PR (call it #1200-followup), once the new `monitoring_dedup_metrics` table has a week of real data to baseline against.
+- Any change to `correlateInsights()`, `insights-store.ts`, or `monitoring-service.ts` dedup logic.
+- A Prometheus exporter. The `monitoring_dedup_metrics` table is the data sink; if the operator wants Prometheus scraping later, they can add an exporter on top of the table. Choosing DB over Prom here because we want historical comparison (week-over-week deltas), not just current values.
+
+## Test plan
+
+- [x] `scripts/analyze-dedup-engine.sql` runs against the dev DB (with synthetic seed) and produces the tables above.
+- [ ] Migration 033 applies cleanly on a fresh DB.
+- [ ] Telemetry job collects metrics from a seeded DB and inserts the expected rows.
+- [ ] `GET /api/dedup-telemetry` rejects non-admin requests (401/403).
+- [ ] Scheduler doesn't crash if the job throws (existing pattern from `runCleanup`).
+- [ ] Full backend test suite green.
+- [ ] tsc + eslint clean.
+
+## Open follow-ups (out of scope for this PR)
+
+1. **#1200-followup** — adopt the RQ1/RQ2/RQ3 changes, gated on the telemetry baseline.
+2. **Prometheus exporter** — only if operators ask. The table is the canonical source.
+3. **Grafana board** — top-emitter dashboard from the new table. Lives in `docs/observability/` if added.
+4. **Migration-runner idempotency bug** — orthogonal pre-existing issue noted during epic #1243 work; new migrations don't always auto-apply on test DBs. Not blocking this PR but should be fixed separately.

--- a/packages/ai-intelligence/src/__tests__/dedup-telemetry-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/dedup-telemetry-route.test.ts
@@ -81,16 +81,19 @@ describe('GET /api/dedup-telemetry', () => {
     expect(body.rows[0].signature).toBe('anomaly:threshold:cpu');
   });
 
-  it('honours the signature query param', async () => {
+  it('honours the signature query param and binds it in the first positional slot', async () => {
     mockQuery.mockResolvedValueOnce([]);
     const res = await adminApp.inject({
       method: 'GET',
       url: '/api/dedup-telemetry?signature=anomaly:threshold:cpu',
     });
     expect(res.statusCode).toBe(200);
-    // The mock was called with the signature filter and a default limit.
+    // Verify positional binding, not just presence — a future bug that swaps
+    // positions would still pass a `.toContain` check.
     const lastCall = mockQuery.mock.calls.at(-1)!;
-    expect(lastCall[1]).toContain('anomaly:threshold:cpu');
+    const sql = lastCall[0] as string;
+    expect(sql).toMatch(/WHERE signature = \?/);
+    expect((lastCall[1] as unknown[])[0]).toBe('anomaly:threshold:cpu');
   });
 
   it('rejects viewer-role callers with 403', async () => {

--- a/packages/ai-intelligence/src/__tests__/dedup-telemetry-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/dedup-telemetry-route.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Route test for /api/dedup-telemetry — verifies the admin RBAC gate and
+ * the basic shape of the response. The DB layer is mocked here; the
+ * integration shape is covered by dedup-telemetry.test.ts.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+
+const mockQuery = vi.fn();
+
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => ({
+    query: (...args: unknown[]) => mockQuery(...args),
+    queryOne: vi.fn(),
+    execute: vi.fn(),
+    transaction: vi.fn(),
+    healthCheck: vi.fn(async () => true),
+  }),
+}));
+
+import { dedupTelemetryRoutes } from '../routes/dedup-telemetry.js';
+
+function buildApp(role: 'viewer' | 'admin'): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.decorate('authenticate', async () => undefined);
+  app.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') =>
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const rank = { viewer: 0, operator: 1, admin: 2 };
+      const userRole = request.user?.role ?? 'viewer';
+      if (rank[userRole as keyof typeof rank] < rank[minRole]) {
+        reply.code(403).send({ error: 'Insufficient permissions' });
+      }
+    });
+  app.decorateRequest('user', undefined);
+  app.addHook('preHandler', async (request) => {
+    request.user = { sub: 'u1', username: 'u1', sessionId: 's1', role };
+  });
+  return app;
+}
+
+describe('GET /api/dedup-telemetry', () => {
+  let adminApp: FastifyInstance;
+  let viewerApp: FastifyInstance;
+
+  beforeAll(async () => {
+    adminApp = buildApp('admin');
+    await adminApp.register(dedupTelemetryRoutes);
+    await adminApp.ready();
+    viewerApp = buildApp('viewer');
+    await viewerApp.register(dedupTelemetryRoutes);
+    await viewerApp.ready();
+  });
+
+  afterAll(async () => {
+    await adminApp.close();
+    await viewerApp.close();
+    mockQuery.mockReset();
+  });
+
+  it('returns the latest metric rows for an admin', async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        collected_at: '2026-05-16T18:00:00Z',
+        window_hours: 168,
+        signature: 'anomaly:threshold:cpu',
+        total_insights: 144,
+        distinct_containers: 8,
+        alerts_per_container: 18,
+        total_incidents: 5,
+        avg_insights_per_incident: 18,
+      },
+    ]);
+
+    const res = await adminApp.inject({ method: 'GET', url: '/api/dedup-telemetry' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { rows: Array<{ signature: string }> };
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0].signature).toBe('anomaly:threshold:cpu');
+  });
+
+  it('honours the signature query param', async () => {
+    mockQuery.mockResolvedValueOnce([]);
+    const res = await adminApp.inject({
+      method: 'GET',
+      url: '/api/dedup-telemetry?signature=anomaly:threshold:cpu',
+    });
+    expect(res.statusCode).toBe(200);
+    // The mock was called with the signature filter and a default limit.
+    const lastCall = mockQuery.mock.calls.at(-1)!;
+    expect(lastCall[1]).toContain('anomaly:threshold:cpu');
+  });
+
+  it('rejects viewer-role callers with 403', async () => {
+    const res = await viewerApp.inject({ method: 'GET', url: '/api/dedup-telemetry' });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 400 on invalid limit', async () => {
+    const res = await adminApp.inject({
+      method: 'GET',
+      url: '/api/dedup-telemetry?limit=99999',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/dedup-telemetry.test.ts
+++ b/packages/ai-intelligence/src/__tests__/dedup-telemetry.test.ts
@@ -23,7 +23,9 @@ import {
   collectDedupMetrics,
   insertDedupMetrics,
   runDedupTelemetryCycle,
+  cleanupOldDedupMetrics,
 } from '../services/dedup-telemetry.js';
+import { deriveSignatureFromTitle } from '../services/signature.js';
 
 interface MetricRow {
   signature: string;
@@ -41,19 +43,21 @@ async function seedInsight(opts: {
   metric_type?: string | null;
   detection_method?: string | null;
   hours_ago?: number;
+  title?: string;
 }): Promise<void> {
   await testDb.execute(
     `INSERT INTO insights (
       id, endpoint_id, endpoint_name, container_id, container_name,
       severity, category, title, description, is_acknowledged,
       created_at, metric_type, detection_method
-    ) VALUES (?, 1, 'e', ?, ?, 'warning', ?, 't', 'd', false,
+    ) VALUES (?, 1, 'e', ?, ?, 'warning', ?, ?, 'd', false,
               NOW() - make_interval(hours => ?), ?, ?)`,
     [
       opts.id,
       'cid-' + opts.container_name,
       opts.container_name,
       opts.category,
+      opts.title ?? 't',
       opts.hours_ago ?? 1,
       opts.metric_type ?? null,
       opts.detection_method ?? null,
@@ -198,6 +202,104 @@ describe('insertDedupMetrics', () => {
     expect(persisted[0].total_insights).toBe(100);
     expect(persisted[0].alerts_per_container).toBeCloseTo(10, 1);
     expect(persisted[0].window_hours).toBe(168);
+  });
+});
+
+describe('collectDedupMetrics — title-rule parity with signature.ts', () => {
+  // The SQL CASE in services/dedup-telemetry.ts mirrors the TITLE_RULES in
+  // services/signature.ts. These cases pin the parity so a future edit to
+  // one side breaks loudly.
+  const cases: Array<{ name: string; title: string; category: string }> = [
+    { name: 'predicted memory exhaustion',  title: 'Predicted memory exhaustion on "x"',           category: 'predictive' },
+    { name: 'predicted cpu exhaustion',     title: 'Predicted cpu exhaustion on "y"',              category: 'predictive' },
+    { name: 'predicted disk exhaustion',    title: 'Predicted disk exhaustion on "z"',             category: 'predictive' },
+    { name: 'anomalous cpu (ML-detected)',  title: 'Anomalous cpu usage on "x" (ML-detected)',     category: 'anomaly' },
+    { name: 'anomalous memory threshold',   title: 'Anomalous memory usage on "x"',                category: 'anomaly' },
+    { name: 'high cpu usage threshold',     title: 'High cpu usage on "x"',                        category: 'anomaly' },
+    { name: 'missing health check',         title: 'No health check configured for "x"',           category: 'config' },
+    { name: 'host network mode',            title: 'Container "x" uses host network mode',         category: 'config' },
+  ];
+
+  it.each(cases)('SQL derives the same signature as deriveSignatureFromTitle: $name', async ({ title }) => {
+    await seedInsight({
+      id: 'ttl-' + Math.random().toString(36).slice(2),
+      category: 'unknown-cat', // forces fall-through to title rules
+      container_name: 'c',
+      title,
+    });
+
+    const rows = await collectDedupMetrics(testDb);
+    const expected = deriveSignatureFromTitle(title);
+    const got = rows.map((r) => r.signature);
+
+    expect(got).toContain(expected);
+  });
+});
+
+describe('cleanupOldDedupMetrics', () => {
+  it('deletes rows older than the given retention window and keeps recent ones', async () => {
+    // Insert one old and one recent row by hand so we can control collected_at.
+    await testDb.execute(
+      `INSERT INTO monitoring_dedup_metrics
+         (collected_at, window_hours, signature, total_insights, distinct_containers,
+          alerts_per_container, total_incidents, avg_insights_per_incident)
+       VALUES
+         (NOW() - INTERVAL '120 days', 168, 'anomaly:threshold:cpu', 10, 1, 10, 0, 0),
+         (NOW() - INTERVAL '30 days',  168, 'anomaly:threshold:cpu', 20, 1, 20, 0, 0)`,
+    );
+
+    const deleted = await cleanupOldDedupMetrics(90);
+    expect(deleted).toBe(1);
+
+    const remaining = await testDb.query<{ count: number }>(
+      `SELECT COUNT(*)::int AS count FROM monitoring_dedup_metrics`,
+    );
+    expect(remaining[0].count).toBe(1);
+  });
+
+  it('is a no-op on an empty table', async () => {
+    expect(await cleanupOldDedupMetrics(90)).toBe(0);
+  });
+
+  it('refuses non-positive day counts and returns 0', async () => {
+    expect(await cleanupOldDedupMetrics(0)).toBe(0);
+    expect(await cleanupOldDedupMetrics(-1)).toBe(0);
+  });
+});
+
+describe('insertDedupMetrics — ON CONFLICT DO NOTHING', () => {
+  it('silently drops a second insert with the same (signature, collected_at)', async () => {
+    // Manually insert a row at a fixed timestamp so we can collide with it.
+    const ts = '2026-05-16 18:00:00+00';
+    await testDb.execute(
+      `INSERT INTO monitoring_dedup_metrics
+         (collected_at, window_hours, signature, total_insights, distinct_containers,
+          alerts_per_container, total_incidents, avg_insights_per_incident)
+       VALUES (?, 168, 'anomaly:threshold:cpu', 100, 5, 20, 1, 100)`,
+      [ts],
+    );
+
+    // Insert the same (signature, collected_at) again — should be a no-op,
+    // not an error.
+    await expect(
+      testDb.execute(
+        `INSERT INTO monitoring_dedup_metrics
+           (collected_at, window_hours, signature, total_insights, distinct_containers,
+            alerts_per_container, total_incidents, avg_insights_per_incident)
+         VALUES (?, 168, 'anomaly:threshold:cpu', 999, 999, 999, 999, 999)
+         ON CONFLICT (signature, collected_at) DO NOTHING`,
+        [ts],
+      ),
+    ).resolves.toBeDefined();
+
+    // Only the original row survives.
+    const rows = await testDb.query<{ total_insights: number }>(
+      `SELECT total_insights FROM monitoring_dedup_metrics
+       WHERE signature = 'anomaly:threshold:cpu' AND collected_at = ?::timestamptz`,
+      [ts],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].total_insights).toBe(100);
   });
 });
 

--- a/packages/ai-intelligence/src/__tests__/dedup-telemetry.test.ts
+++ b/packages/ai-intelligence/src/__tests__/dedup-telemetry.test.ts
@@ -1,0 +1,248 @@
+/**
+ * DB-backed integration test for the dedup-engine telemetry job (#1200).
+ *
+ * Seeds insights + incidents in the test DB, runs `collectDedupMetrics`,
+ * asserts the per-signature rollup matches expected totals, then runs the
+ * full cycle and asserts the snapshot row landed in monitoring_dedup_metrics.
+ *
+ * Run with:
+ *   POSTGRES_TEST_URL=postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test \
+ *   npx vitest run src/__tests__/dedup-telemetry.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+import type { AppDb } from '@dashboard/core/db/app-db.js';
+
+let testDb: AppDb;
+
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => testDb,
+}));
+
+import {
+  collectDedupMetrics,
+  insertDedupMetrics,
+  runDedupTelemetryCycle,
+} from '../services/dedup-telemetry.js';
+
+interface MetricRow {
+  signature: string;
+  total_insights: number;
+  distinct_containers: number;
+  alerts_per_container: number;
+  total_incidents: number;
+  avg_insights_per_incident: number;
+}
+
+async function seedInsight(opts: {
+  id: string;
+  category: string;
+  container_name: string;
+  metric_type?: string | null;
+  detection_method?: string | null;
+  hours_ago?: number;
+}): Promise<void> {
+  await testDb.execute(
+    `INSERT INTO insights (
+      id, endpoint_id, endpoint_name, container_id, container_name,
+      severity, category, title, description, is_acknowledged,
+      created_at, metric_type, detection_method
+    ) VALUES (?, 1, 'e', ?, ?, 'warning', ?, 't', 'd', false,
+              NOW() - make_interval(hours => ?), ?, ?)`,
+    [
+      opts.id,
+      'cid-' + opts.container_name,
+      opts.container_name,
+      opts.category,
+      opts.hours_ago ?? 1,
+      opts.metric_type ?? null,
+      opts.detection_method ?? null,
+    ],
+  );
+}
+
+async function seedIncident(opts: {
+  id: string;
+  signature: string;
+  insight_count: number;
+  status?: 'active' | 'resolved';
+}): Promise<void> {
+  await testDb.execute(
+    `INSERT INTO incidents (
+      id, title, severity, status, related_insight_ids, affected_containers,
+      endpoint_id, endpoint_name, correlation_type, correlation_confidence,
+      insight_count, signature
+    ) VALUES (?, 't', 'warning', ?, '[]'::jsonb, '["c"]'::jsonb, 1, 'e',
+              'dedup', 'medium', ?, ?)`,
+    [opts.id, opts.status ?? 'active', opts.insight_count, opts.signature],
+  );
+}
+
+beforeAll(async () => { testDb = await getTestDb(); });
+afterAll(async () => { await closeTestDb(); });
+beforeEach(async () => {
+  await truncateTestTables('monitoring_dedup_metrics', 'incidents', 'insights');
+});
+
+describe('collectDedupMetrics', () => {
+  it('rolls up insights by derived signature using structured fields', async () => {
+    // 3 CPU threshold insights on container A, 2 on B → signature shared
+    for (let i = 0; i < 3; i++) {
+      await seedInsight({
+        id: 'a' + i, category: 'anomaly', container_name: 'web-a',
+        metric_type: 'cpu', detection_method: 'threshold',
+      });
+    }
+    for (let i = 0; i < 2; i++) {
+      await seedInsight({
+        id: 'b' + i, category: 'anomaly', container_name: 'web-b',
+        metric_type: 'cpu', detection_method: 'threshold',
+      });
+    }
+
+    const rows = await collectDedupMetrics(testDb);
+    const cpu = rows.find((r) => r.signature === 'anomaly:threshold:cpu');
+
+    expect(cpu).toBeDefined();
+    expect(cpu!.total_insights).toBe(5);
+    expect(cpu!.distinct_containers).toBe(2);
+    expect(cpu!.alerts_per_container).toBeCloseTo(2.5, 1);
+  });
+
+  it('uses category-only fallback for security / log / ai-analysis insights', async () => {
+    await seedInsight({ id: 's1', category: 'security',     container_name: 'x' });
+    await seedInsight({ id: 's2', category: 'security',     container_name: 'x' });
+    await seedInsight({ id: 'l1', category: 'log-analysis', container_name: 'y' });
+    await seedInsight({ id: 'a1', category: 'ai-analysis',  container_name: 'z' });
+
+    const rows = await collectDedupMetrics(testDb);
+    const bySig = new Map(rows.map((r) => [r.signature, r]));
+
+    expect(bySig.get('security:scan')?.total_insights).toBe(2);
+    expect(bySig.get('log:pattern')?.total_insights).toBe(1);
+    expect(bySig.get('ai:analysis')?.total_insights).toBe(1);
+  });
+
+  it('respects the window — drops insights older than windowHours', async () => {
+    await seedInsight({
+      id: 'recent', category: 'anomaly', container_name: 'c1',
+      metric_type: 'cpu', detection_method: 'threshold', hours_ago: 1,
+    });
+    await seedInsight({
+      id: 'old', category: 'anomaly', container_name: 'c1',
+      metric_type: 'cpu', detection_method: 'threshold', hours_ago: 200, // > 168 (7 days)
+    });
+
+    const rows = await collectDedupMetrics(testDb, 24 * 7);
+    const cpu = rows.find((r) => r.signature === 'anomaly:threshold:cpu');
+
+    expect(cpu?.total_insights).toBe(1);
+  });
+
+  it('joins incident counts onto matching signatures', async () => {
+    await seedInsight({
+      id: 'i1', category: 'anomaly', container_name: 'c1',
+      metric_type: 'cpu', detection_method: 'threshold',
+    });
+    await seedIncident({ id: 'inc1', signature: 'anomaly:threshold:cpu', insight_count: 18 });
+    await seedIncident({ id: 'inc2', signature: 'anomaly:threshold:cpu', insight_count: 12 });
+
+    const rows = await collectDedupMetrics(testDb);
+    const cpu = rows.find((r) => r.signature === 'anomaly:threshold:cpu');
+
+    expect(cpu?.total_incidents).toBe(2);
+    expect(cpu?.avg_insights_per_incident).toBeCloseTo(15, 0);
+  });
+
+  it('still returns signatures present in incidents but not in insights', async () => {
+    await seedIncident({ id: 'inc1', signature: 'legacy:signature', insight_count: 4 });
+
+    const rows = await collectDedupMetrics(testDb);
+    const legacy = rows.find((r) => r.signature === 'legacy:signature');
+
+    expect(legacy).toBeDefined();
+    expect(legacy!.total_insights).toBe(0);
+    expect(legacy!.alerts_per_container).toBe(0);
+    expect(legacy!.total_incidents).toBe(1);
+  });
+
+  it('returns an empty array when nothing exists in the window', async () => {
+    const rows = await collectDedupMetrics(testDb);
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('insertDedupMetrics', () => {
+  it('writes one row per metric and stamps collected_at', async () => {
+    await insertDedupMetrics(testDb, 168, [
+      {
+        signature: 'anomaly:threshold:cpu',
+        total_insights: 100,
+        distinct_containers: 10,
+        alerts_per_container: 10,
+        total_incidents: 5,
+        avg_insights_per_incident: 20,
+      },
+    ]);
+
+    const persisted = await testDb.query<MetricRow & { window_hours: number }>(
+      `SELECT signature, total_insights, distinct_containers,
+              alerts_per_container::float AS alerts_per_container,
+              total_incidents, avg_insights_per_incident::float AS avg_insights_per_incident,
+              window_hours
+       FROM monitoring_dedup_metrics`,
+    );
+
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].signature).toBe('anomaly:threshold:cpu');
+    expect(persisted[0].total_insights).toBe(100);
+    expect(persisted[0].alerts_per_container).toBeCloseTo(10, 1);
+    expect(persisted[0].window_hours).toBe(168);
+  });
+});
+
+describe('runDedupTelemetryCycle', () => {
+  it('collects + inserts and reports the row count', async () => {
+    await seedInsight({
+      id: 'i1', category: 'anomaly', container_name: 'c1',
+      metric_type: 'memory', detection_method: 'ml-anomaly',
+    });
+
+    const result = await runDedupTelemetryCycle();
+    expect(result.collected).toBe(1);
+    expect(result.inserted).toBe(1);
+    expect(result.windowHours).toBe(168);
+
+    const persisted = await testDb.query<{ signature: string }>(
+      `SELECT signature FROM monitoring_dedup_metrics`,
+    );
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].signature).toBe('anomaly:ml-anomaly:memory');
+  });
+
+  it('is a no-op on an empty DB and reports 0', async () => {
+    const result = await runDedupTelemetryCycle();
+    expect(result.collected).toBe(0);
+    expect(result.inserted).toBe(0);
+
+    const persisted = await testDb.query<{ count: number }>(
+      `SELECT COUNT(*)::int AS count FROM monitoring_dedup_metrics`,
+    );
+    expect(persisted[0].count).toBe(0);
+  });
+
+  it('appends rather than overwriting across repeated cycles', async () => {
+    await seedInsight({
+      id: 'i1', category: 'anomaly', container_name: 'c1',
+      metric_type: 'cpu', detection_method: 'threshold',
+    });
+
+    await runDedupTelemetryCycle();
+    await runDedupTelemetryCycle();
+
+    const persisted = await testDb.query<{ count: number }>(
+      `SELECT COUNT(*)::int AS count FROM monitoring_dedup_metrics`,
+    );
+    expect(persisted[0].count).toBe(2);
+  });
+});

--- a/packages/ai-intelligence/src/index.ts
+++ b/packages/ai-intelligence/src/index.ts
@@ -50,7 +50,7 @@ export { isLlmAvailable, chatStream, buildInfrastructureContext } from './servic
 export { cleanupOldInsights } from './services/insights-store.js';
 
 // Services — dedup-engine telemetry (#1200)
-export { runDedupTelemetryCycle, collectDedupMetrics } from './services/dedup-telemetry.js';
+export { runDedupTelemetryCycle, collectDedupMetrics, cleanupOldDedupMetrics } from './services/dedup-telemetry.js';
 export type { DedupMetricRow, DedupTelemetryCycleResult } from './services/dedup-telemetry.js';
 
 // Services — prompt store

--- a/packages/ai-intelligence/src/index.ts
+++ b/packages/ai-intelligence/src/index.ts
@@ -6,6 +6,7 @@ export {
   investigationRoutes,
   incidentsRoutes,
   correlationRoutes,
+  dedupTelemetryRoutes,
   llmRoutes,
   llmObservabilityRoutes,
   llmFeedbackRoutes,
@@ -47,6 +48,10 @@ export { isLlmAvailable, chatStream, buildInfrastructureContext } from './servic
 
 // Services — insights
 export { cleanupOldInsights } from './services/insights-store.js';
+
+// Services — dedup-engine telemetry (#1200)
+export { runDedupTelemetryCycle, collectDedupMetrics } from './services/dedup-telemetry.js';
+export type { DedupMetricRow, DedupTelemetryCycleResult } from './services/dedup-telemetry.js';
 
 // Services — prompt store
 export { PROMPT_FEATURES, DEFAULT_PROMPTS, getEffectivePrompt } from './services/prompt-store.js';

--- a/packages/ai-intelligence/src/routes/dedup-telemetry.ts
+++ b/packages/ai-intelligence/src/routes/dedup-telemetry.ts
@@ -1,0 +1,72 @@
+/**
+ * Routes for the dedup-engine telemetry collected by the hourly job in
+ * services/dedup-telemetry.ts. Admin-only — emission rates per detector
+ * are sensitive enough that we'd rather not advertise them on a public
+ * endpoint.
+ */
+import '@dashboard/core/plugins/auth.js';
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
+
+const ListQ = z.object({
+  /** Max rows to return. Defaults to the most recent 200. */
+  limit: z.coerce.number().int().min(1).max(2000).optional(),
+  /** Filter to a single signature (e.g. anomaly:threshold:cpu). */
+  signature: z.string().min(1).max(200).optional(),
+});
+
+interface MetricRow {
+  collected_at: string;
+  window_hours: number;
+  signature: string;
+  total_insights: number;
+  distinct_containers: number;
+  alerts_per_container: number;
+  total_incidents: number;
+  avg_insights_per_incident: number;
+}
+
+export async function dedupTelemetryRoutes(fastify: FastifyInstance) {
+  fastify.get('/api/dedup-telemetry', {
+    schema: {
+      tags: ['Monitoring'],
+      summary: 'Latest per-signature dedup metrics (admin-only)',
+      security: [{ bearerAuth: [] }],
+    },
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
+  }, async (request, reply) => {
+    const parsed = ListQ.safeParse(request.query);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'invalid query', details: parsed.error.flatten() });
+    }
+    const { limit = 200, signature } = parsed.data;
+
+    const db = getDbForDomain('monitoring');
+    let rows: MetricRow[];
+    if (signature) {
+      rows = await db.query<MetricRow>(
+        `SELECT collected_at, window_hours, signature,
+                total_insights, distinct_containers, alerts_per_container,
+                total_incidents, avg_insights_per_incident
+         FROM monitoring_dedup_metrics
+         WHERE signature = ?
+         ORDER BY collected_at DESC
+         LIMIT ?`,
+        [signature, limit],
+      );
+    } else {
+      rows = await db.query<MetricRow>(
+        `SELECT collected_at, window_hours, signature,
+                total_insights, distinct_containers, alerts_per_container,
+                total_incidents, avg_insights_per_incident
+         FROM monitoring_dedup_metrics
+         ORDER BY collected_at DESC
+         LIMIT ?`,
+        [limit],
+      );
+    }
+
+    return { rows };
+  });
+}

--- a/packages/ai-intelligence/src/routes/index.ts
+++ b/packages/ai-intelligence/src/routes/index.ts
@@ -4,6 +4,7 @@ export { investigationRoutes } from './investigations.js';
 export { incidentsRoutes } from './incidents.js';
 export { correlationRoutes } from './correlations.js';
 export type { CorrelationRoutesOpts, CorrelationPair, CorrelationInsight, Queryable } from './correlations.js';
+export { dedupTelemetryRoutes } from './dedup-telemetry.js';
 export { llmRoutes } from './llm.js';
 export { llmObservabilityRoutes } from './llm-observability.js';
 export { llmFeedbackRoutes } from './llm-feedback.js';

--- a/packages/ai-intelligence/src/services/dedup-telemetry.ts
+++ b/packages/ai-intelligence/src/services/dedup-telemetry.ts
@@ -41,6 +41,11 @@ interface IncidentAggRow {
 
 const WINDOW_HOURS_DEFAULT = 24 * 7;
 
+// CASE expression mirrors services/signature.ts deriveSignature + TITLE_RULES.
+// Order matters — ml-anomaly must come before the bare "anomalous … usage"
+// rule, otherwise the threshold variant would win for ML-tagged titles.
+// Keep this in lock-step with signature.ts; the unit test
+// `signature-sql-parity` in dedup-telemetry.test.ts pins the parity.
 const INSIGHTS_AGG_SQL = `
   WITH derived AS (
     SELECT
@@ -50,6 +55,18 @@ const INSIGHTS_AGG_SQL = `
         WHEN category = 'security'     THEN 'security:scan'
         WHEN category = 'log-analysis' THEN 'log:pattern'
         WHEN category = 'ai-analysis'  THEN 'ai:analysis'
+        WHEN title ~* 'predicted\\s+(cpu|memory|disk)\\s+exhaustion'
+          THEN 'predictive:prediction:' || lower((regexp_match(title, 'predicted\\s+(cpu|memory|disk)\\s+exhaustion', 'i'))[1])
+        WHEN title ~* 'anomalous\\s+(cpu|memory|disk)\\s+usage[^()]*\\(ml-detected\\)'
+          THEN 'anomaly:ml-anomaly:' || lower((regexp_match(title, 'anomalous\\s+(cpu|memory|disk)', 'i'))[1])
+        WHEN title ~* 'anomalous\\s+(cpu|memory|disk)\\s+usage'
+          THEN 'anomaly:threshold:' || lower((regexp_match(title, 'anomalous\\s+(cpu|memory|disk)', 'i'))[1])
+        WHEN title ~* 'high\\s+(cpu|memory|disk)\\s+usage'
+          THEN 'anomaly:threshold:' || lower((regexp_match(title, 'high\\s+(cpu|memory|disk)', 'i'))[1])
+        WHEN title ~* 'no health check (configured|defined)|missing health check'
+          THEN 'config:health-check:missing'
+        WHEN title ~* 'host network mode'
+          THEN 'config:network:host-mode'
         ELSE category || ':unknown'
       END AS signature,
       container_name
@@ -76,12 +93,17 @@ const INCIDENTS_AGG_SQL = `
   GROUP BY signature
 `;
 
+// ON CONFLICT DO NOTHING pairs with the UNIQUE(signature, collected_at)
+// constraint added in migration 033. Two scheduler firings in the same
+// millisecond would otherwise produce duplicate rows that subtly inflate
+// week-over-week aggregations.
 const INSERT_SQL = `
   INSERT INTO monitoring_dedup_metrics (
     collected_at, window_hours, signature,
     total_insights, distinct_containers, alerts_per_container,
     total_incidents, avg_insights_per_incident
   ) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT (signature, collected_at) DO NOTHING
 `;
 
 /**
@@ -149,6 +171,25 @@ export async function insertDedupMetrics(
       row.avg_insights_per_incident,
     ]);
   }
+}
+
+/**
+ * Daily retention sweep for `monitoring_dedup_metrics`. The hourly job writes
+ * one row per signature per snapshot, so the table grows linearly forever
+ * unless something prunes it. 90 days of history is enough to compare the
+ * dedup engine's behaviour week-over-week through a release cycle; older
+ * data is rarely consulted and can be reconstructed from the raw insights
+ * if needed. Returns the number of rows deleted so the scheduler can log.
+ */
+export async function cleanupOldDedupMetrics(days: number = 90): Promise<number> {
+  if (!Number.isFinite(days) || days <= 0) return 0;
+  const db = getDbForDomain('monitoring');
+  const result = await db.execute(
+    `DELETE FROM monitoring_dedup_metrics
+     WHERE collected_at < NOW() - make_interval(days => ?)`,
+    [days],
+  );
+  return result.changes;
 }
 
 export interface DedupTelemetryCycleResult {

--- a/packages/ai-intelligence/src/services/dedup-telemetry.ts
+++ b/packages/ai-intelligence/src/services/dedup-telemetry.ts
@@ -1,0 +1,177 @@
+/**
+ * Dedup-engine telemetry collector (issue #1200).
+ *
+ * Runs hourly. Computes per-signature emission ratios over the last 7 days
+ * and writes one row per signature to `monitoring_dedup_metrics`. The
+ * follow-up engine PR uses the resulting time series to baseline before/after
+ * tightening cooldowns or admitting non-anomaly categories into correlation.
+ *
+ * SQL derives the signature inline from (category, detection_method,
+ * metric_type) the same way services/signature.ts does for runtime emission.
+ * Keeping the rule in SQL means the rollup follows new structured fields as
+ * they're added without a code deploy.
+ */
+import { createChildLogger } from '@dashboard/core/utils/logger.js';
+import type { AppDb } from '@dashboard/core/db/app-db.js';
+import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
+
+const log = createChildLogger('dedup-telemetry');
+
+export interface DedupMetricRow {
+  signature: string;
+  total_insights: number;
+  distinct_containers: number;
+  alerts_per_container: number;
+  total_incidents: number;
+  avg_insights_per_incident: number;
+}
+
+interface InsightAggRow {
+  signature: string;
+  total_insights: number | string;
+  distinct_containers: number | string;
+  alerts_per_container: number | string;
+}
+
+interface IncidentAggRow {
+  signature: string;
+  total_incidents: number | string;
+  avg_insights_per_incident: number | string;
+}
+
+const WINDOW_HOURS_DEFAULT = 24 * 7;
+
+const INSIGHTS_AGG_SQL = `
+  WITH derived AS (
+    SELECT
+      CASE
+        WHEN metric_type IS NOT NULL AND detection_method IS NOT NULL
+          THEN category || ':' || detection_method || ':' || metric_type
+        WHEN category = 'security'     THEN 'security:scan'
+        WHEN category = 'log-analysis' THEN 'log:pattern'
+        WHEN category = 'ai-analysis'  THEN 'ai:analysis'
+        ELSE category || ':unknown'
+      END AS signature,
+      container_name
+    FROM insights
+    WHERE created_at >= NOW() - make_interval(hours => ?)
+  )
+  SELECT
+    signature,
+    COUNT(*)::int                                                                  AS total_insights,
+    COUNT(DISTINCT container_name)::int                                            AS distinct_containers,
+    ROUND(COUNT(*)::numeric / NULLIF(COUNT(DISTINCT container_name), 0), 2)::float AS alerts_per_container
+  FROM derived
+  GROUP BY signature
+`;
+
+const INCIDENTS_AGG_SQL = `
+  SELECT
+    signature,
+    COUNT(*)::int                                AS total_incidents,
+    ROUND(AVG(insight_count)::numeric, 2)::float AS avg_insights_per_incident
+  FROM incidents
+  WHERE signature IS NOT NULL
+    AND (status = 'active' OR resolved_at >= NOW() - make_interval(hours => ?))
+  GROUP BY signature
+`;
+
+const INSERT_SQL = `
+  INSERT INTO monitoring_dedup_metrics (
+    collected_at, window_hours, signature,
+    total_insights, distinct_containers, alerts_per_container,
+    total_incidents, avg_insights_per_incident
+  ) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?)
+`;
+
+/**
+ * Compute the per-signature dedup metrics over the given window.
+ *
+ * Pure function over the supplied AppDb — no scheduler / wiring coupling — so
+ * tests can hand it a real test DB. Returns one row per derived signature
+ * with at least one insight in the window. Signatures present in incidents
+ * but not in insights are still returned (with total_insights=0,
+ * alerts_per_container=0) so operators see the full set.
+ */
+export async function collectDedupMetrics(
+  db: AppDb,
+  windowHours: number = WINDOW_HOURS_DEFAULT,
+): Promise<DedupMetricRow[]> {
+  const [insightRows, incidentRows] = await Promise.all([
+    db.query<InsightAggRow>(INSIGHTS_AGG_SQL, [windowHours]),
+    db.query<IncidentAggRow>(INCIDENTS_AGG_SQL, [windowHours]),
+  ]);
+
+  const incidentBySignature = new Map<string, IncidentAggRow>();
+  for (const row of incidentRows) incidentBySignature.set(row.signature, row);
+
+  const rows: DedupMetricRow[] = insightRows.map((r) => {
+    const incidentRow = incidentBySignature.get(r.signature);
+    incidentBySignature.delete(r.signature);
+    return {
+      signature: r.signature,
+      total_insights: Number(r.total_insights),
+      distinct_containers: Number(r.distinct_containers),
+      alerts_per_container: Number(r.alerts_per_container ?? 0),
+      total_incidents: Number(incidentRow?.total_incidents ?? 0),
+      avg_insights_per_incident: Number(incidentRow?.avg_insights_per_incident ?? 0),
+    };
+  });
+
+  // Signatures with incidents but no insights in window — still useful to record.
+  for (const r of incidentBySignature.values()) {
+    rows.push({
+      signature: r.signature,
+      total_insights: 0,
+      distinct_containers: 0,
+      alerts_per_container: 0,
+      total_incidents: Number(r.total_incidents),
+      avg_insights_per_incident: Number(r.avg_insights_per_incident ?? 0),
+    });
+  }
+
+  return rows;
+}
+
+export async function insertDedupMetrics(
+  db: AppDb,
+  windowHours: number,
+  rows: DedupMetricRow[],
+): Promise<void> {
+  for (const row of rows) {
+    await db.execute(INSERT_SQL, [
+      windowHours,
+      row.signature,
+      row.total_insights,
+      row.distinct_containers,
+      row.alerts_per_container,
+      row.total_incidents,
+      row.avg_insights_per_incident,
+    ]);
+  }
+}
+
+export interface DedupTelemetryCycleResult {
+  collected: number;
+  inserted: number;
+  windowHours: number;
+}
+
+/**
+ * One pass of the hourly telemetry job: collect → insert → return summary
+ * for logging. Safe to call when no insights exist (returns 0/0/window).
+ */
+export async function runDedupTelemetryCycle(
+  windowHours: number = WINDOW_HOURS_DEFAULT,
+): Promise<DedupTelemetryCycleResult> {
+  const db = getDbForDomain('monitoring');
+  const rows = await collectDedupMetrics(db, windowHours);
+  await insertDedupMetrics(db, windowHours, rows);
+  if (rows.length > 0) {
+    log.info(
+      { signatures: rows.length, windowHours },
+      'dedup telemetry snapshot written',
+    );
+  }
+  return { collected: rows.length, inserted: rows.length, windowHours };
+}

--- a/packages/core/src/db/postgres-migrations/033_monitoring_dedup_metrics.sql
+++ b/packages/core/src/db/postgres-migrations/033_monitoring_dedup_metrics.sql
@@ -7,9 +7,14 @@
 -- pressure week-over-week.
 --
 -- One snapshot per hour × ~10 distinct signatures ≈ 240 rows/day.
--- An optional cleanup job in the same scheduler drops rows older than
--- 90 days; not enforced via FK or trigger so retention can be tuned in
--- one place.
+-- Daily cleanup in scheduler.ts::runCleanup deletes rows older than 90
+-- days via cleanupOldDedupMetrics(90); not enforced via FK or trigger so
+-- retention can be tuned in one place.
+--
+-- The UNIQUE (signature, collected_at) constraint pairs with the
+-- ON CONFLICT DO NOTHING clause in services/dedup-telemetry.ts so that an
+-- overlapping scheduler firing (clock skew, missed callback) can't write
+-- duplicate rows for the same instant.
 
 CREATE TABLE IF NOT EXISTS monitoring_dedup_metrics (
   id                     SERIAL PRIMARY KEY,
@@ -20,7 +25,8 @@ CREATE TABLE IF NOT EXISTS monitoring_dedup_metrics (
   distinct_containers    INTEGER     NOT NULL,
   alerts_per_container   NUMERIC(10, 2) NOT NULL,
   total_incidents        INTEGER     NOT NULL DEFAULT 0,
-  avg_insights_per_incident NUMERIC(10, 2) NOT NULL DEFAULT 0
+  avg_insights_per_incident NUMERIC(10, 2) NOT NULL DEFAULT 0,
+  UNIQUE (signature, collected_at)
 );
 
 CREATE INDEX IF NOT EXISTS idx_monitoring_dedup_metrics_collected

--- a/packages/core/src/db/postgres-migrations/033_monitoring_dedup_metrics.sql
+++ b/packages/core/src/db/postgres-migrations/033_monitoring_dedup_metrics.sql
@@ -1,0 +1,29 @@
+-- Migration 033: monitoring_dedup_metrics — per-signature emission ratios
+--
+-- Feeds the incident-engine dedup follow-up (issue #1200). The hourly
+-- telemetry job in @dashboard/ai/services/dedup-telemetry.ts writes one
+-- row per (signature, collected_at) capturing the four ratios from
+-- scripts/analyze-dedup-engine.sql so operators can baseline emission
+-- pressure week-over-week.
+--
+-- One snapshot per hour × ~10 distinct signatures ≈ 240 rows/day.
+-- An optional cleanup job in the same scheduler drops rows older than
+-- 90 days; not enforced via FK or trigger so retention can be tuned in
+-- one place.
+
+CREATE TABLE IF NOT EXISTS monitoring_dedup_metrics (
+  id                     SERIAL PRIMARY KEY,
+  collected_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  window_hours           INTEGER     NOT NULL,
+  signature              TEXT        NOT NULL,
+  total_insights         INTEGER     NOT NULL,
+  distinct_containers    INTEGER     NOT NULL,
+  alerts_per_container   NUMERIC(10, 2) NOT NULL,
+  total_incidents        INTEGER     NOT NULL DEFAULT 0,
+  avg_insights_per_incident NUMERIC(10, 2) NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_monitoring_dedup_metrics_collected
+  ON monitoring_dedup_metrics(collected_at);
+CREATE INDEX IF NOT EXISTS idx_monitoring_dedup_metrics_signature
+  ON monitoring_dedup_metrics(signature);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -46,6 +46,7 @@ import {
   investigationRoutes,
   incidentsRoutes,
   correlationRoutes,
+  dedupTelemetryRoutes,
   llmRoutes,
   llmObservabilityRoutes,
   llmFeedbackRoutes,
@@ -227,6 +228,7 @@ export async function buildApp() {
     findCorrelatedContainers,
     isUndefinedTableError,
   });
+  await app.register(dedupTelemetryRoutes);
   await app.register(mcpRoutes);
   await app.register(promptProfileRoutes);
   await app.register(llmFeedbackRoutes);

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -7,7 +7,7 @@ import { cachedFetch, cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/p
 import { normalizeEndpoint, type NormalizedEndpoint } from '@dashboard/core/portainer/index.js';
 import { getSetting, getEffectiveHarborConfig, getEffectiveMonitoringSchedulerConfig, cleanExpiredSessions, cleanExpiredStreamTickets } from '@dashboard/core/services/index.js';
 import { runWithTraceContext } from '@dashboard/core/tracing/index.js';
-import { startCooldownSweep, stopCooldownSweep, cleanupOldInsights, pruneCanaryRegistry, runDedupTelemetryCycle } from '@dashboard/ai';
+import { startCooldownSweep, stopCooldownSweep, cleanupOldInsights, pruneCanaryRegistry, runDedupTelemetryCycle, cleanupOldDedupMetrics } from '@dashboard/ai';
 import { collectMetrics, insertMetrics, cleanOldMetrics, cleanOldSpans, type MetricInsert, recordNetworkSample, insertKpiSnapshot, cleanOldKpiSnapshots, pruneStaleEntries } from '@dashboard/observability';
 import { cleanupOldCaptures, cleanupOrphanedSidecars, runStalenessChecks, runHarborSync, isHarborSyncRunning, isHarborConfiguredAsync, cleanupOldVulnerabilities } from '@dashboard/security';
 import { createPortainerBackup, cleanupOldPortainerBackups, startWebhookListener, stopWebhookListener, processRetries } from '@dashboard/operations';
@@ -380,6 +380,15 @@ export async function runCleanup(): Promise<void> {
     }
   } catch (err) {
     log.error({ err }, 'Insights cleanup failed');
+  }
+
+  try {
+    const dedupMetricsDeleted = await cleanupOldDedupMetrics(90);
+    if (dedupMetricsDeleted > 0) {
+      log.info({ deleted: dedupMetricsDeleted }, 'Old dedup telemetry rows cleaned up');
+    }
+  } catch (err) {
+    log.error({ err }, 'Dedup telemetry cleanup failed');
   }
 
   try {

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -7,7 +7,7 @@ import { cachedFetch, cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/p
 import { normalizeEndpoint, type NormalizedEndpoint } from '@dashboard/core/portainer/index.js';
 import { getSetting, getEffectiveHarborConfig, getEffectiveMonitoringSchedulerConfig, cleanExpiredSessions, cleanExpiredStreamTickets } from '@dashboard/core/services/index.js';
 import { runWithTraceContext } from '@dashboard/core/tracing/index.js';
-import { startCooldownSweep, stopCooldownSweep, cleanupOldInsights, pruneCanaryRegistry } from '@dashboard/ai';
+import { startCooldownSweep, stopCooldownSweep, cleanupOldInsights, pruneCanaryRegistry, runDedupTelemetryCycle } from '@dashboard/ai';
 import { collectMetrics, insertMetrics, cleanOldMetrics, cleanOldSpans, type MetricInsert, recordNetworkSample, insertKpiSnapshot, cleanOldKpiSnapshots, pruneStaleEntries } from '@dashboard/observability';
 import { cleanupOldCaptures, cleanupOrphanedSidecars, runStalenessChecks, runHarborSync, isHarborSyncRunning, isHarborConfiguredAsync, cleanupOldVulnerabilities } from '@dashboard/security';
 import { createPortainerBackup, cleanupOldPortainerBackups, startWebhookListener, stopWebhookListener, processRetries } from '@dashboard/operations';
@@ -667,6 +667,26 @@ export async function startScheduler(runMonitoringCycle: () => Promise<void>): P
   );
   sessionCleanupInterval.unref();
   intervals.push(sessionCleanupInterval);
+
+  // Hourly dedup-engine telemetry (issue #1200). Writes one row per signature
+  // to monitoring_dedup_metrics so the next round of dedup tuning is
+  // data-driven. Cheap (two indexed aggregates over the 7-day insight window)
+  // and bounded (~10 distinct signatures × 24 rows/day).
+  const dedupTelemetryInterval = setInterval(
+    () => runWithTraceContext({ source: 'scheduler' }, async () => {
+      try {
+        const result = await runDedupTelemetryCycle();
+        if (result.collected > 0) {
+          log.info(result, 'Dedup telemetry snapshot written');
+        }
+      } catch (err) {
+        log.error({ err }, 'Hourly dedup telemetry failed');
+      }
+    }),
+    60 * 60 * 1000,
+  );
+  dedupTelemetryInterval.unref();
+  intervals.push(dedupTelemetryInterval);
   // Run once shortly after startup so a freshly-restarted server clears
   // sessions left over from before the restart promptly.
   setTimeout(() => {

--- a/scripts/analyze-dedup-engine.sql
+++ b/scripts/analyze-dedup-engine.sql
@@ -1,0 +1,103 @@
+-- Analysis queries for the incident-engine dedup follow-up (issue #1200).
+--
+-- Run against the prod / staging Postgres after #1199 has been deployed for
+-- at least one week. The four queries map to the four data-driven questions
+-- in the issue body; run them in order and capture the results in
+--   docs/superpowers/specs/2026-05-16-1200-dedup-telemetry-design.md
+-- under the "Findings" section.
+--
+-- The `insights` table does not have a `signature` column today (signatures
+-- live on `incidents`); these queries derive the signature inline from
+-- (category, detection_method, metric_type) the same way
+-- packages/ai-intelligence/src/services/signature.ts does.
+--
+-- Usage:
+--   psql "$POSTGRES_URL" -f scripts/analyze-dedup-engine.sql
+--   # or, in docker-compose:
+--   docker exec -i <postgres-container> psql -U app_user -d portainer_dashboard \
+--     -f scripts/analyze-dedup-engine.sql
+
+\echo
+\echo === Q1: alerts_per_container ratio per derived signature (top 20) ===
+\echo
+WITH derived AS (
+  SELECT
+    CASE
+      WHEN metric_type IS NOT NULL AND detection_method IS NOT NULL
+        THEN category || ':' || detection_method || ':' || metric_type
+      WHEN category = 'security'     THEN 'security:scan'
+      WHEN category = 'log-analysis' THEN 'log:pattern'
+      WHEN category = 'ai-analysis'  THEN 'ai:analysis'
+      ELSE category || ':unknown'
+    END AS signature,
+    container_name
+  FROM insights
+  WHERE created_at >= NOW() - INTERVAL '7 days'
+)
+SELECT
+  signature,
+  COUNT(*)                                                                       AS total_insights,
+  COUNT(DISTINCT container_name)                                                 AS distinct_containers,
+  ROUND(COUNT(*)::numeric / NULLIF(COUNT(DISTINCT container_name), 0), 2)        AS alerts_per_container
+FROM derived
+GROUP BY signature
+ORDER BY alerts_per_container DESC
+LIMIT 20;
+
+\echo
+\echo === Q2: insights_per_incident per signature ===
+\echo
+SELECT
+  signature,
+  COUNT(*)                                                                       AS total_incidents,
+  ROUND(AVG(insight_count)::numeric, 2)                                          AS avg_insights_per_incident,
+  ROUND(AVG(jsonb_array_length(affected_containers))::numeric, 2)                AS avg_containers_per_incident
+FROM incidents
+WHERE status = 'active' OR resolved_at >= NOW() - INTERVAL '7 days'
+GROUP BY signature
+ORDER BY total_incidents DESC;
+
+\echo
+\echo === Q3: emission share by category ===
+\echo
+SELECT
+  category,
+  COUNT(*)                                                                       AS total,
+  ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER (), 1)                             AS pct
+FROM insights
+WHERE created_at >= NOW() - INTERVAL '7 days'
+GROUP BY category
+ORDER BY total DESC;
+
+\echo
+\echo === Q4: dedup headroom for non-anomaly categories ===
+\echo (How many insights would collapse if (signature, container_name) keying applied.)
+\echo
+WITH derived AS (
+  SELECT
+    CASE
+      WHEN metric_type IS NOT NULL AND detection_method IS NOT NULL
+        THEN category || ':' || detection_method || ':' || metric_type
+      WHEN category = 'security'     THEN 'security:scan'
+      WHEN category = 'log-analysis' THEN 'log:pattern'
+      WHEN category = 'ai-analysis'  THEN 'ai:analysis'
+      ELSE category || ':unknown'
+    END AS signature,
+    category,
+    container_name
+  FROM insights
+  WHERE created_at >= NOW() - INTERVAL '7 days'
+)
+SELECT
+  category,
+  COUNT(*)                                                                       AS insights,
+  COUNT(*) FILTER (WHERE rn > 1)                                                  AS would_be_deduped,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE rn > 1) / NULLIF(COUNT(*), 0), 1)         AS pct_deduped
+FROM (
+  SELECT signature, category, container_name,
+         row_number() OVER (PARTITION BY signature, container_name ORDER BY container_name) AS rn
+  FROM derived
+) d
+WHERE category != 'anomaly'
+GROUP BY category
+ORDER BY insights DESC;

--- a/scripts/analyze-dedup-engine.sql
+++ b/scripts/analyze-dedup-engine.sql
@@ -22,12 +22,27 @@
 \echo
 WITH derived AS (
   SELECT
+    -- Mirrors services/signature.ts deriveSignature + TITLE_RULES so this script
+    -- reports the same signatures the runtime correlator does. Order matters:
+    -- the ml-detected branch must come before the bare anomalous-usage rule.
     CASE
       WHEN metric_type IS NOT NULL AND detection_method IS NOT NULL
         THEN category || ':' || detection_method || ':' || metric_type
       WHEN category = 'security'     THEN 'security:scan'
       WHEN category = 'log-analysis' THEN 'log:pattern'
       WHEN category = 'ai-analysis'  THEN 'ai:analysis'
+      WHEN title ~* 'predicted\s+(cpu|memory|disk)\s+exhaustion'
+        THEN 'predictive:prediction:' || lower((regexp_match(title, 'predicted\s+(cpu|memory|disk)\s+exhaustion', 'i'))[1])
+      WHEN title ~* 'anomalous\s+(cpu|memory|disk)\s+usage[^()]*\(ml-detected\)'
+        THEN 'anomaly:ml-anomaly:' || lower((regexp_match(title, 'anomalous\s+(cpu|memory|disk)', 'i'))[1])
+      WHEN title ~* 'anomalous\s+(cpu|memory|disk)\s+usage'
+        THEN 'anomaly:threshold:' || lower((regexp_match(title, 'anomalous\s+(cpu|memory|disk)', 'i'))[1])
+      WHEN title ~* 'high\s+(cpu|memory|disk)\s+usage'
+        THEN 'anomaly:threshold:' || lower((regexp_match(title, 'high\s+(cpu|memory|disk)', 'i'))[1])
+      WHEN title ~* 'no health check (configured|defined)|missing health check'
+        THEN 'config:health-check:missing'
+      WHEN title ~* 'host network mode'
+        THEN 'config:network:host-mode'
       ELSE category || ':unknown'
     END AS signature,
     container_name
@@ -75,12 +90,25 @@ ORDER BY total DESC;
 \echo
 WITH derived AS (
   SELECT
+    -- Same signature derivation as Q1 above. Keep in sync with both.
     CASE
       WHEN metric_type IS NOT NULL AND detection_method IS NOT NULL
         THEN category || ':' || detection_method || ':' || metric_type
       WHEN category = 'security'     THEN 'security:scan'
       WHEN category = 'log-analysis' THEN 'log:pattern'
       WHEN category = 'ai-analysis'  THEN 'ai:analysis'
+      WHEN title ~* 'predicted\s+(cpu|memory|disk)\s+exhaustion'
+        THEN 'predictive:prediction:' || lower((regexp_match(title, 'predicted\s+(cpu|memory|disk)\s+exhaustion', 'i'))[1])
+      WHEN title ~* 'anomalous\s+(cpu|memory|disk)\s+usage[^()]*\(ml-detected\)'
+        THEN 'anomaly:ml-anomaly:' || lower((regexp_match(title, 'anomalous\s+(cpu|memory|disk)', 'i'))[1])
+      WHEN title ~* 'anomalous\s+(cpu|memory|disk)\s+usage'
+        THEN 'anomaly:threshold:' || lower((regexp_match(title, 'anomalous\s+(cpu|memory|disk)', 'i'))[1])
+      WHEN title ~* 'high\s+(cpu|memory|disk)\s+usage'
+        THEN 'anomaly:threshold:' || lower((regexp_match(title, 'high\s+(cpu|memory|disk)', 'i'))[1])
+      WHEN title ~* 'no health check (configured|defined)|missing health check'
+        THEN 'config:health-check:missing'
+      WHEN title ~* 'host network mode'
+        THEN 'config:network:host-mode'
       ELSE category || ':unknown'
     END AS signature,
     category,


### PR DESCRIPTION
Closes #1200.

## Summary

Ships the per-signature emission telemetry the issue calls for, plus a documented position on each of the five research questions and the Confirmed Issue 2 (non-anomaly correlation) decision from #1195. The code changes for RQ1/RQ2/RQ3 themselves are deliberately deferred to a follow-up PR once the new table has at least a week of real data to baseline against.

## What ships

| Artifact | Purpose |
|---|---|
| `migration 033` (\`monitoring_dedup_metrics\` table) | One row per (signature, collected_at): total_insights, distinct_containers, alerts_per_container, total_incidents, avg_insights_per_incident |
| \`services/dedup-telemetry.ts\` | \`collectDedupMetrics\` (SQL-derives signatures the same way \`services/signature.ts\` does), \`insertDedupMetrics\`, \`runDedupTelemetryCycle\` |
| \`routes/dedup-telemetry.ts\` | \`GET /api/dedup-telemetry\` — admin-only via \`fastify.requireRole('admin')\` (emission rates per detector are sensitive) |
| \`scheduler.ts\` | Hourly hook, \`unref()\`'d, error-isolated |
| \`scripts/analyze-dedup-engine.sql\` | Runnable script with the four analysis queries from the issue body |
| \`docs/superpowers/specs/2026-05-16-1200-dedup-telemetry-design.md\` | Decision doc: RQ1–RQ5 + Confirmed Issue 2, with synthetic-data caveats |

## Decisions (summary — see design doc for full reasoning)

- **RQ1 — Non-anomaly insights joining correlation?** Yes for security / log-analysis / ai-analysis, yes for predictive with longer TTL. Q4 of the analysis shows 67–80% dedup headroom on those categories.
- **RQ2 — Right dedup TTL for predictions?** Per-category: anomaly 60min (current), security 6h, log 30min, ai 2h, **predictive 24h**.
- **RQ3 — Do the three dedup layers conflict?** Yes, they key on different shapes (\`metricType\` vs structured fields vs signature). Recommendation: keep three layers but unify the key as \`signature\` via a single \`dedupKey()\` helper.
- **RQ4 — Top emitters?** \`anomaly:threshold:cpu\` dominates in the synthetic data (3× the next-loudest). The new table is the long-term source of truth.
- **RQ5 — LLM summarizer input?** Keep the deduped incident (current behaviour). Documented to avoid regressions.

## Caveat

Dev DB had zero post-#1199 insights, so the analysis numbers in the design doc came from a synthetic 7-day seed (320 insights / 15 incidents / 8 containers / 8 signatures). Numbers are illustrative of the **shape** of expected production data — they're not a substitute for running \`scripts/analyze-dedup-engine.sql\` against prod once the new table has accrued data. The doc flags this in its Findings section.

## Test plan

- [x] Backend test suite green: 795 ai-intelligence + 41 server pass.
- [x] \`tsc\` clean across all workspaces.
- [x] \`eslint --max-warnings=0\` clean.
- [x] 10 new DB-bound integration tests (signature derivation, category fallbacks, window enforcement, incident joins, empty DB, append semantics).
- [x] 4 new route tests (admin gate 200 vs 403, signature filter, limit validation).
- [ ] Apply migration 033 on staging, leave for ≥1h, query \`monitoring_dedup_metrics\` for first row.

## Out of scope (next PR)

- The RQ1 / RQ2 / RQ3 code changes — they change \`correlateInsights()\` and \`insights-store.ts\` semantics and want a baseline from this telemetry first.
- Prometheus exporter — the DB table is the canonical data sink; add scraping later if operators ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)