### PR TITLE
feat(workload-explorer): trim columns, themed checkboxes, page-level scroll

### DIFF
--- a/docs/workload-explorer-system-grouping.md
+++ b/docs/workload-explorer-system-grouping.md
@@ -36,6 +36,26 @@ A container is classified as `System` when **any** of the following match:
 
 If no rule matches, the container is classified as `Workload`.
 
+## Table columns
+
+Issue: #1288
+
+The on-screen table renders the following columns, in order:
+
+| Column     | Source                                            | Notes                                                                 |
+|------------|---------------------------------------------------|-----------------------------------------------------------------------|
+| Name       | `container.name`                                  | Clickable tag linking to the container detail page; single-line tag.  |
+| Stackname  | resolved via `resolveContainerStackName`          | Clickable tag that filters the table by stack; single-line tag.       |
+| State      | `container.state`                                 | Rendered via `StatusBadge`.                                           |
+| Endpoint   | `container.endpointName`                          | Blue tag.                                                             |
+| Imagename  | `container.image` → `getImageShortName(image)`    | Shows only the segment after the last `/`; full path on `title` hover.|
+| Group      | `getContainerGroupLabel(container)`               | `System` or `Workload`.                                               |
+| Actions    | —                                                 | Hover-revealed "view details" + "view logs" buttons.                  |
+
+Performance-oriented metrics columns (`Rate (/s)`, `Errors`, `p95 (ms)`, `Age`) were removed from the inventory view in #1288 — those signals live in the Trace Explorer / container detail page.
+
+The Workload Explorer table uses the shared `DataTable`'s `windowScroll` mode, so the page (not the table) owns vertical scrolling and the full filtered list renders without pagination or an inner scrollbar.
+
 ## Export behavior
 
 The `Export CSV` button exports the visible rows after endpoint/stack/group filters are applied.
@@ -49,3 +69,5 @@ The export includes columns:
 - `status`
 - `endpoint`
 - `created`
+
+The CSV column set is intentionally broader than the on-screen column set — operators can post-process CSV data offline.

--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -94,13 +94,6 @@ vi.mock('@/shared/hooks/use-auto-refresh', () => ({
   }),
 }));
 
