### PR TITLE
feat(anomaly): correlated suppression for co-occurring p95 + error-rate

### DIFF
--- a/frontend/src/features/ai-intelligence/components/insight-card.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/insight-card.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { InsightCard, type InsightCardProps } from './insight-card';
+import type { AnomalyDimension } from '@dashboard/contracts';
+
+/**
+ * Regression coverage for #1296 / PR #1306 — when a trace-anomaly insight
+ * collapses co-occurring p95 + error-rate signals into a single record, the
+ * UI must surface each underlying dimension instead of hiding the payload
+ * inside the JSONB column. Mirrors the styling of `CorrelatedAnomalyCard`
+ * on the AI monitor page.
+ */
+
+function makeInsight(
+  overrides: Partial<InsightCardProps['insight']> = {},
+): InsightCardProps['insight'] {
+  return {
+    id: 'insight-1',
+    endpoint_id: 1,
+    endpoint_name: 'local',
+    container_id: 'svc-api',
+    container_name: 'api',
+    severity: 'critical',
+    category: 'anomaly',
+    title: 'Correlated anomaly on service "api" (latency_p95 + error_rate)',
+    description: 'Both signals crossed threshold in the same minute bucket.',
+    suggested_action: null,
+    is_acknowledged: 0,
+    created_at: '2026-05-14T13:00:00Z',
+    ...overrides,
+  };
+}
+
+function wrap(node: React.ReactNode) {
+  return <MemoryRouter>{node}</MemoryRouter>;
+}
+
+describe('InsightCard — dimensions breakdown (#1296)', () => {
+  it('does not render the dimensions section for legacy single-signal insights', async () => {
+    render(
+      wrap(
+        <InsightCard
+          insight={makeInsight()}
+          onAcknowledge={() => undefined}
+          isAcknowledging={false}
+        />,
+      ),
+    );
+    // Expand the card so the body is mounted.
+    await userEvent.click(screen.getByRole('button', { name: /Correlated anomaly/ }));
+    expect(screen.queryByTestId('insight-dimension-bars')).not.toBeInTheDocument();
+    expect(screen.queryByText('Correlated Signals')).not.toBeInTheDocument();
+  });
+
+  it('renders one z-score bar per dimension for a 2-signal correlated insight', async () => {
+    const dimensions: AnomalyDimension[] = [
+      { type: 'latency_p95', value: 800, baseline: 20, zScore: 4.8, severity: 'critical' },
+      { type: 'error_rate', value: 0.12, baseline: 0.005, zScore: 2.3, severity: 'warning' },
+    ];
+    render(
+      wrap(
+        <InsightCard
+          insight={makeInsight({ dimensions })}
+          onAcknowledge={() => undefined}
+          isAcknowledging={false}
+        />,
+      ),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Correlated anomaly/ }));
+
+    const bars = screen.getByTestId('insight-dimension-bars');
+    expect(bars).toBeInTheDocument();
+    // One row per dimension, each labelled with its `type`.
+    expect(screen.getByTestId('insight-dimension-latency_p95')).toBeInTheDocument();
+    expect(screen.getByTestId('insight-dimension-error_rate')).toBeInTheDocument();
+    // Z-score labels reflect the underlying values to one decimal place.
+    expect(within(bars).getByText('4.8')).toBeInTheDocument();
+    expect(within(bars).getByText('2.3')).toBeInTheDocument();
+
+    // Value + baseline detail block surfaces both signals.
+    expect(screen.getByText(/baseline 20\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/baseline 0\.01/)).toBeInTheDocument();
+  });
+
+  it('applies the red severity band for |z| >= 3, amber for 2-3, blue otherwise (mirrors CorrelatedAnomalyCard)', async () => {
+    const dimensions: AnomalyDimension[] = [
+      { type: 'latency_p95', value: 800, baseline: 20, zScore: 4.8, severity: 'critical' }, // red
+      { type: 'error_rate', value: 0.12, baseline: 0.005, zScore: 2.3, severity: 'warning' }, // amber
+      { type: 'cpu', value: 30, baseline: 25, zScore: 1.4, severity: 'warning' },             // blue
+    ];
+    const { container } = render(
+      wrap(
+        <InsightCard
+          insight={makeInsight({ dimensions })}
+          onAcknowledge={() => undefined}
+          isAcknowledging={false}
+        />,
+      ),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Correlated anomaly/ }));
+
+    // The bar element is the inner `div` whose className includes the
+    // severity-band utility class. Pulling them out of the rendered DOM
+    // keeps the assertion concrete without coupling to internal markup
+    // beyond what the visual band guarantees.
+    const redBars = container.querySelectorAll('.bg-red-500');
+    const amberBars = container.querySelectorAll('.bg-amber-500');
+    const blueBars = container.querySelectorAll('.bg-blue-500');
+    expect(redBars.length).toBe(1);
+    expect(amberBars.length).toBe(1);
+    expect(blueBars.length).toBe(1);
+  });
+
+  it('renders nothing for an empty dimensions array (defensive — collapsed JSONB never empties to []) ', async () => {
+    render(
+      wrap(
+        <InsightCard
+          insight={makeInsight({ dimensions: [] })}
+          onAcknowledge={() => undefined}
+          isAcknowledging={false}
+        />,
+      ),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Correlated anomaly/ }));
+    expect(screen.queryByTestId('insight-dimension-bars')).not.toBeInTheDocument();
+    expect(screen.queryByText('Correlated Signals')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/ai-intelligence/components/insight-card.tsx
+++ b/frontend/src/features/ai-intelligence/components/insight-card.tsx
@@ -20,6 +20,7 @@ import {
   FileText,
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import type { AnomalyDimension } from '@dashboard/contracts';
 import { cn, formatDate } from '@/shared/lib/utils';
 import { safeParseJson } from '@/features/ai-intelligence/hooks/use-investigations';
 import type { Investigation, RecommendedAction } from '@/features/ai-intelligence/hooks/use-investigations';
@@ -41,11 +42,72 @@ export interface InsightCardProps {
     suggested_action: string | null;
     is_acknowledged: number;
     created_at: string;
+    /**
+     * Optional multi-signal payload — present when correlated suppression
+     * collapsed co-occurring anomalies (e.g. latency p95 + error rate) for
+     * the same `(service, minute)` window into a single insight (#1296).
+     * When non-empty, the card renders a per-dimension breakdown mirroring
+     * `CorrelatedAnomalyCard`'s z-score bars so operators can see each
+     * underlying signal at a glance.
+     */
+    dimensions?: AnomalyDimension[];
   };
   investigation?: Investigation;
   onAcknowledge: (insightId: string) => void;
   isAcknowledging: boolean;
   acknowledgeErrorMessage?: string;
+}
+
+/**
+ * Per-dimension z-score / value / baseline breakdown for a correlated
+ * anomaly insight. Visual language deliberately mirrors
+ * `CorrelatedAnomalyCard` on the AI monitor page (z-bar widths capped at
+ * z=5, severity colour bands red ≥ 3 / amber ≥ 2 / blue < 2) so the two
+ * surfaces feel like the same product. Renders nothing when the array is
+ * empty so single-dimension insights keep their existing look.
+ */
+export function InsightDimensionBreakdown({ dimensions }: { dimensions: AnomalyDimension[] }) {
+  if (dimensions.length === 0) return null;
+  return (
+    <div>
+      <h4 className="text-sm font-medium mb-2">Correlated Signals</h4>
+      <div className="space-y-1.5" data-testid="insight-dimension-bars">
+        {dimensions.map((d) => {
+          const absZ = Math.abs(d.zScore);
+          const widthPct = Math.min((absZ / 5) * 100, 100);
+          // Match CorrelatedAnomalyCard's severity bands (ai-monitor.tsx
+          // lines 58-79): red ≥ 3, amber ≥ 2, blue < 2.
+          const barColor = absZ >= 3 ? 'bg-red-500' : absZ >= 2 ? 'bg-amber-500' : 'bg-blue-500';
+
+          return (
+            <div key={d.type} className="flex items-center gap-2" data-testid={`insight-dimension-${d.type}`}>
+              <span className="text-xs text-muted-foreground w-24 truncate font-mono">{d.type}</span>
+              <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
+                <div
+                  className={cn('h-full rounded-full transition-all', barColor)}
+                  style={{ width: `${widthPct}%` }}
+                />
+              </div>
+              <span className="text-xs tabular-nums text-muted-foreground w-12 text-right" title="z-score">
+                {d.zScore.toFixed(1)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground sm:grid-cols-3">
+        {dimensions.map((d) => (
+          <div key={`${d.type}-detail`} className="flex flex-col">
+            <dt className="font-mono">{d.type}</dt>
+            <dd className="tabular-nums">
+              <span className="font-medium text-foreground">{d.value.toFixed(2)}</span>
+              <span className="ml-1">(baseline {d.baseline.toFixed(2)})</span>
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
 }
 
 /**
@@ -405,6 +467,15 @@ export function InsightCard({
                 {insight.description}
               </p>
             </div>
+
+            {/*
+              Render the correlated-signal breakdown for multi-dimension
+              insights (#1296). Hidden when `dimensions` is missing or
+              empty so single-signal records keep their existing layout.
+            */}
+            {insight.dimensions && insight.dimensions.length > 0 && (
+              <InsightDimensionBreakdown dimensions={insight.dimensions} />
+            )}
 
             {insight.suggested_action && (
               <div>

--- a/packages/ai-intelligence/src/__tests__/insights-store.test.ts
+++ b/packages/ai-intelligence/src/__tests__/insights-store.test.ts
@@ -193,6 +193,46 @@ describe('insights-store', () => {
       expect(insertedIds).toBeInstanceOf(Set);
       expect(insertedIds.size).toBe(0);
     });
+
+    it('persists the `dimensions` JSONB payload for correlated anomalies (#1296)', async () => {
+      const correlated: InsightInsert = makeInsight({
+        id: 'corr-1',
+        container_id: 'svc-api',
+        container_name: 'api',
+        title: 'Correlated anomaly on service "api" (error_rate + latency_p95)',
+        metric_type: 'latency_p95',
+        detection_method: 'ml-anomaly',
+        dimensions: [
+          { type: 'latency_p95', value: 820, baseline: 21, zScore: 4.3, severity: 'critical' },
+          { type: 'error_rate', value: 0.08, baseline: 0.004, zScore: 1.6, severity: 'warning' },
+        ],
+      });
+
+      const insertedIds = await insertInsights([correlated]);
+      expect(insertedIds.has('corr-1')).toBe(true);
+
+      const rows = await testDb.query<{ dimensions: unknown }>(
+        'SELECT dimensions FROM insights WHERE id = ?',
+        ['corr-1'],
+      );
+      expect(rows).toHaveLength(1);
+      // pg driver decodes JSONB into a JS object; normalise to compare.
+      const raw = rows[0].dimensions;
+      const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      expect(parsed).toEqual([
+        { type: 'latency_p95', value: 820, baseline: 21, zScore: 4.3, severity: 'critical' },
+        { type: 'error_rate', value: 0.08, baseline: 0.004, zScore: 1.6, severity: 'warning' },
+      ]);
+    });
+
+    it('stores NULL `dimensions` for legacy single-dimension records', async () => {
+      await insertInsights([makeInsight({ id: 'legacy-1' })]);
+      const rows = await testDb.query<{ dimensions: unknown }>(
+        'SELECT dimensions FROM insights WHERE id = ?',
+        ['legacy-1'],
+      );
+      expect(rows[0].dimensions).toBeNull();
+    });
   });
 
   describe('getRecentInsights', () => {

--- a/packages/ai-intelligence/src/__tests__/insights-store.test.ts
+++ b/packages/ai-intelligence/src/__tests__/insights-store.test.ts
@@ -63,6 +63,53 @@ describe('insights-store', () => {
       expect(rows[0].suggested_action).toBe('Scale up');
       expect(rows[0].is_acknowledged).toBe(false);
     });
+
+    it('round-trips the `dimensions` JSONB payload through the singular insertInsight path (#1306 review parity)', async () => {
+      // Parity with the batch `insertInsights` test — `insertInsight`
+      // (singular) was also updated to accept `dimensions`, but the batch
+      // path was the only one that had explicit coverage. This test
+      // exercises the singular path end-to-end against the real DB so
+      // any future divergence (e.g. forgetting to cast `?::jsonb`) is
+      // caught immediately.
+      const correlated: InsightInsert = makeInsight({
+        id: 'singular-corr-1',
+        container_id: 'svc-api',
+        container_name: 'api',
+        title: 'Correlated anomaly on service "api" (error_rate + latency_p95)',
+        metric_type: 'latency_p95',
+        detection_method: 'ml-anomaly',
+        dimensions: [
+          { type: 'latency_p95', value: 950, baseline: 22, zScore: 4.8, severity: 'critical' },
+          { type: 'error_rate', value: 0.12, baseline: 0.005, zScore: 2.3, severity: 'warning' },
+        ],
+      });
+
+      await insertInsight(correlated);
+
+      const rows = await testDb.query<{ dimensions: unknown }>(
+        'SELECT dimensions FROM insights WHERE id = ?',
+        ['singular-corr-1'],
+      );
+      expect(rows).toHaveLength(1);
+      const raw = rows[0].dimensions;
+      const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      expect(parsed).toEqual([
+        { type: 'latency_p95', value: 950, baseline: 22, zScore: 4.8, severity: 'critical' },
+        { type: 'error_rate', value: 0.12, baseline: 0.005, zScore: 2.3, severity: 'warning' },
+      ]);
+    });
+
+    it('singular insertInsight stores NULL `dimensions` for legacy single-dimension records (#1306 review parity)', async () => {
+      // Inverse of the parity test above: confirms the legacy single-
+      // dimension path doesn't accidentally persist a stringified `null`
+      // or other surprise through the singular writer.
+      await insertInsight(makeInsight({ id: 'singular-legacy-1' }));
+      const rows = await testDb.query<{ dimensions: unknown }>(
+        'SELECT dimensions FROM insights WHERE id = ?',
+        ['singular-legacy-1'],
+      );
+      expect(rows[0].dimensions).toBeNull();
+    });
   });
 
   describe('insertInsights (batch)', () => {

--- a/packages/ai-intelligence/src/__tests__/monitoring-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/monitoring-route.test.ts
@@ -150,6 +150,43 @@ describe('monitoring insights cursor pagination', () => {
     expect(body.total).toBe(1);
   });
 
+  it('counts a correlated multi-dimension record as ONE insight (#1296)', async () => {
+    // Simulate a single row that carries both signals via `dimensions` —
+    // this is the post-#1296 collapsed shape. Aggregates (totals) must
+    // still count it as one anomaly, not two.
+    mockQuery.mockResolvedValueOnce([
+      {
+        id: 'corr-1',
+        severity: 'critical',
+        category: 'anomaly',
+        title: 'Correlated anomaly on service "api" (error_rate + latency_p95)',
+        description: 'Recent p95: 800ms ... Recent error rate: 8%',
+        container_name: 'api',
+        created_at: '2025-01-05T00:00:00Z',
+        metric_type: 'latency_p95',
+        detection_method: 'ml-anomaly',
+        dimensions: [
+          { type: 'latency_p95', value: 800, baseline: 21, zScore: 4.3, severity: 'critical' },
+          { type: 'error_rate', value: 0.08, baseline: 0.004, zScore: 1.6, severity: 'warning' },
+        ],
+      },
+    ]);
+    mockQueryOne.mockResolvedValueOnce({ count: 1 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/monitoring/insights?limit=10',
+      headers: { authorization: 'Bearer test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.insights).toHaveLength(1);
+    expect(body.total).toBe(1);
+    // Dimensions surface unchanged so the UI can render both signals.
+    expect(body.insights[0].dimensions).toHaveLength(2);
+  });
+
   it('acknowledges an insight', async () => {
     const response = await app.inject({
       method: 'POST',

--- a/packages/ai-intelligence/src/services/insights-store.ts
+++ b/packages/ai-intelligence/src/services/insights-store.ts
@@ -1,6 +1,6 @@
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
-import type { Insight } from '@dashboard/core/models/monitoring.js';
+import type { Insight, AnomalyDimension } from '@dashboard/core/models/monitoring.js';
 
 const log = createChildLogger('insights-store');
 
@@ -20,6 +20,13 @@ export interface InsightInsert {
   suggested_action: string | null;
   metric_type?: 'cpu' | 'memory' | 'disk' | 'network' | 'restart' | 'latency_p95' | 'error_rate';
   detection_method?: 'threshold' | 'ml-anomaly' | 'prediction' | 'health-check' | 'log-pattern' | 'security-scan';
+  /**
+   * Multi-signal payload for correlated anomalies (e.g. trace-anomaly's
+   * `(service, minute)` collapse of p95 latency + error rate — see #1296).
+   * `undefined` for single-dimension records; the legacy `metric_type`
+   * column continues to hold the primary signal for those rows.
+   */
+  dimensions?: AnomalyDimension[];
 }
 
 export async function insertInsight(insight: InsightInsert): Promise<void> {
@@ -28,9 +35,9 @@ export async function insertInsight(insight: InsightInsert): Promise<void> {
     `INSERT INTO insights (
       id, endpoint_id, endpoint_name, container_id, container_name,
       severity, category, title, description, suggested_action,
-      metric_type, detection_method,
+      metric_type, detection_method, dimensions,
       is_acknowledged, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, NOW())`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, false, NOW())`,
     [
       insight.id,
       insight.endpoint_id,
@@ -44,6 +51,7 @@ export async function insertInsight(insight: InsightInsert): Promise<void> {
       insight.suggested_action,
       insight.metric_type ?? null,
       insight.detection_method ?? null,
+      insight.dimensions ? JSON.stringify(insight.dimensions) : null,
     ],
   );
 
@@ -129,9 +137,9 @@ export async function insertInsights(insights: InsightInsert[]): Promise<Set<str
     INSERT INTO insights (
       id, endpoint_id, endpoint_name, container_id, container_name,
       severity, category, title, description, suggested_action,
-      metric_type, detection_method,
+      metric_type, detection_method, dimensions,
       is_acknowledged, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, NOW())
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, false, NOW())
   `;
 
   // Two dedup queries: structured for insights that carry metric_type +
@@ -196,6 +204,7 @@ export async function insertInsights(insights: InsightInsert[]): Promise<Set<str
         insight.suggested_action,
         insight.metric_type ?? null,
         insight.detection_method ?? null,
+        insight.dimensions ? JSON.stringify(insight.dimensions) : null,
       ]);
       ids.add(insight.id);
     }

--- a/packages/ai-intelligence/src/services/trace-anomaly.test.ts
+++ b/packages/ai-intelligence/src/services/trace-anomaly.test.ts
@@ -541,11 +541,15 @@ describe('runTraceAnomalyCycle', () => {
         if (q.bucket === '1h') return variedBaseline(baselineP95);
         // recent spike — both signals critical, with raw zScores chosen so
         // that latency's RAW zScore exceeds error_rate's RAW one but the
-        // NORMALISED error_rate wins:
-        //   latency p95 = 32 → zScore = (32-20)/2 = 6   → critical (>5)
-        //                                normalised = 6 / 2.5 = 2.4
-        //   error rate  = 15% → deviationZ = (15-0.1)/5 ≈ 2.98 → critical (>=10%)
-        //                                normalised = 2.98 (already in threshold units)
+        // NORMALISED error_rate wins. Sizing accounts for:
+        //   • TRACES_ANOMALY_P95_ZSCORE = 3.0 (raised from 2.5 in #1294)
+        //   • CV scaling (#1295): baseline mean=20, std=2 → CV=0.1 → medium
+        //     regime → 1.2× → scaledZThreshold = 3.6 → critical cut = 7.2
+        //
+        //   latency p95 = 38 → zScore = (38-20)/2 = 9     → critical (>7.2)
+        //                                  normalised = 9 / 3.0 = 3.0
+        //   error rate  = 22% → deviationZ = (22-0.1)/5 ≈ 4.38 → critical (>=10%)
+        //                                  normalised = 4.38 (already in threshold units)
         const recent: RedResult = {
           buckets: [
             {
@@ -554,10 +558,10 @@ describe('runTraceAnomalyCycle', () => {
                 {
                   group: 'api',
                   rate: 10,
-                  errorRate: 0.15,
-                  p50Ms: 16,
-                  p95Ms: 32,
-                  p99Ms: 35,
+                  errorRate: 0.22,
+                  p50Ms: 19,
+                  p95Ms: 38,
+                  p99Ms: 42,
                   callCount: 100,
                 },
               ],

--- a/packages/ai-intelligence/src/services/trace-anomaly.test.ts
+++ b/packages/ai-intelligence/src/services/trace-anomaly.test.ts
@@ -337,4 +337,164 @@ describe('runTraceAnomalyCycle', () => {
     ).resolves.toBeUndefined();
     expect(spy).not.toHaveBeenCalled();
   });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Correlated suppression (#1296)
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe('correlated suppression (#1296)', () => {
+    /**
+     * Helper: build a computeRed mock whose recent bucket carries both a
+     * p95 spike and an elevated error rate in the SAME minute bucket.
+     */
+    function spikedRecent(p95: number, errorRate: number, bucketIso: string): RedResult {
+      const recent = buildRecent('api', 20, 0.001, 5);
+      recent.buckets.push({
+        bucketStart: bucketIso,
+        rows: [
+          {
+            group: 'api',
+            rate: 10,
+            errorRate,
+            p50Ms: p95 * 0.5,
+            p95Ms: p95,
+            p99Ms: p95 * 1.1,
+            callCount: 100,
+          },
+        ],
+      });
+      return recent;
+    }
+
+    it('collapses two dimensions in the same minute into ONE record with dimensions=[p95, error_rate]', async () => {
+      const inserted: insightsStore.InsightInsert[] = [];
+      vi.spyOn(insightsStore, 'insertInsights').mockImplementation(async (rows) => {
+        inserted.push(...rows);
+        return new Set(rows.map((r) => r.id));
+      });
+
+      const sameMinute = new Date(Date.UTC(2026, 4, 14, 13, 0)).toISOString();
+      const computeRed = vi.fn(async (q: { bucket: string }) => {
+        if (q.bucket === '1h') return buildBaseline('api', 20, 0.001, 24);
+        // Both dimensions cross threshold in the same minute bucket.
+        return spikedRecent(800, 0.08, sameMinute);
+      });
+
+      await runTraceAnomalyCycle({ computeRed: computeRed as never });
+
+      // Exactly one record, with both signals in `dimensions`.
+      expect(inserted).toHaveLength(1);
+      const [record] = inserted;
+      expect(record.dimensions).toBeDefined();
+      expect(record.dimensions).toHaveLength(2);
+      const types = record.dimensions!.map((d) => d.type).sort();
+      expect(types).toEqual(['error_rate', 'latency_p95']);
+      // The primary metric_type drives signature derivation; both signals
+      // are surfaced in the title.
+      expect(['latency_p95', 'error_rate']).toContain(record.metric_type);
+      expect(record.title.toLowerCase()).toContain('correlated');
+      expect(record.title).toContain('error_rate');
+      expect(record.title).toContain('latency_p95');
+      // Service name is projected into container_name so existing
+      // correlation infra picks the record up.
+      expect(record.container_name).toBe('api');
+      // Each dimension carries enough context for downstream UI rendering.
+      for (const d of record.dimensions!) {
+        expect(typeof d.value).toBe('number');
+        expect(typeof d.baseline).toBe('number');
+        expect(typeof d.zScore).toBe('number');
+        expect(['warning', 'critical']).toContain(d.severity);
+      }
+    });
+
+    it('writes TWO separate records when the two dimensions fire in different minutes', async () => {
+      const inserted: insightsStore.InsightInsert[] = [];
+      vi.spyOn(insightsStore, 'insertInsights').mockImplementation(async (rows) => {
+        inserted.push(...rows);
+        return new Set(rows.map((r) => r.id));
+      });
+
+      // First cycle: only p95 spikes in minute T.
+      const cycleAt = (bucketIso: string, p95: number, errorRate: number) => {
+        return vi.fn(async (q: { bucket: string }) => {
+          if (q.bucket === '1h') return buildBaseline('api', 20, 0.001, 24);
+          return spikedRecent(p95, errorRate, bucketIso);
+        });
+      };
+
+      const minute1 = new Date(Date.UTC(2026, 4, 14, 13, 0)).toISOString();
+      const minute2 = new Date(Date.UTC(2026, 4, 14, 13, 15)).toISOString();
+
+      // Cycle 1 — only latency spikes.
+      await runTraceAnomalyCycle({ computeRed: cycleAt(minute1, 800, 0.001) as never });
+      // Reset cooldown so cycle 2 actually fires a new error-rate insert
+      // (the cooldown is real-time, so on a fresh process this is moot —
+      // but be explicit to guard against test-order dependence).
+      __resetTraceAnomalyLogState();
+      // Cycle 2 — only error rate spikes in a different minute.
+      await runTraceAnomalyCycle({ computeRed: cycleAt(minute2, 20, 0.08) as never });
+
+      // No correlated record: each cycle produces a single-dim insight.
+      expect(inserted.filter((r) => r.dimensions)).toHaveLength(0);
+      expect(inserted).toHaveLength(2);
+      const types = inserted.map((r) => r.metric_type).sort();
+      expect(types).toEqual(['error_rate', 'latency_p95']);
+    });
+
+    it('preserves single-dimension behaviour: one dimension only → one record without `dimensions`', async () => {
+      const inserted: insightsStore.InsightInsert[] = [];
+      vi.spyOn(insightsStore, 'insertInsights').mockImplementation(async (rows) => {
+        inserted.push(...rows);
+        return new Set(rows.map((r) => r.id));
+      });
+
+      const computeRed = vi.fn(async (q: { bucket: string }) => {
+        if (q.bucket === '1h') return buildBaseline('api', 20, 0.001, 24);
+        // Only p95 spikes; error rate stays at baseline.
+        return spikedRecent(800, 0.001, new Date(Date.UTC(2026, 4, 14, 13, 0)).toISOString());
+      });
+
+      await runTraceAnomalyCycle({ computeRed: computeRed as never });
+
+      expect(inserted).toHaveLength(1);
+      expect(inserted[0].dimensions).toBeUndefined();
+      expect(inserted[0].metric_type).toBe('latency_p95');
+      // Title is the original single-dim form, NOT the correlated form.
+      expect(inserted[0].title.toLowerCase()).toContain('latency');
+      expect(inserted[0].title.toLowerCase()).not.toContain('correlated');
+    });
+
+    it('correlated cooldown blocks BOTH per-dimension and re-correlated alerts on the same service', async () => {
+      const inserted: insightsStore.InsightInsert[] = [];
+      vi.spyOn(insightsStore, 'insertInsights').mockImplementation(async (rows) => {
+        inserted.push(...rows);
+        return new Set(rows.map((r) => r.id));
+      });
+
+      const minute1 = new Date(Date.UTC(2026, 4, 14, 13, 0)).toISOString();
+      const minute2 = new Date(Date.UTC(2026, 4, 14, 13, 5)).toISOString();
+      const computeRed = vi.fn(async (q: { bucket: string }) => {
+        if (q.bucket === '1h') return buildBaseline('api', 20, 0.001, 24);
+        // Bucket alternates to simulate two different recent minutes
+        // both crossing both thresholds.
+        const callCount = computeRed.mock.calls.length;
+        const bucket = callCount <= 2 ? minute1 : minute2;
+        return spikedRecent(800, 0.08, bucket);
+      });
+
+      // Cycle 1 — fires the correlated insert.
+      await runTraceAnomalyCycle({ computeRed: computeRed as never });
+      // Cycle 2 — even though both thresholds are crossed in a different
+      // minute, the 10-minute cooldown on the per-dimension keys still
+      // suppresses the new alert. The minute-bucket part of the
+      // correlated key is documented as "per minute" — but the
+      // per-dimension keys override that to enforce the existing
+      // "one anomaly per service per cooldown window" guarantee.
+      await runTraceAnomalyCycle({ computeRed: computeRed as never });
+
+      const newInsights = inserted.filter((r) => r.category === 'anomaly');
+      expect(newInsights).toHaveLength(1);
+      expect(newInsights[0].dimensions).toHaveLength(2);
+    });
+  });
 });

--- a/packages/ai-intelligence/src/services/trace-anomaly.test.ts
+++ b/packages/ai-intelligence/src/services/trace-anomaly.test.ts
@@ -496,5 +496,144 @@ describe('runTraceAnomalyCycle', () => {
       expect(newInsights).toHaveLength(1);
       expect(newInsights[0].dimensions).toHaveLength(2);
     });
+
+    it('correlated primary picks the dimension with the larger NORMALISED anomaly score when severities tie (#1306 review)', async () => {
+      // Tie-breaker regression: when both candidates land in the same
+      // severity bucket, the comparator must compare them on a common
+      // "threshold units" scale — NOT the raw zScore, since latency_p95
+      // carries a std-dev z-score while error_rate carries an already-
+      // normalised deviation/threshold ratio. We construct a scenario in
+      // which the RAW latency zScore beats the RAW error_rate one, but
+      // the NORMALISED error_rate score wins — and assert the persisted
+      // record's `metric_type` (primary) is `error_rate`.
+
+      const inserted: insightsStore.InsightInsert[] = [];
+      vi.spyOn(insightsStore, 'insertInsights').mockImplementation(async (rows) => {
+        inserted.push(...rows);
+        return new Set(rows.map((r) => r.id));
+      });
+
+      // Build a baseline whose p95 values have non-zero std so the
+      // latency path takes the real-zscore branch (not the std=0 fallback).
+      // We alternate p95 between 18 and 22 → mean=20, std=2.
+      function variedBaseline(p95Values: number[]): RedResult {
+        const buckets: RedBucket[] = p95Values.map((p95, i) => ({
+          bucketStart: new Date(Date.UTC(2026, 4, 13, i)).toISOString(),
+          rows: [
+            {
+              group: 'api',
+              rate: 10,
+              errorRate: 0.001,
+              p50Ms: p95 * 0.5,
+              p95Ms: p95,
+              p99Ms: p95 * 1.1,
+              callCount: 100,
+            },
+          ],
+        }));
+        return { buckets, truncated: false };
+      }
+      // 24 alternating buckets → mean=20, variance=4, std=2
+      const baselineP95 = Array.from({ length: 24 }, (_, i) => (i % 2 === 0 ? 18 : 22));
+
+      const minute = new Date(Date.UTC(2026, 4, 14, 13, 0)).toISOString();
+      const computeRed = vi.fn(async (q: { bucket: string }) => {
+        if (q.bucket === '1h') return variedBaseline(baselineP95);
+        // recent spike — both signals critical, with raw zScores chosen so
+        // that latency's RAW zScore exceeds error_rate's RAW one but the
+        // NORMALISED error_rate wins:
+        //   latency p95 = 32 → zScore = (32-20)/2 = 6   → critical (>5)
+        //                                normalised = 6 / 2.5 = 2.4
+        //   error rate  = 15% → deviationZ = (15-0.1)/5 ≈ 2.98 → critical (>=10%)
+        //                                normalised = 2.98 (already in threshold units)
+        const recent: RedResult = {
+          buckets: [
+            {
+              bucketStart: minute,
+              rows: [
+                {
+                  group: 'api',
+                  rate: 10,
+                  errorRate: 0.15,
+                  p50Ms: 16,
+                  p95Ms: 32,
+                  p99Ms: 35,
+                  callCount: 100,
+                },
+              ],
+            },
+          ],
+          truncated: false,
+        };
+        return recent;
+      });
+
+      await runTraceAnomalyCycle({ computeRed: computeRed as never });
+
+      expect(inserted).toHaveLength(1);
+      const [record] = inserted;
+      expect(record.dimensions).toHaveLength(2);
+      // Both dimensions are critical — severity tie.
+      const severitiesByType = Object.fromEntries(
+        record.dimensions!.map((d) => [d.type, d.severity]),
+      );
+      expect(severitiesByType.latency_p95).toBe('critical');
+      expect(severitiesByType.error_rate).toBe('critical');
+      // With the normalised comparator, error_rate wins the tie and
+      // becomes the primary metric_type.
+      expect(record.metric_type).toBe('error_rate');
+    });
+
+    it('fires a fresh correlated alert AFTER the 10-minute cooldown window elapses (#1306 review)', async () => {
+      // Without fake timers the 10-minute cooldown can never elapse during
+      // a unit test — so the existing "block during cooldown" check is
+      // only half the story. This test exercises the documented escape
+      // hatch: once the cooldown window has expired, the next correlated
+      // (service, minute) trigger DOES produce a new insight.
+      vi.useFakeTimers();
+      try {
+        const inserted: insightsStore.InsightInsert[] = [];
+        vi.spyOn(insightsStore, 'insertInsights').mockImplementation(async (rows) => {
+          inserted.push(...rows);
+          return new Set(rows.map((r) => r.id));
+        });
+
+        const minute1 = new Date(Date.UTC(2026, 4, 14, 13, 0)).toISOString();
+        const minute2 = new Date(Date.UTC(2026, 4, 14, 13, 30)).toISOString();
+        // Each cycle's "current minute" is decided by the bucket passed in,
+        // so we can flip between minute1 and minute2 by call index.
+        const computeRed = vi.fn(async (q: { bucket: string }) => {
+          if (q.bucket === '1h') return buildBaseline('api', 20, 0.001, 24);
+          // First cycle (two computeRed calls, baseline + recent) uses
+          // minute1; subsequent calls use minute2 so the correlated
+          // minute-bucket key flips.
+          const recentCalls = computeRed.mock.calls.filter((c) => c[0].bucket === '1m').length;
+          const bucket = recentCalls <= 1 ? minute1 : minute2;
+          return spikedRecent(800, 0.08, bucket);
+        });
+
+        // Cycle 1 — produces the first correlated record.
+        await runTraceAnomalyCycle({ computeRed: computeRed as never });
+        expect(inserted).toHaveLength(1);
+        expect(inserted[0].dimensions).toHaveLength(2);
+
+        // Advance the clock past the 10-minute cooldown (11 minutes to be
+        // safely past). The internal `lastInsertedAt` map reads `Date.now()`
+        // when checking cooldown, so fake timers fully control the gate.
+        vi.advanceTimersByTime(11 * 60 * 1000);
+
+        // Cycle 2 — same service, different minute, both signals still
+        // spiked. With the cooldown expired this MUST fire a fresh
+        // correlated record (escape hatch documented inline on
+        // `trace-anomaly.ts`).
+        await runTraceAnomalyCycle({ computeRed: computeRed as never });
+
+        expect(inserted).toHaveLength(2);
+        expect(inserted[1].dimensions).toHaveLength(2);
+        expect(inserted[1].title.toLowerCase()).toContain('correlated');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/packages/ai-intelligence/src/services/trace-anomaly.ts
+++ b/packages/ai-intelligence/src/services/trace-anomaly.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { getConfig } from '@dashboard/core/config/index.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
+import type { AnomalyDimension } from '@dashboard/core/models/monitoring.js';
 import * as insightsStore from './insights-store.js';
 import type { InsightInsert } from './insights-store.js';
 import { classifyCv, cvThresholdMultiplier, meanAndStd } from './anomaly-stats.js';
@@ -74,9 +75,20 @@ export interface TraceAnomalyDeps {
 const LOG_THROTTLE_MS = 60_000;
 const lastLoggedAt = new Map<string, number>();
 
-// Suppress duplicate anomaly inserts for the same (service, metric_type) when
-// the underlying problem is persistent. 10 minutes mirrors the cooldown the
-// existing metric anomaly detector uses for ongoing conditions.
+// Suppress duplicate anomaly inserts when the underlying problem is
+// persistent. 10 minutes mirrors the cooldown the existing metric anomaly
+// detector uses for ongoing conditions.
+//
+// Cooldown key semantics (#1296):
+//   • Single-dimension record  → `<metric_type>:<service>` (e.g.
+//     `latency_p95:api`). One cooldown per (service, dimension) — a service
+//     with persistent latency does NOT block a fresh error-rate alert.
+//   • Correlated (multi-dim) record → `correlated:<service>:<minuteEpoch>`
+//     AND, on insert, the per-dimension keys above are also marked so a
+//     second cycle in the same 10-minute window cannot fire either an
+//     individual or a re-correlated alert. The minute bucket is part of
+//     the key so the next minute's correlation can still flag a NEW
+//     incident if the cooldown has elapsed.
 const COOLDOWN_MS = 10 * 60 * 1000;
 const lastInsertedAt = new Map<string, number>();
 
@@ -165,7 +177,9 @@ function collectHourlyBaselineSeries(
   return out;
 }
 
-function latestBucketOfRecent(recent: RedResult): { hour: number; rows: RedRow[] } | null {
+function latestBucketOfRecent(
+  recent: RedResult,
+): { hour: number; rows: RedRow[]; bucketStart: string } | null {
   // Buckets come back ordered by bucket_start ASC; the trailing bucket is the
   // most recent 1-minute observation. We deliberately inspect ONLY that
   // trailing bucket — older buckets in the 1h recent window are intentionally
@@ -182,11 +196,19 @@ function latestBucketOfRecent(recent: RedResult): { hour: number; rows: RedRow[]
   //      check by a minute or two rather than dropping the anomaly.
   //   2. The hour-of-day baseline now needs a single observation hour to look
   //      up, not a smear across 60 minutes.
+  //
+  // Correlated suppression note (#1296): the `bucketStart` we return here
+  // becomes the `minuteKey` for ALL candidates emitted this cycle, so two
+  // dimensions (latency + error-rate) that fire on the same trailing minute
+  // collapse into a single correlated insight. Because `latestBucketOfRecent`
+  // already restricts evaluation to one bucket, correlated suppression
+  // operates strictly within that trailing minute — which matches the spec's
+  // "same minute" requirement.
   const last = recent.buckets[recent.buckets.length - 1];
   if (!last) return null;
   const hour = new Date(last.bucketStart).getUTCHours();
   if (Number.isNaN(hour)) return null;
-  return { hour, rows: last.rows };
+  return { hour, rows: last.rows, bucketStart: last.bucketStart };
 }
 
 interface BaselineDecision {
@@ -213,6 +235,37 @@ export function pickBaselineSeries(opts: {
     return { series: hourSeries, usedHourOfDay: true };
   }
   return { series: opts.flat.get(opts.service) ?? [], usedHourOfDay: false };
+}
+
+/**
+ * Truncate an ISO timestamp to the minute boundary (UTC). Used as the
+ * correlation key so two signals that fire from the same minute-bucket get
+ * collapsed into a single insight.
+ */
+function minuteEpoch(bucketStart: string): number {
+  return Math.floor(new Date(bucketStart).getTime() / 60_000);
+}
+
+/**
+ * Candidate anomaly emitted by the detection pass before correlated
+ * suppression collapses same-minute signals into a single insight.
+ */
+interface AnomalyCandidate {
+  service: string;
+  minuteKey: number;
+  dimension: AnomalyDimension;
+  /**
+   * Severity for the final insight if this candidate ends up being the
+   * sole signal. Correlated records compute severity as the max across
+   * dimensions.
+   */
+  severity: 'critical' | 'warning';
+  /** Per-dimension human-readable title for single-dim insights. */
+  title: string;
+  /** Per-dimension human-readable description for single-dim insights. */
+  description: string;
+  /** Per-dimension suggested operator action for single-dim insights. */
+  suggestedAction: string;
 }
 
 /**
@@ -264,7 +317,22 @@ export async function runTraceAnomalyCycle(deps: TraceAnomalyDeps): Promise<void
   const hourlyP95 = collectHourlyBaselineSeries(baseline, 'p95Ms');
   const hourlyErr = collectHourlyBaselineSeries(baseline, 'errorRate');
 
-  const insights: InsightInsert[] = [];
+  // ─── Phase 1: detection ──────────────────────────────────────────────
+  // Build a list of (service, dimension) candidates BEFORE deciding what to
+  // persist. Correlated suppression (#1296) needs to see both dimensions at
+  // once so it can collapse same-minute pairs into a single insight.
+  const candidatesByService = new Map<string, AnomalyCandidate[]>();
+
+  function pushCandidate(c: AnomalyCandidate): void {
+    const arr = candidatesByService.get(c.service);
+    if (arr) arr.push(c);
+    else candidatesByService.set(c.service, [c]);
+  }
+
+  // All candidates emitted this cycle share the trailing-bucket minute key:
+  // `latestBucketOfRecent` restricts us to a single 1m bucket, so the
+  // correlated-suppression scope is "same minute" by construction (#1296).
+  const mKey = minuteEpoch(latest.bucketStart);
 
   for (const row of latest.rows) {
     const service = row.group;
@@ -289,10 +357,9 @@ export async function runTraceAnomalyCycle(deps: TraceAnomalyDeps): Promise<void
       const regime = classifyCv(mean, std);
       const scaledZThreshold = zThreshold * cvThresholdMultiplier(regime);
 
-
       // When std == 0 (perfectly stable baseline) z-score is undefined; use a
-      // relative deviation rule instead — flag if recent is > 2x baseline mean
-      // and at least 50ms above it (avoids tiny-value noise).
+      // relative deviation rule instead — flag if recent is > 2x baseline
+      // mean and at least 50ms above it (avoids tiny-value noise).
       let zScore: number;
       let isAnomalous: boolean;
       if (std > 0) {
@@ -320,32 +387,32 @@ export async function runTraceAnomalyCycle(deps: TraceAnomalyDeps): Promise<void
             'trace latency p95 anomaly',
           );
         }
-        if (!inCooldown(seriesKey) && !inServiceRateLimit(service, perServiceWindowMs)) {
-          markInserted(seriesKey, service);
-          insights.push({
-            id: uuidv4(),
-            endpoint_id: null,
-            endpoint_name: null,
-            container_id: null,
-            // Project the service name into container_name so existing
-            // dashboard correlation that groups insights by container surfaces
-            // these anomalies alongside metric-driven ones (#1236 AC).
-            container_name: service,
-            severity: zScore > scaledZThreshold * 2 ? 'critical' : 'warning',
-            category: 'anomaly',
-            title: `High latency p95 on service "${service}"`,
-            description:
-              `Recent p95: ${row.p95Ms.toFixed(1)}ms ` +
-              `(baseline mean: ${mean.toFixed(1)}ms, std: ${std.toFixed(1)}ms, ` +
-              `z-score: ${zScore.toFixed(2)}, threshold: ${scaledZThreshold.toFixed(2)}, ` +
-              `cv-regime: ${regime}, baseline: ${p95Decision.usedHourOfDay ? 'hour-of-day' : 'flat'}). ` +
-              `Latency is ${Math.abs(zScore).toFixed(1)} standard deviations above the baseline.`,
-            suggested_action:
-              'Inspect the Calls tab for the affected service to identify slow endpoints, and check downstream dependencies.',
-            metric_type: 'latency_p95',
-            detection_method: 'ml-anomaly',
-          });
-        }
+        // Severity threshold uses the CV-scaled `scaledZThreshold` (#1295)
+        // so critical/warning splits move in lock-step with the gating
+        // threshold above.
+        const severity: 'critical' | 'warning' =
+          zScore > scaledZThreshold * 2 ? 'critical' : 'warning';
+        pushCandidate({
+          service,
+          minuteKey: mKey,
+          dimension: {
+            type: 'latency_p95',
+            value: row.p95Ms,
+            baseline: mean,
+            zScore,
+            severity,
+          },
+          severity,
+          title: `High latency p95 on service "${service}"`,
+          description:
+            `Recent p95: ${row.p95Ms.toFixed(1)}ms ` +
+            `(baseline mean: ${mean.toFixed(1)}ms, std: ${std.toFixed(1)}ms, ` +
+            `z-score: ${zScore.toFixed(2)}, threshold: ${scaledZThreshold.toFixed(2)}, ` +
+            `cv-regime: ${regime}, baseline: ${p95Decision.usedHourOfDay ? 'hour-of-day' : 'flat'}). ` +
+            `Latency is ${Math.abs(zScore).toFixed(1)} standard deviations above the baseline.`,
+          suggestedAction:
+            'Inspect the Calls tab for the affected service to identify slow endpoints, and check downstream dependencies.',
+        });
       }
     }
 
@@ -366,8 +433,8 @@ export async function runTraceAnomalyCycle(deps: TraceAnomalyDeps): Promise<void
     }
     const recentRatePct = row.errorRate * 100;
     if (recentRatePct >= errorRatePct) {
-      // Compare against the baseline mean as well — only flag if it's clearly
-      // worse than what the service usually emits.
+      // Compare against the baseline mean as well — only flag if it's
+      // clearly worse than what the service usually emits.
       const baselineMeanPct = errSeries.length > 0
         ? (errSeries.reduce((a, b) => a + b, 0) / errSeries.length) * 100
         : 0;
@@ -379,29 +446,143 @@ export async function runTraceAnomalyCycle(deps: TraceAnomalyDeps): Promise<void
             'trace error-rate anomaly',
           );
         }
-        if (!inCooldown(seriesKey) && !inServiceRateLimit(service, perServiceWindowMs)) {
-          markInserted(seriesKey, service);
-          insights.push({
-            id: uuidv4(),
-            endpoint_id: null,
-            endpoint_name: null,
-            container_id: null,
-            // Same correlation projection as latency_p95 above.
-            container_name: service,
-            severity: recentRatePct >= errorRatePct * 2 ? 'critical' : 'warning',
-            category: 'anomaly',
-            title: `Elevated error rate on service "${service}"`,
-            description:
-              `Recent error rate: ${recentRatePct.toFixed(2)}% ` +
-              `(baseline: ${baselineMeanPct.toFixed(2)}%, threshold: ${errorRatePct}%, ` +
-              `baseline-source: ${errDecision.usedHourOfDay ? 'hour-of-day' : 'flat'}).`,
-            suggested_action:
-              'Open the Trace Explorer for this service and inspect failed spans for the root cause.',
-            metric_type: 'error_rate',
-            detection_method: 'ml-anomaly',
-          });
-        }
+        const severity: 'critical' | 'warning' =
+          recentRatePct >= errorRatePct * 2 ? 'critical' : 'warning';
+        // Z-score-like deviation in percentage-point units, normalised by
+        // the floor threshold. Lets multi-dim records carry a comparable
+        // "how bad" number per dimension without needing a real std.
+        const deviationZ = Math.max(0, (recentRatePct - baselineMeanPct) / errorRatePct);
+        pushCandidate({
+          service,
+          minuteKey: mKey,
+          dimension: {
+            type: 'error_rate',
+            value: row.errorRate,
+            baseline: baselineMeanPct / 100,
+            zScore: deviationZ,
+            severity,
+          },
+          severity,
+          title: `Elevated error rate on service "${service}"`,
+          description:
+            `Recent error rate: ${recentRatePct.toFixed(2)}% ` +
+            `(baseline: ${baselineMeanPct.toFixed(2)}%, threshold: ${errorRatePct}%, ` +
+            `baseline-source: ${errDecision.usedHourOfDay ? 'hour-of-day' : 'flat'}).`,
+          suggestedAction:
+            'Open the Trace Explorer for this service and inspect failed spans for the root cause.',
+        });
       }
+    }
+  }
+
+  // ─── Phase 2: correlated suppression + cooldown gating ───────────────
+  // When two candidates share the same (service, minute) bucket, collapse
+  // them into a single insight whose `dimensions` array carries both
+  // signals. Single-dimension candidates flow through unchanged.
+  const insights: InsightInsert[] = [];
+
+  for (const [service, candidates] of candidatesByService) {
+    if (candidates.length === 0) continue;
+
+    // Bucket candidates by minute. In practice the recent query uses 1m
+    // buckets and `latestRowPerGroup` keeps the most-recent row only, so
+    // every candidate for a given service shares the same minute key — but
+    // the grouping is defensive in case that ever changes.
+    const byMinute = new Map<number, AnomalyCandidate[]>();
+    for (const c of candidates) {
+      const arr = byMinute.get(c.minuteKey);
+      if (arr) arr.push(c);
+      else byMinute.set(c.minuteKey, [c]);
+    }
+
+    for (const [minuteKey, group] of byMinute) {
+      // Per-service rate limit (#1294, fix 7): regardless of how many
+      // dimensions fire, a single service must not emit more than one
+      // anomaly inside the configured window. Layered on top of the
+      // per-(service, metric_type) cooldown below; the correlated path
+      // additionally relies on this to prevent rapid back-to-back inserts
+      // when multiple minute-keys queue up for the same service.
+      if (inServiceRateLimit(service, perServiceWindowMs)) continue;
+
+      if (group.length === 1) {
+        // ── Single-dimension path (unchanged behaviour) ───────────────
+        const [c] = group;
+        const dimKey = `${c.dimension.type}:${service}`;
+        if (inCooldown(dimKey) || inCooldown(`correlated:${service}:${minuteKey}`)) continue;
+        markInserted(dimKey, service);
+        insights.push({
+          id: uuidv4(),
+          endpoint_id: null,
+          endpoint_name: null,
+          container_id: null,
+          // Project the service name into container_name so existing
+          // dashboard correlation that groups insights by container
+          // surfaces these anomalies alongside metric-driven ones (#1236).
+          container_name: service,
+          severity: c.severity,
+          category: 'anomaly',
+          title: c.title,
+          description: c.description,
+          suggested_action: c.suggestedAction,
+          metric_type: c.dimension.type,
+          detection_method: 'ml-anomaly',
+        });
+        continue;
+      }
+
+      // ── Correlated path (#1296) ─────────────────────────────────────
+      // Cooldown: skip if EITHER the per-minute correlated key OR any of
+      // the per-dimension keys is hot — a recent single-dim insert for
+      // the same service shouldn't be immediately followed by a
+      // correlated one in the next cycle.
+      const correlatedKey = `correlated:${service}:${minuteKey}`;
+      if (inCooldown(correlatedKey)) continue;
+      if (group.some((c) => inCooldown(`${c.dimension.type}:${service}`))) continue;
+
+      // Pick the more severe dimension as the "primary" — its metric_type
+      // drives signature derivation and the title carries both signals.
+      const sortedBySeverity = [...group].sort((a, b) => {
+        if (a.severity !== b.severity) return a.severity === 'critical' ? -1 : 1;
+        return Math.abs(b.dimension.zScore) - Math.abs(a.dimension.zScore);
+      });
+      const primary = sortedBySeverity[0];
+      const overallSeverity: 'critical' | 'warning' = sortedBySeverity.some(
+        (c) => c.severity === 'critical',
+      )
+        ? 'critical'
+        : 'warning';
+
+      const dimensions = group.map((c) => c.dimension);
+      const dimensionsLabel = group
+        .map((c) => c.dimension.type)
+        .sort()
+        .join(' + ');
+      const combinedDescription = group.map((c) => c.description).join(' ');
+
+      // The correlated insert also bumps the per-service rate-limit clock
+      // via `markInserted(key, service)` — any subsequent single-dim or
+      // correlated firing on the same service is suppressed until the
+      // window elapses.
+      markInserted(correlatedKey, service);
+      // Also mark per-dimension keys so any out-of-band single-dim
+      // detection later in the cooldown window is suppressed.
+      for (const c of group) markInserted(`${c.dimension.type}:${service}`, service);
+
+      insights.push({
+        id: uuidv4(),
+        endpoint_id: null,
+        endpoint_name: null,
+        container_id: null,
+        container_name: service,
+        severity: overallSeverity,
+        category: 'anomaly',
+        title: `Correlated anomaly on service "${service}" (${dimensionsLabel})`,
+        description: combinedDescription,
+        suggested_action: primary.suggestedAction,
+        metric_type: primary.dimension.type,
+        detection_method: 'ml-anomaly',
+        dimensions,
+      });
     }
   }
 

--- a/packages/ai-intelligence/src/services/trace-anomaly.ts
+++ b/packages/ai-intelligence/src/services/trace-anomaly.ts
@@ -249,23 +249,41 @@ function minuteEpoch(bucketStart: string): number {
 /**
  * Candidate anomaly emitted by the detection pass before correlated
  * suppression collapses same-minute signals into a single insight.
+ *
+ * Severity lives ONLY on `dimension.severity` (single source of truth); the
+ * outer severity used to persist the record is derived from it at insert time
+ * — see `pushCandidate` / the correlated path below.
  */
 interface AnomalyCandidate {
   service: string;
   minuteKey: number;
   dimension: AnomalyDimension;
-  /**
-   * Severity for the final insight if this candidate ends up being the
-   * sole signal. Correlated records compute severity as the max across
-   * dimensions.
-   */
-  severity: 'critical' | 'warning';
   /** Per-dimension human-readable title for single-dim insights. */
   title: string;
   /** Per-dimension human-readable description for single-dim insights. */
   description: string;
   /** Per-dimension suggested operator action for single-dim insights. */
   suggestedAction: string;
+}
+
+/**
+ * Normalised "how anomalous is this" score in threshold units. A value of
+ * 1.0 means the signal just crossed threshold; 2.0 means twice the threshold;
+ * etc. Used by correlated-suppression tie-breaking so latency (z-score in
+ * std-deviation units) and error-rate (deviation in error-rate-pct units)
+ * compare on the same scale (#1306 review).
+ */
+function normalisedSignalScore(
+  dim: AnomalyDimension,
+  zThreshold: number,
+): number {
+  if (dim.type === 'latency_p95') {
+    return zThreshold > 0 ? Math.abs(dim.zScore) / zThreshold : Math.abs(dim.zScore);
+  }
+  // For `error_rate`, `zScore` is already
+  //   (recentRatePct - baselineMeanPct) / errorRatePct
+  // i.e. already expressed in threshold units, so use it directly.
+  return Math.abs(dim.zScore);
 }
 
 /**
@@ -402,7 +420,6 @@ export async function runTraceAnomalyCycle(deps: TraceAnomalyDeps): Promise<void
             zScore,
             severity,
           },
-          severity,
           title: `High latency p95 on service "${service}"`,
           description:
             `Recent p95: ${row.p95Ms.toFixed(1)}ms ` +
@@ -462,7 +479,6 @@ export async function runTraceAnomalyCycle(deps: TraceAnomalyDeps): Promise<void
             zScore: deviationZ,
             severity,
           },
-          severity,
           title: `Elevated error rate on service "${service}"`,
           description:
             `Recent error rate: ${recentRatePct.toFixed(2)}% ` +
@@ -519,7 +535,8 @@ export async function runTraceAnomalyCycle(deps: TraceAnomalyDeps): Promise<void
           // dashboard correlation that groups insights by container
           // surfaces these anomalies alongside metric-driven ones (#1236).
           container_name: service,
-          severity: c.severity,
+          // Severity is sourced from the dimension — single source of truth.
+          severity: c.dimension.severity,
           category: 'anomaly',
           title: c.title,
           description: c.description,
@@ -541,13 +558,26 @@ export async function runTraceAnomalyCycle(deps: TraceAnomalyDeps): Promise<void
 
       // Pick the more severe dimension as the "primary" — its metric_type
       // drives signature derivation and the title carries both signals.
+      //
+      // Tie-breaker (#1306 review): when both candidates share the same
+      // severity bucket we compare them on a NORMALISED scale (each signal's
+      // anomaly score divided by its own threshold). Without normalisation,
+      // latency_p95 carries a real std-dev z-score while error_rate carries
+      // a deviation-in-percentage-points/threshold ratio, so a raw
+      // `Math.abs(zScore)` comparison mixed apples and oranges. Normalising
+      // to "threshold units" makes the comparison meaningful.
       const sortedBySeverity = [...group].sort((a, b) => {
-        if (a.severity !== b.severity) return a.severity === 'critical' ? -1 : 1;
-        return Math.abs(b.dimension.zScore) - Math.abs(a.dimension.zScore);
+        if (a.dimension.severity !== b.dimension.severity) {
+          return a.dimension.severity === 'critical' ? -1 : 1;
+        }
+        return (
+          normalisedSignalScore(b.dimension, zThreshold) -
+          normalisedSignalScore(a.dimension, zThreshold)
+        );
       });
       const primary = sortedBySeverity[0];
       const overallSeverity: 'critical' | 'warning' = sortedBySeverity.some(
-        (c) => c.severity === 'critical',
+        (c) => c.dimension.severity === 'critical',
       )
         ? 'critical'
         : 'warning';

--- a/packages/contracts/src/schemas/insight.ts
+++ b/packages/contracts/src/schemas/insight.ts
@@ -3,6 +3,21 @@ import { z } from 'zod/v4';
 export const SeveritySchema = z.enum(['critical', 'warning', 'info']);
 export type Severity = z.infer<typeof SeveritySchema>;
 
+/**
+ * Per-signal payload carried by `Insight.dimensions` when an anomaly fires
+ * for the same `(service, minute)` window across more than one dimension
+ * (e.g. trace-anomaly's correlated p95-latency + error-rate suppression —
+ * see #1296). Single-dimension records leave `dimensions` undefined.
+ */
+export const AnomalyDimensionSchema = z.object({
+  type: z.enum(['cpu', 'memory', 'disk', 'network', 'restart', 'latency_p95', 'error_rate']),
+  value: z.number(),
+  baseline: z.number(),
+  zScore: z.number(),
+  severity: z.enum(['critical', 'warning']),
+});
+export type AnomalyDimension = z.infer<typeof AnomalyDimensionSchema>;
+
 export const InsightSchema = z.object({
   id: z.string(),
   endpoint_id: z.number().nullable(),
@@ -16,6 +31,7 @@ export const InsightSchema = z.object({
   suggested_action: z.string().nullable(),
   is_acknowledged: z.number().default(0),
   created_at: z.string(),
+  dimensions: z.array(AnomalyDimensionSchema).optional(),
 });
 
 export type Insight = z.infer<typeof InsightSchema>;

--- a/packages/core/src/db/postgres-migrations/035_add_insight_dimensions.sql
+++ b/packages/core/src/db/postgres-migrations/035_add_insight_dimensions.sql
@@ -1,0 +1,19 @@
+-- Migration 035: add `dimensions` JSONB column to insights
+--
+-- Supports correlated anomaly suppression (#1296). When the trace detector
+-- would fire two anomalies for the same `(service, minute)` pair across
+-- different dimensions (e.g. p95 latency + error rate), the writer now
+-- persists ONE insight whose `dimensions` array carries both signals
+-- instead of two separate records.
+--
+-- Each element in the array has the shape:
+--   { "type": "latency_p95" | "error_rate", "value": number,
+--     "baseline": number, "zScore": number, "severity": "warning" | "critical" }
+--
+-- Backwards-compatible: NULL for legacy single-dimension records, which
+-- continue to flow through the existing `metric_type` column.
+--
+-- Idempotent (`IF NOT EXISTS`) so re-runs are safe; reversible by
+-- `ALTER TABLE insights DROP COLUMN dimensions` if a rollback is needed.
+
+ALTER TABLE insights ADD COLUMN IF NOT EXISTS dimensions JSONB;

--- a/packages/core/src/models/monitoring.test.ts
+++ b/packages/core/src/models/monitoring.test.ts
@@ -43,4 +43,36 @@ describe('InsightSchema', () => {
     const result = InsightSchema.safeParse({ ...valid, metric_type: 'bogus' });
     expect(result.success).toBe(false);
   });
+
+  it('accepts a multi-signal `dimensions` array for correlated anomalies (#1296)', () => {
+    const result = InsightSchema.safeParse({
+      ...valid,
+      metric_type: 'latency_p95',
+      detection_method: 'ml-anomaly',
+      dimensions: [
+        { type: 'latency_p95', value: 800, baseline: 20, zScore: 4.2, severity: 'critical' },
+        { type: 'error_rate', value: 0.08, baseline: 0.005, zScore: 1.6, severity: 'warning' },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dimensions).toHaveLength(2);
+      expect(result.data.dimensions?.[0].type).toBe('latency_p95');
+    }
+  });
+
+  it('rejects a `dimensions` entry with an unknown type', () => {
+    const result = InsightSchema.safeParse({
+      ...valid,
+      dimensions: [{ type: 'bogus', value: 1, baseline: 0, zScore: 0, severity: 'warning' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts the new trace metric_type values (`latency_p95`, `error_rate`)', () => {
+    for (const t of ['latency_p95', 'error_rate'] as const) {
+      const result = InsightSchema.safeParse({ ...valid, metric_type: t });
+      expect(result.success).toBe(true);
+    }
+  });
 });

--- a/packages/core/src/models/monitoring.ts
+++ b/packages/core/src/models/monitoring.ts
@@ -1,5 +1,23 @@
 import { z } from 'zod/v4';
 
+/**
+ * Per-signal payload carried by `Insight.dimensions` when an anomaly fires
+ * for the same `(service, minute)` window across more than one dimension
+ * (e.g. trace-anomaly's correlated p95-latency + error-rate suppression — see
+ * `packages/ai-intelligence/src/services/trace-anomaly.ts` and issue #1296).
+ *
+ * `type` mirrors `metric_type` so consumers can derive severity per signal.
+ */
+export const AnomalyDimensionSchema = z.object({
+  type: z.enum(['cpu', 'memory', 'disk', 'network', 'restart', 'latency_p95', 'error_rate']),
+  value: z.number(),
+  baseline: z.number(),
+  zScore: z.number(),
+  severity: z.enum(['critical', 'warning']),
+});
+
+export type AnomalyDimension = z.infer<typeof AnomalyDimensionSchema>;
+
 export const InsightSchema = z.object({
   id: z.string(),
   endpoint_id: z.number().nullable(),
@@ -13,10 +31,19 @@ export const InsightSchema = z.object({
   suggested_action: z.string().nullable(),
   is_acknowledged: z.number().default(0),
   created_at: z.string(),
-  metric_type: z.enum(['cpu', 'memory', 'disk', 'network', 'restart']).optional(),
+  metric_type: z.enum(['cpu', 'memory', 'disk', 'network', 'restart', 'latency_p95', 'error_rate']).optional(),
   detection_method: z
     .enum(['threshold', 'ml-anomaly', 'prediction', 'health-check', 'log-pattern', 'security-scan'])
     .optional(),
+  /**
+   * When set, this insight collapses multiple co-occurring signals (e.g.
+   * latency p95 + error-rate spiking in the same minute for the same
+   * service). The legacy `metric_type` field still carries the dominant /
+   * primary signal so existing signature derivation keeps working;
+   * `dimensions` carries the full multi-signal payload for richer UI
+   * rendering. Single-dimension records have `dimensions === undefined`.
+   */
+  dimensions: z.array(AnomalyDimensionSchema).optional(),
 });
 
 export type Insight = z.infer<typeof InsightSchema>;


### PR DESCRIPTION
Closes #1296. Part of epic #1291.

## Summary

Collapses co-occurring p95-latency + error-rate trace anomalies into a single insight on the write path of `trace-anomaly.ts`. When both signals cross threshold for the same service in the same minute bucket, the writer persists one record whose new `dimensions` JSONB column carries both signals instead of two separate rows — operators stop seeing what they read as a "double flag" of the same incident. Single-dimension behavior is unchanged. Adds migration 035 (`dimensions JSONB` column on `insights`, idempotent + reversible), extends the `Insight` model + contracts schema with an optional `dimensions: AnomalyDimension[]` field and adds `latency_p95` / `error_rate` to the `metric_type` enum so the existing trace-anomaly metric types finally validate. Cooldown semantics documented inline on `trace-anomaly.ts`: single-dim records keyed `<metric_type>:<service>`, correlated records keyed `correlated:<service>:<minute>` plus the per-dimension keys (so a recent single-dim alert blocks a correlated one for the cooldown window and vice versa).

## Merge-train slot (epic #1291)

This PR **holds the `035_add_insight_dimensions.sql` slot** in the epic merge order. Downstream PRs #1304 and #1305 are responsible for renumbering their own migrations to `036` / `037` after this lands — no file renames happen here. Reviewers can safely merge in the order #1306 → #1304 → #1305.

## Review follow-ups (PR:Warning round)

- **Finding 1 (migration slot):** confirmed above — `035` belongs to this PR.
- **Finding 2 (UI wiring):** chose **Option A** — `InsightCard` now accepts an optional `dimensions: AnomalyDimension[]` and renders a per-dimension z-score / value / baseline breakdown when present, mirroring `CorrelatedAnomalyCard`'s severity colour bands (red ≥ 3, amber ≥ 2, blue < 2). Single-signal insights keep their existing layout. Covered by `frontend/src/features/ai-intelligence/components/insight-card.test.tsx` (4 cases including a 2-dimension correlated fixture).
- **Finding 3 (cooldown escape hatch):** added a fake-timer test that advances 11 minutes past the 10-minute cooldown and asserts the next correlated cycle fires a fresh record.
- **Finding 4 (severity tie-breaker units):** tie-breaker now compares candidates on a **normalised "threshold units" scale** via a new `normalisedSignalScore()` helper, so latency std-dev z-scores and error-rate percentage-point deviations are no longer mixed apples-to-oranges. Documented inline; regression test asserts error_rate wins the tie when its normalised score beats latency's.
- **Finding 5 (insertInsight parity):** added a DB-backed parity test asserting `insertInsight()` (singular) round-trips the `dimensions` JSONB payload, plus its NULL inverse for the legacy single-dim path.
- **Finding 6 (severity duplication):** removed the duplicated outer `severity` field from `AnomalyCandidate`; severity now lives only on `dimension.severity` and the persisted record derives it from there.

## Test plan
- [x] Two-dim same minute → one record (`dimensions=[error_rate, latency_p95]`, title carries both signals)
- [x] Two-dim different minutes → two records, no `dimensions`
- [x] One-dim regression preserved (single-dim insert path, no `dimensions`)
- [x] Cooldown semantics covered + documented (correlated record blocks subsequent per-dim AND re-correlated alerts on same service)
- [x] Cooldown escape hatch: fake-timer test confirms a fresh correlated alert fires after the 10-minute window elapses
- [x] Severity tie-breaker normalises to threshold units so latency / error-rate compare on the same scale
- [x] Singular `insertInsight()` round-trips the `dimensions` JSONB payload (parity with batch path)
- [x] Migration 035 idempotent (`IF NOT EXISTS`) + reversible (`DROP COLUMN dimensions`)
- [x] Route-level test: collapsed multi-dim record counts as ONE insight in `/api/monitoring/insights` totals (covers fleet-health-summary aggregates)
- [x] `InsightCard` renders the per-dimension breakdown for correlated insights, hidden for single-dim (4 frontend tests)
- [x] Lint / typecheck clean
- [x] All ai-intelligence + core + frontend tests green (ai-intelligence: 818 passed, core: 722 passed, frontend: 1960 passed)
