### PR TITLE
feat(oidc): strip URI prefixes from groups + searchable autocomplete for group mappings

### DIFF
--- a/frontend/src/features/core/components/settings/group-role-mapping-editor.test.tsx
+++ b/frontend/src/features/core/components/settings/group-role-mapping-editor.test.tsx
@@ -42,7 +42,7 @@ describe('GroupRoleMappingEditor', () => {
     const value = JSON.stringify({ 'OldName': 'admin' });
     render(<GroupRoleMappingEditor value={value} onChange={onChange} />);
 
-    const input = screen.getByTestId('mapping-group-0');
+    const input = screen.getByRole('textbox');
     fireEvent.change(input, { target: { value: 'NewName' } });
 
     expect(onChange).toHaveBeenCalledWith(JSON.stringify({ 'NewName': 'admin' }));
@@ -80,7 +80,8 @@ describe('GroupRoleMappingEditor', () => {
     const value = JSON.stringify({ 'Admins': 'admin' });
     render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} disabled />);
 
-    expect(screen.getByTestId('mapping-group-0')).toBeDisabled();
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
     expect(screen.getByTestId('mapping-role-0')).toBeDisabled();
     expect(screen.getByText('Add Mapping')).toBeDisabled();
   });
@@ -91,7 +92,7 @@ describe('GroupRoleMappingEditor', () => {
     render(<GroupRoleMappingEditor value={value} onChange={onChange} />);
 
     // Change the group name to empty
-    const input = screen.getByTestId('mapping-group-0');
+    const input = screen.getByRole('textbox');
     fireEvent.change(input, { target: { value: '' } });
 
     expect(onChange).toHaveBeenCalledWith('{}');

--- a/frontend/src/features/core/components/settings/group-role-mapping-editor.test.tsx
+++ b/frontend/src/features/core/components/settings/group-role-mapping-editor.test.tsx
@@ -12,10 +12,10 @@ describe('GroupRoleMappingEditor', () => {
     const value = JSON.stringify({ 'Dashboard-Admins': 'admin', 'Viewers': 'viewer' });
     render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
 
-    const inputs = screen.getAllByRole('textbox');
-    expect(inputs).toHaveLength(2);
-    expect(inputs[0]).toHaveValue('Dashboard-Admins');
-    expect(inputs[1]).toHaveValue('Viewers');
+    expect(screen.getByTestId('mapping-group-0')).toHaveValue('Dashboard-Admins');
+    expect(screen.getByTestId('mapping-group-1')).toHaveValue('Viewers');
+    // Only one group input per row (and one role select per row).
+    expect(screen.queryByTestId('mapping-group-2')).not.toBeInTheDocument();
   });
 
   it('should add a new empty row when Add Mapping is clicked', () => {
@@ -42,7 +42,7 @@ describe('GroupRoleMappingEditor', () => {
     const value = JSON.stringify({ 'OldName': 'admin' });
     render(<GroupRoleMappingEditor value={value} onChange={onChange} />);
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('mapping-group-0');
     fireEvent.change(input, { target: { value: 'NewName' } });
 
     expect(onChange).toHaveBeenCalledWith(JSON.stringify({ 'NewName': 'admin' }));
@@ -80,8 +80,7 @@ describe('GroupRoleMappingEditor', () => {
     const value = JSON.stringify({ 'Admins': 'admin' });
     render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} disabled />);
 
-    const input = screen.getByRole('textbox');
-    expect(input).toBeDisabled();
+    expect(screen.getByTestId('mapping-group-0')).toBeDisabled();
     expect(screen.getByTestId('mapping-role-0')).toBeDisabled();
     expect(screen.getByText('Add Mapping')).toBeDisabled();
   });
@@ -92,9 +91,120 @@ describe('GroupRoleMappingEditor', () => {
     render(<GroupRoleMappingEditor value={value} onChange={onChange} />);
 
     // Change the group name to empty
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('mapping-group-0');
     fireEvent.change(input, { target: { value: '' } });
 
     expect(onChange).toHaveBeenCalledWith('{}');
+  });
+
+  describe('GroupNameAutocomplete', () => {
+    it('exposes ARIA combobox semantics', () => {
+      const value = JSON.stringify({ 'Admins': 'admin' });
+      render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
+      const input = screen.getByTestId('mapping-group-0');
+      expect(input).toHaveAttribute('role', 'combobox');
+      expect(input).toHaveAttribute('aria-autocomplete', 'list');
+      // Initially closed (no suggestions, single row with own value excluded)
+      expect(input).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('does not show the row\'s own value as a suggestion when focused', () => {
+      // Object with an empty-string key gives us a row whose query is '' (no filter),
+      // so the dropdown opens with every existingGroup. Row 0 should NOT see its own
+      // value ('') and row 1 should NOT see its own value ('Admins').
+      const value = JSON.stringify({ '': 'viewer', 'Admins': 'admin' });
+      render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
+
+      const firstInput = screen.getByTestId('mapping-group-0');
+      fireEvent.focus(firstInput);
+
+      // Row 0 (empty value) sees row 1's value ('Admins') as a suggestion.
+      expect(screen.getByRole('option', { name: 'Admins' })).toBeInTheDocument();
+    });
+
+    it('filters suggestions as the user types', () => {
+      const value = JSON.stringify({
+        '': 'viewer',
+        'Viewers': 'viewer',
+        'Operators': 'operator',
+      });
+      render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
+
+      const firstInput = screen.getByTestId('mapping-group-0');
+      fireEvent.focus(firstInput);
+      fireEvent.change(firstInput, { target: { value: 'view' } });
+
+      expect(screen.getByRole('option', { name: 'Viewers' })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: 'Operators' })).not.toBeInTheDocument();
+    });
+
+    it('commits a suggestion on mouse click', () => {
+      const value = JSON.stringify({ '': 'viewer', 'Admins': 'admin' });
+      render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
+
+      const firstInput = screen.getByTestId('mapping-group-0');
+      fireEvent.focus(firstInput);
+
+      const option = screen.getByRole('option', { name: 'Admins' });
+      fireEvent.mouseDown(option);
+
+      // The autocomplete commits 'Admins' into the empty input.
+      expect(firstInput).toHaveValue('Admins');
+      // Listbox closes after commit.
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('selects highlighted option on Enter and closes the listbox', () => {
+      const value = JSON.stringify({ '': 'viewer', 'Admins': 'admin' });
+      render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
+
+      const firstInput = screen.getByTestId('mapping-group-0');
+      fireEvent.focus(firstInput);
+      fireEvent.keyDown(firstInput, { key: 'ArrowDown' });
+      fireEvent.keyDown(firstInput, { key: 'Enter' });
+
+      expect(firstInput).toHaveValue('Admins');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('closes the listbox on Escape without committing', () => {
+      const value = JSON.stringify({ '': 'viewer', 'Admins': 'admin' });
+      render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
+
+      const firstInput = screen.getByTestId('mapping-group-0');
+      fireEvent.focus(firstInput);
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+      fireEvent.keyDown(firstInput, { key: 'Escape' });
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      // Value was never committed — input is still empty.
+      expect(firstInput).toHaveValue('');
+    });
+
+    it('dedupes suggestions when multiple rows share a value', () => {
+      // Start with one row + one empty row, then change row 1's value to match row 0
+      // before opening row 2's dropdown. After the dedup we expect ONE 'Same' option.
+      const value = JSON.stringify({ 'Same': 'admin', 'Other': 'viewer' });
+      render(<GroupRoleMappingEditor value={value} onChange={vi.fn()} />);
+
+      // Duplicate row 0's value into row 1, then blur to keep that listbox closed.
+      const secondInput = screen.getByTestId('mapping-group-1');
+      fireEvent.focus(secondInput);
+      fireEvent.change(secondInput, { target: { value: 'Same' } });
+      fireEvent.blur(secondInput);
+
+      // Add a third (empty) row and focus it so we see ITS listbox.
+      fireEvent.click(screen.getByText('Add Mapping'));
+      const thirdInput = screen.getByTestId('mapping-group-2');
+      fireEvent.focus(thirdInput);
+
+      // Only one open listbox; assert 'Same' appears once and is not duplicated.
+      const listbox = screen.getByRole('listbox');
+      const options = Array.from(listbox.querySelectorAll('[role="option"]')).map(
+        (el) => el.textContent,
+      );
+      expect(options.filter((t) => t === 'Same')).toHaveLength(1);
+    });
   });
 });

--- a/frontend/src/features/core/components/settings/group-role-mapping-editor.tsx
+++ b/frontend/src/features/core/components/settings/group-role-mapping-editor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useId, useMemo, useRef } from 'react';
 import { Plus, Search, Trash2, Users } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
@@ -45,11 +45,14 @@ function serializeMappings(rows: MappingRow[]): string {
   return JSON.stringify(obj);
 }
 
-function extractExistingGroups(rows: MappingRow[]): string[] {
-  return rows
-    .map((r) => r.group.trim())
-    .filter((g) => g.length > 0)
-    .sort();
+function extractExistingGroups(rows: MappingRow[], excludeIndex?: number): string[] {
+  const seen = new Set<string>();
+  for (let i = 0; i < rows.length; i += 1) {
+    if (i === excludeIndex) continue;
+    const trimmed = rows[i].group.trim();
+    if (trimmed) seen.add(trimmed);
+  }
+  return [...seen].sort();
 }
 
 function GroupNameAutocomplete({
@@ -58,15 +61,21 @@ function GroupNameAutocomplete({
   disabled,
   existingGroups,
   placeholder,
+  testId,
 }: {
   value: string;
   onChange: (val: string) => void;
   disabled?: boolean;
   existingGroups: string[];
   placeholder?: string;
+  testId?: string;
 }) {
   const [show, setShow] = useState(false);
   const [query, setQuery] = useState(value);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const listboxId = useId();
+  const optionIdPrefix = useId();
+  const listboxRef = useRef<HTMLDivElement | null>(null);
 
   const filtered = useMemo(() => {
     const q = query.toLowerCase().trim();
@@ -78,7 +87,21 @@ function GroupNameAutocomplete({
     setQuery(value);
   }, [value]);
 
-  const handleSelect = (group: string) => {
+  // Reset highlight whenever the filtered set changes or the dropdown re-opens.
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [filtered, show]);
+
+  // Keep the highlighted option scrolled into view.
+  useEffect(() => {
+    if (activeIndex < 0 || !listboxRef.current) return;
+    const optionEl = listboxRef.current.querySelector<HTMLElement>(
+      `[data-option-index="${activeIndex}"]`,
+    );
+    optionEl?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex]);
+
+  const commit = (group: string) => {
     setQuery(group);
     onChange(group);
     setShow(false);
@@ -93,11 +116,35 @@ function GroupNameAutocomplete({
       setShow(false);
       return;
     }
+    if (e.key === 'ArrowDown') {
+      if (filtered.length === 0) return;
+      e.preventDefault();
+      setShow(true);
+      setActiveIndex((i) => (i + 1) % filtered.length);
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      if (filtered.length === 0) return;
+      e.preventDefault();
+      setShow(true);
+      setActiveIndex((i) => (i <= 0 ? filtered.length - 1 : i - 1));
+      return;
+    }
     if (e.key === 'Enter') {
-      onChange(query);
-      setShow(false);
+      e.preventDefault();
+      if (show && activeIndex >= 0 && activeIndex < filtered.length) {
+        commit(filtered[activeIndex]);
+      } else {
+        onChange(query);
+        setShow(false);
+      }
     }
   };
+
+  const activeDescendant =
+    show && activeIndex >= 0 && activeIndex < filtered.length
+      ? `${optionIdPrefix}-${activeIndex}`
+      : undefined;
 
   return (
     <div className="relative">
@@ -105,6 +152,11 @@ function GroupNameAutocomplete({
         <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground pointer-events-none" />
         <input
           type="text"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={show && filtered.length > 0}
+          aria-controls={listboxId}
+          aria-activedescendant={activeDescendant}
           value={query}
           onChange={(e) => {
             setQuery(e.target.value);
@@ -117,29 +169,40 @@ function GroupNameAutocomplete({
           disabled={disabled}
           placeholder={placeholder}
           className="h-9 w-full rounded-md border border-input bg-background pl-8 pr-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-          data-testid="mapping-group-input"
+          data-testid={testId}
           autoComplete="off"
         />
       </div>
       {show && filtered.length > 0 && (
-        <div className="absolute z-50 mt-1 max-h-48 w-full overflow-y-auto rounded-md border border-border bg-popover text-popover-foreground shadow-lg">
-          {filtered.map((group) => (
-            <div
-              key={group}
-              className={cn(
-                'px-3 py-2 text-sm cursor-pointer hover:bg-accent hover:text-accent-foreground',
-                group === query
-                  ? 'bg-accent text-accent-foreground'
-                  : '',
-              )}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                handleSelect(group);
-              }}
-            >
-              {group}
-            </div>
-          ))}
+        <div
+          ref={listboxRef}
+          id={listboxId}
+          role="listbox"
+          className="absolute z-50 mt-1 max-h-48 w-full overflow-y-auto rounded-md border border-border bg-popover text-popover-foreground shadow-lg"
+        >
+          {filtered.map((group, index) => {
+            const isActive = index === activeIndex;
+            return (
+              <div
+                key={group}
+                id={`${optionIdPrefix}-${index}`}
+                role="option"
+                aria-selected={isActive}
+                data-option-index={index}
+                className={cn(
+                  'px-3 py-2 text-sm cursor-pointer hover:bg-accent hover:text-accent-foreground',
+                  isActive ? 'bg-accent text-accent-foreground' : '',
+                )}
+                onMouseEnter={() => setActiveIndex(index)}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  commit(group);
+                }}
+              >
+                {group}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>
@@ -148,7 +211,6 @@ function GroupNameAutocomplete({
 
 export function GroupRoleMappingEditor({ value, onChange, disabled }: GroupRoleMappingEditorProps) {
   const [rows, setRows] = useState<MappingRow[]>(() => parseMappings(value));
-  const allGroups = useMemo(() => extractExistingGroups(rows), [rows]);
 
   // Sync from parent when value changes externally
   useEffect(() => {
@@ -228,8 +290,9 @@ export function GroupRoleMappingEditor({ value, onChange, disabled }: GroupRoleM
                   value={row.group}
                   onChange={(val) => updateRow(index, 'group', val)}
                   disabled={disabled}
-                  existingGroups={allGroups}
+                  existingGroups={extractExistingGroups(rows, index)}
                   placeholder="e.g., Dashboard-Admins or *"
+                  testId={`mapping-group-${index}`}
                 />
                 <select
                   value={row.role}

--- a/frontend/src/features/core/components/settings/group-role-mapping-editor.tsx
+++ b/frontend/src/features/core/components/settings/group-role-mapping-editor.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useEffect } from 'react';
-import { Plus, Trash2, Users } from 'lucide-react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { Plus, Search, Trash2, Users } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
 interface MappingRow {
@@ -45,8 +45,110 @@ function serializeMappings(rows: MappingRow[]): string {
   return JSON.stringify(obj);
 }
 
+function extractExistingGroups(rows: MappingRow[]): string[] {
+  return rows
+    .map((r) => r.group.trim())
+    .filter((g) => g.length > 0)
+    .sort();
+}
+
+function GroupNameAutocomplete({
+  value,
+  onChange,
+  disabled,
+  existingGroups,
+  placeholder,
+}: {
+  value: string;
+  onChange: (val: string) => void;
+  disabled?: boolean;
+  existingGroups: string[];
+  placeholder?: string;
+}) {
+  const [show, setShow] = useState(false);
+  const [query, setQuery] = useState(value);
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase().trim();
+    if (!q) return existingGroups;
+    return existingGroups.filter((g) => g.toLowerCase().includes(q));
+  }, [query, existingGroups]);
+
+  useEffect(() => {
+    setQuery(value);
+  }, [value]);
+
+  const handleSelect = (group: string) => {
+    setQuery(group);
+    onChange(group);
+    setShow(false);
+  };
+
+  const handleBlur = () => {
+    setShow(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setShow(false);
+      return;
+    }
+    if (e.key === 'Enter') {
+      onChange(query);
+      setShow(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setShow(true);
+            onChange(e.target.value);
+          }}
+          onFocus={() => setShow(true)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          placeholder={placeholder}
+          className="h-9 w-full rounded-md border border-input bg-background pl-8 pr-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          data-testid="mapping-group-input"
+          autoComplete="off"
+        />
+      </div>
+      {show && filtered.length > 0 && (
+        <div className="absolute z-50 mt-1 max-h-48 w-full overflow-y-auto rounded-md border border-border bg-popover text-popover-foreground shadow-lg">
+          {filtered.map((group) => (
+            <div
+              key={group}
+              className={cn(
+                'px-3 py-2 text-sm cursor-pointer hover:bg-accent hover:text-accent-foreground',
+                group === query
+                  ? 'bg-accent text-accent-foreground'
+                  : '',
+              )}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleSelect(group);
+              }}
+            >
+              {group}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function GroupRoleMappingEditor({ value, onChange, disabled }: GroupRoleMappingEditorProps) {
   const [rows, setRows] = useState<MappingRow[]>(() => parseMappings(value));
+  const allGroups = useMemo(() => extractExistingGroups(rows), [rows]);
 
   // Sync from parent when value changes externally
   useEffect(() => {
@@ -101,8 +203,10 @@ export function GroupRoleMappingEditor({ value, onChange, disabled }: GroupRoleM
       <div className="p-4 space-y-2">
         <p className="text-sm text-muted-foreground mb-3">
           Map IdP group names to dashboard roles. If a user belongs to multiple groups,
-          the <strong>highest-privilege</strong> role is assigned. Use <code>*</code> as
-          a wildcard fallback for unmatched groups.
+          the <strong>highest-privilege</strong> role is assigned. URI prefixes (e.g.,{' '}
+          <code>urn:pingidentity.com:groups:</code>) are stripped automatically — enter
+          the group name only. Use <code>*</code> as a wildcard fallback for unmatched
+          groups.
         </p>
 
         {rows.length === 0 ? (
@@ -120,14 +224,12 @@ export function GroupRoleMappingEditor({ value, onChange, disabled }: GroupRoleM
 
             {rows.map((row, index) => (
               <div key={index} className="grid grid-cols-[1fr_160px_40px] gap-2 items-center">
-                <input
-                  type="text"
+                <GroupNameAutocomplete
                   value={row.group}
-                  onChange={(e) => updateRow(index, 'group', e.target.value)}
+                  onChange={(val) => updateRow(index, 'group', val)}
                   disabled={disabled}
+                  existingGroups={allGroups}
                   placeholder="e.g., Dashboard-Admins or *"
-                  className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-                  data-testid={`mapping-group-${index}`}
                 />
                 <select
                   value={row.role}

--- a/packages/core/src/services/oidc-group-mapping.test.ts
+++ b/packages/core/src/services/oidc-group-mapping.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 // Kept: openid-client mock — external dependency
 vi.mock('openid-client', () => ({}));
 
-import { resolveRoleFromGroups, extractGroups } from './oidc.js';
+import { resolveRoleFromGroups, extractGroups, stripGroupPrefix } from './oidc.js';
 
 describe('resolveRoleFromGroups', () => {
   it('should return undefined when groups array is empty', () => {
@@ -113,6 +113,135 @@ describe('resolveRoleFromGroups', () => {
       },
     );
     expect(result).toBe('operator');
+  });
+
+  describe('with URI-prefixed group claims', () => {
+    it('should match bare mapping key against urn-prefixed group claim', () => {
+      const result = resolveRoleFromGroups(
+        ['urn:pingidentity.com:groups:G-Admin'],
+        { 'G-Admin': 'admin' },
+      );
+      expect(result).toBe('admin');
+    });
+
+    it('should match bare mapping key against multi-segment urn-prefixed group claim', () => {
+      const result = resolveRoleFromGroups(
+        ['urn:vendor:product:groups:G-Admin'],
+        { 'G-Admin': 'admin' },
+      );
+      expect(result).toBe('admin');
+    });
+
+    it('should match bare mapping key against https-prefixed group claim', () => {
+      const result = resolveRoleFromGroups(
+        ['https://idp.example.com/groups/G-Admin'],
+        { 'G-Admin': 'admin' },
+      );
+      expect(result).toBe('admin');
+    });
+
+    it('should match URI-form mapping key against bare group claim (back-compat)', () => {
+      const result = resolveRoleFromGroups(
+        ['G-Admin'],
+        { 'urn:pingidentity.com:groups:G-Admin': 'admin' },
+      );
+      expect(result).toBe('admin');
+    });
+
+    it('should match URI-form mapping key against URI-prefixed group claim (back-compat)', () => {
+      const result = resolveRoleFromGroups(
+        ['urn:pingidentity.com:groups:G-Admin'],
+        { 'urn:pingidentity.com:groups:G-Admin': 'admin' },
+      );
+      expect(result).toBe('admin');
+    });
+
+    it('should preserve wildcard mapping verbatim (no stripping applied)', () => {
+      const result = resolveRoleFromGroups(
+        ['urn:pingidentity.com:groups:Unknown'],
+        { 'G-Admin': 'admin', '*': 'viewer' },
+      );
+      expect(result).toBe('viewer');
+    });
+
+    it('should still pick highest-privilege role across URI-prefixed groups', () => {
+      const result = resolveRoleFromGroups(
+        [
+          'urn:pingidentity.com:groups:G-Viewer',
+          'urn:pingidentity.com:groups:G-Admin',
+        ],
+        { 'G-Viewer': 'viewer', 'G-Admin': 'admin' },
+      );
+      expect(result).toBe('admin');
+    });
+
+    it('should ignore mapping keys whose role is invalid even when key matches', () => {
+      const result = resolveRoleFromGroups(
+        ['urn:pingidentity.com:groups:G-Bad', 'G-Good'],
+        {
+          'G-Bad': 'superadmin' as never,
+          'G-Good': 'operator',
+        },
+      );
+      expect(result).toBe('operator');
+    });
+  });
+});
+
+describe('stripGroupPrefix', () => {
+  it('strips urn:vendor:groups: prefix', () => {
+    expect(stripGroupPrefix('urn:pingidentity.com:groups:G-Foo')).toBe('G-Foo');
+  });
+
+  it('strips multi-segment urn:vendor:product:groups: prefix', () => {
+    expect(stripGroupPrefix('urn:vendor:product:groups:G-Foo')).toBe('G-Foo');
+  });
+
+  it('strips https://host/groups/ prefix', () => {
+    expect(stripGroupPrefix('https://idp.example.com/groups/G-Foo')).toBe('G-Foo');
+  });
+
+  it('strips http://host/groups/ prefix', () => {
+    expect(stripGroupPrefix('http://idp.example.com/groups/G-Foo')).toBe('G-Foo');
+  });
+
+  it('returns bare names unchanged', () => {
+    expect(stripGroupPrefix('G-Foo')).toBe('G-Foo');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripGroupPrefix('  G-Foo  ')).toBe('G-Foo');
+    expect(stripGroupPrefix('  urn:pingidentity.com:groups:G-Foo  ')).toBe('G-Foo');
+  });
+
+  it('returns empty string for empty / whitespace-only input', () => {
+    expect(stripGroupPrefix('')).toBe('');
+    expect(stripGroupPrefix('   ')).toBe('');
+  });
+
+  it('leaves prefix-only inputs untouched (no group name after prefix)', () => {
+    expect(stripGroupPrefix('urn:pingidentity.com:groups:')).toBe(
+      'urn:pingidentity.com:groups:',
+    );
+    expect(stripGroupPrefix('https://idp.example.com/groups/')).toBe(
+      'https://idp.example.com/groups/',
+    );
+  });
+
+  it('does not strip URLs that point at sub-paths other than /groups/', () => {
+    expect(stripGroupPrefix('https://idp.example.com/users/Alice')).toBe(
+      'https://idp.example.com/users/Alice',
+    );
+  });
+
+  it('does not strip arbitrary colon-separated identifiers that are not group URNs', () => {
+    expect(stripGroupPrefix('CN=Admins,OU=Groups,DC=corp,DC=local')).toBe(
+      'CN=Admins,OU=Groups,DC=corp,DC=local',
+    );
+  });
+
+  it('preserves wildcard sentinel verbatim', () => {
+    expect(stripGroupPrefix('*')).toBe('*');
   });
 });
 

--- a/packages/core/src/services/oidc.ts
+++ b/packages/core/src/services/oidc.ts
@@ -262,25 +262,29 @@ const ROLE_PRIORITY: Record<Role, number> = {
 /**
  * Strip common OIDC provider URI prefixes from group names.
  *
- * Providers like PingFederate wrap group names in URIs:
- *   urn:pingidentity.com:groups:G-MyGroup   →  G-MyGroup
- *   https://provider.com/groups/G-MyGroup   →  G-MyGroup
+ * Providers like PingFederate / Auth0 / Keycloak wrap group names in URIs:
+ *   urn:pingidentity.com:groups:G-MyGroup        →  G-MyGroup
+ *   urn:vendor:product:groups:G-MyGroup          →  G-MyGroup
+ *   https://provider.com/groups/G-MyGroup        →  G-MyGroup
  *
- * This lets operators configure mappings using bare group names.
+ * Applied to BOTH incoming group claims and configured mapping keys so that
+ * existing mappings stored in URI form continue to match after upgrade.
  */
 export function stripGroupPrefix(group: string): string {
   const trimmed = group.trim();
   if (!trimmed) return trimmed;
-  const withoutPrefix = trimmed.replace(
-    /^(?:urn:[^:]+:groups:|https?:\/\/[^/]+\/groups\/)(.+)$/,
+  return trimmed.replace(
+    /^(?:urn:.+?:groups:|https?:\/\/[^/]+\/groups\/)(.+)$/,
     '$1',
   );
-  return withoutPrefix;
 }
 
 /**
  * Resolve the highest-privilege role from a user's groups using the configured mappings.
  * Returns undefined if no mapping matches (including wildcard).
+ *
+ * Prefix-stripping is applied symmetrically to incoming groups AND mapping keys so
+ * operators who still have URI-form keys in DB (pre-1281 config) keep working.
  */
 export function resolveRoleFromGroups(
   groups: string[],
@@ -290,15 +294,29 @@ export function resolveRoleFromGroups(
     return undefined;
   }
 
+  // Build a normalized lookup so URI-form mapping keys still match bare group names.
+  // Wildcard ('*') is preserved verbatim. On collision, last-write-wins matches the
+  // pre-existing Object.entries iteration semantics.
+  const normalizedMappings: Record<string, Role> = {};
+  for (const [key, role] of Object.entries(mappings)) {
+    if (!VALID_ROLES.has(role)) continue;
+    if (key === '*') {
+      normalizedMappings['*'] = role;
+      continue;
+    }
+    const normalizedKey = stripGroupPrefix(key);
+    if (normalizedKey) normalizedMappings[normalizedKey] = role;
+  }
+
   let bestRole: Role | undefined;
   let bestPriority = -1;
 
   for (const group of groups) {
-    const sanitized = stripGroupPrefix(group.trim());
+    const sanitized = stripGroupPrefix(group);
     if (!sanitized) continue;
 
-    const mappedRole = mappings[sanitized];
-    if (mappedRole && VALID_ROLES.has(mappedRole)) {
+    const mappedRole = normalizedMappings[sanitized];
+    if (mappedRole) {
       const priority = ROLE_PRIORITY[mappedRole];
       if (priority > bestPriority) {
         bestRole = mappedRole;
@@ -308,8 +326,8 @@ export function resolveRoleFromGroups(
   }
 
   // Check wildcard fallback only if no explicit match
-  if (!bestRole && '*' in mappings && VALID_ROLES.has(mappings['*'])) {
-    bestRole = mappings['*'];
+  if (!bestRole && normalizedMappings['*']) {
+    bestRole = normalizedMappings['*'];
   }
 
   return bestRole;

--- a/packages/core/src/services/oidc.ts
+++ b/packages/core/src/services/oidc.ts
@@ -260,6 +260,25 @@ const ROLE_PRIORITY: Record<Role, number> = {
 };
 
 /**
+ * Strip common OIDC provider URI prefixes from group names.
+ *
+ * Providers like PingFederate wrap group names in URIs:
+ *   urn:pingidentity.com:groups:G-MyGroup   →  G-MyGroup
+ *   https://provider.com/groups/G-MyGroup   →  G-MyGroup
+ *
+ * This lets operators configure mappings using bare group names.
+ */
+export function stripGroupPrefix(group: string): string {
+  const trimmed = group.trim();
+  if (!trimmed) return trimmed;
+  const withoutPrefix = trimmed.replace(
+    /^(?:urn:[^:]+:groups:|https?:\/\/[^/]+\/groups\/)(.+)$/,
+    '$1',
+  );
+  return withoutPrefix;
+}
+
+/**
  * Resolve the highest-privilege role from a user's groups using the configured mappings.
  * Returns undefined if no mapping matches (including wildcard).
  */
@@ -275,7 +294,7 @@ export function resolveRoleFromGroups(
   let bestPriority = -1;
 
   for (const group of groups) {
-    const sanitized = group.trim();
+    const sanitized = stripGroupPrefix(group.trim());
     if (!sanitized) continue;
 
     const mappedRole = mappings[sanitized];


### PR DESCRIPTION
## Changes

- **Backend**: Strip common OIDC provider URI prefixes (e.g. `urn:pingidentity.com:groups:`) from group names before matching against configured role mappings, so operators only enter bare group names like `G-Konzern-Docker-Portainer-Admin`
- **Frontend**: Replace the text input with a searchable autocomplete dropdown in the Group-to-Role Mapping editor for easier group selection
- **DB**: The mapping on the server was cleaned up to use the bare group name only

## Files changed

- `packages/core/src/services/oidc.ts` — added `stripGroupPrefix()` 
- `frontend/.../group-role-mapping-editor.tsx` — added `GroupNameAutocomplete` component
