### PR TITLE
fix(beyla): set UsernsMode=host so deploy works on userns-remap daemons

### DIFF
--- a/docker/docker-compose.beyla-edge-test.yml
+++ b/docker/docker-compose.beyla-edge-test.yml
@@ -5,6 +5,9 @@ services:
     restart: unless-stopped
     privileged: true
     pid: "host"
+    # Docker rejects privileged: true on daemons running with --userns-remap
+    # unless the container opts out of the user namespace. No-op without remap.
+    userns_mode: "host"
     init: true
     environment:
       # Capture common app ports; adjust for your workloads.

--- a/docker/docker-compose.beyla.yml
+++ b/docker/docker-compose.beyla.yml
@@ -33,6 +33,9 @@ services:
     image: grafana/beyla:1.8
     privileged: true
     pid: "host"
+    # Docker rejects privileged: true on daemons running with --userns-remap
+    # unless the container opts out of the user namespace. No-op without remap.
+    userns_mode: "host"
     init: true
     environment:
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT:-80,443,3000-9999}"

--- a/docs/ebpf-trace-ingestion.md
+++ b/docs/ebpf-trace-ingestion.md
@@ -58,6 +58,8 @@ Auto-instrument applications running on Portainer-managed containers using kerne
 | macOS/Windows | Works inside Docker Desktop's Linux VM but cannot instrument host processes |
 | Dashboard env | `TRACES_INGESTION_ENABLED=true` and `TRACES_INGESTION_API_KEY` set |
 
+> **User-namespace remap:** Beyla is deployed with `UsernsMode=host` (and `userns_mode: "host"` in the compose overlays). Required on daemons running with `--userns-remap` — Docker otherwise rejects `Privileged: true` with HTTP 400. Side-effect: the Beyla container runs as real root on the host, even when the daemon remaps other workloads. This matches the existing reality of `Privileged: true` + `PidMode: host` (the userns mapping was never effective for those containers) and is by design.
+
 ## Quick Start
 
 ### 1. Enable trace ingestion on the dashboard

--- a/packages/security/src/__tests__/ebpf-coverage.test.ts
+++ b/packages/security/src/__tests__/ebpf-coverage.test.ts
@@ -404,6 +404,36 @@ describe('ebpf-coverage service', () => {
       expect(mockStartContainer).toHaveBeenCalledWith(1, 'beyla-1');
     });
 
