### PR TITLE
feat(oidc): opt-in insecure-transport flag + fix callback serialization (#1272)

### DIFF
--- a/frontend/src/features/core/components/settings/shared.tsx
+++ b/frontend/src/features/core/components/settings/shared.tsx
@@ -58,6 +58,7 @@ export const DEFAULT_SETTINGS = {
     { key: 'oidc.groups_claim', label: 'Groups Claim', description: 'ID token claim name containing group membership (e.g., groups, roles, or a custom claim)', type: 'string', defaultValue: 'groups' },
     { key: 'oidc.group_role_mappings', label: 'Group-to-Role Mappings', description: 'JSON mapping of IdP group names to dashboard roles. Use * as a wildcard fallback.', type: 'string', defaultValue: '{}' },
     { key: 'oidc.auto_provision', label: 'Auto-Provision OIDC Users', description: 'Automatically create user records for new OIDC-authenticated users', type: 'boolean', defaultValue: 'true' },
+    { key: 'oidc.allow_insecure_transport', label: 'Allow Insecure Transport (HTTP)', description: '⚠ Permit plain-HTTP OIDC discovery and token exchange. Auth codes and tokens travel unencrypted — enable ONLY for local development against an HTTP-only IdP. Never enable in production.', type: 'boolean', defaultValue: 'false' },
   ],
   webhooks: [
     { key: 'webhooks.enabled', label: 'Enable Webhooks', description: 'Enable outbound webhook event delivery', type: 'boolean', defaultValue: 'false' },

--- a/packages/core/src/services/oidc-insecure-transport.test.ts
+++ b/packages/core/src/services/oidc-insecure-transport.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// vi.mock factories are hoisted; bind the mock fns via vi.hoisted so the
+// test body can assert on them later.
+const { discoveryMock, allowInsecureRequestsMock } = vi.hoisted(() => ({
+  discoveryMock: vi.fn().mockResolvedValue({ __fake: 'config' }),
+  allowInsecureRequestsMock: vi.fn(),
+}));
+
+vi.mock('openid-client', () => ({
+  discovery: discoveryMock,
+  allowInsecureRequests: allowInsecureRequestsMock,
+  ClientSecretBasic: vi.fn((secret: string) => ({ __auth: secret })),
+  randomPKCECodeVerifier: vi.fn(() => 'v'),
+  calculatePKCECodeChallenge: vi.fn(async () => 'c'),
+  randomState: vi.fn(() => 's'),
+  randomNonce: vi.fn(() => 'n'),
+  buildAuthorizationUrl: vi.fn(() => new URL('https://idp.example.com/authz')),
+  authorizationCodeGrant: vi.fn(),
+}));
+
+// Stub the settings DB read so we drive `oidc.allow_insecure_transport`
+// directly from the test.
+const settingsRows: { key: string; value: string }[] = [];
+vi.mock('../db/app-db-router.js', () => ({
+  getDbForDomain: () => ({
+    query: vi.fn(async () => settingsRows.slice()),
+  }),
+}));
+
+import { generateAuthorizationUrl, invalidateOIDCCache } from './oidc.js';
+
+function seedSettings(overrides: Record<string, string>) {
+  settingsRows.length = 0;
+  const defaults: Record<string, string> = {
+    'oidc.enabled': 'true',
+    'oidc.issuer_url': 'http://idp.example.com',
+    'oidc.client_id': 'client',
+    'oidc.client_secret': 'secret',
+    'oidc.scopes': 'openid profile email',
+  };
+  for (const [key, value] of Object.entries({ ...defaults, ...overrides })) {
+    settingsRows.push({ key, value });
+  }
+}
+
+describe('OIDC insecure-transport opt-in', () => {
+  beforeEach(() => {
+    discoveryMock.mockClear();
+    allowInsecureRequestsMock.mockClear();
+    invalidateOIDCCache();
+  });
+
+  afterEach(() => {
+    invalidateOIDCCache();
+  });
+
+  it('passes allowInsecureRequests to discovery when the flag is on', async () => {
+    seedSettings({ 'oidc.allow_insecure_transport': 'true' });
+
+    await generateAuthorizationUrl('https://app.example.com/auth/callback', 'openid');
+
+    expect(discoveryMock).toHaveBeenCalledTimes(1);
+    const lastCall = discoveryMock.mock.calls[0];
+    const opts = lastCall[4];
+    expect(opts).toBeDefined();
+    expect(opts.execute).toBeDefined();
+    expect(opts.execute).toHaveLength(1);
+    // The execute hook must be openid-client's allowInsecureRequests symbol.
+    expect(opts.execute[0]).toBe(allowInsecureRequestsMock);
+
+    // Post-discovery extension to token exchange also fires.
+    expect(allowInsecureRequestsMock).toHaveBeenCalledTimes(1);
+    expect(allowInsecureRequestsMock).toHaveBeenCalledWith({ __fake: 'config' });
+  });
+
+  it('omits the option entirely when the flag is off (default)', async () => {
+    seedSettings({ 'oidc.allow_insecure_transport': 'false' });
+
+    await generateAuthorizationUrl('https://app.example.com/auth/callback', 'openid');
+
+    expect(discoveryMock).toHaveBeenCalledTimes(1);
+    const opts = discoveryMock.mock.calls[0][4];
+    expect(opts).toBeUndefined();
+    expect(allowInsecureRequestsMock).not.toHaveBeenCalled();
+  });
+
+  it('defaults to off when the setting is missing', async () => {
+    seedSettings({}); // no allow_insecure_transport key at all
+
+    await generateAuthorizationUrl('https://app.example.com/auth/callback', 'openid');
+
+    const opts = discoveryMock.mock.calls[0][4];
+    expect(opts).toBeUndefined();
+    expect(allowInsecureRequestsMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/services/oidc-redirect-uri.test.ts
+++ b/packages/core/src/services/oidc-redirect-uri.test.ts
@@ -17,6 +17,7 @@ const fullConfig: OIDCConfig = {
   groups_claim: 'groups',
   group_role_mappings: {},
   auto_provision: true,
+  allow_insecure_transport: false,
 };
 
 describe('getEffectiveRedirectUri', () => {

--- a/packages/core/src/services/oidc.ts
+++ b/packages/core/src/services/oidc.ts
@@ -26,6 +26,11 @@ export interface OIDCConfig {
   groups_claim: string;
   group_role_mappings: Record<string, Role>;
   auto_provision: boolean;
+  // Opt-in: allow openid-client to talk to a plain-HTTP issuer. Disabled by
+  // default; enable only for local dev/staging where TLS is not yet wired up.
+  // The library normally refuses non-HTTPS discovery and token-exchange to
+  // prevent leaking auth codes, access tokens, and ID tokens over plaintext.
+  allow_insecure_transport: boolean;
 }
 
 interface StateEntry {
@@ -106,6 +111,7 @@ export async function getOIDCConfig(): Promise<OIDCConfig> {
     groups_claim: settings['oidc.groups_claim'] || 'groups',
     group_role_mappings: groupRoleMappings,
     auto_provision: settings['oidc.auto_provision'] !== 'false',
+    allow_insecure_transport: settings['oidc.allow_insecure_transport'] === 'true',
   };
 }
 
@@ -167,15 +173,33 @@ async function getOrCreateConfiguration(): Promise<client.Configuration> {
     return cachedConfig;
   }
 
-  log.info({ issuer: oidcConfig.issuer_url }, 'Discovering OIDC configuration');
+  log.info(
+    { issuer: oidcConfig.issuer_url, allow_insecure_transport: oidcConfig.allow_insecure_transport },
+    'Discovering OIDC configuration',
+  );
+  if (oidcConfig.allow_insecure_transport) {
+    log.warn(
+      'OIDC allow_insecure_transport is ENABLED — auth codes and tokens will travel in plaintext. Use only for local development.',
+    );
+  }
 
   const issuerUrl = new URL(oidcConfig.issuer_url);
+  // `execute: [client.allowInsecureRequests]` permits HTTP for the discovery
+  // request itself; calling allowInsecureRequests(config) on the returned
+  // Configuration extends the permission to subsequent token-exchange calls.
+  const discoveryOptions = oidcConfig.allow_insecure_transport
+    ? { execute: [client.allowInsecureRequests] }
+    : undefined;
   cachedConfig = await client.discovery(
     issuerUrl,
     oidcConfig.client_id,
     oidcConfig.client_secret,
-    client.ClientSecretBasic(oidcConfig.client_secret)
+    client.ClientSecretBasic(oidcConfig.client_secret),
+    discoveryOptions,
   );
+  if (oidcConfig.allow_insecure_transport) {
+    client.allowInsecureRequests(cachedConfig);
+  }
 
   cachedConfigExpiry = Date.now() + CONFIG_CACHE_TTL_MS;
   log.info('OIDC configuration discovered and cached');

--- a/packages/foundation/src/__tests__/oidc-route.test.ts
+++ b/packages/foundation/src/__tests__/oidc-route.test.ts
@@ -10,8 +10,21 @@ vi.mock('@dashboard/core/services/oidc.js', async (importOriginal) => {
     ...real,
     getOIDCConfig: vi.fn(),
     generateAuthorizationUrl: vi.fn(),
+    exchangeCode: vi.fn(),
   };
 });
+// All user/session/audit boundaries stubbed so the callback test is hermetic.
+vi.mock('@dashboard/core/services/user-store.js', () => ({
+  upsertOIDCUser: vi.fn().mockResolvedValue({ roleChanged: false }),
+  getUserById: vi.fn().mockResolvedValue(null),
+  getUserDefaultLandingPage: vi.fn().mockResolvedValue('/dashboard'),
+}));
+vi.mock('@dashboard/core/services/session-store.js', () => ({
+  createSession: vi.fn().mockResolvedValue({ id: 'sess-1', expires_at: '2099-01-01T00:00:00Z' }),
+  invalidateSession: vi.fn(),
+}));
+vi.mock('@dashboard/core/services/audit-logger.js', () => ({ writeAuditLog: vi.fn() }));
+vi.mock('@dashboard/core/utils/crypto.js', () => ({ signJwt: vi.fn().mockResolvedValue('signed.jwt.token') }));
 
 import * as oidcService from '@dashboard/core/services/oidc.js';
 import { setConfigForTest, resetConfig } from '@dashboard/core/config/index.js';
@@ -19,6 +32,7 @@ import { oidcRoutes } from '../routes/oidc.js';
 
 const mockedGetConfig = vi.mocked(oidcService.getOIDCConfig);
 const mockedGenerateAuthUrl = vi.mocked(oidcService.generateAuthorizationUrl);
+const mockedExchangeCode = vi.mocked(oidcService.exchangeCode);
 
 const baseOidcConfig = {
   enabled: true,
@@ -31,6 +45,7 @@ const baseOidcConfig = {
   groups_claim: 'groups',
   group_role_mappings: {},
   auto_provision: true,
+  allow_insecure_transport: false,
 };
 
 describe('OIDC Routes', () => {
@@ -170,6 +185,35 @@ describe('OIDC Routes', () => {
       expect(response.statusCode).toBe(200);
       expect(response.json()).toEqual({ enabled: false });
       expect(mockedGenerateAuthUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/auth/oidc/callback', () => {
+    it('returns a LoginResponse including defaultLandingPage (regression for serialization)', async () => {
+      setConfigForTest({ DASHBOARD_EXTERNAL_URL: undefined });
+      mockedGetConfig.mockResolvedValue({ ...baseOidcConfig, redirect_uri: 'https://x/auth/callback' });
+      mockedExchangeCode.mockResolvedValue({
+        sub: 'kc-admin-sub',
+        email: 'kc-admin@example.com',
+        name: 'kc-admin',
+        groups: ['Dashboard-Admins'],
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/oidc/callback',
+        payload: { callbackUrl: 'https://x/auth/callback?code=abc&state=xyz', state: 'xyz' },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body).toEqual({
+        token: 'signed.jwt.token',
+        username: 'kc-admin@example.com',
+        expiresAt: '2099-01-01T00:00:00Z',
+        defaultLandingPage: '/dashboard',
+      });
     });
   });
 });

--- a/packages/foundation/src/routes/oidc.ts
+++ b/packages/foundation/src/routes/oidc.ts
@@ -3,7 +3,7 @@ import { getOIDCConfig, generateAuthorizationUrl, exchangeCode, resolveRoleFromG
 import { createSession, invalidateSession } from '@dashboard/core/services/session-store.js';
 import { signJwt } from '@dashboard/core/utils/crypto.js';
 import { writeAuditLog } from '@dashboard/core/services/audit-logger.js';
-import { upsertOIDCUser, getUserById } from '@dashboard/core/services/user-store.js';
+import { upsertOIDCUser, getUserById, getUserDefaultLandingPage } from '@dashboard/core/services/user-store.js';
 import { OidcStatusResponseSchema, OidcCallbackBodySchema, OidcEffectiveRedirectUriResponseSchema, LoginResponseSchema, ErrorResponseSchema, SuccessResponseSchema } from '@dashboard/core/models/api-schemas.js';
 import { getConfig } from '@dashboard/core/config/index.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
@@ -148,6 +148,7 @@ export async function oidcRoutes(fastify: FastifyInstance) {
         token,
         username,
         expiresAt: session.expires_at,
+        defaultLandingPage: await getUserDefaultLandingPage(claims.sub),
       };
     } catch (err) {
       fastify.log.error({ err }, 'OIDC callback failed');


### PR DESCRIPTION
## Summary

Two fixes that together unblock local OIDC testing:

1. **`oidc.allow_insecure_transport` Settings toggle.** `openid-client` v6 refuses plain-HTTP discovery (`OAUTH_HTTP_REQUEST_FORBIDDEN`). The new boolean opts in to the library's `allowInsecureRequests` hook for both `client.discovery()` and the resulting `Configuration`, so token exchange also works. Off by default; UI surfaces a prominent warning that auth codes and tokens travel in plaintext when enabled.
2. **OIDC callback now returns `defaultLandingPage`.** `LoginResponseSchema` was widened (used by the local-auth route) but the OIDC callback never started returning it, so every OIDC login was failing serialization with `FST_ERR_RESPONSE_SERIALIZATION`. Fixed by mirroring the local-auth route's `getUserDefaultLandingPage(claims.sub)` call.

## Why

I tried to validate the OIDC group→role mapping feature against a local Keycloak after merging #1271 and hit two hard walls. (1) blocked discovery for any HTTP IdP — common in dev. (2) is a pre-existing bug that's been silently breaking the OIDC flow since the landing-page field was added; the response shape no longer matched the published schema.

## Verified end-to-end

Spun up Keycloak 26 locally with realm `dashboard`, four users in three groups, and ran the full SSO flow through Playwright against the rebuilt backend:

| User | Groups | Resolved role |
|---|---|---|
| `kc-admin` | `Dashboard-Admins` | `admin` ✓ |
| `kc-operator` | `Dashboard-Operators` | `operator` ✓ |
| `kc-viewer` | `Dashboard-Viewers` | `viewer` ✓ |
| `kc-multi` | `Dashboard-Admins` + `Dashboard-Operators` | **`admin`** (highest-privilege-wins) ✓ |

Audit log captured every login with the full groups array and the resolved role.

Closes #1272

## Test plan

- [x] `packages/core/src/services/oidc-insecure-transport.test.ts` — 3 tests: flag on passes `execute: [allowInsecureRequests]` to discovery and calls `allowInsecureRequests(config)`; flag off omits the option; missing key defaults to off.
- [x] `packages/foundation/src/__tests__/oidc-route.test.ts` — 1 new test for the callback response shape (regression for the `defaultLandingPage` serialization break).
- [x] All existing OIDC tests still pass.
- [x] `npm run typecheck` and `npm run lint` clean.
- [x] Manual end-to-end Playwright run against Keycloak 26 (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)