### PR TITLE
feat(oidc): derive redirect URI from DASHBOARD_EXTERNAL_URL (#1270)

### DIFF
--- a/backend/src/routes/security-regression-auth.test.ts
+++ b/backend/src/routes/security-regression-auth.test.ts
@@ -82,7 +82,6 @@ vi.mock('@dashboard/core/services/oidc.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@dashboard/core/services/oidc.js')>();
   return {
     ...actual,
-    isOIDCEnabled: vi.fn(() => false),
     getOIDCConfig: vi.fn(() => null),
     generateAuthorizationUrl: vi.fn().mockResolvedValue(''),
     exchangeCode: vi.fn().mockResolvedValue(null),

--- a/backend/src/routes/security-regression-stream-tickets.test.ts
+++ b/backend/src/routes/security-regression-stream-tickets.test.ts
@@ -87,7 +87,6 @@ vi.mock('@dashboard/core/services/oidc.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@dashboard/core/services/oidc.js')>();
   return {
     ...actual,
-    isOIDCEnabled: vi.fn(() => false),
     getOIDCConfig: vi.fn(() => null),
     generateAuthorizationUrl: vi.fn().mockResolvedValue(''),
     exchangeCode: vi.fn().mockResolvedValue(null),

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -28,7 +28,10 @@ JWT_SECRET=generate-a-random-64-char-string
 # OIDC_ISSUER_URL=https://auth.example.com
 # OIDC_CLIENT_ID=dashboard-client
 # OIDC_CLIENT_SECRET=your-secret
-# OIDC_REDIRECT_URI=http://localhost:5273/auth/callback
+# The OIDC redirect URI is derived from DASHBOARD_EXTERNAL_URL (see below):
+# ${DASHBOARD_EXTERNAL_URL}/auth/callback. If DASHBOARD_EXTERNAL_URL is unset,
+# the value stored in the Settings UI (oidc.redirect_uri) is used as a manual
+# override. Either way, register the resulting URL with your IdP.
 
 # Portainer
 # For local development with Portainer on host: http://host.docker.internal:9000

--- a/frontend/src/features/core/components/settings/shared.tsx
+++ b/frontend/src/features/core/components/settings/shared.tsx
@@ -282,6 +282,11 @@ interface SettingsSectionProps {
   onChange: (key: string, value: string) => void;
   requiresRestart?: boolean;
   disabled?: boolean;
+  // Per-key disabled overrides. A row is disabled if the section is disabled
+  // OR its key is present here — used when a value is being supplied from
+  // outside the DB (env var, computed default) and editing would have no
+  // effect.
+  disabledKeys?: ReadonlySet<string>;
   footerContent?: React.ReactNode;
   status?: 'configured' | 'not-configured';
   statusLabel?: string;
@@ -297,6 +302,7 @@ export function SettingsSection({
   onChange,
   requiresRestart,
   disabled,
+  disabledKeys,
   footerContent,
   status,
   statusLabel,
@@ -341,7 +347,7 @@ export function SettingsSection({
             value={values[setting.key] ?? setting.defaultValue}
             onChange={(value) => onChange(setting.key, value)}
             hasChanges={values[setting.key] !== originalValues[setting.key]}
-            disabled={disabled}
+            disabled={disabled || disabledKeys?.has(setting.key)}
           />
         ))}
       </div>

--- a/frontend/src/features/core/components/settings/shared.tsx
+++ b/frontend/src/features/core/components/settings/shared.tsx
@@ -52,7 +52,7 @@ export const DEFAULT_SETTINGS = {
     { key: 'oidc.issuer_url', label: 'Issuer URL', description: 'OIDC provider issuer URL (e.g., https://auth.example.com/realms/master)', type: 'string', defaultValue: '' },
     { key: 'oidc.client_id', label: 'Client ID', description: 'OIDC client identifier registered with your provider', type: 'string', defaultValue: '' },
     { key: 'oidc.client_secret', label: 'Client Secret', description: 'OIDC client secret for server-side authentication', type: 'password', defaultValue: '' },
-    { key: 'oidc.redirect_uri', label: 'Redirect URI', description: 'Callback URL (e.g., http://localhost:5273/auth/callback)', type: 'string', defaultValue: '' },
+    { key: 'oidc.redirect_uri', label: 'Redirect URI', description: 'Callback URL registered with your IdP. Leave blank to inherit from DASHBOARD_EXTERNAL_URL — when that env var is set, it takes precedence and the value here is ignored.', type: 'string', defaultValue: '' },
     { key: 'oidc.scopes', label: 'Scopes', description: 'Space-separated OIDC scopes to request', type: 'string', defaultValue: 'openid profile email' },
     { key: 'oidc.local_auth_enabled', label: 'Keep Local Auth Enabled', description: 'Allow username/password login alongside SSO', type: 'boolean', defaultValue: 'true' },
     { key: 'oidc.groups_claim', label: 'Groups Claim', description: 'ID token claim name containing group membership (e.g., groups, roles, or a custom claim)', type: 'string', defaultValue: 'groups' },

--- a/frontend/src/features/core/components/settings/tab-security.tsx
+++ b/frontend/src/features/core/components/settings/tab-security.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
-import { Loader2, Shield } from 'lucide-react';
+import { Info, Loader2, Shield } from 'lucide-react';
 import { useSecurityIgnoreList, useUpdateSecurityIgnoreList } from '@/features/security/hooks/use-security-audit';
+import { useOIDCEffectiveRedirectUri } from '@/features/core/hooks/use-oidc';
 import { SettingsSection, DEFAULT_SETTINGS, type SettingsTabProps } from './shared';
 import { GroupRoleMappingEditor } from './group-role-mapping-editor';
 import { cn } from '@/shared/lib/utils';
@@ -16,6 +17,7 @@ export function SecurityTab({ editedValues, originalValues, onChange, isSaving }
   );
 
   const isOIDCEnabled = editedValues['oidc.enabled'] === 'true';
+  const { data: effectiveRedirect } = useOIDCEffectiveRedirectUri();
 
   return (
     <div className="space-y-6">
@@ -32,6 +34,26 @@ export function SecurityTab({ editedValues, originalValues, onChange, isSaving }
         disabled={isSaving}
         status={isOIDCEnabled ? 'configured' : 'not-configured'}
         statusLabel={isOIDCEnabled ? 'Enabled' : 'Disabled'}
+        footerContent={
+          effectiveRedirect && effectiveRedirect.source !== 'none' ? (
+            <div className="flex items-start gap-2 rounded-md border border-blue-200/60 bg-blue-50/50 p-3 text-sm dark:border-blue-900/50 dark:bg-blue-950/30">
+              <Info className="h-4 w-4 mt-0.5 shrink-0 text-blue-600 dark:text-blue-400" />
+              <div className="space-y-1">
+                <p className="font-medium">
+                  Effective Redirect URI:{' '}
+                  <code className="rounded bg-background px-1.5 py-0.5 font-mono text-xs">
+                    {effectiveRedirect.redirectUri}
+                  </code>
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {effectiveRedirect.source === 'env'
+                    ? 'Derived from the DASHBOARD_EXTERNAL_URL environment variable. The Redirect URI field above is ignored while this env var is set. Register this exact URL with your IdP.'
+                    : 'Derived from the Redirect URI field above. Set DASHBOARD_EXTERNAL_URL to inherit it from the dashboard’s public URL automatically.'}
+                </p>
+              </div>
+            </div>
+          ) : null
+        }
       />
 
       {/* Group-to-Role Mapping Editor (only visible when OIDC is enabled) */}

--- a/frontend/src/features/core/components/settings/tab-security.tsx
+++ b/frontend/src/features/core/components/settings/tab-security.tsx
@@ -18,6 +18,11 @@ export function SecurityTab({ editedValues, originalValues, onChange, isSaving }
 
   const isOIDCEnabled = editedValues['oidc.enabled'] === 'true';
   const { data: effectiveRedirect } = useOIDCEffectiveRedirectUri();
+  const envOverridesRedirectUri = effectiveRedirect?.source === 'env';
+  const disabledAuthKeys = useMemo(
+    () => (envOverridesRedirectUri ? new Set(['oidc.redirect_uri']) : undefined),
+    [envOverridesRedirectUri],
+  );
 
   return (
     <div className="space-y-6">
@@ -32,6 +37,7 @@ export function SecurityTab({ editedValues, originalValues, onChange, isSaving }
         onChange={onChange}
         requiresRestart
         disabled={isSaving}
+        disabledKeys={disabledAuthKeys}
         status={isOIDCEnabled ? 'configured' : 'not-configured'}
         statusLabel={isOIDCEnabled ? 'Enabled' : 'Disabled'}
         footerContent={

--- a/frontend/src/features/core/hooks/use-oidc.ts
+++ b/frontend/src/features/core/hooks/use-oidc.ts
@@ -7,11 +7,25 @@ interface OIDCStatus {
   state?: string;
 }
 
+export interface OIDCEffectiveRedirectUri {
+  redirectUri: string;
+  source: 'env' | 'setting' | 'none';
+}
+
 export function useOIDCStatus() {
   return useQuery<OIDCStatus>({
     queryKey: ['oidc-status'],
     queryFn: () => api.get<OIDCStatus>('/api/auth/oidc/status'),
     staleTime: 30 * 1000,
+    retry: false,
+  });
+}
+
+export function useOIDCEffectiveRedirectUri() {
+  return useQuery<OIDCEffectiveRedirectUri>({
+    queryKey: ['oidc-effective-redirect-uri'],
+    queryFn: () => api.get<OIDCEffectiveRedirectUri>('/api/auth/oidc/effective-redirect-uri'),
+    staleTime: 60 * 1000,
     retry: false,
   });
 }

--- a/packages/core/src/models/api-schemas.ts
+++ b/packages/core/src/models/api-schemas.ts
@@ -62,6 +62,16 @@ export const OidcCallbackBodySchema = z.object({
   state: z.string(),
 });
 
+// Returned by GET /api/auth/oidc/effective-redirect-uri (admin-only).
+// `source` lets the Settings UI explain to the operator where the value comes
+// from: 'env' means DASHBOARD_EXTERNAL_URL is taking precedence and the
+// per-setting field is being ignored; 'setting' means only the manual value
+// applies; 'none' means neither is configured.
+export const OidcEffectiveRedirectUriResponseSchema = z.object({
+  redirectUri: z.string(),
+  source: z.enum(['env', 'setting', 'none']),
+});
+
 // ─── Health schemas ─────────────────────────────────────────────────
 export const HealthResponseSchema = z.object({
   status: z.string(),

--- a/packages/core/src/services/oidc-redirect-uri.test.ts
+++ b/packages/core/src/services/oidc-redirect-uri.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+// Kept: openid-client mock — external dependency
+vi.mock('openid-client', () => ({}));
+
+import { getEffectiveRedirectUri } from './oidc.js';
+import { setConfigForTest, resetConfig } from '../config/index.js';
+
+describe('getEffectiveRedirectUri', () => {
+  afterEach(() => {
+    resetConfig();
+  });
+
+  it('uses DASHBOARD_EXTERNAL_URL when set, regardless of the manual setting', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://dashboard.example.com' });
+    const result = getEffectiveRedirectUri('http://stale.localhost/auth/callback');
+    expect(result).toEqual({
+      redirectUri: 'https://dashboard.example.com/auth/callback',
+      source: 'env',
+    });
+  });
+
+  it('strips trailing slashes from DASHBOARD_EXTERNAL_URL', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://dashboard.example.com///' });
+    const result = getEffectiveRedirectUri('');
+    expect(result.redirectUri).toBe('https://dashboard.example.com/auth/callback');
+    expect(result.source).toBe('env');
+  });
+
+  it('falls back to the manual setting when DASHBOARD_EXTERNAL_URL is unset', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
+    const result = getEffectiveRedirectUri('https://manual.example.com/auth/callback');
+    expect(result).toEqual({
+      redirectUri: 'https://manual.example.com/auth/callback',
+      source: 'setting',
+    });
+  });
+
+  it('trims surrounding whitespace from the manual setting', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
+    const result = getEffectiveRedirectUri('  https://manual.example.com/auth/callback  ');
+    expect(result.redirectUri).toBe('https://manual.example.com/auth/callback');
+    expect(result.source).toBe('setting');
+  });
+
+  it('returns source "none" when neither env nor manual setting is configured', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
+    const result = getEffectiveRedirectUri('');
+    expect(result).toEqual({ redirectUri: '', source: 'none' });
+  });
+
+  it('treats a whitespace-only manual setting as unset', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
+    const result = getEffectiveRedirectUri('   ');
+    expect(result.source).toBe('none');
+  });
+
+  it('env precedence wins even when the env URL is the same as the manual setting', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://dashboard.example.com' });
+    const result = getEffectiveRedirectUri('https://dashboard.example.com/auth/callback');
+    expect(result.source).toBe('env');
+  });
+});

--- a/packages/core/src/services/oidc-redirect-uri.test.ts
+++ b/packages/core/src/services/oidc-redirect-uri.test.ts
@@ -3,8 +3,21 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 // Kept: openid-client mock — external dependency
 vi.mock('openid-client', () => ({}));
 
-import { getEffectiveRedirectUri } from './oidc.js';
+import { getEffectiveRedirectUri, isOIDCConfigEnabled, type OIDCConfig } from './oidc.js';
 import { setConfigForTest, resetConfig } from '../config/index.js';
+
+const fullConfig: OIDCConfig = {
+  enabled: true,
+  issuer_url: 'https://idp.example.com',
+  client_id: 'client',
+  client_secret: 'secret',
+  redirect_uri: '',
+  scopes: 'openid profile email',
+  local_auth_enabled: true,
+  groups_claim: 'groups',
+  group_role_mappings: {},
+  auto_provision: true,
+};
 
 describe('getEffectiveRedirectUri', () => {
   afterEach(() => {
@@ -59,5 +72,49 @@ describe('getEffectiveRedirectUri', () => {
     setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://dashboard.example.com' });
     const result = getEffectiveRedirectUri('https://dashboard.example.com/auth/callback');
     expect(result.source).toBe('env');
+  });
+
+  it('preserves sub-paths in DASHBOARD_EXTERNAL_URL', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://example.com/dashboard' });
+    const result = getEffectiveRedirectUri('');
+    expect(result.redirectUri).toBe('https://example.com/dashboard/auth/callback');
+  });
+
+  it('strips query and fragment from DASHBOARD_EXTERNAL_URL', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://example.com/dashboard?foo=bar#section' });
+    const result = getEffectiveRedirectUri('');
+    expect(result.redirectUri).toBe('https://example.com/dashboard/auth/callback');
+  });
+
+  it('preserves a non-default port in DASHBOARD_EXTERNAL_URL', () => {
+    setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'http://192.168.178.20:3051' });
+    const result = getEffectiveRedirectUri('');
+    expect(result.redirectUri).toBe('http://192.168.178.20:3051/auth/callback');
+  });
+});
+
+describe('isOIDCConfigEnabled', () => {
+  it('returns true when all credentials and a redirect URI are present', () => {
+    expect(isOIDCConfigEnabled(fullConfig, 'https://dashboard.example.com/auth/callback')).toBe(true);
+  });
+
+  it('returns false when the redirect URI is empty', () => {
+    expect(isOIDCConfigEnabled(fullConfig, '')).toBe(false);
+  });
+
+  it('returns false when enabled flag is off', () => {
+    expect(isOIDCConfigEnabled({ ...fullConfig, enabled: false }, 'https://x/auth/callback')).toBe(false);
+  });
+
+  it('returns false when issuer_url is missing', () => {
+    expect(isOIDCConfigEnabled({ ...fullConfig, issuer_url: '' }, 'https://x/auth/callback')).toBe(false);
+  });
+
+  it('returns false when client_id is missing', () => {
+    expect(isOIDCConfigEnabled({ ...fullConfig, client_id: '' }, 'https://x/auth/callback')).toBe(false);
+  });
+
+  it('returns false when client_secret is missing', () => {
+    expect(isOIDCConfigEnabled({ ...fullConfig, client_secret: '' }, 'https://x/auth/callback')).toBe(false);
   });
 });

--- a/packages/core/src/services/oidc.ts
+++ b/packages/core/src/services/oidc.ts
@@ -1,7 +1,17 @@
 import * as client from 'openid-client';
 import { getDbForDomain } from '../db/app-db-router.js';
+import { getConfig } from '../config/index.js';
 import { createChildLogger } from '../utils/logger.js';
 import type { Role } from './user-store.js';
+
+export const OIDC_CALLBACK_PATH = '/auth/callback';
+
+export type RedirectUriSource = 'env' | 'setting' | 'none';
+
+export interface EffectiveRedirectUri {
+  redirectUri: string;
+  source: RedirectUriSource;
+}
 
 const log = createChildLogger('oidc');
 
@@ -97,6 +107,31 @@ export async function getOIDCConfig(): Promise<OIDCConfig> {
     group_role_mappings: groupRoleMappings,
     auto_provision: settings['oidc.auto_provision'] !== 'false',
   };
+}
+
+/**
+ * Compute the effective OIDC redirect URI.
+ *
+ * Precedence:
+ *   1. `DASHBOARD_EXTERNAL_URL` env var → `${baseUrl}/auth/callback`
+ *   2. `oidc.redirect_uri` setting (manual override / legacy)
+ *   3. Empty string (caller should treat as not configured)
+ *
+ * The env var wins by design — operators set their public URL once and the
+ * OIDC flow inherits it automatically, removing a footgun where a forgotten
+ * Settings field broke SSO after a deployment URL change.
+ */
+export function getEffectiveRedirectUri(manualSetting: string): EffectiveRedirectUri {
+  const externalUrl = getConfig().DASHBOARD_EXTERNAL_URL;
+  if (externalUrl) {
+    const base = externalUrl.replace(/\/+$/, '');
+    return { redirectUri: `${base}${OIDC_CALLBACK_PATH}`, source: 'env' };
+  }
+  const trimmed = manualSetting.trim();
+  if (trimmed) {
+    return { redirectUri: trimmed, source: 'setting' };
+  }
+  return { redirectUri: '', source: 'none' };
 }
 
 /**

--- a/packages/core/src/services/oidc.ts
+++ b/packages/core/src/services/oidc.ts
@@ -158,16 +158,6 @@ export function isOIDCConfigEnabled(config: OIDCConfig, resolvedRedirectUri: str
 }
 
 /**
- * Check if OIDC is enabled and fully configured — that includes a resolvable
- * redirect URI (either env-derived or set manually).
- */
-export async function isOIDCEnabled(): Promise<boolean> {
-  const config = await getOIDCConfig();
-  const { redirectUri } = getEffectiveRedirectUri(config.redirect_uri);
-  return isOIDCConfigEnabled(config, redirectUri);
-}
-
-/**
  * Get or create the OIDC discovery configuration, cached for 1 hour.
  */
 async function getOrCreateConfiguration(): Promise<client.Configuration> {

--- a/packages/core/src/services/oidc.ts
+++ b/packages/core/src/services/oidc.ts
@@ -15,7 +15,7 @@ export interface EffectiveRedirectUri {
 
 const log = createChildLogger('oidc');
 
-interface OIDCConfig {
+export interface OIDCConfig {
   enabled: boolean;
   issuer_url: string;
   client_id: string;
@@ -113,19 +113,27 @@ export async function getOIDCConfig(): Promise<OIDCConfig> {
  * Compute the effective OIDC redirect URI.
  *
  * Precedence:
- *   1. `DASHBOARD_EXTERNAL_URL` env var → `${baseUrl}/auth/callback`
+ *   1. `DASHBOARD_EXTERNAL_URL` env var → `${origin}${basePath}/auth/callback`
  *   2. `oidc.redirect_uri` setting (manual override / legacy)
  *   3. Empty string (caller should treat as not configured)
  *
  * The env var wins by design — operators set their public URL once and the
  * OIDC flow inherits it automatically, removing a footgun where a forgotten
  * Settings field broke SSO after a deployment URL change.
+ *
+ * The env URL is parsed via `new URL()` so any query string or fragment is
+ * dropped and the callback path is appended to the URL's own path (supporting
+ * sub-path deployments like `https://example.com/dashboard`).
  */
 export function getEffectiveRedirectUri(manualSetting: string): EffectiveRedirectUri {
   const externalUrl = getConfig().DASHBOARD_EXTERNAL_URL;
   if (externalUrl) {
-    const base = externalUrl.replace(/\/+$/, '');
-    return { redirectUri: `${base}${OIDC_CALLBACK_PATH}`, source: 'env' };
+    const parsed = new URL(externalUrl);
+    const basePath = parsed.pathname.replace(/\/+$/, '');
+    return {
+      redirectUri: `${parsed.origin}${basePath}${OIDC_CALLBACK_PATH}`,
+      source: 'env',
+    };
   }
   const trimmed = manualSetting.trim();
   if (trimmed) {
@@ -135,11 +143,28 @@ export function getEffectiveRedirectUri(manualSetting: string): EffectiveRedirec
 }
 
 /**
- * Check if OIDC is enabled and has required fields configured.
+ * Pure variant: check if a previously-loaded OIDC config + resolved redirect
+ * URI represent a fully-enabled setup. Use this when you already have both
+ * values in hand to avoid a second DB read.
+ */
+export function isOIDCConfigEnabled(config: OIDCConfig, resolvedRedirectUri: string): boolean {
+  return (
+    config.enabled &&
+    !!config.issuer_url &&
+    !!config.client_id &&
+    !!config.client_secret &&
+    !!resolvedRedirectUri
+  );
+}
+
+/**
+ * Check if OIDC is enabled and fully configured — that includes a resolvable
+ * redirect URI (either env-derived or set manually).
  */
 export async function isOIDCEnabled(): Promise<boolean> {
   const config = await getOIDCConfig();
-  return config.enabled && !!config.issuer_url && !!config.client_id && !!config.client_secret;
+  const { redirectUri } = getEffectiveRedirectUri(config.redirect_uri);
+  return isOIDCConfigEnabled(config, redirectUri);
 }
 
 /**

--- a/packages/foundation/src/__tests__/oidc-route.test.ts
+++ b/packages/foundation/src/__tests__/oidc-route.test.ts
@@ -9,7 +9,6 @@ vi.mock('@dashboard/core/services/oidc.js', async (importOriginal) => {
   return {
     ...real,
     getOIDCConfig: vi.fn(),
-    isOIDCEnabled: vi.fn(),
     generateAuthorizationUrl: vi.fn(),
   };
 });
@@ -19,7 +18,6 @@ import { setConfigForTest, resetConfig } from '@dashboard/core/config/index.js';
 import { oidcRoutes } from '../routes/oidc.js';
 
 const mockedGetConfig = vi.mocked(oidcService.getOIDCConfig);
-const mockedIsEnabled = vi.mocked(oidcService.isOIDCEnabled);
 const mockedGenerateAuthUrl = vi.mocked(oidcService.generateAuthorizationUrl);
 
 const baseOidcConfig = {
@@ -58,7 +56,6 @@ describe('OIDC Routes', () => {
 
   beforeEach(() => {
     mockedGetConfig.mockReset();
-    mockedIsEnabled.mockReset();
     mockedGenerateAuthUrl.mockReset();
   });
 
@@ -119,7 +116,6 @@ describe('OIDC Routes', () => {
   describe('GET /api/auth/oidc/status', () => {
     it('passes the env-derived URI to generateAuthorizationUrl', async () => {
       setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://dashboard.example.com' });
-      mockedIsEnabled.mockResolvedValue(true);
       mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: 'http://localhost:5173/auth/callback' });
       mockedGenerateAuthUrl.mockResolvedValue({ url: 'https://idp.example.com/authz?state=xyz', state: 'xyz' });
 
@@ -142,7 +138,6 @@ describe('OIDC Routes', () => {
 
     it('uses the manual setting when env is unset', async () => {
       setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
-      mockedIsEnabled.mockResolvedValue(true);
       mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: 'https://manual.example.com/auth/callback' });
       mockedGenerateAuthUrl.mockResolvedValue({ url: 'https://idp.example.com/authz', state: 's' });
 
@@ -157,8 +152,18 @@ describe('OIDC Routes', () => {
 
     it('reports disabled when redirect URI cannot be resolved', async () => {
       setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
-      mockedIsEnabled.mockResolvedValue(true);
       mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: '' });
+
+      const response = await app.inject({ method: 'GET', url: '/api/auth/oidc/status' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ enabled: false });
+      expect(mockedGenerateAuthUrl).not.toHaveBeenCalled();
+    });
+
+    it('reports disabled when enabled flag is off, even with a resolvable URI', async () => {
+      setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://dashboard.example.com' });
+      mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, enabled: false });
 
       const response = await app.inject({ method: 'GET', url: '/api/auth/oidc/status' });
 

--- a/packages/foundation/src/__tests__/oidc-route.test.ts
+++ b/packages/foundation/src/__tests__/oidc-route.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+
+// Stub external/DB-touching boundaries so the route test stays in-process.
+vi.mock('openid-client', () => ({}));
+vi.mock('@dashboard/core/services/oidc.js', async (importOriginal) => {
+  const real = await importOriginal() as typeof import('@dashboard/core/services/oidc.js');
+  return {
+    ...real,
+    getOIDCConfig: vi.fn(),
+    isOIDCEnabled: vi.fn(),
+    generateAuthorizationUrl: vi.fn(),
+  };
+});
+
+import * as oidcService from '@dashboard/core/services/oidc.js';
+import { setConfigForTest, resetConfig } from '@dashboard/core/config/index.js';
+import { oidcRoutes } from '../routes/oidc.js';
+
+const mockedGetConfig = vi.mocked(oidcService.getOIDCConfig);
+const mockedIsEnabled = vi.mocked(oidcService.isOIDCEnabled);
+const mockedGenerateAuthUrl = vi.mocked(oidcService.generateAuthorizationUrl);
+
+const baseOidcConfig = {
+  enabled: true,
+  issuer_url: 'https://idp.example.com',
+  client_id: 'client',
+  client_secret: 'secret',
+  redirect_uri: '',
+  scopes: 'openid profile email',
+  local_auth_enabled: true,
+  groups_claim: 'groups',
+  group_role_mappings: {},
+  auto_provision: true,
+};
+
+describe('OIDC Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', () => async () => undefined);
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      request.user = { sub: 'u1', username: 'admin', sessionId: 's1', role: 'admin' as const };
+    });
+    await app.register(oidcRoutes);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    mockedGetConfig.mockReset();
+    mockedIsEnabled.mockReset();
+    mockedGenerateAuthUrl.mockReset();
+  });
+
+  afterEach(() => {
+    resetConfig();
+  });
+
+  describe('GET /api/auth/oidc/effective-redirect-uri', () => {
+    it('returns env-derived URI when DASHBOARD_EXTERNAL_URL is set', async () => {
+      setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://dashboard.example.com' });
+      mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: 'https://stale.example.com/auth/callback' });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/auth/oidc/effective-redirect-uri',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        redirectUri: 'https://dashboard.example.com/auth/callback',
+        source: 'env',
+      });
+    });
+
+    it('falls back to the manual setting when env is unset', async () => {
+      setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
+      mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: 'https://manual.example.com/auth/callback' });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/auth/oidc/effective-redirect-uri',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        redirectUri: 'https://manual.example.com/auth/callback',
+        source: 'setting',
+      });
+    });
+
+    it('reports source "none" when neither is configured', async () => {
+      setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
+      mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: '' });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/auth/oidc/effective-redirect-uri',
+        headers: { authorization: 'Bearer test' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ redirectUri: '', source: 'none' });
+    });
+  });
+
+  describe('GET /api/auth/oidc/status', () => {
+    it('passes the env-derived URI to generateAuthorizationUrl', async () => {
+      setConfigForTest({ DASHBOARD_EXTERNAL_URL: 'https://dashboard.example.com' });
+      mockedIsEnabled.mockResolvedValue(true);
+      mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: 'http://localhost:5173/auth/callback' });
+      mockedGenerateAuthUrl.mockResolvedValue({ url: 'https://idp.example.com/authz?state=xyz', state: 'xyz' });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/auth/oidc/status',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        enabled: true,
+        authUrl: 'https://idp.example.com/authz?state=xyz',
+        state: 'xyz',
+      });
+      expect(mockedGenerateAuthUrl).toHaveBeenCalledWith(
+        'https://dashboard.example.com/auth/callback',
+        'openid profile email',
+      );
+    });
+
+    it('uses the manual setting when env is unset', async () => {
+      setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
+      mockedIsEnabled.mockResolvedValue(true);
+      mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: 'https://manual.example.com/auth/callback' });
+      mockedGenerateAuthUrl.mockResolvedValue({ url: 'https://idp.example.com/authz', state: 's' });
+
+      const response = await app.inject({ method: 'GET', url: '/api/auth/oidc/status' });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockedGenerateAuthUrl).toHaveBeenCalledWith(
+        'https://manual.example.com/auth/callback',
+        'openid profile email',
+      );
+    });
+
+    it('reports disabled when redirect URI cannot be resolved', async () => {
+      setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
+      mockedIsEnabled.mockResolvedValue(true);
+      mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: '' });
+
+      const response = await app.inject({ method: 'GET', url: '/api/auth/oidc/status' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ enabled: false });
+      expect(mockedGenerateAuthUrl).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/foundation/src/routes/oidc.ts
+++ b/packages/foundation/src/routes/oidc.ts
@@ -1,10 +1,10 @@
 import { FastifyInstance } from 'fastify';
-import { isOIDCEnabled, getOIDCConfig, generateAuthorizationUrl, exchangeCode, resolveRoleFromGroups } from '@dashboard/core/services/oidc.js';
+import { isOIDCEnabled, getOIDCConfig, generateAuthorizationUrl, exchangeCode, resolveRoleFromGroups, getEffectiveRedirectUri } from '@dashboard/core/services/oidc.js';
 import { createSession, invalidateSession } from '@dashboard/core/services/session-store.js';
 import { signJwt } from '@dashboard/core/utils/crypto.js';
 import { writeAuditLog } from '@dashboard/core/services/audit-logger.js';
 import { upsertOIDCUser, getUserById } from '@dashboard/core/services/user-store.js';
-import { OidcStatusResponseSchema, OidcCallbackBodySchema, LoginResponseSchema, ErrorResponseSchema, SuccessResponseSchema } from '@dashboard/core/models/api-schemas.js';
+import { OidcStatusResponseSchema, OidcCallbackBodySchema, OidcEffectiveRedirectUriResponseSchema, LoginResponseSchema, ErrorResponseSchema, SuccessResponseSchema } from '@dashboard/core/models/api-schemas.js';
 import { getConfig } from '@dashboard/core/config/index.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 
@@ -30,7 +30,7 @@ export async function oidcRoutes(fastify: FastifyInstance) {
 
     try {
       const oidcConfig = await getOIDCConfig();
-      const redirectUri = oidcConfig.redirect_uri;
+      const { redirectUri } = getEffectiveRedirectUri(oidcConfig.redirect_uri);
       if (!redirectUri) {
         return { enabled: false };
       }
@@ -41,6 +41,24 @@ export async function oidcRoutes(fastify: FastifyInstance) {
       fastify.log.error({ err }, 'Failed to generate OIDC authorization URL');
       return reply.code(500).send({ error: 'Failed to initialize OIDC' });
     }
+  });
+
+  // Effective redirect URI (admin-only) — surfaces the value the backend will
+  // actually use, so the Settings UI can show the env-derived URI as a hint
+  // even when no manual value is stored.
+  fastify.get('/api/auth/oidc/effective-redirect-uri', {
+    schema: {
+      tags: ['Auth'],
+      summary: 'Get the effective OIDC redirect URI (env or manual setting)',
+      security: [{ bearerAuth: [] }],
+      response: {
+        200: OidcEffectiveRedirectUriResponseSchema,
+      },
+    },
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
+  }, async () => {
+    const oidcConfig = await getOIDCConfig();
+    return getEffectiveRedirectUri(oidcConfig.redirect_uri);
   });
 
   // OIDC callback (public — no auth required)

--- a/packages/foundation/src/routes/oidc.ts
+++ b/packages/foundation/src/routes/oidc.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify';
-import { isOIDCEnabled, getOIDCConfig, generateAuthorizationUrl, exchangeCode, resolveRoleFromGroups, getEffectiveRedirectUri } from '@dashboard/core/services/oidc.js';
+import { getOIDCConfig, generateAuthorizationUrl, exchangeCode, resolveRoleFromGroups, getEffectiveRedirectUri, isOIDCConfigEnabled } from '@dashboard/core/services/oidc.js';
 import { createSession, invalidateSession } from '@dashboard/core/services/session-store.js';
 import { signJwt } from '@dashboard/core/utils/crypto.js';
 import { writeAuditLog } from '@dashboard/core/services/audit-logger.js';
@@ -24,14 +24,10 @@ export async function oidcRoutes(fastify: FastifyInstance) {
       },
     },
   }, async (_request, reply) => {
-    if (!(await isOIDCEnabled())) {
-      return { enabled: false };
-    }
-
     try {
       const oidcConfig = await getOIDCConfig();
       const { redirectUri } = getEffectiveRedirectUri(oidcConfig.redirect_uri);
-      if (!redirectUri) {
+      if (!isOIDCConfigEnabled(oidcConfig, redirectUri)) {
         return { enabled: false };
       }
 


### PR DESCRIPTION
## Summary

- Adds a `getEffectiveRedirectUri()` helper in `packages/core/src/services/oidc.ts` that computes `${DASHBOARD_EXTERNAL_URL}/auth/callback` when the env var is set, and falls back to the manual `oidc.redirect_uri` Settings field otherwise.
- The OIDC authorization-URL route (`packages/foundation/src/routes/oidc.ts`) now uses the helper, so the URI the dashboard sends to the IdP automatically tracks the public dashboard URL.
- New admin-only `GET /api/auth/oidc/effective-redirect-uri` endpoint surfaces the computed value and its source (`env` / `setting` / `none`). The Security tab in Settings renders it as a banner so operators can copy the canonical URL into their IdP without guessing.

## Why

The Settings page only ever read `oidc.redirect_uri` from the database, and the placeholder hint showed `http://localhost:5273/auth/callback` — a dev-only URL that operators routinely shipped to production. Meanwhile `DASHBOARD_EXTERNAL_URL` already exists (used by the eBPF/Beyla flow) and is exactly the value SSO should inherit. With this change, setting `DASHBOARD_EXTERNAL_URL=https://dashboard.example.com` is enough for the OIDC redirect URI to be correct everywhere, and the manual field remains as an override / fallback so existing deployments don't break.

Closes #1270

## Test plan

- [x] `packages/core/src/services/oidc-redirect-uri.test.ts` — 7 unit tests covering env precedence, trailing-slash normalization, manual-setting fallback, whitespace handling, and the `none` source.
- [x] `packages/foundation/src/__tests__/oidc-route.test.ts` — 6 route tests covering the new admin endpoint (env / setting / none) and that `/api/auth/oidc/status` passes the env-derived URI to `generateAuthorizationUrl`.
- [x] `backend/src/routes/security-regression-auth.test.ts` — passes (verifies the new endpoint is correctly not in the public-routes whitelist and is enforced as admin-only).
- [x] `npm run typecheck` clean across all workspaces.
- [x] `npm run lint` clean.
- [ ] Manual: set `DASHBOARD_EXTERNAL_URL=https://dashboard.example.com`, open Settings → Security → Authentication, confirm the banner shows the env-derived URI with the "Derived from the DASHBOARD_EXTERNAL_URL environment variable" message.
- [ ] Manual: unset `DASHBOARD_EXTERNAL_URL`, set `oidc.redirect_uri` in Settings, confirm the banner shows the manual value with the alternate message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)