+    it('deployBeyla payload pins host namespaces (Privileged + PidMode + UsernsMode) for userns-remap daemons', async () => {
+      mockGetEndpoint.mockResolvedValueOnce({
+        Id: 1,
+        Name: 'prod-1',
+        Type: 1,
+        URL: 'tcp://prod-1',
+        Status: 1,
+        Snapshots: [],
+      } as any);
+      mockGetContainers.mockResolvedValueOnce([]);
+      mockCreateContainer.mockResolvedValueOnce({ Id: 'beyla-1' });
+
+      await deployBeyla(1, {
+        otlpEndpoint: 'http://dashboard.local/api/traces/otlp',
+        tracesApiKey: 'abc123',
+      });
+
+      expect(mockCreateContainer).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          HostConfig: expect.objectContaining({
+            Privileged: true,
+            PidMode: 'host',
+            UsernsMode: 'host',
+          }),
+        }),
+        expect.any(String),
+      );
+    });
+
     it('deployBeyla pre-flights the Edge Agent tunnel for type 4 endpoints', async () => {
       const nowSec = Math.floor(Date.now() / 1000);
       mockGetEndpoint.mockResolvedValueOnce({

--- a/packages/security/src/services/ebpf-coverage.ts
+++ b/packages/security/src/services/ebpf-coverage.ts
@@ -410,11 +410,8 @@ export async function deployBeyla(endpointId: number, options: DeployBeylaOption
     HostConfig: {
       Privileged: true,
       PidMode: 'host',
-      // Required when the target Docker daemon runs with --userns-remap:
-      // Docker refuses Privileged=true unless the container opts out of
-      // user-namespace isolation. No-op on daemons without userns-remap.
-      // Beyla already uses PidMode=host + Privileged, so userns isolation
-      // was never effective anyway — this just makes the contract explicit.
+      // Docker refuses Privileged=true on --userns-remap daemons unless
+      // the container opts out via UsernsMode=host. No-op without remap.
       UsernsMode: 'host',
       Init: true,
       Binds: [

--- a/packages/security/src/services/ebpf-coverage.ts
+++ b/packages/security/src/services/ebpf-coverage.ts
@@ -410,6 +410,12 @@ export async function deployBeyla(endpointId: number, options: DeployBeylaOption
     HostConfig: {
       Privileged: true,
       PidMode: 'host',
+      // Required when the target Docker daemon runs with --userns-remap:
+      // Docker refuses Privileged=true unless the container opts out of
+      // user-namespace isolation. No-op on daemons without userns-remap.
+      // Beyla already uses PidMode=host + Privileged, so userns isolation
+      // was never effective anyway — this just makes the contract explicit.
+      UsernsMode: 'host',
       Init: true,
       Binds: [
         '/sys/fs/cgroup:/sys/fs/cgroup',


### PR DESCRIPTION
## Symptom
Rolling out Beyla from **eBPF Coverage → Deploy** returns:

> HTTP 400: Bad Request — privileged mode is incompatible with user namespaces. You must run the container in the host namespace when running privileged mode.

The error is from the Docker daemon, surfaced via Portainer. It fires when the target host runs `dockerd --userns-remap=…` (or `userns-remap` in `daemon.json`) and the container payload sets `Privileged: true` without explicitly opting out of the user namespace.

## Root cause
`packages/security/src/services/ebpf-coverage.ts` builds the container payload with:

```ts
HostConfig: { Privileged: true, PidMode: 'host', Init: true, Binds: [...] }
```

Docker rejects `Privileged: true` on remap-enabled daemons unless the container also has `UsernsMode: 'host'`. The two local Beyla compose files (`docker/docker-compose.beyla.yml`, `docker/docker-compose.beyla-edge-test.yml`) had the same gap.

## Fix
Add `UsernsMode: 'host'` to the container payload and `userns_mode: "host"` to both compose files.

Why this is safe:
- Beyla already runs `Privileged: true` + `PidMode: host` for eBPF probes — userns mapping was never effective for this container anyway.
- `UsernsMode: 'host'` is the **default** on daemons without `--userns-remap`; setting it explicitly is a no-op there.
- On daemons **with** `--userns-remap` it just makes Docker accept the request that the privileged+pid:host combo was already implicitly asking for.

## Operator note — existing broken Beyla containers do NOT auto-heal
If a Beyla container exists from a previous successful deploy on a non-remap host (or was created out-of-band), this PR does **not** retroactively patch its `UsernsMode`. The detection logic in `findBeylaContainer` returns "already deployed" for any running Beyla container regardless of HostConfig.

For hosts where the earlier deploy failed (HTTP 400 from the original bug), no container exists, so the next deploy attempt will simply succeed with the new payload — no operator action needed.

For hosts that want to enforce the new field on an already-running Beyla container, redeploy with `recreateExisting: true` (the "Re-deploy" toggle in the UI) or remove + redeploy.

## Security note — userns-remap was acting as an implicit guardrail
Operators relying on `--userns-remap` to block privileged container deploys will lose that side-effect for Beyla specifically (the dashboard's existing RBAC + admin gating remain in force). Beyla runs as real root on the host by design — see `docs/ebpf-trace-ingestion.md` Prerequisites section, now updated to call this out explicitly.

## Test plan
- [x] New regression test in `packages/security/src/__tests__/ebpf-coverage.test.ts` asserts the container payload pins `Privileged`, `PidMode`, **and** `UsernsMode` so a future refactor can't quietly drop them.
- [x] `npm test -w @dashboard/security -- src/__tests__/ebpf-coverage.test.ts` — 45 passed.
- [x] `npm run lint` — clean.
- [x] `docker compose -f docker/docker-compose.beyla.yml config` — parses.
- [x] `docker compose -f docker/docker-compose.beyla-edge-test.yml config` — parses.
- [ ] Manual: re-run eBPF Coverage → Deploy on a `--userns-remap` host; expect HTTP 201 and a running Beyla container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)