### PR TITLE
feat(home): surface Overall Health Score on the Home page

### DIFF
--- a/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
+++ b/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
@@ -1,63 +1,17 @@
 import { Activity, AlertCircle, AlertTriangle, CheckCircle2, HelpCircle, Info } from 'lucide-react';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { HealthScoreCard } from '@/shared/components/data-display/health-score-card';
-import type { Container } from '@/features/containers/hooks/use-containers';
+import {
+  calculateHealthStats,
+  calculateHealthScore,
+  type HealthStats,
+} from '@/shared/lib/health-score';
 
-export interface HealthStats {
-  total: number;
-  running: number;
-  stopped: number;
-  paused: number;
-  unhealthy: number;
-  healthy: number;
-  unknown: number;
-  /**
-   * Running containers without a Docker healthcheck configured. These are
-   * excluded from the health-score denominator (score = healthy / (healthy +
-   * unhealthy)) so the operator's choice not to configure a healthcheck
-   * doesn't artificially deflate the fleet health number.
-   */
-  noHealthcheck: number;
-}
-
-export function calculateHealthStats(containers: Container[]): HealthStats {
-  const stats: HealthStats = {
-    total: containers.length,
-    running: 0,
-    stopped: 0,
-    paused: 0,
-    unhealthy: 0,
-    healthy: 0,
-    unknown: 0,
-    noHealthcheck: 0,
-  };
-
-  containers.forEach((container) => {
-    if (container.state === 'running') stats.running++;
-    else if (container.state === 'exited') stats.stopped++;
-    else if (container.state === 'paused') stats.paused++;
-
-    if (container.healthStatus === 'unhealthy') stats.unhealthy++;
-    else if (container.healthStatus === 'healthy') stats.healthy++;
-    else {
-      stats.unknown++;
-      if (container.state === 'running') stats.noHealthcheck++;
-    }
-  });
-
-  return stats;
-}
-
-/**
- * Score = healthy / (healthy + unhealthy). Containers without a healthcheck
- * are excluded so the operator's choice not to configure one doesn't drag
- * the score down. Returns null when no container reports a health signal.
- */
-export function calculateHealthScore(stats: HealthStats): number | null {
-  const reporting = stats.healthy + stats.unhealthy;
-  if (reporting === 0) return null;
-  return (stats.healthy / reporting) * 100;
-}
+// Re-export the shared helpers so existing imports from this module keep
+// working. The canonical home for the types and calculators is
+// `@/shared/lib/health-score` — see that file for the score formula.
+export { calculateHealthStats, calculateHealthScore };
+export type { HealthStats };
 
 /**
  * Compact horizontal stat tile used in the Fleet Vitals strip. Replaces the
@@ -124,8 +78,6 @@ export function FleetHealthSummary({ stats, isLoading, insightStats }: {
     return <SkeletonChart size="md" className="h-44" />;
   }
 
-  const healthScore = calculateHealthScore(stats);
-
   return (
     <div
       className="rounded-lg border bg-card p-6 shadow-sm transition-all duration-200 hover:shadow-md hover:-translate-y-0.5 hover:border-primary/20"
@@ -133,7 +85,7 @@ export function FleetHealthSummary({ stats, isLoading, insightStats }: {
     >
       <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
         {/* Hero — score + issue count */}
-        <HealthScoreCard stats={stats} score={healthScore} />
+        <HealthScoreCard stats={stats} />
 
         {/* Compact status strip — container stats on row 1, insights stats on
             row 2 (when supplied). Two rows of 4 tiles inside the same hero. */}