-// ─── RED hook mock — single source of truth for #1237 ────────────────────────
-let mockRedData: { buckets: { bucketStart: string; rows: Array<{ group: string; rate: number; errorRate: number; p50Ms: number; p95Ms: number; p99Ms: number; callCount: number }> }[]; truncated: boolean } | undefined;
-const mockUseRed = vi.fn(() => ({ data: mockRedData }));
-vi.mock('@/features/observability/hooks/use-red', () => ({
-  useRed: (...args: unknown[]) => mockUseRed(...args),
-}));
-
 vi.mock('@/shared/hooks/use-force-refresh', () => ({
   useForceRefresh: () => ({
     forceRefresh: vi.fn(),
@@ -130,6 +123,7 @@ vi.mock('@/shared/components/tables/data-table', () => ({
     onSelectionChange,
     selectedRowIds,
     onRowClick,
+    windowScroll,
   }: {
     columns?: any[];
     data: Array<{ name: string }>;
@@ -138,6 +132,7 @@ vi.mock('@/shared/components/tables/data-table', () => ({
     onSelectionChange?: (rows: Array<{ id: string; name: string; endpointId: number }>) => void;
     selectedRowIds?: Record<string, boolean>;
     onRowClick?: (row: { id: string; name: string; endpointId: number }) => void;
+    windowScroll?: boolean;
   }) => {
     mockOnSelectionChange = onSelectionChange;
     mockColumns = columns;
@@ -148,6 +143,7 @@ vi.mock('@/shared/components/tables/data-table', () => ({
         data-max-selection={maxSelection}
         data-selected-row-ids={selectedRowIds !== undefined ? JSON.stringify(selectedRowIds) : undefined}
         data-has-row-click={onRowClick ? 'true' : undefined}
+        data-window-scroll={windowScroll ? 'true' : undefined}
       >
         {data.map((container) => container.name).join(',')}
       </div>
@@ -851,133 +847,94 @@ describe('WorkloadExplorerPage — header Compare button', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// RED metrics columns (#1237)
+// Column set, ordering, and cell rendering (#1288)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('WorkloadExplorerPage — RED columns (#1237)', () => {
+describe('WorkloadExplorerPage — columns (#1288)', () => {
   beforeEach(() => {
     mockQueryString = 'endpoint=1';
     mockSetSearchParams.mockReset();
     mockNavigate.mockReset();
     mockUseContainers.mockReturnValue(defaultContainersMock);
-    mockUseRed.mockClear();
-    mockRedData = undefined;
+    mockColumns = undefined;
   });
 
-  function findColumn(id: string) {
-    return mockColumns?.find((c) => c.id === id || c.accessorKey === id);
+  function columnHeader(col: any): string | undefined {
+    return typeof col?.header === 'string' ? col.header : undefined;
   }
 
-  function renderCell(col: any, row: any) {
-    return col.cell({
-      row: { original: row },
+  it('renders columns in order Name, Stackname, State, Endpoint, Imagename, Group, Actions', () => {
+    render(<WorkloadExplorerPage />);
+    const ids = mockColumns?.map((c) => c.id ?? c.accessorKey);
+    expect(ids).toEqual(['name', 'stack', 'state', 'endpointName', 'image', 'group', 'actions']);
+  });
+
+  it('renames the stack and image headers to Stackname and Imagename', () => {
+    render(<WorkloadExplorerPage />);
+    const stack = mockColumns?.find((c) => c.id === 'stack');
+    const image = mockColumns?.find((c) => c.accessorKey === 'image');
+    expect(columnHeader(stack)).toBe('Stackname');
+    expect(columnHeader(image)).toBe('Imagename');
+  });
+
+  it('omits the rate, errorRate, p95Ms, and age columns', () => {
+    render(<WorkloadExplorerPage />);
+    const ids = new Set(mockColumns?.map((c) => c.id ?? c.accessorKey));
+    expect(ids.has('rate')).toBe(false);
+    expect(ids.has('errorRate')).toBe(false);
+    expect(ids.has('p95Ms')).toBe(false);
+    expect(ids.has('age')).toBe(false);
+  });
+
+  it('passes windowScroll to the DataTable', () => {
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByTestId('workloads-table')).toHaveAttribute('data-window-scroll', 'true');
+  });
+
+  it('Imagename cell renders only the segment after the last "/" with the full path on title', () => {
+    render(<WorkloadExplorerPage />);
+    const imageCol = mockColumns?.find((c) => c.accessorKey === 'image');
+    expect(imageCol).toBeDefined();
+    const cellResult = imageCol.cell({
+      row: { original: defaultContainersMock.data[0] },
+      getValue: () => 'registry.harbor.example.com/library/team-x/api-service:1.4.2',
+    });
+    const { container } = render(cellResult);
+    const span = container.querySelector('span');
+    expect(span?.textContent).toBe('api-service:1.4.2');
+    expect(span?.getAttribute('title')).toBe(
+      'registry.harbor.example.com/library/team-x/api-service:1.4.2',
+    );
+  });
+
+  it('Name cell applies whitespace-nowrap on the tag wrapper and tag button', () => {
+    render(<WorkloadExplorerPage />);
+    const nameCol = mockColumns?.find((c) => c.accessorKey === 'name');
+    expect(nameCol).toBeDefined();
+    const cellResult = nameCol.cell({
+      row: { original: defaultContainersMock.data[0] },
+      getValue: () => 'workers-api-1',
+    });
+    const { container } = render(cellResult);
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper?.className).toContain('whitespace-nowrap');
+    // The name tag button is the one that links to the container detail page
+    // (the FavoriteButton mock is a separate <button>). Find it by its bg class.
+    const tagButton = wrapper?.querySelector('button.bg-primary\\/10');
+    expect(tagButton).not.toBeNull();
+    expect(tagButton?.className).toContain('whitespace-nowrap');
+  });
+
+  it('Stackname cell renders the stack tag with whitespace-nowrap', () => {
+    render(<WorkloadExplorerPage />);
+    const stackCol = mockColumns?.find((c) => c.id === 'stack');
+    const cellResult = stackCol.cell({
+      row: { original: defaultContainersMock.data[0] },
       getValue: () => undefined,
     });
-  }
-
-  it('issues a single useRed call per render with groupBy="service"', () => {
-    render(<WorkloadExplorerPage />);
-    expect(mockUseRed).toHaveBeenCalled();
-    const optsAll = mockUseRed.mock.calls.map((c) => c[0] as { groupBy: string; bucket: string });
-    // All calls use groupBy=service — proves we are not calling per-row.
-    for (const opts of optsAll) {
-      expect(opts.groupBy).toBe('service');
-      expect(opts.bucket).toBe('5m');
-    }
-    // And there's only one distinct fetch shape — meaning ONE batched query.
-    const distinct = new Set(optsAll.map((o) => JSON.stringify(o)));
-    expect(distinct.size).toBe(1);
-  });
-
-  it('adds Rate / Errors / p95 columns to the table', () => {
-    render(<WorkloadExplorerPage />);
-    expect(findColumn('rate')).toBeDefined();
-    expect(findColumn('errorRate')).toBeDefined();
-    expect(findColumn('p95Ms')).toBeDefined();
-  });
-
-  function cellText(col: any, row: any): string {
-    const el = renderCell(col, row);
-    const { container } = render(el);
-    const text = container.textContent ?? '';
-    container.remove();
-    return text;
-  }
-
-  it('renders RED values for containers with matching service_name rows', () => {
-    mockRedData = {
-      truncated: false,
-      buckets: [
-        {
-          bucketStart: '2026-05-14T11:55:00.000Z',
-          rows: [
-            {
-              group: 'workers-api-1',
-              rate: 2.5,
-              errorRate: 0.03,
-              p50Ms: 8,
-              p95Ms: 42,
-              p99Ms: 95,
-              callCount: 750,
-            },
-          ],
-        },
-      ],
-    };
-    render(<WorkloadExplorerPage />);
-
-    const rateCol = findColumn('rate');
-    const errorCol = findColumn('errorRate');
-    const p95Col = findColumn('p95Ms');
-
-    const container = defaultContainersMock.data[0]; // workers-api-1
-    expect(cellText(rateCol, container)).toMatch(/2\.50/);
-    expect(cellText(errorCol, container)).toMatch(/3\.00%/);
-    expect(cellText(p95Col, container)).toMatch(/42/);
-  });
-
-  it('renders en-dash for workloads with NO matching RED row (not "0")', () => {
-    mockRedData = {
-      truncated: false,
-      buckets: [
-        {
-          bucketStart: '2026-05-14T11:55:00.000Z',
-          rows: [
-            // Only workers-api-1 has data; billing-api-1 / beyla have none
-            {
-              group: 'workers-api-1',
-              rate: 1, errorRate: 0,
-              p50Ms: 1, p95Ms: 2, p99Ms: 3, callCount: 10,
-            },
-          ],
-        },
-      ],
-    };
-    render(<WorkloadExplorerPage />);
-
-    const rateCol = findColumn('rate');
-    const beyla = defaultContainersMock.data.find((c) => c.name === 'beyla')!;
-    // En-dash (–) for "no data", not "0"
-    expect(cellText(rateCol, beyla)).toBe('–');
-  });
-
-  it('renders "0" for workloads with explicit zero-traffic RED rows', () => {
-    mockRedData = {
-      truncated: false,
-      buckets: [
-        {
-          bucketStart: '2026-05-14T11:55:00.000Z',
-          rows: [
-            { group: 'beyla', rate: 0, errorRate: 0, p50Ms: 0, p95Ms: 0, p99Ms: 0, callCount: 0 },
-          ],
-        },
-      ],
-    };
-    render(<WorkloadExplorerPage />);
-
-    const rateCol = findColumn('rate');
-    const beyla = defaultContainersMock.data.find((c) => c.name === 'beyla')!;
-    // 0 traffic — explicit zero, not en-dash.
-    expect(cellText(rateCol, beyla)).toMatch(/^0\.00/);
+    const { container } = render(cellResult);
+    const tagButton = container.querySelector('button');
+    expect(tagButton).not.toBeNull();
+    expect(tagButton?.className).toContain('whitespace-nowrap');
   });
 });

--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -907,7 +907,7 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
     );
   });
 
-  it('Name cell applies whitespace-nowrap on the tag wrapper and tag button', () => {
+  it('Name cell tag button is single-line (whitespace-nowrap)', () => {
     render(<WorkloadExplorerPage />);
     const nameCol = mockColumns?.find((c) => c.accessorKey === 'name');
     expect(nameCol).toBeDefined();
@@ -916,11 +916,9 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
       getValue: () => 'workers-api-1',
     });
     const { container } = render(cellResult);
-    const wrapper = container.firstElementChild as HTMLElement;
-    expect(wrapper?.className).toContain('whitespace-nowrap');
     // The name tag button is the one that links to the container detail page
     // (the FavoriteButton mock is a separate <button>). Find it by its bg class.
-    const tagButton = wrapper?.querySelector('button.bg-primary\\/10');
+    const tagButton = container.querySelector('button.bg-primary\\/10');
     expect(tagButton).not.toBeNull();
     expect(tagButton?.className).toContain('whitespace-nowrap');
   });

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -298,7 +298,7 @@ export default function WorkloadExplorerPage() {
       cell: ({ row, getValue }) => {
         const container = row.original;
         return (
-          <div className="flex items-center gap-1 whitespace-nowrap">
+          <div className="flex items-center gap-1">
             <FavoriteButton size="sm" endpointId={container.endpointId} containerId={container.id} />
             <button
               onClick={(e) => {

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -8,7 +8,6 @@ import { useContainers, type Container } from '@/features/containers/hooks/use-c
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
 import { useStacks } from '@/features/containers/hooks/use-stacks';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
-import { useRed, type RedRow } from '@/features/observability/hooks/use-red';
 import { DataTable } from '@/shared/components/tables/data-table';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
@@ -20,7 +19,7 @@ import { SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { resolveContainerStackName } from '@/features/containers/lib/container-stack-grouping';
 import { exportToCsv } from '@/shared/lib/csv-export';
 import { getContainerGroup, getContainerGroupLabel, type ContainerGroup } from '@/features/containers/lib/system-container-grouping';
-import { cn, formatDate, truncate, formatRelativeAge } from '@/shared/lib/utils';
+import { cn, formatDate, getImageShortName, truncate, formatRelativeAge } from '@/shared/lib/utils';
 import { transition } from '@/shared/lib/motion-tokens';
 import { WorkloadSmartSearch } from '@/shared/components/forms/workload-smart-search';
 import { SelectionActionBar } from '@/shared/components/layout/selection-action-bar';
@@ -106,32 +105,6 @@ export default function WorkloadExplorerPage() {
   const { data: stacks } = useStacks();
   const { data: containers, isLoading, isError, error, refetch, isFetching } = useContainers(selectedEndpoint !== undefined ? { endpointId: selectedEndpoint } : undefined);
 
-  // ── RED columns (#1237) — ONE fetch per page render, server-side groupBy=service.
-  // Window is the most recent 5-minute bucket, rounded so React Query can
-  // dedupe across renders within the same 5-minute window.
-  const redWindow = useMemo(() => {
-    const to = new Date();
-    to.setSeconds(0, 0);
-    to.setMinutes(Math.floor(to.getMinutes() / 5) * 5);
-    const from = new Date(to.getTime() - 5 * 60 * 1000);
-    return { from, to };
-  }, []);
-  const { data: redData } = useRed({
-    from: redWindow.from,
-    to: redWindow.to,
-    bucket: '5m',
-    groupBy: 'service',
-  });
-  // Flatten across buckets, keyed by group (= service_name).
-  const redByService = useMemo(() => {
-    const map = new Map<string, RedRow>();
-    for (const b of redData?.buckets ?? []) {
-      for (const row of b.rows) {
-        map.set(row.group, row);
-      }
-    }
-    return map;
-  }, [redData]);
   const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', refetch);
   const { interval, setInterval } = useAutoRefresh(30);
 
@@ -325,14 +298,14 @@ export default function WorkloadExplorerPage() {
       cell: ({ row, getValue }) => {
         const container = row.original;
         return (
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1 whitespace-nowrap">
             <FavoriteButton size="sm" endpointId={container.endpointId} containerId={container.id} />
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 navigate(`/containers/${container.endpointId}/${container.id}`);
               }}
-              className="inline-flex items-center rounded-lg bg-primary/10 px-3 py-1 text-sm font-medium text-primary transition-all duration-200 hover:bg-primary/20 hover:shadow-sm hover:ring-1 hover:ring-primary/20"
+              className="inline-flex items-center whitespace-nowrap rounded-lg bg-primary/10 px-3 py-1 text-sm font-medium text-primary transition-all duration-200 hover:bg-primary/20 hover:shadow-sm hover:ring-1 hover:ring-primary/20"
             >
               {truncate(getValue<string>(), 45)}
             </button>
@@ -341,18 +314,59 @@ export default function WorkloadExplorerPage() {
       },
     },
     {
-      accessorKey: 'image',
-      header: 'Image',
-      cell: ({ getValue }) => (
-        <span className="inline-flex items-center rounded-md bg-muted/50 px-2 py-0.5 text-xs font-mono text-muted-foreground">
-          {truncate(getValue<string>(), 50)}
-        </span>
-      ),
+      id: 'stack',
+      header: 'Stackname',
+      size: 160,
+      cell: ({ row }) => {
+        const stackName = resolveContainerStackName(row.original, knownStackNames);
+        if (!stackName) {
+          return <span className="text-muted-foreground/50 text-xs">—</span>;
+        }
+        return (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setSelectedStack(stackName);
+            }}
+            className="inline-flex items-center whitespace-nowrap rounded-md bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-800 transition-colors hover:bg-purple-200 hover:ring-1 hover:ring-purple-300 dark:bg-purple-900/30 dark:text-purple-300 dark:hover:bg-purple-900/50"
+            title={`Filter by stack: ${stackName}`}
+          >
+            {truncate(stackName, 25)}
+          </button>
+        );
+      },
     },
     {
       accessorKey: 'state',
       header: 'State',
       cell: ({ getValue }) => <StatusBadge status={getValue<string>()} />,
+    },
+    {
+      accessorKey: 'endpointName',
+      header: 'Endpoint',
+      cell: ({ row }) => {
+        const container = row.original;
+        return (
+          <span className="inline-flex items-center rounded-md bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+            {container.endpointName}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: 'image',
+      header: 'Imagename',
+      cell: ({ getValue }) => {
+        const full = getValue<string>();
+        return (
+          <span
+            className="inline-flex items-center rounded-md bg-muted/50 px-2 py-0.5 text-xs font-mono text-muted-foreground"
+            title={full}
+          >
+            {truncate(getImageShortName(full), 50)}
+          </span>
+        );
+      },
     },
     {
       id: 'group',
@@ -369,170 +383,6 @@ export default function WorkloadExplorerPage() {
             }
           >
             {label}
-          </span>
-        );
-      },
-    },
-    {
-      id: 'stack',
-      header: 'Stack',
-      size: 160,
-      cell: ({ row }) => {
-        const stackName = resolveContainerStackName(row.original, knownStackNames);
-        if (!stackName) {
-          return <span className="text-muted-foreground/50 text-xs">—</span>;
-        }
-        return (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setSelectedStack(stackName);
-            }}
-            className="inline-flex items-center rounded-md bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-800 transition-colors hover:bg-purple-200 hover:ring-1 hover:ring-purple-300 dark:bg-purple-900/30 dark:text-purple-300 dark:hover:bg-purple-900/50"
-            title={`Filter by stack: ${stackName}`}
-          >
-            {truncate(stackName, 25)}
-          </button>
-        );
-      },
-    },
-    {
-      accessorKey: 'endpointName',
-      header: 'Endpoint',
-      cell: ({ row }) => {
-        const container = row.original;
-        return (
-          <span className="inline-flex items-center rounded-md bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
-            {container.endpointName}
-          </span>
-        );
-      },
-    },
-    {
-      id: 'rate',
-      header: 'Rate (/s)',
-      enableSorting: true,
-      accessorFn: (row: Container) => redByService.get(row.name)?.rate ?? Number.NEGATIVE_INFINITY,
-      cell: ({ row }) => {
-        const r = redByService.get(row.original.name);
-        if (!r) {
-          return <span className="text-xs text-muted-foreground/50">–</span>;
-        }
-        return (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              navigate(
-                `/traces?service=${encodeURIComponent(row.original.name)}`
-                  + `&from=${encodeURIComponent(redWindow.from.toISOString())}`
-                  + `&to=${encodeURIComponent(redWindow.to.toISOString())}`,
-              );
-            }}
-            className="font-mono text-xs hover:text-primary"
-            title="Open in Trace Explorer"
-          >
-            {r.rate.toFixed(2)}/s
-          </button>
-        );
-      },
-    },
-    {
-      id: 'errorRate',
-      header: 'Errors',
-      enableSorting: true,
-      accessorFn: (row: Container) => redByService.get(row.name)?.errorRate ?? Number.NEGATIVE_INFINITY,
-      cell: ({ row }) => {
-        const r = redByService.get(row.original.name);
-        if (!r) {
-          return <span className="text-xs text-muted-foreground/50">–</span>;
-        }
-        const pct = r.errorRate * 100;
-        const colorClass = pct >= 5
-          ? 'text-red-600 dark:text-red-400'
-          : pct >= 1
-            ? 'text-amber-600 dark:text-amber-400'
-            : 'text-emerald-600 dark:text-emerald-400';
-        return (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              navigate(
-                `/traces?service=${encodeURIComponent(row.original.name)}`
-                  + `&status=error`
-                  + `&from=${encodeURIComponent(redWindow.from.toISOString())}`
-                  + `&to=${encodeURIComponent(redWindow.to.toISOString())}`,
-              );
-            }}
-            className={`font-mono text-xs hover:underline ${colorClass}`}
-            title="Open error traces in Trace Explorer"
-          >
-            {pct.toFixed(2)}%
-          </button>
-        );
-      },
-    },
-    {
-      id: 'p95Ms',
-      header: 'p95 (ms)',
-      enableSorting: true,
-      accessorFn: (row: Container) => redByService.get(row.name)?.p95Ms ?? Number.NEGATIVE_INFINITY,
-      cell: ({ row }) => {
-        const r = redByService.get(row.original.name);
-        if (!r) {
-          return <span className="text-xs text-muted-foreground/50">–</span>;
-        }
-        return (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              navigate(
-                `/traces?service=${encodeURIComponent(row.original.name)}`
-                  + `&from=${encodeURIComponent(redWindow.from.toISOString())}`
-                  + `&to=${encodeURIComponent(redWindow.to.toISOString())}`,
-              );
-            }}
-            className="font-mono text-xs hover:text-primary"
-            title="Open in Trace Explorer"
-          >
-            {r.p95Ms.toFixed(0)} ms
-          </button>
-        );
-      },
-    },
-    {
-      id: 'age',
-      header: 'Age',
-      accessorKey: 'created',
-      cell: ({ row }) => {
-        const container = row.original;
-        const age = formatRelativeAge(container.created);
-        const absoluteDate = formatDate(new Date(container.created * 1000));
-        const state = container.state;
-
-        let prefix = '';
-        let colorClass = 'text-muted-foreground';
-
-        if (state === 'running') {
-          colorClass = 'text-emerald-600 dark:text-emerald-400';
-        } else if (state === 'exited' || state === 'stopped') {
-          prefix = state === 'exited' ? 'Exited ' : 'Stopped ';
-          colorClass = 'text-muted-foreground';
-        } else if (state === 'paused') {
-          prefix = 'Paused ';
-          colorClass = 'text-amber-600 dark:text-amber-400';
-        } else if (state === 'dead') {
-          prefix = 'Dead ';
-          colorClass = 'text-red-600 dark:text-red-400';
-        }
-
-        const display = state === 'running' ? age : `${prefix}${age} ago`;
-
-        return (
-          <span className={`text-xs ${colorClass}`} title={absoluteDate}>
-            {display}
           </span>
         );
       },
@@ -574,7 +424,7 @@ export default function WorkloadExplorerPage() {
         );
       },
     },
-  ], [navigate, knownStackNames, selectedEndpoint, selectedGroup, selectedState, redByService, redWindow]);
+  ], [navigate, knownStackNames, selectedEndpoint, selectedGroup, selectedState]);
 
   if (isError) {
     return (
@@ -860,6 +710,7 @@ export default function WorkloadExplorerPage() {
                 data={searchFilteredContainers ?? filteredContainers}
                 hideSearch
                 pageSize={15}
+                windowScroll
                 enableRowSelection
                 maxSelection={MAX_COMPARE}
                 onSelectionChange={handleSelectionChange}

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -512,6 +512,12 @@ describe('DataTable', () => {
       expect(screen.getByTestId('select-all-checkbox')).toBeInTheDocument();
       expect(screen.getByTestId('row-checkbox-0')).toBeInTheDocument();
     });
+
+    it('renders the "No results." empty row when there are no rows', () => {
+      render(<DataTable columns={testColumns} data={[]} windowScroll />);
+      expect(screen.getByTestId('window-scroll-container')).toBeInTheDocument();
+      expect(screen.getByText('No results.')).toBeInTheDocument();
+    });
   });
 
   describe('themed checkbox (#1288)', () => {

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -484,4 +484,63 @@ describe('DataTable', () => {
       expect(screen.getByTestId('table-row-0').className).not.toContain('bg-primary/5');
     });
   });
+
+  describe('windowScroll mode (#1288)', () => {
+    it('renders the window-scroll container instead of the virtual or pagination one', () => {
+      const data = makeRows(200);
+      render(<DataTable columns={testColumns} data={data} windowScroll />);
+
+      expect(screen.getByTestId('window-scroll-container')).toBeInTheDocument();
+      expect(screen.queryByTestId('virtual-scroll-container')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument();
+    });
+
+    it('renders every row at once (no pagination, no virtualization)', () => {
+      const data = makeRows(75);
+      render(<DataTable columns={testColumns} data={data} windowScroll />);
+
+      expect(screen.getByText('container-1')).toBeInTheDocument();
+      expect(screen.getByText('container-75')).toBeInTheDocument();
+    });
+
+    it('still renders the themed checkboxes when row selection is enabled', () => {
+      const data = makeRows(60);
+      render(
+        <DataTable columns={testColumns} data={data} windowScroll enableRowSelection />,
+      );
+
+      expect(screen.getByTestId('select-all-checkbox')).toBeInTheDocument();
+      expect(screen.getByTestId('row-checkbox-0')).toBeInTheDocument();
+    });
+  });
+
+  describe('themed checkbox (#1288)', () => {
+    it('header checkbox uses the themed primitive (input + adjacent indicator icon)', () => {
+      render(
+        <DataTable columns={testColumns} data={makeRows(3)} enableRowSelection />,
+      );
+      const selectAll = screen.getByTestId('select-all-checkbox');
+      // The native input is preserved (so click/keyboard semantics work) …
+      expect(selectAll.tagName).toBe('INPUT');
+      // … but it now lives inside a themed wrapper (relative inline-flex span).
+      const wrapper = selectAll.parentElement;
+      expect(wrapper?.tagName).toBe('SPAN');
+      expect(wrapper?.className).toContain('inline-flex');
+    });
+
+    it('themed row checkbox is clickable and still bubbles its change', () => {
+      const onSelectionChange = vi.fn();
+      const data = makeRows(2);
+      render(
+        <DataTable
+          columns={testColumns}
+          data={data}
+          enableRowSelection
+          onSelectionChange={onSelectionChange}
+        />,
+      );
+      fireEvent.click(screen.getByTestId('row-checkbox-0'));
+      expect(onSelectionChange).toHaveBeenCalledWith([data[0]]);
+    });
+  });
 });

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -14,6 +14,7 @@ import {
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { cn } from '@/shared/lib/utils';
+import { Checkbox } from '@/shared/components/ui/checkbox';
 import { ArrowUpDown, ChevronLeft, ChevronRight, ArrowUp } from 'lucide-react';
 
 const ROW_HEIGHT = 48;
@@ -46,6 +47,12 @@ interface DataTableProps<T> {
   getRowId?: (row: T) => string;
   /** Controlled selection state — pass an empty object to clear all checkboxes */
   selectedRowIds?: RowSelectionState;
+  /**
+   * Render the full list with the document as the scroll container (no inner
+   * scrollbar, no pagination). Disables virtualization — use only when the
+   * dataset is bounded to a few hundred rows.
+   */
+  windowScroll?: boolean;
 }
 
 export function DataTable<T>({
@@ -64,6 +71,7 @@ export function DataTable<T>({
   onSelectionChange,
   getRowId: getRowIdProp,
   selectedRowIds,
+  windowScroll,
 }: DataTableProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -80,7 +88,10 @@ export function DataTable<T>({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const isServerPaginated = !!serverPagination;
-  const useVirtual = !isServerPaginated && (virtualScrolling ?? data.length > VIRTUAL_THRESHOLD);
+  const useWindowScroll = !!windowScroll && !isServerPaginated;
+  const useVirtual = !useWindowScroll
+    && !isServerPaginated
+    && (virtualScrolling ?? data.length > VIRTUAL_THRESHOLD);
 
   // Build the checkbox column when row selection is enabled
   const selectionColumn = useMemo<ColumnDef<T, any> | null>(() => {
@@ -93,16 +104,12 @@ export function DataTable<T>({
         const allPageSelected = tbl.getIsAllPageRowsSelected();
         const somePageSelected = tbl.getIsSomePageRowsSelected();
         return (
-          <input
-            type="checkbox"
+          <Checkbox
             data-testid="select-all-checkbox"
             aria-label="Select all on page"
             checked={allPageSelected}
-            ref={(el) => {
-              if (el) el.indeterminate = somePageSelected && !allPageSelected;
-            }}
+            indeterminate={somePageSelected && !allPageSelected}
             onChange={tbl.getToggleAllPageRowsSelectedHandler()}
-            className="h-4 w-4 rounded border-gray-300 accent-primary cursor-pointer"
           />
         );
       },
@@ -111,8 +118,7 @@ export function DataTable<T>({
         const isSelected = row.getIsSelected();
         const isDisabled = !isSelected && maxSelection !== undefined && selectedCount >= maxSelection;
         return (
-          <input
-            type="checkbox"
+          <Checkbox
             data-testid={`row-checkbox-${row.id}`}
             aria-label={`Select row ${row.id}`}
             checked={isSelected}
@@ -120,7 +126,6 @@ export function DataTable<T>({
             title={isDisabled ? `Maximum of ${maxSelection} containers can be compared at once` : undefined}
             onChange={row.getToggleSelectedHandler()}
             onClick={(e) => e.stopPropagation()}
-            className="h-4 w-4 rounded border-gray-300 accent-primary cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
           />
         );
       },
@@ -138,7 +143,7 @@ export function DataTable<T>({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    ...(useVirtual || isServerPaginated ? {} : { getPaginationRowModel: getPaginationRowModel() }),
+    ...(useVirtual || isServerPaginated || useWindowScroll ? {} : { getPaginationRowModel: getPaginationRowModel() }),
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     ...(enableRowSelection
@@ -156,7 +161,7 @@ export function DataTable<T>({
       columnFilters,
       ...(enableRowSelection ? { rowSelection } : {}),
     },
-    ...(useVirtual || isServerPaginated ? {} : { initialState: { pagination: { pageSize } } }),
+    ...(useVirtual || isServerPaginated || useWindowScroll ? {} : { initialState: { pagination: { pageSize } } }),
     ...(getRowIdProp ? { getRowId: (row: T) => getRowIdProp(row) } : {}),
   });
 
@@ -334,7 +339,24 @@ export function DataTable<T>({
         </div>
       )}
 
-      {useVirtual ? (
+      {useWindowScroll ? (
+        <div className="rounded-md border" data-testid="window-scroll-container">
+          <table className="w-full caption-bottom text-sm">
+            {renderHeader()}
+            <tbody className="[&_tr:last-child]:border-0">
+              {rows.length ? (
+                rows.map((row) => renderRow(row))
+              ) : (
+                <tr>
+                  <td colSpan={allColumns.length} className="h-24 text-center text-muted-foreground">
+                    No results.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      ) : useVirtual ? (
         <div className="relative rounded-md border">
           <div
             ref={scrollContainerRef}

--- a/frontend/src/shared/components/ui/checkbox.test.tsx
+++ b/frontend/src/shared/components/ui/checkbox.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
+import { Checkbox } from './checkbox';
+
+describe('Checkbox', () => {
+  it('renders a native input wrapped in a themed span', () => {
+    render(<Checkbox data-testid="cb" aria-label="row" />);
+    const input = screen.getByTestId('cb');
+    expect(input.tagName).toBe('INPUT');
+    expect(input.getAttribute('type')).toBe('checkbox');
+    const wrapper = input.parentElement;
+    expect(wrapper?.tagName).toBe('SPAN');
+    expect(wrapper?.className).toContain('inline-flex');
+  });
+
+  it('fires onChange when clicked', () => {
+    const onChange = vi.fn();
+    render(<Checkbox data-testid="cb" aria-label="row" onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('cb'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects the indeterminate prop on the DOM input', () => {
+    render(<Checkbox data-testid="cb" aria-label="row" indeterminate />);
+    const input = screen.getByTestId('cb') as HTMLInputElement;
+    expect(input.indeterminate).toBe(true);
+  });
+
+  it('clears DOM indeterminate when the prop transitions to false', () => {
+    const { rerender } = render(
+      <Checkbox data-testid="cb" aria-label="row" indeterminate />,
+    );
+    const input = screen.getByTestId('cb') as HTMLInputElement;
+    expect(input.indeterminate).toBe(true);
+
+    rerender(<Checkbox data-testid="cb" aria-label="row" indeterminate={false} />);
+    expect(input.indeterminate).toBe(false);
+  });
+
+  it('renders the dash indicator when indeterminate and the check indicator otherwise', () => {
+    const { container, rerender } = render(
+      <Checkbox data-testid="cb" aria-label="row" indeterminate />,
+    );
+    // Lucide icons render as inline SVGs — assert by lucide class.
+    expect(container.querySelector('svg.lucide-minus')).not.toBeNull();
+    expect(container.querySelector('svg.lucide-check')).toBeNull();
+
+    rerender(<Checkbox data-testid="cb" aria-label="row" indeterminate={false} />);
+    expect(container.querySelector('svg.lucide-check')).not.toBeNull();
+    expect(container.querySelector('svg.lucide-minus')).toBeNull();
+  });
+
+  it('applies disabled attribute and the disabled-opacity utility', () => {
+    render(<Checkbox data-testid="cb" aria-label="row" disabled />);
+    const input = screen.getByTestId('cb') as HTMLInputElement;
+    expect(input).toBeDisabled();
+    expect(input.className).toContain('disabled:opacity-40');
+    expect(input.className).toContain('disabled:cursor-not-allowed');
+  });
+
+  it('forwards refs to the underlying input', () => {
+    let captured: HTMLInputElement | null = null;
+    function Host() {
+      const ref = useRef<HTMLInputElement>(null);
+      return (
+        <Checkbox
+          ref={(el) => {
+            ref.current = el;
+            captured = el;
+          }}
+          data-testid="cb"
+          aria-label="row"
+        />
+      );
+    }
+    render(<Host />);
+    expect(captured).not.toBeNull();
+    expect(captured?.tagName).toBe('INPUT');
+  });
+
+  it('uses small dimensions when size="sm"', () => {
+    render(<Checkbox data-testid="cb" aria-label="row" size="sm" />);
+    const input = screen.getByTestId('cb');
+    expect(input.className).toContain('h-3.5');
+    expect(input.className).toContain('w-3.5');
+  });
+});

--- a/frontend/src/shared/components/ui/checkbox.tsx
+++ b/frontend/src/shared/components/ui/checkbox.tsx
@@ -1,0 +1,75 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import type { InputHTMLAttributes } from 'react';
+import { Check, Minus } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+
+type NativeProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'>;
+
+export interface CheckboxProps extends NativeProps {
+  indeterminate?: boolean;
+  size?: 'sm' | 'md';
+}
+
+/**
+ * Themed checkbox. Renders a native `<input type="checkbox">` so click,
+ * keyboard, disabled, and form semantics match the platform — the icon
+ * sibling is purely cosmetic and pointer-events-none.
+ */
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  { className, indeterminate, disabled, checked, size = 'md', ...rest },
+  forwardedRef,
+) {
+  const innerRef = useRef<HTMLInputElement>(null);
+  useImperativeHandle(forwardedRef, () => innerRef.current as HTMLInputElement);
+
+  useEffect(() => {
+    const el = innerRef.current;
+    if (!el) return;
+    el.indeterminate = Boolean(indeterminate);
+  }, [indeterminate]);
+
+  const box = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
+  const icon = size === 'sm' ? 'h-2.5 w-2.5' : 'h-3 w-3';
+
+  return (
+    <span className={cn('relative inline-flex shrink-0 items-center justify-center', box)}>
+      <input
+        ref={innerRef}
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        className={cn(
+          'peer m-0 cursor-pointer appearance-none rounded-[4px] border border-input bg-background',
+          'transition-colors duration-150',
+          'hover:border-primary/60',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          'checked:border-primary checked:bg-primary',
+          'indeterminate:border-primary indeterminate:bg-primary',
+          'disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-input',
+          box,
+          className,
+        )}
+        {...rest}
+      />
+      {indeterminate ? (
+        <Minus
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute text-primary-foreground opacity-0 peer-indeterminate:opacity-100',
+            icon,
+          )}
+          strokeWidth={3}
+        />
+      ) : (
+        <Check
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute text-primary-foreground opacity-0 peer-checked:opacity-100',
+            icon,
+          )}
+          strokeWidth={3}
+        />
+      )}
+    </span>
+  );
+});

--- a/frontend/src/shared/lib/utils.test.ts
+++ b/frontend/src/shared/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { escapeRegExp, formatBytes, formatDuration, formatRelativeAge, truncate, cn } from './utils';
+import { escapeRegExp, formatBytes, formatDuration, formatRelativeAge, getImageShortName, truncate, cn } from './utils';
 
 describe('formatBytes', () => {
   it('should return "0 B" for 0 bytes', () => {
@@ -178,6 +178,39 @@ describe('escapeRegExp', () => {
     const re = new RegExp(escapeRegExp(input));
     expect(re.test('file.log')).toBe(true);
     expect(re.test('filexlog')).toBe(false);
+  });
+});
+
+describe('getImageShortName', () => {
+  it('strips a Harbor-style multi-segment path', () => {
+    expect(getImageShortName('registry.harbor.example.com/library/team-x/api-service:1.4.2')).toBe(
+      'api-service:1.4.2',
+    );
+  });
+
+  it('strips a Docker Hub library prefix', () => {
+    expect(getImageShortName('library/nginx:latest')).toBe('nginx:latest');
+  });
+
+  it('returns unscoped images unchanged', () => {
+    expect(getImageShortName('alpine')).toBe('alpine');
+    expect(getImageShortName('alpine:3.19')).toBe('alpine:3.19');
+  });
+
+  it('preserves digest suffix', () => {
+    expect(
+      getImageShortName('ghcr.io/owner/repo/app@sha256:abc123'),
+    ).toBe('app@sha256:abc123');
+  });
+
+  it('handles empty / null / undefined inputs', () => {
+    expect(getImageShortName('')).toBe('');
+    expect(getImageShortName(null)).toBe('');
+    expect(getImageShortName(undefined)).toBe('');
+  });
+
+  it('returns empty segment if the image ends with a slash', () => {
+    expect(getImageShortName('foo/')).toBe('');
   });
 });
 

--- a/frontend/src/shared/lib/utils.ts
+++ b/frontend/src/shared/lib/utils.ts
@@ -60,6 +60,19 @@ export function truncate(str: string, length: number): string {
 }
 
 /**
+ * Return only the segment after the last `/` of an OCI image reference.
+ *
+ * `registry.example.com/team/api-service:1.4.2` → `api-service:1.4.2`.
+ * Strings without a `/` (or empty inputs) are returned unchanged. Tag and
+ * digest suffixes are preserved.
+ */
+export function getImageShortName(image: string | null | undefined): string {
+  if (!image) return '';
+  const slash = image.lastIndexOf('/');
+  return slash === -1 ? image : image.slice(slash + 1);
+}
+
+/**
  * Escape special regex characters in a string so it can be safely used
  * inside `new RegExp()` without risk of ReDoS (CWE-1333).
  *


### PR DESCRIPTION
Closes #1288.

## Summary

- Drop the `Rate (/s)` / `Errors` / `p95 (ms)` / `Age` columns from the Workload Explorer table and reorder to `Name, Stackname, State, Endpoint, Imagename, Group, Actions`. Rename `Stack` → `Stackname` and `Image` → `Imagename`.
- Image cell now renders only the segment after the last `/` of the OCI reference (e.g. `registry.harbor.example.com/library/team-x/api-service:1.4.2` → `api-service:1.4.2`); the full path is exposed via the `title` attribute on hover.
- Apply `whitespace-nowrap` to the Name and Stackname tags so they stay on a single line at narrow column widths.
- Add an opt-in `windowScroll` prop on the shared `DataTable` that renders the full list with the document as the scroll container — no inner `overflow-auto`, no pagination, no scroll-to-top floater. Default behavior is unchanged for all other consumers. The Workload Explorer page passes `windowScroll` to drop its dedicated inner scrollbar.
- Extract a themed `Checkbox` primitive at `frontend/src/shared/components/ui/checkbox.tsx`. Native `<input type=\"checkbox\">` inside a themed wrapper (themed border / background, focus ring, check + dash indicator icons, indeterminate + disabled handling) — preserves click, keyboard, `disabled`, `title`, and `data-testid` semantics so existing tests and a11y stay intact. Adopted in `DataTable`'s selection column.
- Remove the now-unused RED metrics fetching (`useRed`, `redByService`, `redWindow`) from the Workload Explorer page.

## Files of note

- `frontend/src/features/containers/pages/workload-explorer.tsx`
- `frontend/src/shared/components/tables/data-table.tsx`
- `frontend/src/shared/components/ui/checkbox.tsx` (new)
- `frontend/src/shared/lib/utils.ts` (`getImageShortName` helper)

## Test plan

- [x] `npm run lint -w frontend` — clean
- [x] `npm run typecheck -w frontend` — clean
- [x] `npx vitest run` — 1947 / 1947 pass
- [x] New tests cover: image short-name helper (Harbor, library/, unscoped, digest, empty/null), column ordering + header renames, omission of removed columns, image cell short-name + full-path title, `whitespace-nowrap` on Name + Stackname tags, `windowScroll` mode (no virtual scroll container, no pagination, all rows rendered, themed checkboxes still work), themed checkbox structure + change handler.
- [ ] Manual visual review of the Workload Explorer page across light/dark and at least two accent themes for the themed checkbox styling (per issue acceptance criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)