### PR TITLE
fix(dev-compose): resolve workspace-isolated tsx for backend container

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,7 +3,11 @@ services:
     build:
       context: ..
       dockerfile: backend/Dockerfile.dev
-    command: ["npx", "tsx", "watch", "packages/server/src/index.ts"]
+    # npm 11 with workspaces does not hoist `tsx` from backend/devDependencies
+    # to the root `node_modules/.bin/`, so a bare `npx tsx` from WORKDIR=/app
+    # fails with "tsx: not found". Use `npm exec --workspace=backend` so npm
+    # finds the workspace-installed binary regardless of hoisting outcome.
+    command: ["npm", "exec", "--workspace=backend", "--", "tsx", "watch", "/app/packages/server/src/index.ts"]
     ports:
       # Publish backend API on all host interfaces so edge nodes can reach OTLP ingest.
       - "0.0.0.0:3051:3051"


### PR DESCRIPTION
## Summary

The dev backend container fails to start with `sh: tsx: not found` after any image rebuild.

## Root cause

After the recent `tsx` version bump (`4.21.0 → 4.22.3`, #1266) and the move to npm 11, `npm ci` no longer hoists `tsx` from `backend/devDependencies` to the root `/app/node_modules/.bin/`. The binary still ships, but only at `/app/backend/node_modules/.bin/tsx` — outside the `npx` search path from `WORKDIR=/app`.

The currently running production-style backend container was last built before that bump landed, so the bug only surfaces on a fresh rebuild (which is what I hit when rebuilding the container after merging the 8 PRs landed today).

Reproduce:

\`\`\`bash
docker compose -f docker/docker-compose.dev.yml build backend
docker compose -f docker/docker-compose.dev.yml up -d backend
docker logs docker-backend-1   # sh: tsx: not found, exit 127
\`\`\`

## Fix

Use `npm exec --workspace=backend` so npm resolves the workspace's local bin regardless of hoisting outcome, and an absolute path for the entry script (since `--workspace` shifts the CWD into `backend/`). Added an inline comment recording the constraint so this is not silently "cleaned up" in a future drive-by.

## Test plan

- [x] `docker compose -f docker/docker-compose.dev.yml build backend` — succeeds (unchanged)
- [x] `docker compose -f docker/docker-compose.dev.yml up -d backend` — container reaches `healthy`
- [x] `curl -s http://127.0.0.1:3051/health` → `{"status":"ok"}`
- [x] `tsx watch` still reloads on source change (verified by editing a `packages/server/src/*.ts` file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)