### PR TITLE
feat(refresh): collapse Refresh + Bypass cache into single pill (#1312)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
 - **Elasticsearch Integration** — Optional Kibana/Elasticsearch log search
 - **Modern UI** — Apple-inspired glassmorphism theme with light/dark modes and command palette (`Ctrl+K`)
 
+### Data freshness & caching
+
+A Redis-backed server cache sits between Portainer and the dashboard so background polls and auto-refresh intervals don't hammer the upstream API. Clicking **Refresh** on any page is treated as a foreground request for the latest data — it invalidates the cache for that resource and re-fetches from Portainer directly. Non-admin users still get a fresh page render (the cache-invalidate endpoint is admin-only, so non-admin clicks gracefully degrade to a plain refetch with no error toast). Auto-refresh and React Query background revalidation continue to read the cache.
+
 ---
 
 ## Architecture

--- a/docs/ai-instructions/architecture.md
+++ b/docs/ai-instructions/architecture.md
@@ -184,6 +184,16 @@ Each feature contains: `pages/`, `components/`, `hooks/`, and optionally `lib/`.
 Composition order in `App.tsx`:
 ThemeProvider > QueryProvider > AuthProvider > SocketProvider > SearchProvider > LazyMotion > RouterProvider
 
+## Caching model
+
+```
+[Portainer API]  →  [Server cache (Redis)]  →  [React Query]  →  [UI]
+```
+
+- The **server cache** is a Redis-backed layer in front of Portainer. Auto-refresh intervals, React Query background revalidation, and cross-panel re-renders read from it so the upstream Portainer API isn't hammered on every poll.
+- The **explicit Refresh button** (`frontend/src/shared/components/ui/refresh-button.tsx`) treats a user click as a foreground freshness signal: it invalidates the server cache for the active resource via `POST /api/admin/cache/invalidate?resource=…` and then re-fetches. `useForceRefresh` (`frontend/src/shared/hooks/use-force-refresh.ts`) swallows the 403 non-admins get from the admin-only invalidate endpoint and falls through to a plain refetch — non-admins keep working, no error toast.
+- The invalidate endpoint is admin-only (`packages/foundation/src/routes/cache-admin.ts`). Cache TTLs, keys, and invalidation patterns belong to the kernel (`packages/core/src/portainer/`).
+
 ## Key Patterns
 
 - **Observer-first**: Visibility prioritized; mutating actions require explicit approval via remediation workflow.

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -864,7 +864,9 @@ describe('InfrastructurePage — forceRefresh error toast', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: /Bypass cache/i }));
+    // Clicking the single Refresh pill triggers the force-refresh path
+    // when `onForceRefresh` is wired (the page wires it via useForceRefresh).
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/i }));
 
     await waitFor(() => {
       expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to refresh endpoints');
@@ -885,7 +887,9 @@ describe('InfrastructurePage — forceRefresh error toast', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: /Bypass cache/i }));
+    // Clicking the single Refresh pill triggers the force-refresh path
+    // when `onForceRefresh` is wired (the page wires it via useForceRefresh).
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/i }));
 
     await waitFor(() => {
       expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to refresh stacks');
@@ -898,7 +902,9 @@ describe('InfrastructurePage — forceRefresh error toast', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: /Bypass cache/i }));
+    // Clicking the single Refresh pill triggers the force-refresh path
+    // when `onForceRefresh` is wired (the page wires it via useForceRefresh).
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/i }));
 
     // Wait a tick for async resolution
     await waitFor(() => {

--- a/frontend/src/features/core/components/settings/tab-general.test.tsx
+++ b/frontend/src/features/core/components/settings/tab-general.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GeneralTab } from './tab-general';
+
+vi.mock('@/features/core/hooks/use-cache-admin', () => ({
+  useCacheStats: () => ({ data: undefined }),
+  useCacheClear: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+function renderTab() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GeneralTab theme="glass-light" />
+    </QueryClientProvider>,
+  );
+}
+
+describe('GeneralTab — caching model note (#1312)', () => {
+  it('renders the informational caching note below the cache stats', () => {
+    renderTab();
+    const note = screen.getByTestId('caching-model-note');
+    expect(note).toBeInTheDocument();
+    expect(note).toHaveTextContent(/auto-refresh and background polls read from the server cache/i);
+    expect(note).toHaveTextContent(/clicking/i);
+    expect(note).toHaveTextContent(/refresh/i);
+    expect(note).toHaveTextContent(/non-admin clicks fall back to a plain refresh/i);
+  });
+});

--- a/frontend/src/features/core/components/settings/tab-general.tsx
+++ b/frontend/src/features/core/components/settings/tab-general.tsx
@@ -137,6 +137,21 @@ export function GeneralTab({ theme }: GeneralTabProps) {
           </div>
         </div>
       </div>
+
+      {/* Caching model — informational, not a toggle. See #1312. */}
+      <div
+        data-testid="caching-model-note"
+        className="rounded-lg border border-border/60 bg-muted/30 p-4"
+      >
+        <h3 className="text-sm font-semibold">About data freshness</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Auto-refresh and background polls read from the server cache to reduce load on Portainer.
+          Clicking <strong className="font-medium text-foreground">Refresh</strong> on any page
+          invalidates the cache for that resource and fetches fresh data from Portainer directly.
+          Cache invalidation requires admin permissions; non-admin clicks fall back to a plain
+          refresh.
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/shared/components/ui/refresh-button.test.tsx
+++ b/frontend/src/shared/components/ui/refresh-button.test.tsx
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { RefreshButton } from './refresh-button';
 
-function getButtons() {
-  return screen.getAllByRole('button');
+function getButton() {
+  return screen.getByRole('button', { name: /refresh/i });
 }
 
 describe('RefreshButton', () => {
@@ -15,32 +15,45 @@ describe('RefreshButton', () => {
     vi.useRealTimers();
   });
 
-  it('always renders split control with two buttons', () => {
+  it('renders a single pill button labelled Refresh', () => {
     const onClick = vi.fn();
     render(<RefreshButton onClick={onClick} />);
 
-    const buttons = getButtons();
-    expect(buttons).toHaveLength(2);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(1);
     expect(buttons[0]).toHaveTextContent('Refresh');
-    expect(buttons[1]).toHaveTextContent('Bypass cache');
+    expect(buttons[0]).toHaveClass('rounded-full');
+    expect(buttons[0]).toHaveClass('h-10');
+    expect(buttons[0]).toHaveClass('border-input');
+    expect(buttons[0]).toHaveClass('bg-background');
   });
 
-  it('calls onClick when primary refresh button is clicked', () => {
+  it('clicking the button prefers onForceRefresh when supplied', () => {
+    const onClick = vi.fn();
+    const onForceRefresh = vi.fn();
+    render(<RefreshButton onClick={onClick} onForceRefresh={onForceRefresh} />);
+
+    fireEvent.click(getButton());
+    expect(onForceRefresh).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('clicking the button falls back to onClick when no force handler is supplied', () => {
     const onClick = vi.fn();
     render(<RefreshButton onClick={onClick} />);
 
-    fireEvent.click(getButtons()[0]);
+    fireEvent.click(getButton());
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps Refresh label when loading to avoid width changes', () => {
+  it('keeps the Refresh label while loading (no width jitter)', () => {
     const onClick = vi.fn();
     render(<RefreshButton onClick={onClick} isLoading={true} />);
 
-    expect(getButtons()[0]).toHaveTextContent('Refresh');
+    expect(getButton()).toHaveTextContent('Refresh');
   });
 
-  it('applies spin animation to icon when loading', () => {
+  it('applies the spin animation to the icon while loading', () => {
     const onClick = vi.fn();
     const { container } = render(<RefreshButton onClick={onClick} isLoading={true} />);
 
@@ -48,7 +61,7 @@ describe('RefreshButton', () => {
     expect(icon).toHaveClass('animate-spin');
   });
 
-  it('keeps spin visible briefly after loading ends', () => {
+  it('keeps the spin visible for the minimum duration after loading ends', () => {
     const onClick = vi.fn();
     const { container, rerender } = render(<RefreshButton onClick={onClick} isLoading={true} />);
 
@@ -64,50 +77,10 @@ describe('RefreshButton', () => {
     expect(icon).not.toHaveClass('animate-spin');
   });
 
-  it('applies custom className to outer container', () => {
+  it('forwards className onto the button', () => {
     const onClick = vi.fn();
-    const { container } = render(<RefreshButton onClick={onClick} className="custom-class" />);
+    render(<RefreshButton onClick={onClick} className="custom-class" />);
 
-    expect(container.firstElementChild).toHaveClass('custom-class');
-  });
-
-  it('uses rounded-full pill styling', () => {
-    const onClick = vi.fn();
-    render(<RefreshButton onClick={onClick} />);
-
-    expect(getButtons()[0]).toHaveClass('rounded-full');
-    expect(getButtons()[1]).toHaveClass('rounded-full');
-  });
-
-  it('calls onForceRefresh when flash button is clicked and handler exists', () => {
-    const onClick = vi.fn();
-    const onForceRefresh = vi.fn();
-    render(<RefreshButton onClick={onClick} onForceRefresh={onForceRefresh} />);
-
-    fireEvent.click(getButtons()[1]);
-    expect(onForceRefresh).toHaveBeenCalledTimes(1);
-    expect(onClick).not.toHaveBeenCalled();
-  });
-
-  it('falls back to onClick when flash button is clicked without force handler', () => {
-    const onClick = vi.fn();
-    render(<RefreshButton onClick={onClick} />);
-
-    fireEvent.click(getButtons()[1]);
-    expect(onClick).toHaveBeenCalledTimes(1);
-  });
-
-  it('uses clear bypass-cache tooltip when force handler exists', () => {
-    const onClick = vi.fn();
-    const onForceRefresh = vi.fn();
-    render(<RefreshButton onClick={onClick} onForceRefresh={onForceRefresh} />);
-
-    expect(getButtons()[1]).toHaveAttribute('title', 'Bypass cache and fetch fresh data');
-  });
-
-  it('uses fallback tooltip when force handler is unavailable', () => {
-    const onClick = vi.fn();
-    render(<RefreshButton onClick={onClick} />);
-    expect(getButtons()[1]).toHaveAttribute('title', 'Refresh (cache bypass unavailable on this page)');
+    expect(getButton()).toHaveClass('custom-class');
   });
 });

--- a/frontend/src/shared/components/ui/refresh-button.tsx
+++ b/frontend/src/shared/components/ui/refresh-button.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, Zap } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { useEffect, useRef, useState } from 'react';
 
@@ -14,10 +14,12 @@ export function RefreshButton({ onClick, isLoading, className, onForceRefresh }:
   const [showSpin, setShowSpin] = useState(Boolean(isLoading));
   const spinStartedAtRef = useRef(0);
   const stopTimerRef = useRef<number | null>(null);
-  const forceAction = onForceRefresh ?? onClick;
-  const forceTitle = onForceRefresh
-    ? 'Bypass cache and fetch fresh data'
-    : 'Refresh (cache bypass unavailable on this page)';
+  // An explicit click is a foreground signal that the user wants the
+  // freshest data, so prefer the cache-bypassing path when the page wires
+  // one up. `useForceRefresh` already swallows the 403 non-admins get from
+  // the invalidate endpoint and falls through to a plain refetch, so this
+  // is safe to default on.
+  const handleClick = () => (onForceRefresh ?? onClick)();
 
   useEffect(() => {
     if (stopTimerRef.current !== null) {
@@ -52,23 +54,16 @@ export function RefreshButton({ onClick, isLoading, className, onForceRefresh }:
   }, []);
 
   return (
-    <div className={cn('inline-flex h-10 items-center gap-1 rounded-full border border-input bg-background p-1', className)}>
-      <button
-        onClick={onClick}
-        className="inline-flex h-8 items-center gap-2 rounded-full px-4 text-sm font-medium hover:bg-accent"
-      >
-        <RefreshCw className={cn('h-4 w-4', showSpin && 'animate-spin')} />
-        Refresh
-      </button>
-      <button
-        onClick={forceAction}
-        title={forceTitle}
-        aria-label={forceTitle}
-        className="inline-flex h-8 items-center gap-1.5 rounded-full px-3 text-xs font-medium hover:bg-accent"
-      >
-        <Zap className="h-4 w-4" />
-        <span>Bypass cache</span>
-      </button>
-    </div>
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        'inline-flex h-10 items-center gap-2 rounded-full border border-input bg-background px-4 text-sm font-medium hover:bg-accent',
+        className,
+      )}
+    >
+      <RefreshCw className={cn('h-4 w-4', showSpin && 'animate-spin')} />
+      Refresh
+    </button>
   );
 }


### PR DESCRIPTION
## Summary

Closes #1312. The Refresh button rendered as a split pill — `Refresh` (cheap, possibly stale) + `Bypass cache` (admin-only force) — forcing operators to pick between paths most don't understand. Collapsed to a single pill that always prefers the cache-invalidating path; non-admins gracefully degrade.

## Behaviour

- Single `<button>` with the existing pill chrome (`h-10 rounded-full border border-input bg-background hover:bg-accent`).
- Click handler: `(onForceRefresh ?? onClick)()`. Pages that wire `onForceRefresh` (e.g. Workload Explorer, Fleet Overview) get cache invalidation on every click; pages that don't continue to do a plain refetch — same behavior as the old left button.
- Non-admins hit a 403 on the admin-only `/api/admin/cache/invalidate`; `useForceRefresh` already swallows that and falls through to `refetch()`. No error toast, no UX regression.
- `MIN_SPIN_MS = 1500` minimum-spin animation preserved.
- The `Zap` icon and "Bypass cache" label/tooltip are deleted.

## Prop interface — unchanged

```ts
interface RefreshButtonProps {
  onClick: () => void;
  isLoading?: boolean;
  className?: string;
  onForceRefresh?: () => void;
}
```

The 14 consumer pages compile unchanged. `npx tsc --noEmit` exits 0.

## Tests

- `refresh-button.test.tsx` rewritten — 7/7 pass. Asserts single pill, click handler precedence (`onForceRefresh` wins), spin animation, className forwarding.
- `fleet-overview.test.tsx` (lines 867/888/901) updated: three tests previously clicked the now-deleted `Bypass cache` button to exercise the force-refresh path. They now click `Refresh` — same path, since Fleet Overview wires `onForceRefresh` via `useForceRefresh`. 58/58 pass.
- New `tab-general.test.tsx` — asserts the informational caching-model card renders.
- Full frontend suite via the pre-push hook: 2000/2000 pass.

## Docs

- **README** — new "Data freshness & caching" subsection at the end of Features.
- **docs/ai-instructions/architecture.md** — new "Caching model" section with the `[Portainer API] → [Server cache (Redis)] → [React Query] → [UI]` diagram.
- **Settings → General tab** — new informational "About data freshness" card below the cache stats. Browser-verified.

Note is **informational, not a toggle** — no setting to disable the cache or change click behavior.

## Test plan

- [x] `npx tsc --noEmit` (frontend) — exit 0
- [x] `npm run test -w frontend` — 2000/2000 pass
- [x] Settings page renders the new informational card (DevTools verified)
- [ ] **For reviewer (Portainer needed):** admin click on Workload Explorer Refresh → DevTools shows `POST /api/admin/cache/invalidate?resource=containers` then GET `/api/containers`
- [ ] **For reviewer:** mock invalidate to 403 (or use a viewer account) → click Refresh → no toast, data still refetches

## Coordination

- **Unblocks #1311** — the toolbar pill restyle can target a single-button pill, not a split.
- No file conflict with #1309, #1310, #1313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)