### PR TITLE
fix(dev-cors): allow 127.0.0.1 loopback aliases in dev allow-list

### DIFF
--- a/packages/core/src/plugins/cors.test.ts
+++ b/packages/core/src/plugins/cors.test.ts
@@ -66,6 +66,46 @@ describe('cors plugin', () => {
     await app.close();
   });
 
+  it('sends credentials header for 127.0.0.1:8080 (loopback alias of localhost)', async () => {
+    process.env.NODE_ENV = 'development';
+    const app = Fastify();
+    await app.register(corsPlugin);
+    app.get('/ping', async () => ({ ok: true }));
+    await app.ready();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/ping',
+      headers: { origin: 'http://127.0.0.1:8080' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['access-control-allow-origin']).toBe('http://127.0.0.1:8080');
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+
+    await app.close();
+  });
+
+  it('sends credentials header for 127.0.0.1:5273 (loopback alias of localhost)', async () => {
+    process.env.NODE_ENV = 'development';
+    const app = Fastify();
+    await app.register(corsPlugin);
+    app.get('/ping', async () => ({ ok: true }));
+    await app.ready();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/ping',
+      headers: { origin: 'http://127.0.0.1:5273' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['access-control-allow-origin']).toBe('http://127.0.0.1:5273');
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+
+    await app.close();
+  });
+
   it('does not send CORS headers for disallowed origins', async () => {
     process.env.NODE_ENV = 'development';
     const app = Fastify();

--- a/packages/core/src/plugins/dev-origins.ts
+++ b/packages/core/src/plugins/dev-origins.ts
@@ -1,8 +1,16 @@
 /**
  * Single source of truth for development-mode allowed origins.
  * Used by both the CORS plugin and Socket.IO plugin to avoid drift.
+ *
+ * Browsers treat `localhost` and `127.0.0.1` as distinct origins for CORS
+ * purposes (RFC 6454 §4: origin = scheme+host+port, where host is a string
+ * compare). Both loopback aliases are listed so a developer hitting either
+ * URL gets the same allow-list behaviour. Production allow-listing is
+ * controlled separately via CORS_ALLOWED_ORIGINS — this constant is dev-only.
  */
 export const DEV_ALLOWED_ORIGINS = [
   'http://localhost:5273',
   'http://localhost:8080',
+  'http://127.0.0.1:5273',
+  'http://127.0.0.1:8080',
 ];


### PR DESCRIPTION
## Summary

The dev CORS allow-list at `packages/core/src/plugins/dev-origins.ts` only lists the `localhost` forms (`http://localhost:5273`, `http://localhost:8080`), so opening the app at `http://127.0.0.1:8080/` fails every API call at the browser's preflight check — including `POST /api/auth/login`, which means the login form returns a generic failure even when the user enters the right credentials.

Browsers treat `localhost` and `127.0.0.1` as distinct origins (RFC 6454 §4 — origin is `scheme + host + port`, where host is a string compare, not a DNS-aware compare).

## Reproducing

Before this fix:
1. `docker compose -f docker/docker-compose.dev.yml up -d`
2. Open `http://127.0.0.1:8080/`, log in with the configured `dashboard-admin` user.
3. DevTools Console: `Access to fetch at 'http://localhost:3051/api/auth/login' from origin 'http://127.0.0.1:8080' has been blocked by CORS policy`.
4. Network tab: `POST /api/auth/login → ERR_FAILED` (never reaches the backend).

## Fix

Add the 127.0.0.1 variants to `DEV_ALLOWED_ORIGINS`:

```ts
export const DEV_ALLOWED_ORIGINS = [
  'http://localhost:5273',
  'http://localhost:8080',
  'http://127.0.0.1:5273',  // new
  'http://127.0.0.1:8080',  // new
];
```

Production behaviour is unchanged — that is gated by `CORS_ALLOWED_ORIGINS` (set in `docker/.env` for prod), not by this constant. Both `@fastify/cors` (REST) and Socket.IO read from the same `DEV_ALLOWED_ORIGINS` source, so the change applies to both.

## Test plan

- [x] `npm run lint` — clean
- [x] `tsc --build tsconfig.build.json` — clean (pre-existing per-workspace `tsc --noEmit` test-file errors on `dev` are unchanged)
- [x] `packages/core/src/plugins/cors.test.ts` — 9 tests pass (7 original + 2 new regression tests for `127.0.0.1:8080` and `127.0.0.1:5273`)
- [x] Repro walkthrough verified live with Playwright on the running dev container before opening this PR — `POST /api/auth/login` now succeeds on either loopback alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)