--- a/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
+++ b/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
@@ -1,5 +1,6 @@
-import { Activity, AlertCircle, AlertTriangle, CheckCircle2, HelpCircle, Info, XCircle } from 'lucide-react';
+import { Activity, AlertCircle, AlertTriangle, CheckCircle2, HelpCircle, Info } from 'lucide-react';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
+import { HealthScoreCard } from '@/shared/components/data-display/health-score-card';
 import type { Container } from '@/features/containers/hooks/use-containers';
 
 export interface HealthStats {
@@ -124,8 +125,6 @@ export function FleetHealthSummary({ stats, isLoading, insightStats }: {
   }
 
   const healthScore = calculateHealthScore(stats);
-  const reporting = stats.healthy + stats.unhealthy;
-  const issueCount = stats.unhealthy + stats.stopped;
 
   return (
     <div
@@ -134,48 +133,7 @@ export function FleetHealthSummary({ stats, isLoading, insightStats }: {
     >
       <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
         {/* Hero — score + issue count */}
-        <div className="flex items-center gap-5 min-w-0">
-          <div className="flex h-24 w-24 flex-shrink-0 items-center justify-center rounded-full border-8 border-primary/20 bg-muted/30">
-            {healthScore === null ? (
-              <HelpCircle className="h-12 w-12 text-muted-foreground" />
-            ) : healthScore >= 80 ? (
-              <CheckCircle2 className="h-12 w-12 text-emerald-500" />
-            ) : healthScore >= 50 ? (
-              <AlertCircle className="h-12 w-12 text-amber-500" />
-            ) : (
-              <XCircle className="h-12 w-12 text-red-500" />
-            )}
-          </div>
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-muted-foreground">Overall Health Score</p>
-            {healthScore === null ? (
-              <>
-                <p className="text-2xl font-semibold text-muted-foreground" data-testid="health-score-na">
-                  No healthchecks configured
-                </p>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {stats.total} containers tracked. Configure Docker healthchecks to enable scoring.
-                </p>
-              </>
-            ) : (
-              <>
-                <p className="text-4xl font-bold tabular-nums leading-none mt-1" data-testid="health-score">
-                  {healthScore.toFixed(1)}%
-                </p>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {stats.healthy} of {reporting} reporting healthy
-                  {stats.noHealthcheck > 0 && ` · ${stats.noHealthcheck} without healthcheck`}
-                </p>
-              </>
-            )}
-            {issueCount > 0 && (
-              <p className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium text-red-700 dark:text-red-400">
-                <AlertTriangle className="h-4 w-4" />
-                {issueCount} container{issueCount === 1 ? '' : 's'} need{issueCount === 1 ? 's' : ''} attention
-              </p>
-            )}
-          </div>
-        </div>
+        <HealthScoreCard stats={stats} score={healthScore} />
 
         {/* Compact status strip — container stats on row 1, insights stats on
             row 2 (when supplied). Two rows of 4 tiles inside the same hero. */}

--- a/frontend/src/features/core/pages/home.test.tsx
+++ b/frontend/src/features/core/pages/home.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@/features/core/hooks/use-dashboard-full', () => ({
 
 vi.mock('@/features/containers/hooks/use-containers', () => ({
   useFavoriteContainers: () => ({ data: [] }),
+  useContainers: vi.fn(),
 }));
 
 vi.mock('@/features/containers/hooks/use-endpoints', () => ({
@@ -107,9 +108,29 @@ vi.mock('@/features/ai-intelligence/hooks/use-nl-query', () => ({
 }));
 
 import { useDashboardFull } from '@/features/core/hooks/use-dashboard-full';
+import { useContainers } from '@/features/containers/hooks/use-containers';
 import type { DashboardSummary } from '@/features/core/hooks/use-dashboard';
+import type { Container } from '@/features/containers/hooks/use-containers';
 
 const mockUseDashboardFull = vi.mocked(useDashboardFull);
+const mockUseContainers = vi.mocked(useContainers);
+
+function makeContainer(overrides: Partial<Container>): Container {
+  return {
+    id: 'c',
+    name: 'c',
+    image: 'nginx',
+    state: 'running',
+    status: 'Up 1 hour',
+    endpointId: 1,
+    endpointName: 'local',
+    ports: [],
+    created: 0,
+    labels: {},
+    networks: [],
+    ...overrides,
+  };
+}
 
 function makeDashboardData() {
   return {
@@ -157,6 +178,13 @@ function renderPage() {
 describe('HomePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: containers query is idle / empty. Individual tests override
+    // this when they need a specific fleet shape (e.g. 9 healthy / 1 unhealthy).
+    mockUseContainers.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    } as any);
   });
 
   it('renders KPI cards when data is loaded', () => {
@@ -223,6 +251,36 @@ describe('HomePage', () => {
 
     // KPI cards should not be visible while loading
     expect(screen.queryByText('Endpoints')).not.toBeInTheDocument();
+  });
+
+  it('renders the Overall Health Score card on row 2 with 9 healthy / 1 unhealthy (green)', () => {
+    mockUseDashboardFull.mockReturnValue({
+      data: makeDashboardData(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    // 9 healthy + 1 unhealthy → score = 90.0% → green band (>= 80%)
+    const healthy = Array.from({ length: 9 }, (_, i) =>
+      makeContainer({ id: `h${i}`, name: `h${i}`, healthStatus: 'healthy' }),
+    );
+    const unhealthy = [makeContainer({ id: 'u0', name: 'u0', healthStatus: 'unhealthy' })];
+    mockUseContainers.mockReturnValue({
+      data: [...healthy, ...unhealthy],
+      isLoading: false,
+      isError: false,
+    } as any);
+
+    renderPage();
+
+    expect(screen.getByTestId('health-score-card')).toBeInTheDocument();
+    expect(screen.getByTestId('health-score')).toHaveTextContent('90.0%');
+    // ≥80% renders the green CheckCircle2 icon.
+    expect(screen.getByTestId('health-score-icon-green')).toBeInTheDocument();
+    expect(screen.getByText('9 of 10 reporting healthy')).toBeInTheDocument();
   });
 
   it('renders the page subtitle without mentioning recent containers', () => {

--- a/frontend/src/features/core/pages/home.tsx
+++ b/frontend/src/features/core/pages/home.tsx
@@ -2,9 +2,14 @@ import { lazy, Suspense, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Server, Boxes, PackageOpen, Layers, AlertTriangle, Star, ShieldAlert } from 'lucide-react';
 import { useDashboardFull } from '@/features/core/hooks/use-dashboard-full';
-import { useFavoriteContainers } from '@/features/containers/hooks/use-containers';
+import { useContainers, useFavoriteContainers } from '@/features/containers/hooks/use-containers';
+import {
+  calculateHealthScore,
+  calculateHealthStats,
+} from '@/features/ai-intelligence/components/fleet-health-summary';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
+import { HealthScoreCard } from '@/shared/components/data-display/health-score-card';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { SkeletonKpi, SkeletonChart } from '@/shared/components/feedback/skeleton';
@@ -41,6 +46,22 @@ export default function HomePage() {
   const { data: favoriteContainers = [] } = useFavoriteContainers(favoriteIds);
   // KPI history is included in the unified /api/dashboard/full response — no separate call needed
   const kpiHistory = fullData?.kpiHistory;
+
+  // Containers feed the Overall Health Score row (row 2). Uses the same
+  // helpers as the Health & Monitoring page so the two views never disagree.
+  const {
+    data: containers,
+    isLoading: isLoadingContainers,
+    isError: isContainersError,
+  } = useContainers();
+  const healthStats = useMemo(() => {
+    if (!containers) return null;
+    return calculateHealthStats(containers);
+  }, [containers]);
+  const healthScore = useMemo(() => {
+    if (!healthStats) return null;
+    return calculateHealthScore(healthStats);
+  }, [healthStats]);
 
   const endpointChartData = useMemo(() => {
     if (!endpoints) return [];
@@ -225,6 +246,32 @@ export default function HomePage() {
                 />
               </button>
             </TiltCard>
+          </MotionReveal>
+        </MotionStagger>
+      ) : null}
+
+      {/* Overall Health Score — single hero row that answers "is everything OK?"
+          without a click. Same component as Health & Monitoring so the two
+          pages can never drift apart. */}
+      {isContainersError ? (
+        <EmptyState
+          variant="error"
+          icon={AlertTriangle}
+          title="Failed to load fleet health"
+          description="Could not compute the Overall Health Score from container data."
+        />
+      ) : isLoadingContainers ? (
+        <div data-testid="health-score-skeleton">
+          <SkeletonKpi />
+        </div>
+      ) : healthStats ? (
+        <MotionStagger stagger={0.05}>
+          <MotionReveal>
+            <SpotlightCard>
+              <div className="rounded-lg border bg-card p-6 shadow-sm">
+                <HealthScoreCard stats={healthStats} score={healthScore} />
+              </div>
+            </SpotlightCard>
           </MotionReveal>
         </MotionStagger>
       ) : null}

--- a/frontend/src/features/core/pages/home.tsx
+++ b/frontend/src/features/core/pages/home.tsx
@@ -3,10 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Server, Boxes, PackageOpen, Layers, AlertTriangle, Star, ShieldAlert } from 'lucide-react';
 import { useDashboardFull } from '@/features/core/hooks/use-dashboard-full';
 import { useContainers, useFavoriteContainers } from '@/features/containers/hooks/use-containers';
-import {
-  calculateHealthScore,
-  calculateHealthStats,
-} from '@/features/ai-intelligence/components/fleet-health-summary';
+import { calculateHealthStats } from '@/shared/lib/health-score';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
 import { HealthScoreCard } from '@/shared/components/data-display/health-score-card';
@@ -58,10 +55,6 @@ export default function HomePage() {
     if (!containers) return null;
     return calculateHealthStats(containers);
   }, [containers]);
-  const healthScore = useMemo(() => {
-    if (!healthStats) return null;
-    return calculateHealthScore(healthStats);
-  }, [healthStats]);
 
   const endpointChartData = useMemo(() => {
     if (!endpoints) return [];
@@ -269,7 +262,7 @@ export default function HomePage() {
           <MotionReveal>
             <SpotlightCard>
               <div className="rounded-lg border bg-card p-6 shadow-sm">
-                <HealthScoreCard stats={healthStats} score={healthScore} />
+                <HealthScoreCard stats={healthStats} />
               </div>
             </SpotlightCard>
           </MotionReveal>

--- a/frontend/src/shared/components/data-display/health-score-card.test.tsx
+++ b/frontend/src/shared/components/data-display/health-score-card.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { HealthScoreCard } from './health-score-card';
-import type { HealthStats } from '@/features/ai-intelligence/components/fleet-health-summary';
+import type { HealthStats } from '@/shared/lib/health-score';
 
 function makeStats(overrides: Partial<HealthStats> = {}): HealthStats {
   return {
@@ -22,7 +22,6 @@ describe('HealthScoreCard', () => {
     render(
       <HealthScoreCard
         stats={makeStats({ total: 10, healthy: 9, unhealthy: 1, running: 10 })}
-        score={90}
       />,
     );
 
@@ -35,7 +34,6 @@ describe('HealthScoreCard', () => {
     render(
       <HealthScoreCard
         stats={makeStats({ total: 4, healthy: 2, unhealthy: 2, running: 4 })}
-        score={50}
       />,
     );
 
@@ -46,7 +44,6 @@ describe('HealthScoreCard', () => {
     render(
       <HealthScoreCard
         stats={makeStats({ total: 4, healthy: 1, unhealthy: 3, running: 4 })}
-        score={25}
       />,
     );
 
@@ -57,7 +54,6 @@ describe('HealthScoreCard', () => {
     render(
       <HealthScoreCard
         stats={makeStats({ total: 3, running: 3, noHealthcheck: 3, unknown: 3 })}
-        score={null}
       />,
     );
 
@@ -73,7 +69,6 @@ describe('HealthScoreCard', () => {
     render(
       <HealthScoreCard
         stats={makeStats({ total: 5, healthy: 3, unhealthy: 1, stopped: 1, running: 4 })}
-        score={75}
       />,
     );
 
@@ -92,7 +87,6 @@ describe('HealthScoreCard', () => {
           noHealthcheck: 2,
           unknown: 2,
         })}
-        score={100}
       />,
     );
 

--- a/frontend/src/shared/components/data-display/health-score-card.test.tsx
+++ b/frontend/src/shared/components/data-display/health-score-card.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HealthScoreCard } from './health-score-card';
+import type { HealthStats } from '@/features/ai-intelligence/components/fleet-health-summary';
+
+function makeStats(overrides: Partial<HealthStats> = {}): HealthStats {
+  return {
+    total: 0,
+    running: 0,
+    stopped: 0,
+    paused: 0,
+    healthy: 0,
+    unhealthy: 0,
+    unknown: 0,
+    noHealthcheck: 0,
+    ...overrides,
+  };
+}
+
+describe('HealthScoreCard', () => {
+  it('renders the score and green icon when ≥80%', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({ total: 10, healthy: 9, unhealthy: 1, running: 10 })}
+        score={90}
+      />,
+    );
+
+    expect(screen.getByTestId('health-score')).toHaveTextContent('90.0%');
+    expect(screen.getByTestId('health-score-icon-green')).toBeInTheDocument();
+    expect(screen.getByText('9 of 10 reporting healthy')).toBeInTheDocument();
+  });
+
+  it('renders the amber icon between 50% and 80%', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({ total: 4, healthy: 2, unhealthy: 2, running: 4 })}
+        score={50}
+      />,
+    );
+
+    expect(screen.getByTestId('health-score-icon-amber')).toBeInTheDocument();
+  });
+
+  it('renders the red icon when below 50%', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({ total: 4, healthy: 1, unhealthy: 3, running: 4 })}
+        score={25}
+      />,
+    );
+
+    expect(screen.getByTestId('health-score-icon-red')).toBeInTheDocument();
+  });
+
+  it('renders the "no healthchecks configured" gray state when score is null', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({ total: 3, running: 3, noHealthcheck: 3, unknown: 3 })}
+        score={null}
+      />,
+    );
+
+    expect(screen.getByTestId('health-score-na')).toHaveTextContent(
+      'No healthchecks configured',
+    );
+    expect(
+      screen.getByText(/3 containers tracked\. Configure Docker healthchecks/),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces "needs attention" when there are unhealthy or stopped containers', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({ total: 5, healthy: 3, unhealthy: 1, stopped: 1, running: 4 })}
+        score={75}
+      />,
+    );
+
+    // 1 unhealthy + 1 stopped = 2 issues
+    expect(screen.getByText(/2 containers need attention/)).toBeInTheDocument();
+  });
+
+  it('appends "N without healthcheck" suffix when running containers lack a healthcheck', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({
+          total: 5,
+          healthy: 3,
+          unhealthy: 0,
+          running: 5,
+          noHealthcheck: 2,
+          unknown: 2,
+        })}
+        score={100}
+      />,
+    );
+
+    expect(
+      screen.getByText(/3 of 3 reporting healthy · 2 without healthcheck/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/data-display/health-score-card.tsx
+++ b/frontend/src/shared/components/data-display/health-score-card.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, AlertTriangle, CheckCircle2, HelpCircle, XCircle } from 'lucide-react';
-import type { HealthStats } from '@/features/ai-intelligence/components/fleet-health-summary';
+import { calculateHealthScore, type HealthStats } from '@/shared/lib/health-score';
 
 /**
  * Presentational tile that surfaces the Overall Health Score. Extracted from
@@ -7,19 +7,17 @@ import type { HealthStats } from '@/features/ai-intelligence/components/fleet-he
  * stay in sync — both render through this component and reuse the shared
  * `calculateHealthStats` / `calculateHealthScore` helpers for the formula and
  * color-band thresholds (≥80% green, ≥50% amber, <50% red, null = gray).
+ *
+ * The score is derived internally from `stats` via `calculateHealthScore` so
+ * callers can't accidentally pass a score that disagrees with the stats.
  */
 export interface HealthScoreCardProps {
   /** Aggregated container health stats from `calculateHealthStats`. */
   stats: HealthStats;
-  /**
-   * Score from `calculateHealthScore(stats)`. `null` indicates no container
-   * reports a health signal — rendered as the gray "No healthchecks
-   * configured" state.
-   */
-  score: number | null;
 }
 
-export function HealthScoreCard({ stats, score }: HealthScoreCardProps) {
+export function HealthScoreCard({ stats }: HealthScoreCardProps) {
+  const score = calculateHealthScore(stats);
   const reporting = stats.healthy + stats.unhealthy;
   const issueCount = stats.unhealthy + stats.stopped;
 

--- a/frontend/src/shared/components/data-display/health-score-card.tsx
+++ b/frontend/src/shared/components/data-display/health-score-card.tsx
@@ -1,0 +1,70 @@
+import { AlertCircle, AlertTriangle, CheckCircle2, HelpCircle, XCircle } from 'lucide-react';
+import type { HealthStats } from '@/features/ai-intelligence/components/fleet-health-summary';
+
+/**
+ * Presentational tile that surfaces the Overall Health Score. Extracted from
+ * `fleet-health-summary.tsx` so the Home page and the Health & Monitoring page
+ * stay in sync — both render through this component and reuse the shared
+ * `calculateHealthStats` / `calculateHealthScore` helpers for the formula and
+ * color-band thresholds (≥80% green, ≥50% amber, <50% red, null = gray).
+ */
+export interface HealthScoreCardProps {
+  /** Aggregated container health stats from `calculateHealthStats`. */
+  stats: HealthStats;
+  /**
+   * Score from `calculateHealthScore(stats)`. `null` indicates no container
+   * reports a health signal — rendered as the gray "No healthchecks
+   * configured" state.
+   */
+  score: number | null;
+}
+
+export function HealthScoreCard({ stats, score }: HealthScoreCardProps) {
+  const reporting = stats.healthy + stats.unhealthy;
+  const issueCount = stats.unhealthy + stats.stopped;
+
+  return (
+    <div className="flex items-center gap-5 min-w-0" data-testid="health-score-card">
+      <div className="flex h-24 w-24 flex-shrink-0 items-center justify-center rounded-full border-8 border-primary/20 bg-muted/30">
+        {score === null ? (
+          <HelpCircle className="h-12 w-12 text-muted-foreground" />
+        ) : score >= 80 ? (
+          <CheckCircle2 className="h-12 w-12 text-emerald-500" data-testid="health-score-icon-green" />
+        ) : score >= 50 ? (
+          <AlertCircle className="h-12 w-12 text-amber-500" data-testid="health-score-icon-amber" />
+        ) : (
+          <XCircle className="h-12 w-12 text-red-500" data-testid="health-score-icon-red" />
+        )}
+      </div>
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-muted-foreground">Overall Health Score</p>
+        {score === null ? (
+          <>
+            <p className="text-2xl font-semibold text-muted-foreground" data-testid="health-score-na">
+              No healthchecks configured
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {stats.total} containers tracked. Configure Docker healthchecks to enable scoring.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="text-4xl font-bold tabular-nums leading-none mt-1" data-testid="health-score">
+              {score.toFixed(1)}%
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {stats.healthy} of {reporting} reporting healthy
+              {stats.noHealthcheck > 0 && ` · ${stats.noHealthcheck} without healthcheck`}
+            </p>
+          </>
+        )}
+        {issueCount > 0 && (
+          <p className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium text-red-700 dark:text-red-400">
+            <AlertTriangle className="h-4 w-4" />
+            {issueCount} container{issueCount === 1 ? '' : 's'} need{issueCount === 1 ? 's' : ''} attention
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shared/lib/health-score.test.ts
+++ b/frontend/src/shared/lib/health-score.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Container } from '@/features/containers/hooks/use-containers';
-import { calculateHealthScore, calculateHealthStats } from './fleet-health-summary';
+import { calculateHealthScore, calculateHealthStats } from './health-score';
 
 function makeContainer(overrides: Partial<Container> = {}): Container {
   return {

--- a/frontend/src/shared/lib/health-score.ts
+++ b/frontend/src/shared/lib/health-score.ts
@@ -1,0 +1,63 @@
+import type { Container } from '@/features/containers/hooks/use-containers';
+
+/**
+ * Aggregated fleet health stats used by the Overall Health Score tile. Lives
+ * in `shared/lib` (not `features/`) so cross-feature consumers — including
+ * shared presentational components like `HealthScoreCard` — can depend on it
+ * without violating the `features/ → shared/` import direction.
+ */
+export interface HealthStats {
+  total: number;
+  running: number;
+  stopped: number;
+  paused: number;
+  unhealthy: number;
+  healthy: number;
+  unknown: number;
+  /**
+   * Running containers without a Docker healthcheck configured. These are
+   * excluded from the health-score denominator (score = healthy / (healthy +
+   * unhealthy)) so the operator's choice not to configure a healthcheck
+   * doesn't artificially deflate the fleet health number.
+   */
+  noHealthcheck: number;
+}
+
+export function calculateHealthStats(containers: Container[]): HealthStats {
+  const stats: HealthStats = {
+    total: containers.length,
+    running: 0,
+    stopped: 0,
+    paused: 0,
+    unhealthy: 0,
+    healthy: 0,
+    unknown: 0,
+    noHealthcheck: 0,
+  };
+
+  containers.forEach((container) => {
+    if (container.state === 'running') stats.running++;
+    else if (container.state === 'exited') stats.stopped++;
+    else if (container.state === 'paused') stats.paused++;
+
+    if (container.healthStatus === 'unhealthy') stats.unhealthy++;
+    else if (container.healthStatus === 'healthy') stats.healthy++;
+    else {
+      stats.unknown++;
+      if (container.state === 'running') stats.noHealthcheck++;
+    }
+  });
+
+  return stats;
+}
+
+/**
+ * Score = healthy / (healthy + unhealthy). Containers without a healthcheck
+ * are excluded so the operator's choice not to configure one doesn't drag
+ * the score down. Returns null when no container reports a health signal.
+ */
+export function calculateHealthScore(stats: HealthStats): number | null {
+  const reporting = stats.healthy + stats.unhealthy;
+  if (reporting === 0) return null;
+  return (stats.healthy / reporting) * 100;
+}


### PR DESCRIPTION
Closes #1293.

## Summary
Extracts the score-tile JSX from `fleet-health-summary.tsx` (lines 136-177) into a new presentational `<HealthScoreCard>` under `frontend/src/shared/components/data-display/`, reusing the existing exported `calculateHealthScore` / `calculateHealthStats` helpers so the Home page and the Health & Monitoring page can never disagree on the score formula, color bands, or empty-state copy. Renders the card as a new row 2 on Home (between the KPI grid and Pinned Favorites) inside the same `MotionStagger` + `MotionReveal` + `SpotlightCard` animation primitives as the rest of the page, with loading (`SkeletonKpi`), error (`<EmptyState variant="error">`), and zero-healthcheck (gray "no healthchecks configured") states.

## Test plan
- [x] Lint / typecheck / tests green (`npm run lint -w frontend`, `npm run typecheck -w frontend`, `cd frontend && npx vitest run` — 208 files, 1957 tests pass)
- [x] New test: HealthScoreCard renders on Home with 9 healthy / 1 unhealthy fixture, asserts the 90.0% score and the green CheckCircle2 icon
- [x] Standalone HealthScoreCard tests cover all four bands (green/amber/red/gray) plus the "needs attention" and "without healthcheck" sub-copy
- [ ] Manual verification in Glass Light + Glass Dark + one accent theme (e.g. Catppuccin Mocha or Hyperpop Chaos)
- [x] Health & Monitoring page (`ai-monitor.tsx`) is visually unchanged after the extraction — outer wrapper `<div className="flex items-center gap-5 min-w-0">` and inner DOM are byte-identical, only the JSX origin moved into the shared component