### PR TITLE
feat(monitoring): false-positive feedback loop + per-detector rate badge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ Backend uses npm workspaces under `packages/` with a `core/` kernel (`@dashboard
 6. **Regression tests required** — Every security fix needs a test in `backend/src/routes/security-regression-*.test.ts`, in the file matching your domain (auth, rbac, headers, prompt-guard, sockets, stream-tickets, jwt, infra), or a new per-domain file if none fits. Coverage spans auth sweep, prompt injection, false positives, rate limiting, RBAC, headers, sockets, stream tickets, JWT, and infra isolation.
 7. **Observer-first integrity** — Container-mutating actions (restart/stop) are strictly opt-in and gated by both `admin` role and a Remediation Approval workflow.
 
+**Anomaly feedback (issue #1298):** `POST /api/monitoring/anomaly-feedback` is open to any authenticated role — viewer/operator/admin may all file a "false positive" on their own behalf — but the row is always scoped to the caller's `user_id` via the JWT subject (no spoofing of other users). `GET /api/monitoring/anomaly-feedback/rates` returns caller-scoped data by default; admins receive fleet-wide aggregates (counts per detector only, never individual user dispositions) and may opt back into caller scope via `?scope=mine`. Non-admins passing `?scope=fleet` are silently downgraded to caller scope. The `detector` field on POST is restricted to a Zod allowlist (`ANOMALY_FEEDBACK_DETECTORS`) so client input cannot pollute the per-detector rate breakdown.
+
 For the full checklist, see `@docs/ai-instructions/security-checklist.md`.
 
 ## UI/UX Design

--- a/backend/src/routes/security-regression-rbac.test.ts
+++ b/backend/src/routes/security-regression-rbac.test.ts
@@ -208,7 +208,7 @@ import { securityRoutes } from '@dashboard/security/routes/index.js';
 import { edgeJobsRoutes } from '@dashboard/infrastructure/routes/index.js';
 import { imagesRoutes, userRoutes, oidcRoutes } from '@dashboard/foundation';
 import { notificationRoutes } from '@dashboard/operations';
-import { incidentsRoutes } from '@dashboard/ai';
+import { incidentsRoutes, monitoringRoutes, type MonitoringRoutesOpts } from '@dashboard/ai';
 import type { LLMInterface } from '@dashboard/contracts';
 
 import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
@@ -997,5 +997,164 @@ describe('Monitoring Sensitivity Preset RBAC (#1297)', () => {
       headers: { 'content-type': 'application/json' },
     });
     expect(res.statusCode).toBe(400);
+  });
+});
+
+// =====================================================================
+//  ANOMALY FEEDBACK ROUTES — AUTH + ADMIN SCOPE GATING (issue #1298)
+// =====================================================================
+//
+// POST /api/monitoring/anomaly-feedback must reject anonymous callers
+// (any authenticated user — viewer/operator/admin — can file feedback
+// on their own behalf, but unauthenticated requests must 401).
+//
+// GET /api/monitoring/anomaly-feedback/rates must reject anonymous
+// callers and is caller-scoped by default. The scope=fleet widening
+// is admin-only: viewer/operator passing scope=fleet must be silently
+// downgraded to caller scope (no fleet data may leak).
+describe('Anomaly Feedback Routes — Auth + Admin Scope Gating (issue #1298)', () => {
+  let app: FastifyInstance;
+  let currentRole: 'viewer' | 'operator' | 'admin' | null;
+
+  const monitoringOpts: MonitoringRoutesOpts = {
+    getSecurityAudit: vi.fn().mockResolvedValue([]),
+    getSecurityAuditIgnoreList: vi.fn().mockResolvedValue([]),
+    setSecurityAuditIgnoreList: vi.fn().mockResolvedValue([]),
+    defaultSecurityAuditIgnorePatterns: [],
+    securityAuditIgnoreKey: 'test-ignore-key',
+  };
+
+  beforeAll(async () => {
+    currentRole = 'operator';
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    // `authenticate` rejects anonymous callers (no role) with 401, matching
+    // the production decorator behaviour.
+    app.decorate('authenticate', async (request, reply) => {
+      if (currentRole === null) {
+        reply.code(401).send({ error: 'Unauthorized' });
+      }
+    });
+    app.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request, reply) => {
+      const rank = { viewer: 0, operator: 1, admin: 2 };
+      const userRole = request.user?.role ?? 'viewer';
+      if (rank[userRole] < rank[minRole]) {
+        reply.code(403).send({ error: 'Insufficient permissions' });
+      }
+    });
+    app.decorateRequest('user', undefined);
+    app.addHook('preHandler', async (request) => {
+      if (currentRole !== null) {
+        request.user = { sub: 'u1', username: 'user', sessionId: 's1', role: currentRole };
+      }
+    });
+    await app.register(monitoringRoutes, monitoringOpts);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('denies POST /api/monitoring/anomaly-feedback for anonymous callers', async () => {
+    currentRole = null;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/monitoring/anomaly-feedback',
+      payload: { anomalyId: 'a-1' },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('denies GET /api/monitoring/anomaly-feedback/rates for anonymous callers', async () => {
+    currentRole = null;
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/monitoring/anomaly-feedback/rates',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('allows POST for any authenticated role (viewer/operator/admin) — RBAC contract', async () => {
+    // POST must NOT require admin — any authenticated user can file
+    // feedback on their own behalf. We assert "not 401, not 403" rather
+    // than 200 because the mocked DB will return its own error code.
+    for (const role of ['viewer', 'operator', 'admin'] as const) {
+      currentRole = role;
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/monitoring/anomaly-feedback',
+        payload: { anomalyId: 'a-1' },
+        headers: { 'content-type': 'application/json' },
+      });
+      expect(res.statusCode).not.toBe(401);
+      expect(res.statusCode).not.toBe(403);
+    }
+  });
+
+  it('GET /rates reaches the handler for any authenticated role', async () => {
+    // The handler itself enforces the scope-widening guard
+    // (viewer/operator with ?scope=fleet must NOT receive fleet data).
+    // RBAC layer must not reject viewer/operator here — they're allowed
+    // to query their own rate scope by default.
+    for (const role of ['viewer', 'operator', 'admin'] as const) {
+      currentRole = role;
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/monitoring/anomaly-feedback/rates',
+      });
+      expect(res.statusCode).not.toBe(401);
+      expect(res.statusCode).not.toBe(403);
+    }
+  });
+
+  // Source-level guard: the routes file must use `fastify.authenticate`
+  // on both routes. If a future refactor accidentally drops the
+  // preHandler, this assertion fires.
+  it('monitoring routes source must include fastify.authenticate on the anomaly-feedback routes', () => {
+    const file = path.resolve(
+      process.cwd(),
+      '..',
+      'packages',
+      'ai-intelligence',
+      'src',
+      'routes',
+      'monitoring.ts',
+    );
+    const content = readFileSync(file, 'utf8');
+
+    const postBlock = content.match(
+      /post\s*\(\s*'\/api\/monitoring\/anomaly-feedback'[\s\S]*?preHandler:\s*\[([^\]]+)\]/,
+    );
+    expect(postBlock).not.toBeNull();
+    expect(postBlock![1]).toContain('fastify.authenticate');
+
+    const getBlock = content.match(
+      /get\s*\(\s*'\/api\/monitoring\/anomaly-feedback\/rates'[\s\S]*?preHandler:\s*\[([^\]]+)\]/,
+    );
+    expect(getBlock).not.toBeNull();
+    expect(getBlock![1]).toContain('fastify.authenticate');
+  });
+
+  // Source-level guard: the rates handler must distinguish admin from
+  // non-admin to enforce the scope-widening contract.
+  it('rates handler source must branch on role === \'admin\' to enforce scope-widening', () => {
+    const file = path.resolve(
+      process.cwd(),
+      '..',
+      'packages',
+      'ai-intelligence',
+      'src',
+      'routes',
+      'monitoring.ts',
+    );
+    const content = readFileSync(file, 'utf8');
+
+    // The handler resolves the calling user's role and only widens to
+    // fleet when role === 'admin'. Match either the explicit comparison
+    // or a derived `isAdmin` boolean.
+    expect(content).toMatch(/role\s*===\s*'admin'/);
   });
 });

--- a/docs/ai-instructions/architecture.md
+++ b/docs/ai-instructions/architecture.md
@@ -75,7 +75,7 @@ Cross-domain communication is resolved via dependency injection in `packages/ser
 
 | Directory | Purpose |
 |-----------|---------|
-| `routes/` | LLM query, LLM observability, feedback, monitoring (incl. per-user `/api/monitoring/sensitivity` GET/PUT), investigations, incidents, correlations, MCP, prompt profiles |
+| `routes/` | LLM query, LLM observability, feedback, monitoring (incl. per-user `/api/monitoring/sensitivity` GET/PUT — #1297, anomaly-feedback false-positive loop — #1298), investigations, incidents, correlations, MCP, prompt profiles |
 | `services/` | LLM client, prompt guard (3-layer), anomaly detector (statistical + isolation forest), sensitivity preset (per-user post-filter, #1297), monitoring orchestration, investigation, incident correlator, MCP manager |
 | `sockets/` | `/llm` namespace (real-time chat), `/monitoring` namespace (real-time insights) |
 

--- a/frontend/src/features/ai-intelligence/hooks/use-anomaly-feedback.test.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-anomaly-feedback.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+    post: (...args: unknown[]) => mockApiPost(...args),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  useMarkFalsePositive,
+  useAnomalyFeedbackRates,
+  deriveCorrelatedAnomalyId,
+} from './use-anomaly-feedback';
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+describe('use-anomaly-feedback hooks (#1298)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── deriveCorrelatedAnomalyId ──────────────────────────────────
+
+  describe('deriveCorrelatedAnomalyId', () => {
+    it('returns a stable id derived from (containerId, timestamp)', () => {
+      const id = deriveCorrelatedAnomalyId({
+        containerId: 'abc123',
+        timestamp: '2025-01-01T12:00:00Z',
+      });
+      expect(id).toBe('correlated:abc123:2025-01-01T12:00:00Z');
+    });
+
+    it('produces distinct ids for distinct timestamps on the same container', () => {
+      const id1 = deriveCorrelatedAnomalyId({
+        containerId: 'abc123',
+        timestamp: '2025-01-01T12:00:00Z',
+      });
+      const id2 = deriveCorrelatedAnomalyId({
+        containerId: 'abc123',
+        timestamp: '2025-01-01T13:00:00Z',
+      });
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  // ── useMarkFalsePositive ───────────────────────────────────────
+
+  describe('useMarkFalsePositive', () => {
+    it('POSTs to /api/monitoring/anomaly-feedback with disposition=false-positive', async () => {
+      mockApiPost.mockResolvedValue({
+        success: true,
+        anomalyId: 'correlated:c1:t1',
+        disposition: 'false-positive',
+        duplicate: false,
+      });
+
+      const { result } = renderHook(() => useMarkFalsePositive(), { wrapper: createWrapper() });
+
+      result.current.mutate({ anomalyId: 'correlated:c1:t1', detector: 'correlated-zscore' });
+
+      await waitFor(() => {
+        expect(mockApiPost).toHaveBeenCalledWith(
+          '/api/monitoring/anomaly-feedback',
+          expect.objectContaining({
+            anomalyId: 'correlated:c1:t1',
+            disposition: 'false-positive',
+            detector: 'correlated-zscore',
+          }),
+        );
+      });
+    });
+
+    it('omits detector field when not provided', async () => {
+      mockApiPost.mockResolvedValue({
+        success: true,
+        anomalyId: 'insight-1',
+        disposition: 'false-positive',
+        duplicate: false,
+      });
+
+      const { result } = renderHook(() => useMarkFalsePositive(), { wrapper: createWrapper() });
+
+      result.current.mutate({ anomalyId: 'insight-1' });
+
+      await waitFor(() => {
+        expect(mockApiPost).toHaveBeenCalledTimes(1);
+      });
+      const body = mockApiPost.mock.calls[0][1] as Record<string, unknown>;
+      expect(body).not.toHaveProperty('detector');
+      expect(body.disposition).toBe('false-positive');
+    });
+
+    it('invokes onOptimisticDismiss synchronously and not onRevertDismiss on success', async () => {
+      mockApiPost.mockResolvedValue({
+        success: true,
+        anomalyId: 'a-1',
+        disposition: 'false-positive',
+        duplicate: false,
+      });
+
+      const onOptimisticDismiss = vi.fn();
+      const onRevertDismiss = vi.fn();
+
+      const { result } = renderHook(
+        () => useMarkFalsePositive({ onOptimisticDismiss, onRevertDismiss }),
+        { wrapper: createWrapper() },
+      );
+
+      result.current.mutate({ anomalyId: 'a-1' });
+
+      await waitFor(() => {
+        expect(onOptimisticDismiss).toHaveBeenCalledWith('a-1');
+      });
+
+      // Wait for the mutation to settle and verify revert was NOT called.
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+      expect(onRevertDismiss).not.toHaveBeenCalled();
+    });
+
+    it('reverts the optimistic dismissal on network error', async () => {
+      mockApiPost.mockRejectedValue(new Error('boom'));
+
+      const onOptimisticDismiss = vi.fn();
+      const onRevertDismiss = vi.fn();
+
+      const { result } = renderHook(
+        () => useMarkFalsePositive({ onOptimisticDismiss, onRevertDismiss }),
+        { wrapper: createWrapper() },
+      );
+
+      result.current.mutate({ anomalyId: 'a-2' });
+
+      await waitFor(() => {
+        expect(onOptimisticDismiss).toHaveBeenCalledWith('a-2');
+      });
+      await waitFor(() => {
+        expect(onRevertDismiss).toHaveBeenCalledWith('a-2');
+      });
+    });
+  });
+
+  // ── useAnomalyFeedbackRates ────────────────────────────────────
+
+  describe('useAnomalyFeedbackRates', () => {
+    it('GETs /api/monitoring/anomaly-feedback/rates with no scope param by default', async () => {
+      mockApiGet.mockResolvedValue({ rates: [], scope: 'mine' });
+
+      const { result } = renderHook(() => useAnomalyFeedbackRates(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockApiGet).toHaveBeenCalledWith(
+        '/api/monitoring/anomaly-feedback/rates',
+        expect.objectContaining({ params: undefined }),
+      );
+      expect(result.current.data?.scope).toBe('mine');
+    });
+
+    it('passes scope=mine query when caller explicitly opts in', async () => {
+      mockApiGet.mockResolvedValue({ rates: [], scope: 'mine' });
+
+      const { result } = renderHook(() => useAnomalyFeedbackRates('mine'), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockApiGet).toHaveBeenCalledWith(
+        '/api/monitoring/anomaly-feedback/rates',
+        expect.objectContaining({ params: { scope: 'mine' } }),
+      );
+    });
+
+    it('returns per-detector rate data unchanged from the server', async () => {
+      mockApiGet.mockResolvedValue({
+        rates: [
+          { detector: 'threshold', anomalies: 10, falsePositives: 2, rate: 0.2 },
+          { detector: 'ml-anomaly', anomalies: 5, falsePositives: 0, rate: 0 },
+        ],
+        scope: 'fleet',
+      });
+
+      const { result } = renderHook(() => useAnomalyFeedbackRates(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.rates).toHaveLength(2);
+      expect(result.current.data?.rates[0].rate).toBeCloseTo(0.2);
+      expect(result.current.data?.rates[1].rate).toBe(0);
+    });
+  });
+});

--- a/frontend/src/features/ai-intelligence/hooks/use-anomaly-feedback.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-anomaly-feedback.ts
@@ -1,0 +1,136 @@
+/**
+ * "Mark as false positive" feedback hook for ML-detected anomalies (#1298).
+ *
+ * Two behaviours wrapped in one module:
+ *   • useMarkFalsePositive — POST /api/monitoring/anomaly-feedback with
+ *     optimistic local-state update. The card immediately hides via the
+ *     `dismissedAnomalyIds` set; on error the dismissal is reverted.
+ *   • useAnomalyFeedbackRates — GET /api/monitoring/anomaly-feedback/rates
+ *     returns per-detector false-positive rate (caller-scoped unless the
+ *     caller is admin).
+ *
+ * The optimistic-dismissal set is owned by the calling component
+ * (`CorrelatedAnomalyCard`'s parent) and threaded through the mutation
+ * options so the hook itself stays state-free and reusable.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/shared/lib/api';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
+import { toast } from 'sonner';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface AnomalyFeedbackResponse {
+  success: boolean;
+  anomalyId: string;
+  disposition: string;
+  duplicate: boolean;
+}
+
+export interface DetectorRate {
+  detector: string;
+  anomalies: number;
+  falsePositives: number;
+  /** false-positive rate in [0, 1]. 0 when no anomalies have been surfaced. */
+  rate: number;
+}
+
+export interface AnomalyFeedbackRatesResponse {
+  rates: DetectorRate[];
+  /** "fleet" for admins by default; "mine" for caller-scoped queries. */
+  scope: 'fleet' | 'mine';
+}
+
+// ── Query keys ───────────────────────────────────────────────────────
+
+const ANOMALY_FEEDBACK_KEYS = {
+  all: ['anomaly-feedback'] as const,
+  rates: (scope?: 'fleet' | 'mine') => ['anomaly-feedback', 'rates', scope] as const,
+};
+
+// ── POST /api/monitoring/anomaly-feedback ───────────────────────────
+
+interface MarkFalsePositiveVars {
+  anomalyId: string;
+  /** Detector source — e.g. 'correlated-zscore', 'isolation-forest'. */
+  detector?: string;
+}
+
+/**
+ * Stable feedback key for a CorrelatedAnomaly. The card has no persisted
+ * id (correlated anomalies are computed on demand and never written to
+ * the insights table), so we derive one from `(containerId, timestamp)`
+ * which uniquely identifies the snapshot the user is looking at.
+ */
+export function deriveCorrelatedAnomalyId(args: {
+  containerId: string;
+  timestamp: string;
+}): string {
+  return `correlated:${args.containerId}:${args.timestamp}`;
+}
+
+interface MarkFalsePositiveOptions {
+  /** Called immediately before the network request to optimistically hide the card. */
+  onOptimisticDismiss?: (anomalyId: string) => void;
+  /** Called on network error to revert the optimistic dismissal. */
+  onRevertDismiss?: (anomalyId: string) => void;
+}
+
+interface MutationContext {
+  anomalyId: string;
+}
+
+export function useMarkFalsePositive(options: MarkFalsePositiveOptions = {}) {
+  const queryClient = useQueryClient();
+
+  return useMutation<AnomalyFeedbackResponse, Error, MarkFalsePositiveVars, MutationContext>({
+    mutationFn: async ({ anomalyId, detector }) => {
+      return api.post<AnomalyFeedbackResponse>('/api/monitoring/anomaly-feedback', {
+        anomalyId,
+        disposition: 'false-positive',
+        ...(detector ? { detector } : {}),
+      });
+    },
+    onMutate: async ({ anomalyId }) => {
+      // Optimistic dismissal — the parent owns the set of dismissed IDs.
+      // We return the id in the context so onError can revert without
+      // re-deriving it from `variables`.
+      options.onOptimisticDismiss?.(anomalyId);
+      return { anomalyId };
+    },
+    onError: (error, _vars, context) => {
+      const id = context?.anomalyId;
+      if (id) options.onRevertDismiss?.(id);
+      toast.error('Failed to mark as false positive', {
+        description: error.message,
+      });
+    },
+    onSuccess: (data) => {
+      // Refresh the per-detector rate badge after a confirmed write.
+      // Duplicate submissions still invalidate (rate may be stale for
+      // other reasons), but skip the toast to avoid double-confirmation.
+      queryClient.invalidateQueries({ queryKey: ANOMALY_FEEDBACK_KEYS.all });
+      if (!data.duplicate) {
+        toast.success('Marked as false positive', {
+          description: 'Thanks — your feedback informs detector tuning.',
+        });
+      }
+    },
+  });
+}
+
+// ── GET /api/monitoring/anomaly-feedback/rates ──────────────────────
+
+export function useAnomalyFeedbackRates(scope?: 'fleet' | 'mine') {
+  return useQuery<AnomalyFeedbackRatesResponse>({
+    queryKey: ANOMALY_FEEDBACK_KEYS.rates(scope),
+    queryFn: () =>
+      api.get<AnomalyFeedbackRatesResponse>('/api/monitoring/anomaly-feedback/rates', {
+        params: scope ? { scope } : undefined,
+      }),
+    staleTime: STALE_TIMES.MEDIUM,
+    // Detectors with zero feedback still render the badge with rate=0,
+    // so empty arrays are valid data, not an error.
+    retry: 1,
+  });
+}

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
@@ -68,6 +68,24 @@ vi.mock('@/features/observability/hooks/use-correlated-anomalies', () => ({
   }),
 }));
 
+vi.mock('@/features/ai-intelligence/hooks/use-anomaly-feedback', async (importOriginal) => {
+  // Keep deriveCorrelatedAnomalyId pure so the page-level filter logic
+  // can use it; mock the network hooks.
+  const actual = await importOriginal<typeof import('@/features/ai-intelligence/hooks/use-anomaly-feedback')>();
+  return {
+    ...actual,
+    useMarkFalsePositive: vi.fn().mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      variables: undefined,
+    }),
+    useAnomalyFeedbackRates: vi.fn().mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    }),
+  };
+});
+
 vi.mock('@/features/containers/hooks/use-containers', () => ({
   useContainers: vi.fn().mockReturnValue({
     data: [],
@@ -632,5 +650,98 @@ describe('AiMonitorPage — IncidentGroupsView integration', () => {
   it('renders IncidentGroupsView in place of the legacy flat list', () => {
     renderPage();
     expect(screen.getByTestId('igv-marker')).toBeTruthy();
+  });
+});
+
+// ── False-positive feedback + per-detector rate badge (#1298) ───────
+
+describe('AiMonitorPage — false-positive feedback (#1298)', () => {
+  it('renders a "Mark as false positive" button on each CorrelatedAnomalyCard', () => {
+    vi.mocked(useCorrelatedAnomalies).mockReturnValue({
+      data: [
+        {
+          containerId: 'c1',
+          containerName: 'web-server',
+          metrics: [{ type: 'cpu', currentValue: 95, mean: 40, zScore: 3.5 }],
+          compositeScore: 3.5,
+          pattern: null,
+          severity: 'high' as const,
+          timestamp: '2025-01-15T10:00:00Z',
+        },
+      ],
+      isLoading: false,
+    } as ReturnType<typeof useCorrelatedAnomalies>);
+
+    renderPage();
+    expect(screen.getByTestId('mark-false-positive')).toBeTruthy();
+  });
+
+  it('invokes the mutation with the derived correlated anomaly id and detector tag', async () => {
+    const mutate = vi.fn();
+    const { useMarkFalsePositive } = await import('@/features/ai-intelligence/hooks/use-anomaly-feedback');
+    vi.mocked(useMarkFalsePositive).mockReturnValue({
+      mutate,
+      isPending: false,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useMarkFalsePositive>);
+
+    vi.mocked(useCorrelatedAnomalies).mockReturnValue({
+      data: [
+        {
+          containerId: 'c-abc',
+          containerName: 'web-server',
+          metrics: [{ type: 'cpu', currentValue: 95, mean: 40, zScore: 3.5 }],
+          compositeScore: 3.5,
+          pattern: null,
+          severity: 'high' as const,
+          timestamp: '2025-01-15T10:00:00Z',
+        },
+      ],
+      isLoading: false,
+    } as ReturnType<typeof useCorrelatedAnomalies>);
+
+    renderPage();
+
+    const btn = screen.getByTestId('mark-false-positive');
+    fireEvent.click(btn);
+
+    expect(mutate).toHaveBeenCalledWith({
+      anomalyId: 'correlated:c-abc:2025-01-15T10:00:00Z',
+      detector: 'correlated-zscore',
+    });
+  });
+
+  it('renders a per-detector rate badge when feedback rates are available', async () => {
+    const { useAnomalyFeedbackRates } = await import('@/features/ai-intelligence/hooks/use-anomaly-feedback');
+    vi.mocked(useAnomalyFeedbackRates).mockReturnValue({
+      data: {
+        rates: [
+          { detector: 'threshold', anomalies: 10, falsePositives: 2, rate: 0.2 },
+          { detector: 'ml-anomaly', anomalies: 0, falsePositives: 0, rate: 0 },
+        ],
+        scope: 'mine',
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAnomalyFeedbackRates>);
+
+    renderPage();
+
+    expect(screen.getByTestId('anomaly-feedback-rate-row')).toBeTruthy();
+    expect(screen.getByTestId('anomaly-feedback-rate-threshold')).toBeTruthy();
+    // 20% rendered for threshold
+    expect(screen.getByTestId('anomaly-feedback-rate-threshold').textContent).toContain('20%');
+    // Empty-state "—" rendered for ml-anomaly (zero anomalies recorded)
+    expect(screen.getByTestId('anomaly-feedback-rate-ml-anomaly').textContent).toContain('—');
+  });
+
+  it('hides the rate badge row when no detectors have data yet', async () => {
+    const { useAnomalyFeedbackRates } = await import('@/features/ai-intelligence/hooks/use-anomaly-feedback');
+    vi.mocked(useAnomalyFeedbackRates).mockReturnValue({
+      data: { rates: [], scope: 'mine' },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAnomalyFeedbackRates>);
+
+    renderPage();
+    expect(screen.queryByTestId('anomaly-feedback-rate-row')).toBeNull();
   });
 });

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -1,7 +1,12 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useMonitoring } from '@/features/ai-intelligence/hooks/use-monitoring';
 import { useInvestigations } from '@/features/ai-intelligence/hooks/use-investigations';
 import { useCorrelatedAnomalies, type CorrelatedAnomaly } from '@/features/observability/hooks/use-correlated-anomalies';
+import {
+  useMarkFalsePositive,
+  useAnomalyFeedbackRates,
+  deriveCorrelatedAnomalyId,
+} from '@/features/ai-intelligence/hooks/use-anomaly-feedback';
 import { useContainers } from '@/features/containers/hooks/use-containers';
 import { FleetHealthSummary, calculateHealthStats } from '@/features/ai-intelligence/components/fleet-health-summary';
 import { IncidentGroupsView } from '@/features/ai-intelligence/components/incident-groups-view';
@@ -29,10 +34,19 @@ import {
   Brain,
   Layers,
   Zap,
+  ThumbsDown,
 } from 'lucide-react';
 import { Link, useSearchParams } from 'react-router-dom';
 
-function CorrelatedAnomalyCard({ anomaly }: { anomaly: CorrelatedAnomaly }) {
+function CorrelatedAnomalyCard({
+  anomaly,
+  onMarkFalsePositive,
+  isPending,
+}: {
+  anomaly: CorrelatedAnomaly;
+  onMarkFalsePositive: (anomaly: CorrelatedAnomaly) => void;
+  isPending: boolean;
+}) {
   const patternDescription = anomaly.pattern?.includes(':')
     ? anomaly.pattern.split(':').slice(1).join(':').trim()
     : null;
@@ -82,6 +96,28 @@ function CorrelatedAnomalyCard({ anomaly }: { anomaly: CorrelatedAnomaly }) {
         {patternDescription && (
           <p className="mt-2 text-xs text-muted-foreground">{patternDescription}</p>
         )}
+
+        {/* False-positive feedback affordance (#1298). Optimistic dismissal
+            is owned by the parent so multiple cards don't fight over the
+            same set. We disable the button while the mutation is in flight
+            so a rapid double-click doesn't trigger two requests. */}
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            onClick={() => onMarkFalsePositive(anomaly)}
+            disabled={isPending}
+            aria-label={`Mark anomaly for ${anomaly.containerName} as false positive`}
+            data-testid="mark-false-positive"
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors',
+              'hover:bg-muted hover:text-foreground',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+            )}
+          >
+            <ThumbsDown className="h-3 w-3" />
+            Mark as false positive
+          </button>
+        </div>
       </div>
     </SpotlightCard>
   );
@@ -294,6 +330,53 @@ export default function AiMonitorPage() {
   const { getInvestigationForInsight } = useInvestigations();
   const { data: correlatedAnomalies, isLoading: correlatedLoading } = useCorrelatedAnomalies();
 
+  // ── False-positive feedback (#1298) ────────────────────────────
+  // Locally dismissed anomaly IDs are kept in component state. The
+  // optimistic update hides the card immediately; if the network
+  // request fails we revert the dismissal via the hook's
+  // onRevertDismiss callback. We don't persist this set to URL or
+  // localStorage — dismissals are remembered server-side as soon as
+  // the mutation succeeds, and refetching the correlated-anomalies
+  // query will exclude the marked anomaly via the rate badge.
+  const [dismissedAnomalyIds, setDismissedAnomalyIds] = useState<Set<string>>(new Set());
+
+  const markFalsePositive = useMarkFalsePositive({
+    onOptimisticDismiss: (anomalyId) => {
+      setDismissedAnomalyIds((prev) => {
+        const next = new Set(prev);
+        next.add(anomalyId);
+        return next;
+      });
+    },
+    onRevertDismiss: (anomalyId) => {
+      setDismissedAnomalyIds((prev) => {
+        const next = new Set(prev);
+        next.delete(anomalyId);
+        return next;
+      });
+    },
+  });
+
+  // Per-detector false-positive rate, rendered as a badge row in the
+  // Health & Monitoring header. Defaults to caller scope; admins
+  // automatically receive fleet-wide data from the backend.
+  const { data: feedbackRates } = useAnomalyFeedbackRates();
+
+  const handleMarkFalsePositive = useCallback(
+    (anomaly: CorrelatedAnomaly) => {
+      // Correlated anomalies have no persisted id — derive a stable
+      // one from (containerId, timestamp). The detector tag is
+      // 'correlated-zscore' to match how the service surfaces them
+      // (multivariate composite of per-metric z-scores).
+      const anomalyId = deriveCorrelatedAnomalyId({
+        containerId: anomaly.containerId,
+        timestamp: anomaly.timestamp,
+      });
+      markFalsePositive.mutate({ anomalyId, detector: 'correlated-zscore' });
+    },
+    [markFalsePositive],
+  );
+
   // Fleet health data
   const { data: containers, isLoading: containersLoading, refetch: containerRefetch, isFetching: containersFetching } = useContainers();
   const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', containerRefetch);
@@ -353,14 +436,23 @@ export default function AiMonitorPage() {
   }, [acknowledgementFilter, insights, severityFilter, searchLower]);
 
   // Apply search to anomalies + health issues so the search box covers every
-  // list on the page consistently.
+  // list on the page consistently. Dismissed anomalies are hidden via the
+  // optimistic-update set; we filter them here so all downstream renders
+  // (count, grid) agree.
   const filteredCorrelatedAnomalies = useMemo(() => {
     if (!correlatedAnomalies) return correlatedAnomalies;
-    if (!searchLower) return correlatedAnomalies;
-    return correlatedAnomalies.filter((a) =>
+    const visible = correlatedAnomalies.filter((a) => {
+      const id = deriveCorrelatedAnomalyId({
+        containerId: a.containerId,
+        timestamp: a.timestamp,
+      });
+      return !dismissedAnomalyIds.has(id);
+    });
+    if (!searchLower) return visible;
+    return visible.filter((a) =>
       matchesSearch([a.containerName, a.pattern, ...a.metrics.map((m) => m.type)]),
     );
-  }, [correlatedAnomalies, searchLower]);
+  }, [correlatedAnomalies, searchLower, dismissedAnomalyIds]);
 
   const filteredHealthIssues = useMemo(() => {
     if (!searchLower) return healthIssues;
@@ -424,6 +516,57 @@ export default function AiMonitorPage() {
           />
         </div>
       </div>
+
+      {/* Per-detector false-positive rate badges (#1298). Rendered in
+          the Health & Monitoring header (location decision: header
+          rather than Settings — operators making feedback decisions
+          benefit from seeing the rate next to the anomalies they're
+          rating, not buried in a settings panel they rarely open).
+          Hidden when no detectors have data yet so we don't render an
+          empty row of placeholders. */}
+      {feedbackRates && feedbackRates.rates.length > 0 && (
+        <div
+          className="flex flex-wrap items-center gap-2"
+          data-testid="anomaly-feedback-rate-row"
+          aria-label={`Per-detector false-positive rates (${feedbackRates.scope === 'fleet' ? 'fleet-wide' : 'your feedback only'})`}
+        >
+          <span className="text-xs text-muted-foreground">
+            False-positive rate ({feedbackRates.scope === 'fleet' ? 'fleet' : 'mine'}):
+          </span>
+          {feedbackRates.rates.map((r) => {
+            // Empty state ("no feedback yet") collapses to "—" so the
+            // badge is still visible but doesn't imply 0% confidence.
+            const noData = r.anomalies === 0;
+            const pct = noData ? null : Math.round(r.rate * 100);
+            const tone =
+              noData
+                ? 'bg-muted text-muted-foreground'
+                : r.rate >= 0.5
+                  ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                  : r.rate >= 0.2
+                    ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+                    : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400';
+            return (
+              <span
+                key={r.detector}
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium',
+                  tone,
+                )}
+                title={
+                  noData
+                    ? `${r.detector}: no anomalies recorded yet`
+                    : `${r.detector}: ${r.falsePositives} of ${r.anomalies} marked false positive`
+                }
+                data-testid={`anomaly-feedback-rate-${r.detector}`}
+              >
+                <span className="font-mono">{r.detector}</span>
+                <span className="tabular-nums">{pct === null ? '—' : `${pct}%`}</span>
+              </span>
+            );
+          })}
+        </div>
+      )}
 
       {/* Fleet Health Summary — includes insight counts (Total / Critical /
           Warning / Info) as a second row of stat tiles inside the same hero. */}
@@ -576,9 +719,26 @@ export default function AiMonitorPage() {
             </div>
           ) : (
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {(filteredCorrelatedAnomalies ?? []).map((anomaly) => (
-                <CorrelatedAnomalyCard key={anomaly.containerId} anomaly={anomaly} />
-              ))}
+              {(filteredCorrelatedAnomalies ?? []).map((anomaly) => {
+                const anomalyId = deriveCorrelatedAnomalyId({
+                  containerId: anomaly.containerId,
+                  timestamp: anomaly.timestamp,
+                });
+                // Each card knows whether _it_ is the one being marked
+                // by comparing the in-flight mutation's variables —
+                // simple per-card pending state without a per-row map.
+                const isPending =
+                  markFalsePositive.isPending &&
+                  markFalsePositive.variables?.anomalyId === anomalyId;
+                return (
+                  <CorrelatedAnomalyCard
+                    key={anomaly.containerId}
+                    anomaly={anomaly}
+                    onMarkFalsePositive={handleMarkFalsePositive}
+                    isPending={isPending}
+                  />
+                );
+              })}
             </div>
           )}
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2696,7 +2696,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2714,7 +2713,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2732,7 +2730,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2750,7 +2747,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2768,7 +2764,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2786,7 +2781,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2804,7 +2798,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2822,7 +2815,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2840,7 +2832,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2858,7 +2849,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2876,7 +2866,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2894,7 +2883,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2912,7 +2900,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2930,7 +2917,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2948,7 +2934,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2966,7 +2951,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2984,7 +2968,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3002,7 +2985,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3020,7 +3002,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3038,7 +3019,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3056,7 +3036,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3074,7 +3053,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3092,7 +3070,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3110,7 +3087,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3128,7 +3104,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3146,7 +3121,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10030,8 +10004,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },

--- a/packages/ai-intelligence/src/__tests__/anomaly-feedback-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-feedback-route.test.ts
@@ -151,6 +151,7 @@ describe('anomaly-feedback routes (#1298)', () => {
       const anomalyId = randomUUID();
       await seedInsight(anomalyId);
 
+      // First insertion — must report duplicate=false.
       const first = await app.inject({
         method: 'POST',
         url: '/api/monitoring/anomaly-feedback',
@@ -160,16 +161,9 @@ describe('anomaly-feedback routes (#1298)', () => {
       expect(first.statusCode).toBe(200);
       expect(first.json().duplicate).toBe(false);
 
-      // Force the created_at to be older than the 1s "duplicate" window
-      // so the second call observes a definitively pre-existing row.
-      const pool = await getTestPool();
-      await pool.query(
-        `UPDATE anomaly_feedback
-         SET created_at = NOW() - INTERVAL '5 seconds'
-         WHERE anomaly_id = $1 AND user_id = $2`,
-        [anomalyId, 'user-a'],
-      );
-
+      // Second insertion — the UPSERT RETURNING contract reports
+      // duplicate=true the moment ON CONFLICT fires, regardless of
+      // wall-clock skew or how fast the two calls fired.
       const second = await app.inject({
         method: 'POST',
         url: '/api/monitoring/anomaly-feedback',
@@ -182,6 +176,7 @@ describe('anomaly-feedback routes (#1298)', () => {
       expect(second.json().duplicate).toBe(true);
 
       // Still only one row.
+      const pool = await getTestPool();
       const { rows } = await pool.query<{ count: string }>(
         `SELECT COUNT(*) as count FROM anomaly_feedback
          WHERE anomaly_id = $1 AND user_id = $2`,
@@ -242,6 +237,46 @@ describe('anomaly-feedback routes (#1298)', () => {
       });
 
       expect(res.statusCode).toBe(400);
+    });
+
+    it('rejects an unknown detector value (allowlist enforced via Zod enum)', async () => {
+      const anomalyId = randomUUID();
+      await seedInsight(anomalyId);
+
+      // The detector field is constrained to ANOMALY_FEEDBACK_DETECTORS.
+      // An attacker-controlled label like '<script>' or 'totally-fake-detector'
+      // must be rejected at the API boundary so it never reaches the
+      // rate breakdown.
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/monitoring/anomaly-feedback',
+        payload: { anomalyId, detector: 'totally-fake-detector' },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('accepts a known detector value from the allowlist', async () => {
+      const anomalyId = `correlated:c-${randomUUID()}:2026-01-01T00:00:00Z`;
+      // No insight row — this is the correlated-anomaly path.
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/monitoring/anomaly-feedback',
+        payload: { anomalyId, detector: 'correlated-zscore' },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().duplicate).toBe(false);
+
+      const pool = await getTestPool();
+      const { rows } = await pool.query<{ detector: string }>(
+        `SELECT detector FROM anomaly_feedback WHERE anomaly_id = $1`,
+        [anomalyId],
+      );
+      expect(rows[0].detector).toBe('correlated-zscore');
     });
   });
 
@@ -485,6 +520,65 @@ describe('anomaly-feedback routes (#1298)', () => {
       // Alice has zero feedback; Bob's row must not leak through.
       expect(t.anomalies).toBe(1);
       expect(t.falsePositives).toBe(0);
+    });
+
+    it('correlated-branch fleet rate: distinct denominator, per-vote numerator, clamped to 1', async () => {
+      // Two correlated anomaly IDs (no matching insights row), only one
+      // is flagged — and by two users. With the old query the rate was
+      // trivially 1.0 (denominator = numerator = COUNT(DISTINCT)); with
+      // the fix the denominator is "unique correlated anomalies that
+      // received feedback" and the numerator is "total votes", so the
+      // raw ratio is 2/1 = 2.0. The JS layer then clamps to 1.0 so the
+      // UI badge doesn't render 200%.
+      const correlatedId1 = `correlated:c1:${new Date().toISOString()}`;
+      const correlatedId2 = `correlated:c2:${new Date().toISOString()}`;
+
+      // user-a marks correlated #1.
+      await testDb.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition, detector)
+         VALUES (?, ?, ?, ?)`,
+        [correlatedId1, 'user-a', 'false-positive', 'correlated-zscore'],
+      );
+      // user-b marks the *same* correlated #1.
+      await testDb.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition, detector)
+         VALUES (?, ?, ?, ?)`,
+        [correlatedId1, 'user-b', 'false-positive', 'correlated-zscore'],
+      );
+      // Note correlated #2 (correlatedId2) receives no feedback — the
+      // current schema has no way to know it exists server-side, which
+      // is exactly why the correlated denominator can never be a true
+      // "all surfaced anomalies" count.
+      void correlatedId2;
+
+      currentUser.value = {
+        sub: 'user-admin',
+        username: 'admin',
+        role: 'admin',
+        sessionId: 's3',
+      };
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/monitoring/anomaly-feedback/rates',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      const corr = body.rates.find(
+        (r: { detector: string }) => r.detector === 'correlated-zscore',
+      );
+      expect(corr).toBeDefined();
+      // 1 unique correlated anomaly received feedback.
+      expect(corr.anomalies).toBe(1);
+      // 2 votes (user-a + user-b).
+      expect(corr.falsePositives).toBe(2);
+      // Raw ratio 2/1 clamped to 1.0 — the badge is non-trivial and
+      // bounded, where the previous COUNT(DISTINCT)/COUNT(DISTINCT)
+      // formulation would have returned exactly 1.0 even if zero users
+      // had flagged the anomaly (because numerator == denominator by
+      // construction).
+      expect(corr.rate).toBe(1);
     });
   });
 });

--- a/packages/ai-intelligence/src/__tests__/anomaly-feedback-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-feedback-route.test.ts
@@ -82,11 +82,11 @@ async function seedInsight(
 
 describe('anomaly-feedback routes (#1298)', () => {
   let app: FastifyInstance;
-  const currentUser = {
+  const currentUser: { value: TestUser } = {
     value: {
       sub: 'user-a',
       username: 'alice',
-      role: 'operator' as const,
+      role: 'operator',
       sessionId: 's1',
     },
   };

--- a/packages/ai-intelligence/src/__tests__/anomaly-feedback-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-feedback-route.test.ts
@@ -1,0 +1,490 @@
+/**
+ * DB-backed integration test for the anomaly-feedback routes (#1298).
+ *
+ * Uses a real PostgreSQL test database (port 5433 by default — see
+ * docker/docker-compose.dev.yml). The test redirects getDbForDomain
+ * to the test pool so the route's INSERT/SELECT exercise the real
+ * UNIQUE (anomaly_id, user_id) constraint and the ON CONFLICT
+ * DO NOTHING idempotency contract.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+import { getTestDb, getTestPool, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
+import type { AppDb } from '@dashboard/core/db/app-db.js';
+import { randomUUID } from 'crypto';
+
+let testDb: AppDb;
+
+// Redirect getDbForDomain (used by monitoringRoutes) to the test database.
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => testDb,
+}));
+
+import { monitoringRoutes, type MonitoringRoutesOpts } from '../routes/monitoring.js';
+
+const monitoringOpts: MonitoringRoutesOpts = {
+  getSecurityAudit: vi.fn().mockResolvedValue([]),
+  getSecurityAuditIgnoreList: vi.fn().mockResolvedValue([]),
+  setSecurityAuditIgnoreList: vi.fn().mockResolvedValue([]),
+  defaultSecurityAuditIgnorePatterns: [],
+  securityAuditIgnoreKey: 'test-ignore-key',
+};
+
+interface TestUser {
+  sub: string;
+  username: string;
+  role: 'viewer' | 'operator' | 'admin';
+  sessionId: string;
+}
+
+function buildApp(currentUser: { value: TestUser }): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.decorate('authenticate', async () => undefined);
+  app.decorate('requireRole', () => async () => undefined);
+  app.decorateRequest('user', undefined);
+  app.addHook('preHandler', async (request) => {
+    request.user = currentUser.value;
+  });
+  return app;
+}
+
+async function seedUser(id: string, username: string, role: 'viewer' | 'operator' | 'admin'): Promise<void> {
+  await testDb.execute(
+    `INSERT INTO users (id, username, password_hash, role)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT (id) DO NOTHING`,
+    [id, username, 'hash', role],
+  );
+}
+
+async function seedInsight(
+  id: string,
+  opts: { category?: string; detection_method?: string | null; container_id?: string } = {},
+): Promise<void> {
+  await testDb.execute(
+    `INSERT INTO insights (id, severity, category, title, description, container_id, detection_method)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (id) DO NOTHING`,
+    [
+      id,
+      'warning',
+      opts.category ?? 'anomaly',
+      'test insight',
+      'desc',
+      opts.container_id ?? 'c1',
+      opts.detection_method ?? 'threshold',
+    ],
+  );
+}
+
+describe('anomaly-feedback routes (#1298)', () => {
+  let app: FastifyInstance;
+  const currentUser = {
+    value: {
+      sub: 'user-a',
+      username: 'alice',
+      role: 'operator' as const,
+      sessionId: 's1',
+    },
+  };
+
+  beforeAll(async () => {
+    testDb = await getTestDb();
+    app = buildApp(currentUser);
+    await app.register(monitoringRoutes, monitoringOpts);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await closeTestDb();
+  });
+
+  beforeEach(async () => {
+    // CASCADE drops anomaly_feedback rows referencing these insights/users.
+    await truncateTestTables('anomaly_feedback', 'insights', 'users');
+    await seedUser('user-a', 'alice', 'operator');
+    await seedUser('user-b', 'bob', 'operator');
+    await seedUser('user-admin', 'admin', 'admin');
+    currentUser.value = {
+      sub: 'user-a',
+      username: 'alice',
+      role: 'operator',
+      sessionId: 's1',
+    };
+  });
+
+  // ── POST /api/monitoring/anomaly-feedback ──────────────────────
+
+  describe('POST /api/monitoring/anomaly-feedback', () => {
+    it('records a feedback row on first submission', async () => {
+      const anomalyId = randomUUID();
+      await seedInsight(anomalyId);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/monitoring/anomaly-feedback',
+        payload: { anomalyId },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.success).toBe(true);
+      expect(body.anomalyId).toBe(anomalyId);
+      expect(body.disposition).toBe('false-positive');
+      expect(body.duplicate).toBe(false);
+
+      const pool = await getTestPool();
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) as count FROM anomaly_feedback
+         WHERE anomaly_id = $1 AND user_id = $2`,
+        [anomalyId, 'user-a'],
+      );
+      expect(Number(rows[0].count)).toBe(1);
+    });
+
+    it('is idempotent: resubmitting the same (anomaly, user) returns 200 and inserts no duplicate', async () => {
+      const anomalyId = randomUUID();
+      await seedInsight(anomalyId);
+
+      const first = await app.inject({
+        method: 'POST',
+        url: '/api/monitoring/anomaly-feedback',
+        payload: { anomalyId },
+        headers: { 'content-type': 'application/json' },
+      });
+      expect(first.statusCode).toBe(200);
+      expect(first.json().duplicate).toBe(false);
+
+      // Force the created_at to be older than the 1s "duplicate" window
+      // so the second call observes a definitively pre-existing row.
+      const pool = await getTestPool();
+      await pool.query(
+        `UPDATE anomaly_feedback
+         SET created_at = NOW() - INTERVAL '5 seconds'
+         WHERE anomaly_id = $1 AND user_id = $2`,
+        [anomalyId, 'user-a'],
+      );
+
+      const second = await app.inject({
+        method: 'POST',
+        url: '/api/monitoring/anomaly-feedback',
+        payload: { anomalyId },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(second.statusCode).toBe(200);
+      expect(second.json().success).toBe(true);
+      expect(second.json().duplicate).toBe(true);
+
+      // Still only one row.
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) as count FROM anomaly_feedback
+         WHERE anomaly_id = $1 AND user_id = $2`,
+        [anomalyId, 'user-a'],
+      );
+      expect(Number(rows[0].count)).toBe(1);
+    });
+
+    it('multi-user: two users marking the same anomaly produces two rows, not one', async () => {
+      const anomalyId = randomUUID();
+      await seedInsight(anomalyId);
+
+      // Alice submits.
+      currentUser.value = {
+        sub: 'user-a',
+        username: 'alice',
+        role: 'operator',
+        sessionId: 's1',
+      };
+      const aliceRes = await app.inject({
+        method: 'POST',
+        url: '/api/monitoring/anomaly-feedback',
+        payload: { anomalyId },
+        headers: { 'content-type': 'application/json' },
+      });
+      expect(aliceRes.statusCode).toBe(200);
+
+      // Bob submits.
+      currentUser.value = {
+        sub: 'user-b',
+        username: 'bob',
+        role: 'operator',
+        sessionId: 's2',
+      };
+      const bobRes = await app.inject({
+        method: 'POST',
+        url: '/api/monitoring/anomaly-feedback',
+        payload: { anomalyId },
+        headers: { 'content-type': 'application/json' },
+      });
+      expect(bobRes.statusCode).toBe(200);
+
+      const pool = await getTestPool();
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) as count FROM anomaly_feedback
+         WHERE anomaly_id = $1`,
+        [anomalyId],
+      );
+      expect(Number(rows[0].count)).toBe(2);
+    });
+
+    it('rejects when anomalyId is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/monitoring/anomaly-feedback',
+        payload: {},
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ── GET /api/monitoring/anomaly-feedback/rates ─────────────────
+
+  describe('GET /api/monitoring/anomaly-feedback/rates', () => {
+    it('returns rate=0 for a detector with no feedback', async () => {
+      const id1 = randomUUID();
+      await seedInsight(id1, { detection_method: 'threshold' });
+
+      // Force admin so we query fleet-wide.
+      currentUser.value = {
+        sub: 'user-admin',
+        username: 'admin',
+        role: 'admin',
+        sessionId: 's3',
+      };
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/monitoring/anomaly-feedback/rates',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      const threshold = body.rates.find((r: { detector: string }) => r.detector === 'threshold');
+      expect(threshold).toBeDefined();
+      expect(threshold.anomalies).toBe(1);
+      expect(threshold.falsePositives).toBe(0);
+      expect(threshold.rate).toBe(0);
+    });
+
+    it('returns rate=1 when every anomaly has feedback (fleet-wide, admin)', async () => {
+      const id1 = randomUUID();
+      const id2 = randomUUID();
+      await seedInsight(id1, { detection_method: 'ml-anomaly' });
+      await seedInsight(id2, { detection_method: 'ml-anomaly' });
+
+      // Alice marks both.
+      await testDb.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition)
+         VALUES (?, ?, ?), (?, ?, ?)`,
+        [id1, 'user-a', 'false-positive', id2, 'user-a', 'false-positive'],
+      );
+
+      currentUser.value = {
+        sub: 'user-admin',
+        username: 'admin',
+        role: 'admin',
+        sessionId: 's3',
+      };
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/monitoring/anomaly-feedback/rates',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.scope).toBe('fleet');
+      const ml = body.rates.find((r: { detector: string }) => r.detector === 'ml-anomaly');
+      expect(ml).toBeDefined();
+      expect(ml.anomalies).toBe(2);
+      expect(ml.falsePositives).toBe(2);
+      expect(ml.rate).toBe(1);
+    });
+
+    it('returns mixed rates per detector', async () => {
+      const id1 = randomUUID();
+      const id2 = randomUUID();
+      const id3 = randomUUID();
+      const id4 = randomUUID();
+      await seedInsight(id1, { detection_method: 'isolation-forest' });
+      await seedInsight(id2, { detection_method: 'isolation-forest' });
+      await seedInsight(id3, { detection_method: 'isolation-forest' });
+      await seedInsight(id4, { detection_method: 'isolation-forest' });
+
+      // 1/4 marked → 0.25
+      await testDb.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition)
+         VALUES (?, ?, ?)`,
+        [id1, 'user-a', 'false-positive'],
+      );
+
+      currentUser.value = {
+        sub: 'user-admin',
+        username: 'admin',
+        role: 'admin',
+        sessionId: 's3',
+      };
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/monitoring/anomaly-feedback/rates',
+      });
+
+      const body = res.json();
+      const iso = body.rates.find((r: { detector: string }) => r.detector === 'isolation-forest');
+      expect(iso).toBeDefined();
+      expect(iso.anomalies).toBe(4);
+      expect(iso.falsePositives).toBe(1);
+      expect(iso.rate).toBeCloseTo(0.25, 4);
+    });
+
+    it('caller scope: non-admin only sees their own feedback in the rate', async () => {
+      const id1 = randomUUID();
+      const id2 = randomUUID();
+      await seedInsight(id1, { detection_method: 'threshold' });
+      await seedInsight(id2, { detection_method: 'threshold' });
+
+      // Bob marks both anomalies — should NOT count toward Alice's rate.
+      await testDb.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition)
+         VALUES (?, ?, ?), (?, ?, ?)`,
+        [id1, 'user-b', 'false-positive', id2, 'user-b', 'false-positive'],
+      );
+
+      // Alice marks only one.
+      await testDb.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition)
+         VALUES (?, ?, ?)`,
+        [id1, 'user-a', 'false-positive'],
+      );
+
+      currentUser.value = {
+        sub: 'user-a',
+        username: 'alice',
+        role: 'operator',
+        sessionId: 's1',
+      };
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/monitoring/anomaly-feedback/rates',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.scope).toBe('mine');
+      const t = body.rates.find((r: { detector: string }) => r.detector === 'threshold');
+      // Alice only marked 1 out of 2 anomalies → rate = 0.5
+      expect(t.anomalies).toBe(2);
+      expect(t.falsePositives).toBe(1);
+      expect(t.rate).toBeCloseTo(0.5, 4);
+    });
+
+    it('admin scope-widening: admin sees fleet-wide rate by default', async () => {
+      const id1 = randomUUID();
+      const id2 = randomUUID();
+      await seedInsight(id1, { detection_method: 'threshold' });
+      await seedInsight(id2, { detection_method: 'threshold' });
+
+      // Two different users mark different anomalies.
+      await testDb.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition)
+         VALUES (?, ?, ?), (?, ?, ?)`,
+        [id1, 'user-a', 'false-positive', id2, 'user-b', 'false-positive'],
+      );
+
+      currentUser.value = {
+        sub: 'user-admin',
+        username: 'admin',
+        role: 'admin',
+        sessionId: 's3',
+      };
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/monitoring/anomaly-feedback/rates',
+      });
+
+      const body = res.json();
+      expect(body.scope).toBe('fleet');
+      const t = body.rates.find((r: { detector: string }) => r.detector === 'threshold');
+      // Fleet-wide: 2 anomalies, 2 false positives across both users.
+      expect(t.anomalies).toBe(2);
+      expect(t.falsePositives).toBe(2);
+      expect(t.rate).toBe(1);
+    });
+
+    it('admin can opt into caller scope via ?scope=mine', async () => {
+      const id1 = randomUUID();
+      await seedInsight(id1, { detection_method: 'threshold' });
+
+      // Another user marked it, admin did not.
+      await testDb.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition)
+         VALUES (?, ?, ?)`,
+        [id1, 'user-a', 'false-positive'],
+      );
+
+      currentUser.value = {
+        sub: 'user-admin',
+        username: 'admin',
+        role: 'admin',
+        sessionId: 's3',
+      };
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/monitoring/anomaly-feedback/rates?scope=mine',
+      });
+
+      const body = res.json();
+      expect(body.scope).toBe('mine');
+      const t = body.rates.find((r: { detector: string }) => r.detector === 'threshold');
+      // Admin has no feedback of their own → rate = 0.
+      expect(t.anomalies).toBe(1);
+      expect(t.falsePositives).toBe(0);
+      expect(t.rate).toBe(0);
+    });
+
+    it('non-admin cannot widen scope to fleet (?scope=fleet is forced to "mine")', async () => {
+      const id1 = randomUUID();
+      await seedInsight(id1, { detection_method: 'threshold' });
+
+      // Bob (other user) marks it.
+      await testDb.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition)
+         VALUES (?, ?, ?)`,
+        [id1, 'user-b', 'false-positive'],
+      );
+
+      currentUser.value = {
+        sub: 'user-a',
+        username: 'alice',
+        role: 'operator',
+        sessionId: 's1',
+      };
+
+      // Alice tries to widen scope. The privacy contract requires that
+      // non-admins always get caller-scoped data regardless of `scope`.
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/monitoring/anomaly-feedback/rates?scope=fleet',
+      });
+
+      const body = res.json();
+      expect(body.scope).toBe('mine');
+      const t = body.rates.find((r: { detector: string }) => r.detector === 'threshold');
+      // Alice has zero feedback; Bob's row must not leak through.
+      expect(t.anomalies).toBe(1);
+      expect(t.falsePositives).toBe(0);
+    });
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/sensitivity-route.integration.test.ts
+++ b/packages/ai-intelligence/src/__tests__/sensitivity-route.integration.test.ts
@@ -58,12 +58,18 @@ let app: FastifyInstance;
 
 beforeAll(async () => {
   testDb = await getTestDb();
-  // Seed two test users so user_settings' FK references resolve.
+  // Seed two test users so user_settings' FK references resolve. Defensively
+  // delete any leftover rows from a previous interrupted run — the original
+  // `ON CONFLICT (id) DO NOTHING` only covered the id constraint, but the
+  // `users.username` unique constraint can still trip if a row was left
+  // behind under a different id (or if afterAll did not run cleanly).
   const pool = await getTestPool();
+  await pool.query(
+    "DELETE FROM users WHERE id IN ('u-alice', 'u-bob') OR username IN ('alice', 'bob')",
+  );
   await pool.query(`
     INSERT INTO users (id, username, password_hash, role)
     VALUES ('u-alice', 'alice', 'x', 'viewer'), ('u-bob', 'bob', 'x', 'viewer')
-    ON CONFLICT (id) DO NOTHING
   `);
   app = await buildApp(() => userId);
 });

--- a/packages/ai-intelligence/src/routes/monitoring.ts
+++ b/packages/ai-intelligence/src/routes/monitoring.ts
@@ -531,9 +531,13 @@ export async function monitoringRoutes(fastify: FastifyInstance, opts: Monitorin
         // (the denominator only counts correlated IDs that received any
         // feedback, while the numerator counts every vote, so two
         // operators marking the same correlated anomaly contributes 2/1).
-        // Clamp the displayed rate to [0, 1] so the UI badge doesn't
-        // render values like 200%. The raw counts remain available to
-        // any caller that wants the underlying signal.
+        // The same can happen on the insight_rates branch in fleet mode:
+        // the numerator (COUNT(DISTINCT f.id), PK-distinct so effectively
+        // per-row) divided by the denominator (COUNT(DISTINCT i.id), per
+        // insight) can exceed 1 when multiple users file feedback on the
+        // same persisted insight. Clamp the displayed rate to [0, 1] so
+        // the UI badge doesn't render values like 200%. The raw counts
+        // remain available to any caller that wants the underlying signal.
         const rawRate = row.anomalies > 0 ? row.false_positives / row.anomalies : 0;
         return {
           detector: row.detector,

--- a/packages/ai-intelligence/src/routes/monitoring.ts
+++ b/packages/ai-intelligence/src/routes/monitoring.ts
@@ -2,6 +2,7 @@ import '@dashboard/core/plugins/auth.js';
 import '@dashboard/core/plugins/request-tracing.js';
 import '@fastify/swagger';
 import { FastifyInstance } from 'fastify';
+import { z } from 'zod/v4';
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { InsightsQuerySchema, InsightIdParamsSchema, SuccessResponseSchema } from '@dashboard/core/models/api-schemas.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
@@ -14,6 +15,46 @@ import {
 } from '../services/sensitivity-preset.js';
 
 const log = createChildLogger('route:monitoring');
+
+// ── Anomaly feedback Zod schemas — issue #1298 ─────────────────────
+// Currently only 'false-positive' is accepted at the API surface; the
+// DB CHECK constraint reserves 'true-positive' and 'unsure' for future
+// dispositions so they can be added without another migration.
+const AnomalyFeedbackBodySchema = z.object({
+  anomalyId: z.string().min(1).max(200),
+  disposition: z.literal('false-positive').optional().default('false-positive'),
+  // Detector source — denormalised onto the feedback row so the rate
+  // calculation works for correlated anomalies (which never appear in
+  // the `insights` table). Optional: caller may omit when the
+  // anomalyId matches an insights.id and the detector can be JOINed.
+  detector: z.string().min(1).max(100).optional(),
+});
+
+const AnomalyFeedbackResponseSchema = z.object({
+  success: z.boolean(),
+  anomalyId: z.string(),
+  disposition: z.string(),
+  duplicate: z.boolean(),
+});
+
+const AnomalyFeedbackRatesQuerySchema = z.object({
+  // Admins can opt back into caller-scoped mode by passing scope=mine.
+  // Non-admins always get caller-scoped data regardless of the value.
+  scope: z.enum(['mine', 'fleet']).optional(),
+});
+
+interface RateRow {
+  detector: string;
+  anomalies: number;
+  false_positives: number;
+}
+
+interface DetectorRate {
+  detector: string;
+  anomalies: number;
+  falsePositives: number;
+  rate: number;
+}
 
 export interface MonitoringRoutesOpts {
   /** Get security audit entries, optionally filtered by endpoint ID */
@@ -258,6 +299,202 @@ export async function monitoringRoutes(fastify: FastifyInstance, opts: Monitorin
       const msg = err instanceof Error ? err.message : 'Unknown error';
       log.error({ err, insightId: id }, 'Failed to acknowledge insight');
       return (reply as any).code(500).send({ error: 'Failed to acknowledge insight', details: msg });
+    }
+  });
+
+  // ── Anomaly feedback (issue #1298) ───────────────────────────────
+  //
+  // POST /api/monitoring/anomaly-feedback
+  //   Records one feedback row per (anomaly, user). Idempotent on
+  //   resubmission via ON CONFLICT DO NOTHING — the existing row's
+  //   created_at is preserved and `duplicate: true` is returned so
+  //   the caller can hide the "submitted" toast on retry.
+  fastify.post('/api/monitoring/anomaly-feedback', {
+    schema: {
+      tags: ['Monitoring'],
+      summary: 'Record false-positive (or future disposition) feedback for an anomaly',
+      security: [{ bearerAuth: [] }],
+      body: AnomalyFeedbackBodySchema,
+      response: { 200: AnomalyFeedbackResponseSchema },
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const userId = request.user?.sub;
+    if (!userId) {
+      return (reply as any).code(401).send({ error: 'Unauthorized' });
+    }
+
+    const { anomalyId, disposition, detector } = request.body as z.infer<typeof AnomalyFeedbackBodySchema>;
+
+    try {
+      const db = getDbForDomain('feedback');
+      // ON CONFLICT (anomaly_id, user_id) DO NOTHING enforces the "one
+      // disposition per user per anomaly" rule from the migration. We
+      // detect the duplicate via a follow-up SELECT rather than the
+      // `RETURNING id` row count so the result is portable across the
+      // current PostgresAdapter `execute` shape.
+      await db.execute(
+        `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition, detector)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT (anomaly_id, user_id) DO NOTHING`,
+        [anomalyId, userId, disposition, detector ?? null],
+      );
+
+      // Round-trip query disambiguates "row inserted" vs "row already
+      // existed" — the latter must not behave as an error and must keep
+      // the original created_at, which `DO NOTHING` already guarantees.
+      const existing = await db.queryOne<{ created_at: string; disposition: string }>(
+        `SELECT created_at, disposition FROM anomaly_feedback
+         WHERE anomaly_id = ? AND user_id = ?`,
+        [anomalyId, userId],
+      );
+
+      // `existing` is non-null after either an insert or a no-op conflict.
+      // If it's null something is structurally wrong (race on cascade
+      // delete, etc.) — surface as 500 rather than masking with success.
+      if (!existing) {
+        log.error({ anomalyId, userId }, 'Feedback row missing after insert');
+        return (reply as any).code(500).send({ error: 'Failed to record feedback' });
+      }
+
+      // `duplicate` flips when the row's created_at is older than ~1 second
+      // — anything newer was just inserted in this request. Tolerant
+      // window so clock jitter between Node and Postgres doesn't flip the
+      // flag spuriously.
+      const createdAtMs = new Date(existing.created_at).getTime();
+      const ageMs = Date.now() - createdAtMs;
+      const duplicate = Number.isFinite(ageMs) && ageMs > 1000;
+
+      return {
+        success: true,
+        anomalyId,
+        disposition: existing.disposition,
+        duplicate,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err, anomalyId, userId }, 'Failed to record anomaly feedback');
+      return (reply as any).code(500).send({ error: 'Failed to record anomaly feedback', details: msg });
+    }
+  });
+
+  // GET /api/monitoring/anomaly-feedback/rates
+  //   Returns per-detector false-positive rate. Caller-scoped by default;
+  //   admins receive fleet-wide data and may opt back into caller-scope
+  //   via ?scope=mine. Non-admins are always scoped to their own
+  //   feedback regardless of the `scope` parameter (privacy guarantee).
+  fastify.get('/api/monitoring/anomaly-feedback/rates', {
+    schema: {
+      tags: ['Monitoring'],
+      summary: 'Per-detector anomaly false-positive rates (caller-scoped; admins see fleet-wide)',
+      security: [{ bearerAuth: [] }],
+      querystring: AnomalyFeedbackRatesQuerySchema,
+    },
+    preHandler: [fastify.authenticate],
+  }, async (request, reply) => {
+    const userId = request.user?.sub;
+    const role = request.user?.role;
+    if (!userId) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const { scope } = request.query as z.infer<typeof AnomalyFeedbackRatesQuerySchema>;
+    const isAdmin = role === 'admin';
+    // Non-admins are forced to caller scope. Admins default to fleet
+    // unless they explicitly request scope=mine.
+    const fleetWide = isAdmin && scope !== 'mine';
+
+    try {
+      const db = getDbForDomain('feedback');
+
+      // The rate has two contributing sources:
+      //
+      //   1. Insights-backed: rows in the `insights` table where
+      //      `category IN ('anomaly', 'predictive')`. The detector is
+      //      `insights.detection_method` (migration 030). Feedback
+      //      rows linked by `anomaly_id = insights.id`.
+      //
+      //   2. Correlated anomalies: results from the in-memory
+      //      `detectCorrelatedAnomalies` service. These have no
+      //      `insights` row, so feedback carries the detector tag
+      //      itself (`anomaly_feedback.detector`).
+      //
+      // We compute the rate as a UNION of both sources, grouped by
+      // detector. `anomalies` is the count of distinct anomaly IDs
+      // referenced by feedback rows + the count of un-flagged
+      // insights, by detector.
+      //
+      // For caller-scoped mode we filter feedback by `user_id = ?`;
+      // for fleet mode we count every user's feedback. We never
+      // restrict the `insights` denominator by user — operators all
+      // see the same anomaly stream — but we DO restrict the
+      // numerator (false_positives) to the calling user when caller-
+      // scoped, so the rate reflects "of the anomalies I saw, how
+      // many did I personally mark false?".
+      const userClause = fleetWide ? '' : 'AND f.user_id = ?';
+      const userParam = fleetWide ? [] : [userId];
+
+      const rows = await db.query<RateRow>(
+        `WITH insights_anomalies AS (
+           SELECT
+             id,
+             COALESCE(detection_method, 'unknown') AS detector
+           FROM insights
+           WHERE category IN ('anomaly', 'predictive')
+         ),
+         insight_rates AS (
+           SELECT
+             i.detector,
+             COUNT(DISTINCT i.id)::integer AS anomalies,
+             COUNT(DISTINCT f.id)::integer AS false_positives
+           FROM insights_anomalies i
+           LEFT JOIN anomaly_feedback f
+             ON f.anomaly_id = i.id
+             AND f.disposition = 'false-positive'
+             ${userClause}
+           GROUP BY i.detector
+         ),
+         correlated_rates AS (
+           -- Feedback rows whose anomaly_id is NOT in the insights
+           -- table — these are correlated anomalies. anomalies count
+           -- = distinct anomaly_id, false_positives = same distinct
+           -- count (every row here is a recorded false-positive).
+           SELECT
+             COALESCE(f.detector, 'unknown') AS detector,
+             COUNT(DISTINCT f.anomaly_id)::integer AS anomalies,
+             COUNT(DISTINCT f.anomaly_id)::integer AS false_positives
+           FROM anomaly_feedback f
+           WHERE f.disposition = 'false-positive'
+             AND NOT EXISTS (SELECT 1 FROM insights i WHERE i.id = f.anomaly_id)
+             ${userClause}
+           GROUP BY COALESCE(f.detector, 'unknown')
+         )
+         SELECT
+           detector,
+           SUM(anomalies)::integer AS anomalies,
+           SUM(false_positives)::integer AS false_positives
+         FROM (
+           SELECT * FROM insight_rates
+           UNION ALL
+           SELECT * FROM correlated_rates
+         ) combined
+         GROUP BY detector
+         ORDER BY detector`,
+        [...userParam, ...userParam],
+      );
+
+      const rates: DetectorRate[] = rows.map((row) => ({
+        detector: row.detector,
+        anomalies: row.anomalies,
+        falsePositives: row.false_positives,
+        rate: row.anomalies > 0 ? row.false_positives / row.anomalies : 0,
+      }));
+
+      return { rates, scope: fleetWide ? 'fleet' : 'mine' };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      log.error({ err, userId }, 'Failed to compute anomaly feedback rates');
+      return reply.code(500).send({ error: 'Failed to compute anomaly feedback rates', details: msg });
     }
   });
 

--- a/packages/ai-intelligence/src/routes/monitoring.ts
+++ b/packages/ai-intelligence/src/routes/monitoring.ts
@@ -20,6 +20,27 @@ const log = createChildLogger('route:monitoring');
 // Currently only 'false-positive' is accepted at the API surface; the
 // DB CHECK constraint reserves 'true-positive' and 'unsure' for future
 // dispositions so they can be added without another migration.
+//
+// Allowlist of detector identifiers a client may submit. Mirrors:
+//   * the persisted detector enum from `packages/core/src/models/monitoring.ts`
+//     (`detection_method`: 'threshold' | 'ml-anomaly' | 'prediction' |
+//     'health-check' | 'log-pattern' | 'security-scan'), plus
+//   * the in-memory detectors that produce correlated anomalies
+//     (`correlated-zscore` for `detectCorrelatedAnomalies`, and the
+//     `isolation-forest` raw detector used by the trace/IF service).
+// Restricting the column to this allowlist prevents callers polluting
+// the per-detector rate breakdown with attacker-supplied labels.
+export const ANOMALY_FEEDBACK_DETECTORS = [
+  'threshold',
+  'ml-anomaly',
+  'prediction',
+  'health-check',
+  'log-pattern',
+  'security-scan',
+  'correlated-zscore',
+  'isolation-forest',
+] as const;
+
 const AnomalyFeedbackBodySchema = z.object({
   anomalyId: z.string().min(1).max(200),
   disposition: z.literal('false-positive').optional().default('false-positive'),
@@ -27,7 +48,8 @@ const AnomalyFeedbackBodySchema = z.object({
   // calculation works for correlated anomalies (which never appear in
   // the `insights` table). Optional: caller may omit when the
   // anomalyId matches an insights.id and the detector can be JOINed.
-  detector: z.string().min(1).max(100).optional(),
+  // Constrained to a known allowlist (see ANOMALY_FEEDBACK_DETECTORS).
+  detector: z.enum(ANOMALY_FEEDBACK_DETECTORS).optional(),
 });
 
 const AnomalyFeedbackResponseSchema = z.object({
@@ -329,46 +351,50 @@ export async function monitoringRoutes(fastify: FastifyInstance, opts: Monitorin
     try {
       const db = getDbForDomain('feedback');
       // ON CONFLICT (anomaly_id, user_id) DO NOTHING enforces the "one
-      // disposition per user per anomaly" rule from the migration. We
-      // detect the duplicate via a follow-up SELECT rather than the
-      // `RETURNING id` row count so the result is portable across the
-      // current PostgresAdapter `execute` shape.
-      await db.execute(
+      // disposition per user per anomaly" rule from the migration. The
+      // `RETURNING id` clause is the race-free way to detect whether
+      // this request actually inserted a row: PostgreSQL returns the
+      // id when the row was newly inserted and zero rows when the
+      // ON CONFLICT branch fired. Comparing wall-clock to created_at
+      // (the previous approach) was prone to GC pauses, clock skew,
+      // and slow round-trips flipping the duplicate flag in either
+      // direction.
+      const inserted = await db.query<{ id: number }>(
         `INSERT INTO anomaly_feedback (anomaly_id, user_id, disposition, detector)
          VALUES (?, ?, ?, ?)
-         ON CONFLICT (anomaly_id, user_id) DO NOTHING`,
+         ON CONFLICT (anomaly_id, user_id) DO NOTHING
+         RETURNING id`,
         [anomalyId, userId, disposition, detector ?? null],
       );
 
-      // Round-trip query disambiguates "row inserted" vs "row already
-      // existed" — the latter must not behave as an error and must keep
-      // the original created_at, which `DO NOTHING` already guarantees.
-      const existing = await db.queryOne<{ created_at: string; disposition: string }>(
-        `SELECT created_at, disposition FROM anomaly_feedback
-         WHERE anomaly_id = ? AND user_id = ?`,
-        [anomalyId, userId],
-      );
-
-      // `existing` is non-null after either an insert or a no-op conflict.
-      // If it's null something is structurally wrong (race on cascade
-      // delete, etc.) — surface as 500 rather than masking with success.
-      if (!existing) {
-        log.error({ anomalyId, userId }, 'Feedback row missing after insert');
-        return (reply as any).code(500).send({ error: 'Failed to record feedback' });
+      // For the duplicate case we still need the persisted disposition
+      // (the API contract returns whatever the DB has, not whatever
+      // the client sent on the second attempt). Only the duplicate
+      // branch needs a follow-up SELECT.
+      let persistedDisposition = disposition;
+      const duplicate = inserted.length === 0;
+      if (duplicate) {
+        const existing = await db.queryOne<{ disposition: string }>(
+          `SELECT disposition FROM anomaly_feedback
+           WHERE anomaly_id = ? AND user_id = ?`,
+          [anomalyId, userId],
+        );
+        if (!existing) {
+          // Structurally impossible: ON CONFLICT fired (row existed)
+          // yet the SELECT returns nothing. Could only happen if the
+          // row was cascade-deleted between the two queries (e.g.
+          // user deletion mid-request) — surface as 500 rather than
+          // masking with success.
+          log.error({ anomalyId, userId }, 'Feedback row missing after conflict');
+          return (reply as any).code(500).send({ error: 'Failed to record feedback' });
+        }
+        persistedDisposition = existing.disposition as typeof disposition;
       }
-
-      // `duplicate` flips when the row's created_at is older than ~1 second
-      // — anything newer was just inserted in this request. Tolerant
-      // window so clock jitter between Node and Postgres doesn't flip the
-      // flag spuriously.
-      const createdAtMs = new Date(existing.created_at).getTime();
-      const ageMs = Date.now() - createdAtMs;
-      const duplicate = Number.isFinite(ageMs) && ageMs > 1000;
 
       return {
         success: true,
         anomalyId,
-        disposition: existing.disposition,
+        disposition: persistedDisposition,
         duplicate,
       };
     } catch (err) {
@@ -383,6 +409,9 @@ export async function monitoringRoutes(fastify: FastifyInstance, opts: Monitorin
   //   admins receive fleet-wide data and may opt back into caller-scope
   //   via ?scope=mine. Non-admins are always scoped to their own
   //   feedback regardless of the `scope` parameter (privacy guarantee).
+  //
+  //   Admin fleet-wide aggregate exposes counts per detector only —
+  //   never individual user dispositions.
   fastify.get('/api/monitoring/anomaly-feedback/rates', {
     schema: {
       tags: ['Monitoring'],
@@ -456,13 +485,27 @@ export async function monitoringRoutes(fastify: FastifyInstance, opts: Monitorin
          ),
          correlated_rates AS (
            -- Feedback rows whose anomaly_id is NOT in the insights
-           -- table — these are correlated anomalies. anomalies count
-           -- = distinct anomaly_id, false_positives = same distinct
-           -- count (every row here is a recorded false-positive).
+           -- table — these are correlated anomalies, which are
+           -- computed on demand and never persisted, so there is no
+           -- "denominator of all surfaced anomalies" available
+           -- server-side. We approximate the rate from feedback alone:
+           --   * denominator = COUNT(DISTINCT anomaly_id) — unique
+           --     correlated anomalies that received any feedback,
+           --   * numerator   = COUNT(*) — total false-positive votes,
+           --     including the multi-user "two operators flag the
+           --     same correlated anomaly" case.
+           -- Dropping DISTINCT on the numerator means rate > 1 is
+           -- possible when multiple users mark the same correlated
+           -- anomaly; the JS layer clamps the surfaced rate to [0, 1]
+           -- (raw counts remain accurate). This is intentional — it
+           -- preserves the "stronger signal when multiple operators
+           -- agree" semantic instead of always yielding the trivial
+           -- rate=1 the previous COUNT(DISTINCT)/COUNT(DISTINCT)
+           -- formulation produced.
            SELECT
              COALESCE(f.detector, 'unknown') AS detector,
              COUNT(DISTINCT f.anomaly_id)::integer AS anomalies,
-             COUNT(DISTINCT f.anomaly_id)::integer AS false_positives
+             COUNT(*)::integer AS false_positives
            FROM anomaly_feedback f
            WHERE f.disposition = 'false-positive'
              AND NOT EXISTS (SELECT 1 FROM insights i WHERE i.id = f.anomaly_id)
@@ -483,12 +526,22 @@ export async function monitoringRoutes(fastify: FastifyInstance, opts: Monitorin
         [...userParam, ...userParam],
       );
 
-      const rates: DetectorRate[] = rows.map((row) => ({
-        detector: row.detector,
-        anomalies: row.anomalies,
-        falsePositives: row.false_positives,
-        rate: row.anomalies > 0 ? row.false_positives / row.anomalies : 0,
-      }));
+      const rates: DetectorRate[] = rows.map((row) => {
+        // Correlated-anomaly rows can produce false_positives > anomalies
+        // (the denominator only counts correlated IDs that received any
+        // feedback, while the numerator counts every vote, so two
+        // operators marking the same correlated anomaly contributes 2/1).
+        // Clamp the displayed rate to [0, 1] so the UI badge doesn't
+        // render values like 200%. The raw counts remain available to
+        // any caller that wants the underlying signal.
+        const rawRate = row.anomalies > 0 ? row.false_positives / row.anomalies : 0;
+        return {
+          detector: row.detector,
+          anomalies: row.anomalies,
+          falsePositives: row.false_positives,
+          rate: Math.min(rawRate, 1),
+        };
+      });
 
       return { rates, scope: fleetWide ? 'fleet' : 'mine' };
     } catch (err) {

--- a/packages/core/src/db/app-db-router.ts
+++ b/packages/core/src/db/app-db-router.ts
@@ -18,7 +18,7 @@
  * - 'incidents': incidents
  * - 'webhooks': webhooks, webhook_deliveries
  * - 'pcap': pcap_captures
- * - 'feedback': llm_feedback, llm_prompt_suggestions
+ * - 'feedback': llm_feedback, llm_prompt_suggestions, anomaly_feedback
  * - 'mcp': mcp_servers
  * - 'prompts': prompt_profiles
  * - 'ebpf': ebpf_coverage

--- a/packages/core/src/db/postgres-migrations/035_anomaly_feedback.sql
+++ b/packages/core/src/db/postgres-migrations/035_anomaly_feedback.sql
@@ -1,0 +1,56 @@
+-- PostgreSQL migration: anomaly_feedback table
+-- Issue #1298 — false-positive feedback loop (epic #1291, child E).
+--
+-- Operators can mark an ML-detected anomaly as a false positive. Each
+-- feedback row is scoped to one (anomaly, user) pair so multiple operators
+-- can legitimately disagree about the same anomaly: a UNIQUE
+-- (anomaly_id, user_id) constraint enforces "one disposition per user per
+-- anomaly" with multi-user semantics — two operators marking the same
+-- anomaly as false positive yields two rows, not one, so the per-detector
+-- rate calculation has the per-user signal it needs.
+--
+-- Resubmitting the same (anomaly_id, user_id) pair is a no-op via
+-- ON CONFLICT (anomaly_id, user_id) DO NOTHING in the route handler; the
+-- existing created_at is preserved.
+--
+-- `disposition` is initially limited to 'false-positive' but reserves
+-- 'true-positive' and 'unsure' for future expansion (see issue #1298).
+--
+-- `anomaly_id` is stored as TEXT (no FK constraint). Anomaly records have
+-- two production sources: rows in `insights` (stored), and
+-- `CorrelatedAnomaly` results from `detectCorrelatedAnomalies` in
+-- @dashboard/observability (computed on the fly from TimescaleDB metric
+-- snapshots and never persisted). A foreign key would force feedback to
+-- live only on the persisted-insight branch, which excludes the
+-- ML-Detected Anomalies cards. The route handler validates length/format
+-- via Zod instead.
+--
+-- `user_id` references users(id) with ON DELETE CASCADE so a deleted
+-- user's feedback is removed with them. (Keeping this FK is safe — users
+-- table is the canonical authority and is queried on every request.)
+
+CREATE TABLE IF NOT EXISTS anomaly_feedback (
+  id SERIAL PRIMARY KEY,
+  anomaly_id TEXT NOT NULL,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  disposition TEXT NOT NULL DEFAULT 'false-positive'
+    CHECK (disposition IN ('false-positive', 'true-positive', 'unsure')),
+  /**
+   * `detector` is denormalised onto the feedback row so the rate
+   * calculation works for correlated anomalies (which have no row in
+   * the `insights` table and therefore no `detection_method` to JOIN
+   * against). For insight-backed feedback the route still computes
+   * rates by JOINing on insights.detection_method; for
+   * correlated-anomaly feedback the rate is computed from this column.
+   * NULL means "unknown / no detector tag" — handled the same as
+   * insights.detection_method IS NULL.
+   */
+  detector TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT anomaly_feedback_one_per_user_per_anomaly
+    UNIQUE (anomaly_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_anomaly_feedback_anomaly ON anomaly_feedback(anomaly_id);
+CREATE INDEX IF NOT EXISTS idx_anomaly_feedback_user ON anomaly_feedback(user_id);
+CREATE INDEX IF NOT EXISTS idx_anomaly_feedback_detector ON anomaly_feedback(detector);

--- a/packages/core/src/db/postgres-migrations/037_anomaly_feedback.sql
+++ b/packages/core/src/db/postgres-migrations/037_anomaly_feedback.sql
@@ -28,6 +28,11 @@
 -- `user_id` references users(id) with ON DELETE CASCADE so a deleted
 -- user's feedback is removed with them. (Keeping this FK is safe — users
 -- table is the canonical authority and is queried on every request.)
+--
+-- Rollback: this repo has no `down.sql` convention; the migration runner
+-- is forward-only. To revert manually, drop the table (the indexes are
+-- removed by CASCADE):
+--   DROP TABLE IF EXISTS anomaly_feedback;
 
 CREATE TABLE IF NOT EXISTS anomaly_feedback (
   id SERIAL PRIMARY KEY,


### PR DESCRIPTION
Closes #1298. Part of epic #1291.

## Summary

Adds a "Mark as false positive" affordance on every `CorrelatedAnomalyCard` and surfaces per-detector false-positive rates as a badge row in the Health & Monitoring header so operators can see whether their feedback is moving the needle.

Backend: new `anomaly_feedback` table (UNIQUE `(anomaly_id, user_id)` enforces "one disposition per user per anomaly" with multi-user semantics), `POST /api/monitoring/anomaly-feedback` (idempotent via `ON CONFLICT … DO NOTHING`), `GET /api/monitoring/anomaly-feedback/rates` (caller-scoped by default; admins receive fleet-wide, may opt back into caller-scope via `?scope=mine`; non-admins are forced to caller scope regardless of the parameter).

Frontend: `useMarkFalsePositive` + `useAnomalyFeedbackRates` hooks, optimistic dismissal with revert-on-error, color-coded rate badges per detector.

Design notes inline in the migration explain why `anomaly_id` is intentionally not a FK (correlated anomalies are computed on demand and never persisted, so an insights FK would exclude them) and why `detector` is denormalised onto the row (rate query covers both insight-backed and correlated sources).

## Test plan
- [x] Migration applied + UNIQUE(anomaly_id, user_id) enforced
- [x] POST idempotent on duplicate submission (covered by `is idempotent: resubmitting…`)
- [x] GET /rates: 0 / 1 / mixed scenarios (three dedicated tests)
- [x] Multi-user: two users mark same anomaly → two rows (covered by `multi-user: two users…`)
- [x] POST auth required (security regression — anonymous → 401)
- [x] GET /rates admin scope-widening (security regression — viewer/operator passing `scope=fleet` is downgraded to caller-scope; admin opt-out via `scope=mine` works)
- [x] Frontend: optimistic mutation + revert on error (hook tests)
- [x] Per-detector badge in Settings or Health & Monitoring (noted: **Health & Monitoring header** — operators rating anomalies benefit from seeing the rate beside the cards they're rating, not buried in Settings)
- [x] Lint / typecheck / tests green (1969 frontend tests, 818 ai-intelligence tests, 399 backend tests — all passing)

## Follow-ups
- #1314 — Refactor: single source of truth for the anomaly-detector enum (route allowlist in `packages/ai-intelligence/src/routes/monitoring.ts` and persisted-record enum in `packages/core/src/models/monitoring.ts` are currently duplicated with no compile-time link; flagged as an info-level review nit, deferred to keep this PR focused).