### PR TITLE
feat(workload-explorer): pill-style toolbar — Compare, Export CSV, Refresh (#1311)

### DIFF
--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -847,6 +847,76 @@ describe('WorkloadExplorerPage — header Compare button', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Header toolbar — pill-style Compare / Export CSV (#1311)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('WorkloadExplorerPage — header toolbar pill buttons (#1311)', () => {
+  beforeEach(() => {
+    mockQueryString = 'endpoint=1';
+    mockSetSearchParams.mockReset();
+    mockNavigate.mockReset();
+    mockUseContainers.mockReturnValue(defaultContainersMock);
+  });
+
+  it('renders Export CSV in the header toolbar (not in the filter pane)', () => {
+    render(<WorkloadExplorerPage />);
+
+    const exportBtn = screen.getByRole('button', { name: 'Export CSV' });
+    const compareBtn = screen.getByRole('button', { name: /^Compare$/ });
+    // Both must share an ancestor `<div>` (the header toolbar). The filter
+    // pane sits inside a SpotlightCard; the header is just a flex row.
+    const headerToolbar = compareBtn.parentElement;
+    expect(headerToolbar).not.toBeNull();
+    expect(headerToolbar?.contains(exportBtn)).toBe(true);
+  });
+
+  it('renders header buttons left-to-right as Compare → Export CSV → Refresh', () => {
+    render(<WorkloadExplorerPage />);
+
+    const compareBtn = screen.getByRole('button', { name: /^Compare$/ });
+    const exportBtn = screen.getByRole('button', { name: 'Export CSV' });
+    // Refresh button comes from the RefreshButton primitive; match by name.
+    const refreshBtn = screen.getByRole('button', { name: /Refresh/i });
+
+    const order = [compareBtn, exportBtn, refreshBtn].map((el) =>
+      Array.prototype.indexOf.call(el.parentElement?.children ?? [], el),
+    );
+    // All three sit in the same flex row (header toolbar), and their
+    // indices are strictly ascending.
+    expect(compareBtn.parentElement).toBe(exportBtn.parentElement);
+    expect(order[0]).toBeLessThan(order[1]);
+    expect(order[1]).toBeLessThan(order[2]);
+  });
+
+  it('Compare and Export CSV use the pill chrome (rounded-full + h-10)', () => {
+    render(<WorkloadExplorerPage />);
+
+    const compareBtn = screen.getByRole('button', { name: /^Compare$/ });
+    const exportBtn = screen.getByRole('button', { name: 'Export CSV' });
+
+    for (const btn of [compareBtn, exportBtn]) {
+      expect(btn).toHaveClass('rounded-full');
+      expect(btn).toHaveClass('h-10');
+      expect(btn).toHaveClass('border-input');
+      expect(btn).toHaveClass('bg-background');
+    }
+  });
+
+  it('Compare stays disabled when fewer than 2 containers are selected', () => {
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByRole('button', { name: /^Compare$/ })).toBeDisabled();
+  });
+
+  it('Export CSV disabled-state semantics still trigger handleExportCsv when clicked enabled', () => {
+    render(<WorkloadExplorerPage />);
+    const exportBtn = screen.getByRole('button', { name: 'Export CSV' });
+    expect(exportBtn).not.toBeDisabled();
+    fireEvent.click(exportBtn);
+    expect(mockExportToCsv).toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Column set, ordering, and cell rendering (#1288)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useCallback } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { type ColumnDef, type RowSelectionState } from '@tanstack/react-table';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import { AlertTriangle, Boxes, Eye, GitCompareArrows, ScrollText, X } from 'lucide-react';
+import { AlertTriangle, Boxes, Download, Eye, GitCompareArrows, ScrollText, X } from 'lucide-react';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { useContainers, type Container } from '@/features/containers/hooks/use-containers';
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
@@ -19,7 +19,7 @@ import { SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { resolveContainerStackName } from '@/features/containers/lib/container-stack-grouping';
 import { exportToCsv } from '@/shared/lib/csv-export';
 import { getContainerGroup, getContainerGroupLabel, type ContainerGroup } from '@/features/containers/lib/system-container-grouping';
-import { cn, formatDate, getImageShortName, truncate, formatRelativeAge } from '@/shared/lib/utils';
+import { formatDate, getImageShortName, truncate, formatRelativeAge } from '@/shared/lib/utils';
 import { transition } from '@/shared/lib/motion-tokens';
 import { WorkloadSmartSearch } from '@/shared/components/forms/workload-smart-search';
 import { SelectionActionBar } from '@/shared/components/layout/selection-action-bar';
@@ -483,23 +483,30 @@ export default function WorkloadExplorerPage() {
             </>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {!compareMode && (
-            <button
-              type="button"
-              onClick={handleCompare}
-              disabled={selectedContainers.length < 2}
-              title={selectedContainers.length < 2 ? 'Select 2 or more containers to compare' : `Compare ${selectedContainers.length} selected containers`}
-              className={cn(
-                'inline-flex items-center gap-1.5 rounded-md border border-input px-3 py-1.5 text-sm font-medium transition-colors',
-                selectedContainers.length < 2
-                  ? 'cursor-not-allowed bg-muted/30 text-muted-foreground'
-                  : 'bg-primary text-primary-foreground hover:bg-primary/90',
-              )}
-            >
-              <GitCompareArrows className="h-4 w-4" />
-              {selectedContainers.length < 2 ? 'Compare' : `Compare ${selectedContainers.length}`}
-            </button>
+            <>
+              <button
+                type="button"
+                onClick={handleCompare}
+                disabled={selectedContainers.length < 2}
+                title={selectedContainers.length < 2 ? 'Select 2 or more containers to compare' : `Compare ${selectedContainers.length} selected containers`}
+                className="inline-flex h-10 items-center gap-2 rounded-full border border-input bg-background px-4 text-sm font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
+              >
+                <GitCompareArrows className="h-4 w-4" />
+                {selectedContainers.length < 2 ? 'Compare' : `Compare ${selectedContainers.length}`}
+              </button>
+              <button
+                type="button"
+                onClick={handleExportCsv}
+                disabled={!exportRows.length}
+                title={!exportRows.length ? 'Nothing to export' : 'Export the current view as CSV'}
+                className="inline-flex h-10 items-center gap-2 rounded-full border border-input bg-background px-4 text-sm font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
+              >
+                <Download className="h-4 w-4" />
+                Export CSV
+              </button>
+            </>
           )}
           <AutoRefreshToggle interval={interval} onIntervalChange={setInterval} />
           <RefreshButton onClick={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
@@ -631,15 +638,6 @@ export default function WorkloadExplorerPage() {
                   ]}
                 />
               </div>
-
-              <button
-                type="button"
-                onClick={handleExportCsv}
-                disabled={!exportRows.length}
-                className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
-              >
-                Export CSV
-              </button>
             </div>
 
             {preStateFilteredContainers.length > 0 && (


### PR DESCRIPTION
## Summary

Closes #1311. Moves Export CSV from the filter pane into the header toolbar (immediately after Compare) and restyles Compare + Export CSV to match the Refresh button's pill chrome. The three controls now read as a single, coherent action group.

## Before / after

```
Header:  [Compare (filled-primary md)]              [AutoRefresh] [Refresh (pill)]
Filter:  [Endpoint] [Stack] [Group] [State]       [Export CSV (outline md)]

Header:  [Compare (pill)] [Export CSV (pill)]    [AutoRefresh] [Refresh (pill)]
Filter:  [Endpoint] [Stack] [Group] [State]
```

## Changes

- `frontend/src/features/containers/pages/workload-explorer.tsx`
  - Add the Export CSV button to the header toolbar after Compare; remove its previous spot inside `SpotlightCard` #1.
  - Restyle both Compare and Export CSV to `inline-flex h-10 items-center gap-2 rounded-full border border-input bg-background px-4 text-sm font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background`.
  - `Download` icon added to Export CSV; Compare keeps `GitCompareArrows`.
  - Toolbar wrapper gets `flex-wrap` so the row collapses gracefully at narrow widths.
  - Preserve disabled-state semantics: Compare requires `selectedContainers.length >= 2`; Export CSV requires `exportRows.length`.
  - Drop the `cn` import — no longer used after Compare's className became a static string.
  - Drop `cn` usage by Compare; add `Download` to the lucide-react import.

## Tests

- `workload-explorer.test.tsx` — 5 new assertions in a new "header toolbar pill buttons (#1311)" describe:
  - Export CSV's parent element is the same as Compare's parent (the header), not the filter-pane SpotlightCard.
  - Visual order in that parent: Compare → Export CSV → Refresh.
  - Both buttons carry the pill class set (`rounded-full h-10 border-input bg-background`).
  - Compare stays disabled until 2+ rows are selected.
  - Clicking Export CSV still invokes `handleExportCsv` (the existing CSV export pathway is untouched).
- Full file: 49/49 pass.

## Pill primitive: inline, not extracted

Three buttons that share a shape isn't enough to justify a new `PillButton` primitive — issue explicitly allows either route, and an inline approach keeps the surface area small. If a fourth pill-shaped control appears, extracting becomes the natural follow-up.

## Test plan

- [x] `npx tsc --noEmit` (frontend) — exit 0
- [x] `npx vitest run workload-explorer.test.tsx` — 49/49 pass
- [x] Full frontend suite via pre-push hook — passes
- [ ] **For reviewer (Portainer reachable):** open Workload Explorer, confirm header reads Compare → Export CSV → AutoRefresh → Refresh; pills visually consistent; disabled states legible across Glass Light / Glass Dark / one Catppuccin
- [ ] **For reviewer:** narrow viewport (~768px) — three pills wrap onto a second row rather than overflowing

## Coordination

- Depends visually on #1312 (single-pill Refresh) — if #1312 lands first, Compare/Export pills line up with a single-button pill instead of a split. Same selectors, no rebase pain.
- Touches the same file as #1313 (`workload-explorer.tsx`) and #1309 (call site). Suggested merge order: #1309 → #1312 → #1311 → #1313 → #1310 (independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)