### PR TITLE
feat(workload-explorer): drop redundant container-count label (#1309)

### DIFF
--- a/frontend/src/shared/components/forms/workload-smart-search.test.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.test.tsx
@@ -87,9 +87,10 @@ describe('WorkloadSmartSearch', () => {
     expect(screen.getByRole('button', { name: /all nginx containers on prod/i })).toBeInTheDocument();
   });
 
-  it('shows container count when empty', () => {
+  it('does not render the redundant container-count label (issue #1309)', () => {
     renderComponent();
-    expect(screen.getByText('3 containers')).toBeInTheDocument();
+    expect(screen.queryByText('3 containers')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Showing \d+ of \d+ containers?$/)).not.toBeInTheDocument();
   });
 
   it('typing calls onFiltered and stays in filter mode (no AI mutate)', () => {
@@ -120,12 +121,6 @@ describe('WorkloadSmartSearch', () => {
     renderComponent();
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'nginx' } });
     expect(screen.queryByRole('button', { name: /state:running/i })).not.toBeInTheDocument();
-  });
-
-  it('shows "Showing X of Y" count when filtered', () => {
-    renderComponent();
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'nginx' } });
-    expect(screen.getByText('Showing 1 of 3 containers')).toBeInTheDocument();
   });
 
   it('pressing Enter calls mutate (AI mode) and shows AI badge', async () => {
@@ -177,7 +172,6 @@ describe('WorkloadSmartSearch', () => {
     // onFiltered called with all containers after clear
     const lastCall = onFiltered.mock.calls[onFiltered.mock.calls.length - 1][0] as Container[];
     expect(lastCall).toHaveLength(3);
-    expect(screen.getByText('3 containers')).toBeInTheDocument();
   });
 
   it('Escape key resets all state', () => {
@@ -254,11 +248,6 @@ describe('WorkloadSmartSearch', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/logs');
   });
 
-  it('shows singular "container" for totalCount=1', () => {
-    renderComponent({ containers: [containers[0]], totalCount: 1 });
-    expect(screen.getByText('1 container')).toBeInTheDocument();
-  });
-
   describe('filter action (AI search filtering)', () => {
     it('applies AI filter and calls onFiltered with matching containers', async () => {
       const { onFiltered } = renderComponent();
@@ -304,9 +293,9 @@ describe('WorkloadSmartSearch', () => {
       });
 
       await waitFor(() => {
-        // The count text appears in the card badge area and the footer count display
-        const matches = screen.getAllByText('AI found 2 of 3 containers');
-        expect(matches.length).toBeGreaterThanOrEqual(1);
+        // The count text now only appears inside the AI result card badge
+        // (the footer count label was removed in #1309).
+        expect(screen.getByText('AI found 2 of 3 containers')).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/shared/components/forms/workload-smart-search.test.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.test.tsx
@@ -89,7 +89,12 @@ describe('WorkloadSmartSearch', () => {
 
   it('does not render the redundant container-count label (issue #1309)', () => {
     renderComponent();
-    expect(screen.queryByText('3 containers')).not.toBeInTheDocument();
+    // Cover all three branches of the deleted label, with arbitrary totals:
+    // - `N container(s)` (no filter)
+    // - `Showing N of M container(s)` (text filter)
+    // - `AI found N of M container(s)` would only render via the AI-filter
+    //   card, which is preserved — we explicitly do NOT assert it absent.
+    expect(screen.queryByText(/^\d+ containers?$/)).not.toBeInTheDocument();
     expect(screen.queryByText(/^Showing \d+ of \d+ containers?$/)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/shared/components/forms/workload-smart-search.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.tsx
@@ -47,13 +47,11 @@ export function WorkloadSmartSearch({
   const [mode, setMode] = useState<SearchMode>('filter');
   const [aiResult, setAiResult] = useState<NlQueryResult | null>(null);
   const [aiFilteredCount, setAiFilteredCount] = useState<number | null>(null);
-  const [filteredCount, setFilteredCount] = useState(containers.length);
   const nlQuery = useNlQuery();
 
   const applyFilter = useCallback(
     (q: string, conts: Container[]) => {
       const filtered = filterContainers(conts, q, knownStackNames);
-      setFilteredCount(filtered.length);
       onFiltered(filtered);
     },
     [knownStackNames, onFiltered],
@@ -76,7 +74,6 @@ export function WorkloadSmartSearch({
 
   // Re-apply filter when upstream containers change (dropdown filter changed)
   useEffect(() => {
-    setFilteredCount(containers.length);
     if (query && mode === 'filter') {
       applyFilter(query, containers);
     }
@@ -120,7 +117,6 @@ export function WorkloadSmartSearch({
     setMode('filter');
     setAiResult(null);
     setAiFilteredCount(null);
-    setFilteredCount(containers.length);
     onFiltered(containers);
   }, [containers, onFiltered]);
 
@@ -164,7 +160,6 @@ export function WorkloadSmartSearch({
 
   const isAiMode = mode === 'ai';
   const isAiFilterActive = isAiMode && aiResult?.action === 'filter' && aiFilteredCount !== null;
-  const showFilteredCount = query && mode === 'filter' && filteredCount !== totalCount;
 
   return (
     <div className="space-y-3">
@@ -336,15 +331,6 @@ export function WorkloadSmartSearch({
           )}
         </div>
       )}
-
-      {/* Count display */}
-      <p className="text-sm text-muted-foreground">
-        {isAiFilterActive
-          ? `AI found ${aiFilteredCount} of ${totalCount} container${totalCount !== 1 ? 's' : ''}`
-          : showFilteredCount
-            ? `Showing ${filteredCount} of ${totalCount} container${totalCount !== 1 ? 's' : ''}`
-            : `${totalCount} container${totalCount !== 1 ? 's' : ''}`}
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #1309. Removes the small label below the Workload Explorer search bar that rendered one of `135 containers`, `Showing 12 of 135 containers`, or `AI found 3 of 135 containers`. The data table already conveys volume via its rows and pagination, so the label was redundant.

- Picked **Option A** (delete the label) because `git grep "WorkloadSmartSearch"` confirmed `workload-explorer.tsx` is the only runtime consumer.
- Removed the internal `filteredCount` state and the `showFilteredCount` derived flag — both existed only to feed the deleted label.
- **Kept** the `totalCount` prop and `aiFilteredCount` / `isAiFilterActive` state: they still drive the "AI filter active — AI found N of M containers" badge **inside** the AI result card, which is a separate affordance the issue does not target. So the call site in `workload-explorer.tsx` does not change.

## Files

- `frontend/src/shared/components/forms/workload-smart-search.tsx` — delete the `<p>` label + the now-orphaned state/derivation.
- `frontend/src/shared/components/forms/workload-smart-search.test.tsx` — drop three assertions targeting the label (`'3 containers'`, `'Showing 1 of 3 containers'`, `'1 container'`); add a regression assertion that the label is not rendered; tighten the AI-card count assertion to expect exactly one match.

## Test plan

- [x] `npx tsc --noEmit` (frontend) — exit 0
- [x] `npx vitest run src/shared/components/forms/workload-smart-search.test.tsx` — 23/23 pass
- [ ] **For reviewer:** load Workload Explorer in the browser, run a text search, then trigger an AI filter — confirm no count label between the search input and the table in any of the three states. The "AI filter active — AI found N of M containers" badge inside the AI result card should still render.

## Coordination

Touches the shared component but not `workload-explorer.tsx`, so this PR is conflict-free with #1310, #1311, #1312, #1313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)