### PR TITLE
feat(workload-explorer): auto-fit pagination, search-above-filters, compact Group icon, sort & checkbox UX

### DIFF
--- a/docs/superpowers/plans/2026-05-29-workload-explorer-ui-refinements.md
+++ b/docs/superpowers/plans/2026-05-29-workload-explorer-ui-refinements.md
@@ -1,0 +1,1147 @@
+# Workload Explorer UI Refinements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refine the Workload Explorer list — auto-fit pagination, search above filters, horizontal scroll on narrow widths, a compact Group icon, a bigger checkbox hit-box, and a sort-direction indicator.
+
+**Architecture:** Two reusable-component changes in `data-table.tsx` (auto-fit pagination + horizontal scroll, sort indicator, enlarged selection hit-box) and two page changes in `workload-explorer.tsx` (search-above-filters reorder, Group-column icon + wiring to `autoFit`). The page's test suite mocks `DataTable`, so the scroll→pagination switch is isolated to `data-table.test.tsx` plus one mock/prop update in the page suite.
+
+**Tech Stack:** React 19, TanStack Table v8 (`getPaginationRowModel`), Tailwind CSS, lucide-react icons, Vitest + @testing-library/react (jsdom).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-workload-explorer-ui-refinements-design.md`
+
+**Branch:** `feature/workload-explorer-ui-refinements` (already created off `dev`).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `frontend/src/shared/components/tables/data-table.tsx` | Reusable table | Add `autoFit` + `minTableWidth` props, controlled auto-fit pagination, directional sort indicator, enlarged selection hit-box, `overflow-x-auto` wrappers |
+| `frontend/src/shared/components/tables/data-table.test.tsx` | Table tests | New tests for sort indicator, hit-box, auto-fit, horizontal scroll |
+| `frontend/src/features/containers/pages/workload-explorer.tsx` | Explorer page | Reorder search above filters; Group column → icon; switch `windowScroll`→`autoFit` + `minTableWidth` |
+| `frontend/src/features/containers/pages/workload-explorer.test.tsx` | Page tests | Update `DataTable` mock + `windowScroll` test; add search-order, Group-icon, `autoFit`/`minTableWidth` tests |
+
+All commands run from the repo root unless noted. Single-file test command pattern:
+`cd frontend && npx vitest run <path>`
+
+---
+
+## Task 1: Sort-direction indicator (data-table)
+
+**Files:**
+- Modify: `frontend/src/shared/components/tables/data-table.tsx` (import line 18; `renderHeader`, lines 258-285)
+- Test: `frontend/src/shared/components/tables/data-table.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this `describe` block inside the top-level `describe('DataTable', …)` in `data-table.test.tsx` (e.g. right after the existing `describe('sorting', …)` block, before `describe('server-side pagination mode', …)`):
+
+```tsx
+  describe('sort direction indicator', () => {
+    it('marks sortable headers aria-sort="none" before any sort', () => {
+      render(<DataTable columns={testColumns} data={makeRows(5)} />);
+      const nameHeader = screen.getByText('Name').closest('th');
+      expect(nameHeader).toHaveAttribute('aria-sort', 'none');
+    });
+
+    it('sets aria-sort ascending then descending when toggling a header', () => {
+      render(<DataTable columns={testColumns} data={makeRows(5)} />);
+      const nameHeader = screen.getByText('Name').closest('th')!;
+      fireEvent.click(nameHeader);
+      expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
+      fireEvent.click(nameHeader);
+      expect(nameHeader).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('swaps the neutral icon for a directional arrow on the active column', () => {
+      render(<DataTable columns={testColumns} data={makeRows(5)} />);
+      const nameHeader = screen.getByText('Name').closest('th')!;
+      // inactive → neutral up/down icon
+      expect(nameHeader.querySelector('svg.lucide-arrow-up-down')).toBeInTheDocument();
+      fireEvent.click(nameHeader);
+      // ascending → arrow-up, neutral icon gone
+      expect(nameHeader.querySelector('svg.lucide-arrow-up')).toBeInTheDocument();
+      expect(nameHeader.querySelector('svg.lucide-arrow-up-down')).not.toBeInTheDocument();
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/shared/components/tables/data-table.test.tsx -t "sort direction indicator"`
+Expected: FAIL — `aria-sort` attribute absent; `lucide-arrow-up` not found (header always renders `ArrowUpDown`).
+
+- [ ] **Step 3: Implement the directional indicator**
+
+In `data-table.tsx`, add `ArrowDown` to the lucide import (line 18):
+
+```tsx
+import { ArrowUpDown, ChevronLeft, ChevronRight, ArrowUp, ArrowDown } from 'lucide-react';
+```
+
+Replace the entire `renderHeader` function (lines 258-285) with:
+
+```tsx
+  const renderHeader = () => (
+    <thead className={cn('[&_tr]:border-b', useVirtual && 'sticky top-0 z-10 bg-card')}>
+      {table.getHeaderGroups().map((headerGroup) => (
+        <tr key={headerGroup.id} className="border-b transition-colors hover:bg-muted/50">
+          {headerGroup.headers.map((header) => {
+            const canSort = header.column.getCanSort();
+            const sorted = header.column.getIsSorted(); // 'asc' | 'desc' | false
+            return (
+              <th
+                key={header.id}
+                style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}
+                aria-sort={
+                  !canSort
+                    ? undefined
+                    : sorted === 'asc'
+                      ? 'ascending'
+                      : sorted === 'desc'
+                        ? 'descending'
+                        : 'none'
+                }
+                className={cn(
+                  'h-10 px-4 text-left align-middle font-medium',
+                  canSort && 'cursor-pointer select-none',
+                  sorted ? 'text-foreground' : 'text-muted-foreground',
+                )}
+                onClick={header.column.getToggleSortingHandler()}
+              >
+                <div className="flex items-center gap-2">
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(header.column.columnDef.header, header.getContext())}
+                  {canSort &&
+                    (sorted === 'asc' ? (
+                      <ArrowUp className="h-4 w-4 text-foreground" />
+                    ) : sorted === 'desc' ? (
+                      <ArrowDown className="h-4 w-4 text-foreground" />
+                    ) : (
+                      <ArrowUpDown className="h-4 w-4 text-muted-foreground/40" />
+                    ))}
+                </div>
+              </th>
+            );
+          })}
+        </tr>
+      ))}
+    </thead>
+  );
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/shared/components/tables/data-table.test.tsx`
+Expected: PASS — the new `sort direction indicator` tests pass and all existing `data-table` tests (including `describe('sorting')`, which only checks an svg exists per sortable header) still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/tables/data-table.tsx frontend/src/shared/components/tables/data-table.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(data-table): show active sort column and direction
+
+Sortable headers now render an up/down arrow for the active column
+(emphasized) and a faint neutral icon when inactive, and expose
+aria-sort for assistive tech.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Bigger checkbox hit-box (data-table selection cell)
+
+**Files:**
+- Modify: `frontend/src/shared/components/tables/data-table.tsx` (`selectionColumn`, lines 97-133)
+- Test: `frontend/src/shared/components/tables/data-table.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this `describe` block inside the top-level `describe('DataTable', …)` (e.g. after `describe('row selection', …)`):
+
+```tsx
+  describe('selection hit-box', () => {
+    it('wraps the row checkbox in a padded label to enlarge the click target', () => {
+      render(<DataTable columns={testColumns} data={makeRows(2)} enableRowSelection />);
+      const input = screen.getByTestId('row-checkbox-0');
+      const label = input.closest('label');
+      expect(label).not.toBeNull();
+      expect(label?.className).toContain('p-2.5');
+      expect(label?.className).toContain('cursor-pointer');
+    });
+
+    it('toggles selection when the padded label is clicked, without firing onRowClick', () => {
+      const onRowClick = vi.fn();
+      const onSelectionChange = vi.fn();
+      const data = makeRows(2);
+      render(
+        <DataTable
+          columns={testColumns}
+          data={data}
+          enableRowSelection
+          onRowClick={onRowClick}
+          onSelectionChange={onSelectionChange}
+        />,
+      );
+      const label = screen.getByTestId('row-checkbox-0').closest('label')!;
+      fireEvent.click(label);
+      expect(onSelectionChange).toHaveBeenCalledWith([data[0]]);
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
+  });
+```
+
+> Note: jsdom forwards a click on a `<label>` to the checkbox it wraps, so `fireEvent.click(label)` toggles the input. If this jsdom version does not forward, change that line to `await userEvent.click(label)` (`import userEvent from '@testing-library/user-event'`) and make the test `async`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/shared/components/tables/data-table.test.tsx -t "selection hit-box"`
+Expected: FAIL — the checkbox has no wrapping `<label>` (`input.closest('label')` is null).
+
+- [ ] **Step 3: Implement the padded label wrapper**
+
+In `data-table.tsx`, replace the `selectionColumn` `useMemo` (lines 97-133) with:
+
+```tsx
+  // Build the checkbox column when row selection is enabled
+  const selectionColumn = useMemo<ColumnDef<T, any> | null>(() => {
+    if (!enableRowSelection) return null;
+    return {
+      id: '_selection',
+      size: 52,
+      enableSorting: false,
+      header: ({ table: tbl }) => {
+        const allPageSelected = tbl.getIsAllPageRowsSelected();
+        const somePageSelected = tbl.getIsSomePageRowsSelected();
+        return (
+          <label
+            className="-m-2.5 inline-flex cursor-pointer items-center justify-center p-2.5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Checkbox
+              data-testid="select-all-checkbox"
+              aria-label="Select all on page"
+              checked={allPageSelected}
+              indeterminate={somePageSelected && !allPageSelected}
+              onChange={tbl.getToggleAllPageRowsSelectedHandler()}
+            />
+          </label>
+        );
+      },
+      cell: ({ row }) => {
+        const selectedCount = Object.keys(rowSelection).filter((k) => rowSelection[k]).length;
+        const isSelected = row.getIsSelected();
+        const isDisabled = !isSelected && maxSelection !== undefined && selectedCount >= maxSelection;
+        return (
+          <label
+            className="-m-2.5 inline-flex cursor-pointer items-center justify-center p-2.5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Checkbox
+              data-testid={`row-checkbox-${row.id}`}
+              aria-label={`Select row ${row.id}`}
+              checked={isSelected}
+              disabled={isDisabled}
+              title={isDisabled ? `Maximum of ${maxSelection} containers can be compared at once` : undefined}
+              onChange={row.getToggleSelectedHandler()}
+              onClick={(e) => e.stopPropagation()}
+            />
+          </label>
+        );
+      },
+    };
+  }, [enableRowSelection, maxSelection, rowSelection]);
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/shared/components/tables/data-table.test.tsx`
+Expected: PASS — new hit-box tests pass; existing `row selection` and `themed checkbox` tests still pass (the input's immediate parent is still the Checkbox `<span>`, so the `selectAll.parentElement.tagName === 'SPAN'` assertion holds).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/tables/data-table.tsx frontend/src/shared/components/tables/data-table.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(data-table): enlarge row-selection checkbox hit target
+
+Wrap the selection checkbox in a padded label (~36px target) so the
+column is easy to click without changing the visible box; stop click
+propagation so it never triggers row navigation.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Auto-fit pagination + horizontal scroll (data-table)
+
+**Files:**
+- Modify: `frontend/src/shared/components/tables/data-table.tsx` (imports, constants, props, mode flags, table options, effects, render)
+- Test: `frontend/src/shared/components/tables/data-table.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two `describe` blocks inside the top-level `describe('DataTable', …)` (e.g. after the `describe('windowScroll mode (#1288)', …)` block):
+
+```tsx
+  describe('autoFit mode', () => {
+    let rectSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    const setViewport = (innerHeight: number, top: number) => {
+      Object.defineProperty(window, 'innerHeight', { value: innerHeight, configurable: true });
+      rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({
+          top,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          width: 0,
+          height: 0,
+          x: 0,
+          y: top,
+          toJSON: () => ({}),
+        } as DOMRect);
+    };
+
+    afterEach(() => {
+      rectSpy?.mockRestore();
+      rectSpy = undefined;
+      Object.defineProperty(window, 'innerHeight', { value: 768, configurable: true });
+    });
+
+    it('computes page size from the available viewport height', () => {
+      // available = 1000 - 200 - 40 - 56 - 24 = 680 → floor(680 / 48) = 14 rows/page
+      setViewport(1000, 200);
+      render(<DataTable columns={testColumns} data={makeRows(30)} autoFit />);
+      expect(screen.getByTestId('auto-fit-container')).toBeInTheDocument();
+      expect(screen.getByText('container-14')).toBeInTheDocument();
+      expect(screen.queryByText('container-15')).not.toBeInTheDocument();
+      expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument(); // ceil(30/14) = 3
+    });
+
+    it('paginates to the next page of rows', () => {
+      setViewport(1000, 200); // 14 rows/page
+      render(<DataTable columns={testColumns} data={makeRows(30)} autoFit />);
+      const buttons = screen.getAllByRole('button');
+      fireEvent.click(buttons[buttons.length - 1]); // next page
+      expect(screen.getByText('container-15')).toBeInTheDocument();
+      expect(screen.queryByText('container-14')).not.toBeInTheDocument();
+      expect(screen.getByText(/Page 2 of 3/)).toBeInTheDocument();
+    });
+
+    it('floors page size to a minimum of 5 rows on very short viewports', () => {
+      // available = 200 - 180 - 40 - 56 - 24 = -100 → max(5, floor(-100/48)) = 5
+      setViewport(200, 180);
+      render(<DataTable columns={testColumns} data={makeRows(12)} autoFit />);
+      expect(screen.getByText('container-5')).toBeInTheDocument();
+      expect(screen.queryByText('container-6')).not.toBeInTheDocument();
+      expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument(); // ceil(12/5) = 3
+    });
+
+    it('does not virtualize or window-scroll in autoFit mode', () => {
+      setViewport(1000, 200);
+      render(<DataTable columns={testColumns} data={makeRows(100)} autoFit />);
+      expect(screen.queryByTestId('virtual-scroll-container')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('window-scroll-container')).not.toBeInTheDocument();
+      expect(screen.getByTestId('auto-fit-container')).toBeInTheDocument();
+    });
+  });
+
+  describe('horizontal scroll (minTableWidth)', () => {
+    let rectSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    afterEach(() => {
+      rectSpy?.mockRestore();
+      rectSpy = undefined;
+      Object.defineProperty(window, 'innerHeight', { value: 768, configurable: true });
+    });
+
+    it('applies overflow-x-auto and a min-width on the table when minTableWidth is set', () => {
+      Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true });
+      rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({ top: 100, toJSON: () => ({}) } as DOMRect);
+      render(<DataTable columns={testColumns} data={makeRows(5)} autoFit minTableWidth={860} />);
+      const container = screen.getByTestId('auto-fit-container');
+      expect(container.className).toContain('overflow-x-auto');
+      const table = container.querySelector('table');
+      expect(table?.style.minWidth).toBe('860px');
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/shared/components/tables/data-table.test.tsx -t "autoFit mode"`
+Expected: FAIL — `autoFit` prop is unknown; no `auto-fit-container` testid.
+
+- [ ] **Step 3a: Update imports and add constants**
+
+In `data-table.tsx`, update the React import (line 1) to add `useLayoutEffect`:
+
+```tsx
+import { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
+```
+
+Update the `@tanstack/react-table` import (lines 2-14) to add `PaginationState` and `Updater` types — add these two lines inside the import block:
+
+```tsx
+  type PaginationState,
+  type Updater,
+```
+
+Add these constants after `const SCROLL_TO_TOP_THRESHOLD = 20;` (line 24):
+
+```tsx
+const AUTO_FIT_HEADER_PX = 40; // sticky header row (h-10)
+const AUTO_FIT_FOOTER_PX = 56; // pagination footer reserve
+const AUTO_FIT_MARGIN_PX = 24; // breathing room above the viewport bottom
+const MIN_AUTO_ROWS = 5; // never page smaller than this
+```
+
+- [ ] **Step 3b: Add the props**
+
+In the `DataTableProps<T>` interface, add after `windowScroll?: boolean;` (line 55):
+
+```tsx
+  /**
+   * Paginate with a page size computed to fill the available viewport
+   * height. Recomputes on resize and when `data` changes. Mutually
+   * exclusive with `windowScroll`, virtualization, and `serverPagination`.
+   */
+  autoFit?: boolean;
+  /**
+   * Minimum table width in px. When the container is narrower the table
+   * overflows horizontally (themed scrollbar) instead of squashing columns.
+   */
+  minTableWidth?: number;
+```
+
+In the destructured props (lines 58-75), add `autoFit,` and `minTableWidth,` (e.g. after `windowScroll,`).
+
+- [ ] **Step 3c: Add state and the mode flags**
+
+After `const [rowSelection, setRowSelection] = useState<RowSelectionState>({});` (line 78), add:
+
+```tsx
+  const [pageIndex, setPageIndex] = useState(0);
+  const [autoPageSize, setAutoPageSize] = useState(MIN_AUTO_ROWS);
+  const autoFitWrapperRef = useRef<HTMLDivElement>(null);
+```
+
+Replace the mode-flag block (lines 90-94) with:
+
+```tsx
+  const isServerPaginated = !!serverPagination;
+  const useAutoFit = !!autoFit && !isServerPaginated;
+  const useWindowScroll = !!windowScroll && !isServerPaginated && !useAutoFit;
+  const useVirtual = !useWindowScroll
+    && !useAutoFit
+    && !isServerPaginated
+    && (virtualScrolling ?? data.length > VIRTUAL_THRESHOLD);
+  const useClientPagination = !useVirtual && !useWindowScroll && !isServerPaginated;
+```
+
+- [ ] **Step 3d: Wire pagination into the table options**
+
+In the `useReactTable` call:
+
+Replace line 146:
+```tsx
+    ...(useVirtual || isServerPaginated || useWindowScroll ? {} : { getPaginationRowModel: getPaginationRowModel() }),
+```
+with:
+```tsx
+    ...(useClientPagination ? { getPaginationRowModel: getPaginationRowModel() } : {}),
+```
+
+Immediately after `onColumnFiltersChange: setColumnFilters,` (line 148), add:
+```tsx
+    ...(useAutoFit
+      ? {
+          onPaginationChange: (updater: Updater<PaginationState>) => {
+            setPageIndex((prev) => {
+              const next =
+                typeof updater === 'function'
+                  ? updater({ pageIndex: prev, pageSize: autoPageSize })
+                  : updater;
+              return next.pageIndex;
+            });
+          },
+        }
+      : {}),
+```
+
+Replace the `state` object (lines 159-163) with:
+```tsx
+    state: {
+      sorting,
+      columnFilters,
+      ...(enableRowSelection ? { rowSelection } : {}),
+      ...(useAutoFit ? { pagination: { pageIndex, pageSize: autoPageSize } } : {}),
+    },
+```
+
+Replace line 164:
+```tsx
+    ...(useVirtual || isServerPaginated || useWindowScroll ? {} : { initialState: { pagination: { pageSize } } }),
+```
+with:
+```tsx
+    ...(useClientPagination && !useAutoFit ? { initialState: { pagination: { pageSize } } } : {}),
+```
+
+- [ ] **Step 3e: Add the measurement + clamp effects**
+
+After the "Sync external search value into column filter" effect (ends line 180), add:
+
+```tsx
+  // Auto-fit: compute a page size that fills the available viewport height.
+  const recomputeAutoPageSize = useCallback(() => {
+    if (!useAutoFit) return;
+    const el = autoFitWrapperRef.current;
+    if (!el) return;
+    const top = el.getBoundingClientRect().top;
+    const available =
+      window.innerHeight - top - AUTO_FIT_HEADER_PX - AUTO_FIT_FOOTER_PX - AUTO_FIT_MARGIN_PX;
+    const size = Math.max(MIN_AUTO_ROWS, Math.floor(available / ROW_HEIGHT));
+    setAutoPageSize((prev) => (prev === size ? prev : size));
+  }, [useAutoFit]);
+
+  useLayoutEffect(() => {
+    recomputeAutoPageSize();
+  }, [recomputeAutoPageSize, data]);
+
+  useEffect(() => {
+    if (!useAutoFit) return;
+    let raf = 0;
+    const onResize = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(recomputeAutoPageSize);
+    };
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      cancelAnimationFrame(raf);
+    };
+  }, [useAutoFit, recomputeAutoPageSize]);
+
+  // Keep pageIndex in range when the page size or data shrinks.
+  useEffect(() => {
+    if (!useAutoFit) return;
+    const pageCount = table.getPageCount();
+    if (pageCount > 0 && pageIndex > pageCount - 1) {
+      setPageIndex(pageCount - 1);
+    }
+  }, [useAutoFit, autoPageSize, data, pageIndex, table]);
+```
+
+- [ ] **Step 3f: Add `tableStyle` and `renderClientPagination`**
+
+After `const serverPageCount = …` / `const canServerNext = …` block (ends ~line 233), add:
+
+```tsx
+  const tableStyle = minTableWidth ? { minWidth: minTableWidth } : undefined;
+
+  const renderClientPagination = () => {
+    if (table.getPageCount() <= 1) return null;
+    return (
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()} ({data.length} total)
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            aria-label="Next page"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    );
+  };
+```
+
+- [ ] **Step 3g: Replace the render return**
+
+Replace the entire `return (…)` block (lines 318-474) with:
+
+```tsx
+  return (
+    <div data-testid="data-table" className="space-y-4">
+      {!hideSearch && (
+        <div className="flex items-center justify-between gap-4">
+          {searchKey && (
+            <input
+              data-testid="data-table-search"
+              type="text"
+              placeholder={searchPlaceholder}
+              value={searchValue}
+              onChange={(e) => table.getColumn(searchKey)?.setFilterValue(e.target.value)}
+              className="w-full max-w-sm rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          )}
+          {useVirtual && (
+            <p className="shrink-0 text-sm text-muted-foreground" data-testid="virtual-row-count">
+              {isFiltered
+                ? `${filteredCount} of ${totalCount} match${filteredCount !== 1 ? '' : 'es'}`
+                : `${totalCount} total`}
+            </p>
+          )}
+        </div>
+      )}
+
+      {useAutoFit ? (
+        <>
+          <div
+            ref={autoFitWrapperRef}
+            className="overflow-x-auto rounded-md border"
+            data-testid="auto-fit-container"
+          >
+            <table className="w-full caption-bottom text-sm" style={tableStyle}>
+              {renderHeader()}
+              <tbody className="[&_tr:last-child]:border-0">
+                {table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row) => renderRow(row))
+                ) : (
+                  <tr>
+                    <td colSpan={allColumns.length} className="h-24 text-center text-muted-foreground">
+                      No results.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+          {renderClientPagination()}
+        </>
+      ) : useWindowScroll ? (
+        <div className="overflow-x-auto rounded-md border" data-testid="window-scroll-container">
+          <table className="w-full caption-bottom text-sm" style={tableStyle}>
+            {renderHeader()}
+            <tbody className="[&_tr:last-child]:border-0">
+              {rows.length ? (
+                rows.map((row) => renderRow(row))
+              ) : (
+                <tr>
+                  <td colSpan={allColumns.length} className="h-24 text-center text-muted-foreground">
+                    No results.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      ) : useVirtual ? (
+        <div className="relative rounded-md border">
+          <div
+            ref={scrollContainerRef}
+            className="overflow-auto"
+            style={{ maxHeight: SCROLL_CONTAINER_HEIGHT }}
+            tabIndex={0}
+            onKeyDown={handleKeyDown}
+            role="grid"
+            aria-label="Data table with virtual scrolling"
+            data-testid="virtual-scroll-container"
+          >
+            <table className="w-full caption-bottom text-sm" style={tableStyle}>
+              {renderHeader()}
+              <tbody className="[&_tr:last-child]:border-0">
+                {rows.length ? (
+                  <>
+                    {virtualizer.getVirtualItems().length > 0 && (
+                      <tr>
+                        <td
+                          colSpan={allColumns.length}
+                          style={{ height: virtualizer.getVirtualItems()[0]?.start ?? 0, padding: 0 }}
+                        />
+                      </tr>
+                    )}
+                    {virtualizer.getVirtualItems().map((virtualRow) => {
+                      const row = rows[virtualRow.index];
+                      return renderRow(row);
+                    })}
+                    {virtualizer.getVirtualItems().length > 0 && (
+                      <tr>
+                        <td
+                          colSpan={allColumns.length}
+                          style={{
+                            height:
+                              virtualizer.getTotalSize() -
+                              (virtualizer.getVirtualItems().at(-1)?.end ?? 0),
+                            padding: 0,
+                          }}
+                        />
+                      </tr>
+                    )}
+                  </>
+                ) : (
+                  <tr>
+                    <td colSpan={allColumns.length} className="h-24 text-center text-muted-foreground">
+                      No results.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {showScrollTop && (
+            <button
+              onClick={scrollToTop}
+              className="absolute bottom-4 right-4 inline-flex h-8 w-8 items-center justify-center rounded-full border bg-background shadow-md transition-opacity hover:bg-accent"
+              aria-label="Scroll to top"
+              data-testid="scroll-to-top"
+            >
+              <ArrowUp className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="overflow-x-auto rounded-md border">
+            <table className="w-full caption-bottom text-sm" style={tableStyle}>
+              {renderHeader()}
+              <tbody className="[&_tr:last-child]:border-0">
+                {table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row) => renderRow(row))
+                ) : (
+                  <tr>
+                    <td colSpan={allColumns.length} className="h-24 text-center text-muted-foreground">
+                      No results.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {isServerPaginated ? renderServerPagination() : renderClientPagination()}
+        </>
+      )}
+    </div>
+  );
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/shared/components/tables/data-table.test.tsx`
+Expected: PASS — all `autoFit mode`, `horizontal scroll`, and pre-existing tests pass. (The default-mode pagination tests still see `Page 1 of 3` / `25 total` from `renderClientPagination`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/shared/components/tables/data-table.tsx frontend/src/shared/components/tables/data-table.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(data-table): add autoFit pagination and horizontal scroll
+
+autoFit computes a page size that fills the viewport height
+(recomputed on resize/data change, min 5 rows) and paginates
+client-side. minTableWidth lets narrow viewports scroll the table
+horizontally instead of squashing columns.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Search above filters (workload-explorer)
+
+**Files:**
+- Modify: `frontend/src/features/containers/pages/workload-explorer.tsx` (lines 566-694)
+- Test: `frontend/src/features/containers/pages/workload-explorer.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test inside the top-level `describe('WorkloadExplorerPage', …)` (e.g. after the `'merges filter dropdowns and table into a single pane (#1313)'` test):
+
+```tsx
+  it('renders the search bar above the filter dropdowns', () => {
+    mockQueryString = 'endpoint=1';
+    render(<WorkloadExplorerPage />);
+    const search = screen.getByTestId('workload-smart-search');
+    const endpointSelect = screen.getByTestId('endpoint-select');
+    // endpoint dropdown follows the search bar in document order
+    expect(
+      search.compareDocumentPosition(endpointSelect) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/workload-explorer.test.tsx -t "search bar above"`
+Expected: FAIL — search currently renders after the dropdowns, so `endpointSelect` precedes `search`.
+
+- [ ] **Step 3: Move the search block above the dropdowns**
+
+In `workload-explorer.tsx`:
+
+1. Update the comment on line 566 from:
+```tsx
+          {/* Merged filter + table pane (#1313): dropdowns → chips → search → table */}
+```
+to:
+```tsx
+          {/* Merged filter + table pane: search → dropdowns → chips → table */}
+```
+
+2. Delete the entire `{/* Smart search */}` block (lines 688-694):
+```tsx
+              {/* Smart search */}
+              <WorkloadSmartSearch
+                containers={filteredContainers}
+                knownStackNames={knownStackNames}
+                onFiltered={setSearchFilteredContainers}
+                totalCount={filteredContainers.length}
+              />
+```
+
+3. Re-insert it immediately after the opening `<div data-testid="workload-pane" …>` (i.e. directly before the `<div className="flex items-center gap-4 flex-wrap">` dropdown row at line 575):
+
+```tsx
+              {/* Smart search */}
+              <WorkloadSmartSearch
+                containers={filteredContainers}
+                knownStackNames={knownStackNames}
+                onFiltered={setSearchFilteredContainers}
+                totalCount={filteredContainers.length}
+              />
+
+              <div className="flex items-center gap-4 flex-wrap">
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/workload-explorer.test.tsx`
+Expected: PASS — the new ordering test passes; the `'merges filter dropdowns and table into a single pane'` test still passes (both the state select and table remain inside `workload-pane`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/containers/pages/workload-explorer.tsx frontend/src/features/containers/pages/workload-explorer.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(workload-explorer): move search bar above filter dropdowns
+
+Order is now search -> dropdowns -> chips -> table.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Group column → compact icon (workload-explorer)
+
+**Files:**
+- Modify: `frontend/src/features/containers/pages/workload-explorer.tsx` (lucide import line 5; group column lines 370-388)
+- Test: `frontend/src/features/containers/pages/workload-explorer.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to the `describe('WorkloadExplorerPage — columns (#1288)', …)` block (bottom of the file):
+
+```tsx
+  it('renders the Group cell as a labelled icon (System=Cog, Workload=Box)', () => {
+    render(<WorkloadExplorerPage />);
+    const groupCol = mockColumns?.find((c) => c.id === 'group');
+    expect(groupCol).toBeDefined();
+
+    // System container (beyla → grafana/beyla image)
+    const systemCell = groupCol.cell({ row: { original: defaultContainersMock.data[1] } });
+    const { container: sysC } = render(systemCell);
+    const sysWrap = sysC.querySelector('span[aria-label="System"]');
+    expect(sysWrap).not.toBeNull();
+    expect(sysWrap?.querySelector('svg.lucide-cog')).toBeInTheDocument();
+    expect(sysWrap?.className).toContain('bg-amber-100');
+
+    // Workload container (workers-api-1)
+    const workloadCell = groupCol.cell({ row: { original: defaultContainersMock.data[0] } });
+    const { container: wlC } = render(workloadCell);
+    const wlWrap = wlC.querySelector('span[aria-label="Workload"]');
+    expect(wlWrap).not.toBeNull();
+    expect(wlWrap?.querySelector('svg.lucide-box')).toBeInTheDocument();
+    expect(wlWrap?.className).toContain('bg-slate-100');
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/workload-explorer.test.tsx -t "Group cell as a labelled icon"`
+Expected: FAIL — the cell renders the text label, not an `aria-label`-ed icon span.
+
+- [ ] **Step 3: Implement the icon cell**
+
+In `workload-explorer.tsx`, add `Box` and `Cog` to the lucide import (line 5). New import line:
+
+```tsx
+import { AlertTriangle, Box, Boxes, Cog, Download, Eye, GitCompareArrows, ScrollText, X } from 'lucide-react';
+```
+
+Replace the `group` column definition (lines 370-388) with:
+
+```tsx
+    {
+      id: 'group',
+      header: 'Group',
+      size: 72,
+      cell: ({ row }) => {
+        const label = getContainerGroupLabel(row.original);
+        const isSystem = label === 'System';
+        const Icon = isSystem ? Cog : Box;
+        return (
+          <span
+            title={label}
+            aria-label={label}
+            className={
+              isSystem
+                ? 'inline-flex items-center justify-center rounded-md bg-amber-100 p-1 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300'
+                : 'inline-flex items-center justify-center rounded-md bg-slate-100 p-1 text-slate-700 dark:bg-slate-900/30 dark:text-slate-300'
+            }
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="sr-only">{label}</span>
+          </span>
+        );
+      },
+    },
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/workload-explorer.test.tsx`
+Expected: PASS — new Group-icon test passes; column-order test (`group` present) and CSV-export test (`row.group === 'System'`, driven by `getContainerGroupLabel`, not the cell) still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/containers/pages/workload-explorer.tsx frontend/src/features/containers/pages/workload-explorer.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(workload-explorer): compact Group column with labelled icons
+
+System -> amber cog, Workload -> slate box, in a narrower column.
+Keeps title/aria-label/sr-only text for accessibility.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Wire explorer to autoFit + horizontal scroll
+
+**Files:**
+- Modify: `frontend/src/features/containers/pages/workload-explorer.tsx` (DataTable usage, lines 696-708)
+- Test: `frontend/src/features/containers/pages/workload-explorer.test.tsx` (DataTable mock lines 117-152; `windowScroll` test lines 954-957)
+
+- [ ] **Step 1: Update the DataTable mock and rewrite the failing test**
+
+In `workload-explorer.test.tsx`, replace the `DataTable` mock (lines 117-152) with one that surfaces `autoFit`/`minTableWidth` instead of `windowScroll`:
+
+```tsx
+vi.mock('@/shared/components/tables/data-table', () => ({
+  DataTable: ({
+    columns,
+    data,
+    enableRowSelection,
+    maxSelection,
+    onSelectionChange,
+    selectedRowIds,
+    onRowClick,
+    autoFit,
+    minTableWidth,
+  }: {
+    columns?: any[];
+    data: Array<{ name: string }>;
+    enableRowSelection?: boolean;
+    maxSelection?: number;
+    onSelectionChange?: (rows: Array<{ id: string; name: string; endpointId: number }>) => void;
+    selectedRowIds?: Record<string, boolean>;
+    onRowClick?: (row: { id: string; name: string; endpointId: number }) => void;
+    autoFit?: boolean;
+    minTableWidth?: number;
+  }) => {
+    mockOnSelectionChange = onSelectionChange;
+    mockColumns = columns;
+    return (
+      <div
+        data-testid="workloads-table"
+        data-enable-row-selection={enableRowSelection ? 'true' : undefined}
+        data-max-selection={maxSelection}
+        data-selected-row-ids={selectedRowIds !== undefined ? JSON.stringify(selectedRowIds) : undefined}
+        data-has-row-click={onRowClick ? 'true' : undefined}
+        data-auto-fit={autoFit ? 'true' : undefined}
+        data-min-table-width={minTableWidth}
+      >
+        {data.map((container) => container.name).join(',')}
+      </div>
+    );
+  },
+}));
+```
+
+Then replace the test `'passes windowScroll to the DataTable'` (lines 954-957) with:
+
+```tsx
+  it('passes autoFit to the DataTable', () => {
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByTestId('workloads-table')).toHaveAttribute('data-auto-fit', 'true');
+  });
+
+  it('passes minTableWidth to the DataTable for horizontal scrolling', () => {
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByTestId('workloads-table')).toHaveAttribute('data-min-table-width', '860');
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/workload-explorer.test.tsx -t "to the DataTable"`
+Expected: FAIL — the page still passes `windowScroll` (so `data-auto-fit` / `data-min-table-width` are absent).
+
+- [ ] **Step 3: Switch the page to autoFit + minTableWidth**
+
+In `workload-explorer.tsx`, replace the `<DataTable …>` usage (lines 696-708) with:
+
+```tsx
+              <DataTable
+                columns={columns}
+                data={searchFilteredContainers ?? filteredContainers}
+                hideSearch
+                autoFit
+                minTableWidth={860}
+                enableRowSelection
+                maxSelection={MAX_COMPARE}
+                onSelectionChange={handleSelectionChange}
+                getRowId={(row) => `${row.endpointId}:${row.id}`}
+                selectedRowIds={controlledRowIds}
+                onRowClick={(row) => navigate(`/containers/${row.endpointId}/${row.id}`)}
+              />
+```
+
+(Removes `pageSize={15}` and `windowScroll`; adds `autoFit` and `minTableWidth={860}`.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/workload-explorer.test.tsx`
+Expected: PASS — `passes autoFit` and `passes minTableWidth` pass; no remaining reference to `data-window-scroll`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/containers/pages/workload-explorer.tsx frontend/src/features/containers/pages/workload-explorer.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(workload-explorer): paginate the list to fit the screen
+
+Switch the table from window-scroll to autoFit pagination and pass
+minTableWidth so narrow windows scroll horizontally.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Full verification + docs
+
+**Files:**
+- Modify (if applicable): `docs/architecture.md`
+- Verify: whole frontend workspace
+
+- [ ] **Step 1: Check for other callers / e2e references that assume the old behavior**
+
+Run:
+```bash
+grep -rn "windowScroll" frontend/src e2e 2>/dev/null
+grep -rn "Workload" e2e 2>/dev/null
+```
+Expected: `windowScroll` still appears as a `DataTable` prop/definition and any *other* callers (those are unaffected — the prop still exists). If any e2e spec asserts the Workload Explorer scrolls, or asserts the visible Group text "System"/"Workload" in a table cell, update it to expect pagination / the icon `aria-label`. If none, note "no e2e changes needed".
+
+- [ ] **Step 2: Typecheck, lint, and run the full frontend suite**
+
+Run:
+```bash
+npm run typecheck
+npm run lint
+npm run test -w frontend
+```
+Expected: all pass. If lint flags import ordering on the lucide imports, apply the autofix (`npm run lint -- --fix` in the affected workspace) and re-run.
+
+- [ ] **Step 3: Build the frontend**
+
+Run: `npm run build -w frontend`
+Expected: build succeeds (no TS or bundler errors from the new props/effects).
+
+- [ ] **Step 4: Update docs**
+
+- Open `docs/architecture.md`; if it documents the Workload Explorer list or the `DataTable` modes (window-scroll/virtual/pagination), add a one-line note that the explorer uses `autoFit` pagination and `minTableWidth` horizontal scroll. If no such section exists, add nothing and record that in the commit body.
+- Update the spec status line in `docs/superpowers/specs/2026-05-29-workload-explorer-ui-refinements-design.md` from `Status: Approved (design)` to `Status: Implemented`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+docs(workload-explorer): note autoFit list behavior; mark spec implemented
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 6: Manual verification (recommended)**
+
+Use the `verify` or `run` skill to launch the app and confirm in a browser:
+- The list pages instead of scrolling; the page fills the viewport and re-fits on window resize.
+- The search bar sits above the four filter dropdowns.
+- Narrowing the window shows a horizontal scrollbar on the table.
+- The Group column is a small amber cog (System) / slate box (Workload) with a tooltip.
+- The selection checkbox is easy to click (larger target).
+- Clicking a header shows an up/down arrow and highlights the active column.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Search above filters → Task 4. ✅
+- Auto-fit pagination → Task 3 + Task 6. ✅
+- Horizontal scrollbar (narrow widths) → Task 3 (`minTableWidth` + `overflow-x-auto`) + Task 6. ✅
+- Group column icon + smaller → Task 5 (`size: 72`, Cog/Box, sr-only/aria-label). ✅
+- Bigger checkbox hit-box → Task 2. ✅
+- Sort-direction visualization → Task 1. ✅
+- Testing (data-table unit tests, group-icon a11y, hit-box, ordering, pagination accounting) → Tasks 1-6; full suite + build in Task 7. ✅
+- Docs → Task 7. ✅
+
+**Type consistency:** `autoFit`/`minTableWidth` prop names match between `DataTableProps`, the page usage (Task 6), and the page mock (Task 6). `recomputeAutoPageSize`, `autoPageSize`, `pageIndex`, `autoFitWrapperRef`, `tableStyle`, `renderClientPagination` are each defined once in Task 3 and referenced consistently. Constants (`AUTO_FIT_HEADER_PX=40`, `AUTO_FIT_FOOTER_PX=56`, `AUTO_FIT_MARGIN_PX=24`, `MIN_AUTO_ROWS=5`, `ROW_HEIGHT=48`) match the values used in the test arithmetic (Task 3 Step 1).
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; commands include expected output.
+
+**Known fragilities (called out inline):** lucide `svg.lucide-*` class assertions (stable across current lucide-react; `aria-sort`/`aria-label` are the load-bearing assertions); jsdom label-click forwarding (fallback to `userEvent` noted in Task 2).

--- a/docs/superpowers/specs/2026-05-29-workload-explorer-ui-refinements-design.md
+++ b/docs/superpowers/specs/2026-05-29-workload-explorer-ui-refinements-design.md
@@ -1,7 +1,7 @@
 # Workload Explorer UI refinements — design
 
 **Date:** 2026-05-29
-**Status:** Approved (design)
+**Status:** Implemented
 **Scope:** Frontend only — `frontend/src/features/containers/pages/workload-explorer.tsx`, `frontend/src/shared/components/tables/data-table.tsx`, `frontend/src/shared/components/ui/checkbox.tsx` (and their tests).
 
 ## Problem

--- a/docs/superpowers/specs/2026-05-29-workload-explorer-ui-refinements-design.md
+++ b/docs/superpowers/specs/2026-05-29-workload-explorer-ui-refinements-design.md
@@ -1,0 +1,111 @@
+# Workload Explorer UI refinements — design
+
+**Date:** 2026-05-29
+**Status:** Approved (design)
+**Scope:** Frontend only — `frontend/src/features/containers/pages/workload-explorer.tsx`, `frontend/src/shared/components/tables/data-table.tsx`, `frontend/src/shared/components/ui/checkbox.tsx` (and their tests).
+
+## Problem
+
+The Workload Explorer list has six rough edges the user wants smoothed:
+
+1. The container list scrolls (window-scroll) instead of paging; it should be paginated with a page size that fills the screen.
+2. The search bar sits *below* the filter dropdowns; it should be *above* them.
+3. On narrow windows the table squashes instead of offering a horizontal scrollbar.
+4. The Group column is wide and shows the words "System"/"Workload"; it should be a compact symbol.
+5. The selection checkbox hit-box equals the 16px visible box, so it is hard to click.
+6. Clicking a column header sorts, but nothing shows which column or which direction is active.
+
+## Goals / non-goals
+
+**Goals:** the six fixes above, with tests, matching the existing glassmorphic design system and the reusable `DataTable` contract.
+
+**Non-goals:** no changes to container data fetching, compare mode, CSV export, filter semantics, or the grouping detection logic. No server-side pagination. No new dependencies.
+
+## Design
+
+### 1. Search above filters (page)
+
+In `workload-explorer.tsx` the merged pane currently renders **dropdowns → chips → search → table** (commented `#1313`). Reorder to:
+
+```
+WorkloadSmartSearch          (search)
+filter dropdowns row         (endpoint / stack / group / state)
+active filter chips
+DataTable
+```
+
+Pure JSX move of the `<WorkloadSmartSearch>` block above the dropdown `<div className="flex items-center gap-4 flex-wrap">`. Update the ordering comment. No logic changes — `WorkloadSmartSearch` keeps the same props.
+
+### 2. Auto-fit pagination (DataTable `autoFit` mode)
+
+Replace the explorer's `windowScroll` usage with a new `autoFit` mode on `DataTable`.
+
+**Behavior:**
+- `autoFit` implies client-side pagination via TanStack's `getPaginationRowModel` — **not** virtualized, **not** window-scroll, **not** server-paginated. These modes are mutually exclusive; `autoFit` wins if combined with `windowScroll`.
+- `pageSize` is **controlled and computed** from available viewport height:
+  - `top = wrapperRef.current.getBoundingClientRect().top` (top of the table region — independent of how many rows render, since everything above it is search/filters/chips).
+  - `available = window.innerHeight - top - HEADER_ROW(40) - FOOTER_RESERVE(56) - BOTTOM_MARGIN(24)`.
+  - `pageSize = max(MIN_AUTO_ROWS=5, floor(available / ROW_HEIGHT=48))`.
+- Recompute on: mount (`useLayoutEffect`), `window` `resize`, and whenever the `data` prop reference changes (filter/search changes toggle the chips row, which shifts `top`; those same actions change `data`). A `requestAnimationFrame`-guarded handler avoids resize thrash.
+- `pageIndex` is controlled; clamp to `[0, pageCount-1]` whenever `pageSize` or `data` changes so a shrinking list never strands the view on an empty page.
+- Footer: reuse the existing client-pagination footer ("Page X of Y (N total)" + prev/next chevron buttons), rendered when `pageCount > 1`.
+
+**Why in DataTable, not the page:** keeps the page declarative (`autoFit` instead of `windowScroll`), makes the behavior reusable, and keeps the measurement logic unit-testable in isolation.
+
+**Loop safety:** `top` depends only on layout *above* the table, never on the rendered row count, so computing `pageSize` from `top` cannot feed back into `top`.
+
+### 3. Horizontal scrollbar on narrow widths (DataTable)
+
+- Wrap each table in a container with `overflow-x-auto` (harmless for existing callers — only scrolls when content overflows; inherits the global themed scrollbar from `index.css`).
+- Add an optional `minTableWidth?: number` prop applied as an inline `min-width` style on the `<table>`. Only Workload Explorer passes it (`~860`). Callers that omit it never force overflow, so other tables are unaffected.
+
+### 4. Group column → compact icon (page)
+
+In the `group` column def:
+- Render a small lucide icon inside a tinted chip instead of the text badge:
+  - **System** → amber `Cog`.
+  - **Workload** → slate `Box`.
+- Preserve accessibility & tests: include an `sr-only` span with the label and set `title` + `aria-label` to "System"/"Workload".
+- Set the column `size` to ~72 and center the icon.
+
+Icon import added to the existing `lucide-react` import in `workload-explorer.tsx`.
+
+### 5. Bigger checkbox hit-box (DataTable selection cell)
+
+Keep the `Checkbox` visual size at `md` (16px). In `data-table.tsx`'s selection column, wrap both the header and row `<Checkbox>` in a padded `<label className="inline-flex items-center justify-center cursor-pointer p-2.5 -m-2.5">`:
+- The native `<label>` makes the whole padded area (~36px) toggle the checkbox.
+- `onClick={(e) => e.stopPropagation()}` on the label prevents the row-navigation click (mirrors the existing input `stopPropagation`).
+- The negative margin keeps layout unchanged.
+- Widen the selection column `size` from 40 to ~52 to fit the padded target.
+
+No change to the generic `Checkbox` component API (the bigger target is a table-selection concern, scoped to where the row-click conflict exists).
+
+### 6. Sort direction visualization (DataTable header)
+
+In `renderHeader`, drive the indicator off `header.column.getIsSorted()` (`'asc' | 'desc' | false`):
+- `asc` → `ArrowUp`, `desc` → `ArrowDown`, both `text-foreground` (emphasized).
+- sortable but inactive → `ArrowUpDown` at `text-muted-foreground/40` (faint).
+- Emphasize the active header: `text-foreground` (vs `text-muted-foreground`) on the `<th>`.
+- Add `aria-sort` (`ascending`/`descending`/`none`) to the `<th>` for accessibility.
+
+`ArrowDown` added to the existing `lucide-react` import in `data-table.tsx`.
+
+## Testing
+
+TDD throughout. New/updated tests:
+
+- **`data-table.test.tsx`**
+  - `autoFit`: with mocked `window.innerHeight` and `getBoundingClientRect().top`, asserts computed `pageSize`, that only one page of rows renders, that prev/next paginate, and the `MIN_AUTO_ROWS` floor on tiny viewports.
+  - `minTableWidth`: asserts the inline `min-width` style is applied and the wrapper has `overflow-x-auto`.
+  - Sort indicator: clicking a sortable header swaps the icon to up/down and sets `aria-sort`; inactive sortable headers show the faint neutral icon.
+  - Selection hit-box: clicking the padded label area (not the input directly) toggles selection and does not trigger `onRowClick`.
+- **`workload-explorer.test.tsx`**
+  - Update for search-above-filters ordering if any test asserts DOM order.
+  - Group cell: assert icon + `aria-label`/`sr-only` "System"/"Workload" instead of visible text.
+  - Account for client pagination: jsdom (no layout) yields `top=0`, `innerHeight=768` → ~13 rows/page. Fixtures are expected to be ≤ one page; any test needing a row beyond page 1 navigates to its page first. Confirm fixture sizes during implementation and adjust the few affected assertions.
+- **`checkbox.test.tsx`** unchanged (component API unchanged).
+
+## Risks
+
+- **Auto-fit measurement** is the only nuanced piece. jsdom performs no layout, so tests mock `innerHeight`/`getBoundingClientRect`. On very short viewports the `MIN_AUTO_ROWS=5` floor means the list keeps 5 rows and gains vertical scroll within the page rather than collapsing to one row.
+- **Existing test churn** from the scroll→pagination switch is bounded to assertions that expect all rows in the DOM at once; mitigated by small fixtures and per-test page navigation where needed.

--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -1011,4 +1011,26 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
     expect(tagButton).not.toBeNull();
     expect(tagButton?.className).toContain('whitespace-nowrap');
   });
+
+  it('renders the Group cell as a labelled icon (System=Cog, Workload=Box)', () => {
+    render(<WorkloadExplorerPage />);
+    const groupCol = mockColumns?.find((c) => c.id === 'group');
+    expect(groupCol).toBeDefined();
+
+    // System container (beyla → grafana/beyla image)
+    const systemCell = groupCol.cell({ row: { original: defaultContainersMock.data[1] } });
+    const { container: sysC } = render(systemCell);
+    const sysWrap = sysC.querySelector('span[aria-label="System"]');
+    expect(sysWrap).not.toBeNull();
+    expect(sysWrap?.querySelector('svg.lucide-cog')).toBeInTheDocument();
+    expect(sysWrap?.className).toContain('bg-amber-100');
+
+    // Workload container (workers-api-1)
+    const workloadCell = groupCol.cell({ row: { original: defaultContainersMock.data[0] } });
+    const { container: wlC } = render(workloadCell);
+    const wlWrap = wlC.querySelector('span[aria-label="Workload"]');
+    expect(wlWrap).not.toBeNull();
+    expect(wlWrap?.querySelector('svg.lucide-box')).toBeInTheDocument();
+    expect(wlWrap?.className).toContain('bg-slate-100');
+  });
 });

--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -1030,6 +1030,7 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
     const { container: sysC } = render(systemCell);
     const sysWrap = sysC.querySelector('span[aria-label="System"]');
     expect(sysWrap).not.toBeNull();
+    expect(sysWrap).toHaveAttribute('role', 'img');
     expect(sysWrap?.querySelector('svg.lucide-cog')).toBeInTheDocument();
     expect(sysWrap?.className).toContain('bg-amber-100');
 

--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -403,6 +403,17 @@ describe('WorkloadExplorerPage', () => {
     expect(screen.queryByTestId('workload-status-summary')).not.toBeInTheDocument();
   });
 
+  it('renders the search bar above the filter dropdowns', () => {
+    mockQueryString = 'endpoint=1';
+    render(<WorkloadExplorerPage />);
+    const search = screen.getByTestId('workload-smart-search');
+    const endpointSelect = screen.getByTestId('endpoint-select');
+    // endpoint dropdown follows the search bar in document order
+    expect(
+      search.compareDocumentPosition(endpointSelect) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it('merges filter dropdowns and table into a single pane (#1313)', () => {
     mockQueryString = 'endpoint=1';
     render(<WorkloadExplorerPage />);

--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -123,7 +123,8 @@ vi.mock('@/shared/components/tables/data-table', () => ({
     onSelectionChange,
     selectedRowIds,
     onRowClick,
-    windowScroll,
+    autoFit,
+    minTableWidth,
   }: {
     columns?: any[];
     data: Array<{ name: string }>;
@@ -132,7 +133,8 @@ vi.mock('@/shared/components/tables/data-table', () => ({
     onSelectionChange?: (rows: Array<{ id: string; name: string; endpointId: number }>) => void;
     selectedRowIds?: Record<string, boolean>;
     onRowClick?: (row: { id: string; name: string; endpointId: number }) => void;
-    windowScroll?: boolean;
+    autoFit?: boolean;
+    minTableWidth?: number;
   }) => {
     mockOnSelectionChange = onSelectionChange;
     mockColumns = columns;
@@ -143,7 +145,8 @@ vi.mock('@/shared/components/tables/data-table', () => ({
         data-max-selection={maxSelection}
         data-selected-row-ids={selectedRowIds !== undefined ? JSON.stringify(selectedRowIds) : undefined}
         data-has-row-click={onRowClick ? 'true' : undefined}
-        data-window-scroll={windowScroll ? 'true' : undefined}
+        data-auto-fit={autoFit ? 'true' : undefined}
+        data-min-table-width={minTableWidth}
       >
         {data.map((container) => container.name).join(',')}
       </div>
@@ -962,9 +965,14 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
     expect(ids.has('age')).toBe(false);
   });
 
-  it('passes windowScroll to the DataTable', () => {
+  it('passes autoFit to the DataTable', () => {
     render(<WorkloadExplorerPage />);
-    expect(screen.getByTestId('workloads-table')).toHaveAttribute('data-window-scroll', 'true');
+    expect(screen.getByTestId('workloads-table')).toHaveAttribute('data-auto-fit', 'true');
+  });
+
+  it('passes minTableWidth to the DataTable for horizontal scrolling', () => {
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByTestId('workloads-table')).toHaveAttribute('data-min-table-width', '860');
   });
 
   it('Imagename cell renders only the segment after the last "/" with the full path on title', () => {

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -377,6 +377,7 @@ export default function WorkloadExplorerPage() {
         const Icon = isSystem ? Cog : Box;
         return (
           <span
+            role="img"
             title={label}
             aria-label={label}
             className={
@@ -386,7 +387,6 @@ export default function WorkloadExplorerPage() {
             }
           >
             <Icon className="h-3.5 w-3.5" aria-hidden="true" />
-            <span className="sr-only">{label}</span>
           </span>
         );
       },

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -702,8 +702,8 @@ export default function WorkloadExplorerPage() {
                 columns={columns}
                 data={searchFilteredContainers ?? filteredContainers}
                 hideSearch
-                pageSize={15}
-                windowScroll
+                autoFit
+                minTableWidth={860}
                 enableRowSelection
                 maxSelection={MAX_COMPARE}
                 onSelectionChange={handleSelectionChange}

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useCallback } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { type ColumnDef, type RowSelectionState } from '@tanstack/react-table';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import { AlertTriangle, Boxes, Download, Eye, GitCompareArrows, ScrollText, X } from 'lucide-react';
+import { AlertTriangle, Box, Boxes, Cog, Download, Eye, GitCompareArrows, ScrollText, X } from 'lucide-react';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { useContainers, type Container } from '@/features/containers/hooks/use-containers';
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
@@ -370,18 +370,23 @@ export default function WorkloadExplorerPage() {
     {
       id: 'group',
       header: 'Group',
+      size: 72,
       cell: ({ row }) => {
         const label = getContainerGroupLabel(row.original);
         const isSystem = label === 'System';
+        const Icon = isSystem ? Cog : Box;
         return (
           <span
+            title={label}
+            aria-label={label}
             className={
               isSystem
-                ? 'inline-flex items-center rounded-md bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900 dark:bg-amber-900/30 dark:text-amber-300'
-                : 'inline-flex items-center rounded-md bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-900/30 dark:text-slate-300'
+                ? 'inline-flex items-center justify-center rounded-md bg-amber-100 p-1 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300'
+                : 'inline-flex items-center justify-center rounded-md bg-slate-100 p-1 text-slate-700 dark:bg-slate-900/30 dark:text-slate-300'
             }
           >
-            {label}
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="sr-only">{label}</span>
           </span>
         );
       },

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -563,7 +563,7 @@ export default function WorkloadExplorerPage() {
       ) : (
         // ── Original table / filter pane / selection-action-bar block ──
         <>
-          {/* Merged filter + table pane (#1313): dropdowns → chips → search → table */}
+          {/* Merged filter + table pane: search → dropdowns → chips → table */}
           {isLoading ? (
             <SkeletonChart size="lg" />
           ) : filteredContainers ? (
@@ -572,6 +572,14 @@ export default function WorkloadExplorerPage() {
               data-testid="workload-pane"
               className="rounded-lg border bg-card p-6 shadow-sm space-y-4"
             >
+              {/* Smart search */}
+              <WorkloadSmartSearch
+                containers={filteredContainers}
+                knownStackNames={knownStackNames}
+                onFiltered={setSearchFilteredContainers}
+                totalCount={filteredContainers.length}
+              />
+
               <div className="flex items-center gap-4 flex-wrap">
                 <div className="flex items-center gap-2">
                   <label htmlFor="endpoint-select" className="text-sm font-medium">
@@ -684,14 +692,6 @@ export default function WorkloadExplorerPage() {
                   )}
                 </div>
               )}
-
-              {/* Smart search */}
-              <WorkloadSmartSearch
-                containers={filteredContainers}
-                knownStackNames={knownStackNames}
-                onFiltered={setSearchFilteredContainers}
-                totalCount={filteredContainers.length}
-              />
 
               <DataTable
                 columns={columns}

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -552,6 +552,36 @@ describe('DataTable', () => {
     });
   });
 
+  describe('selection hit-box', () => {
+    it('wraps the row checkbox in a padded label to enlarge the click target', () => {
+      render(<DataTable columns={testColumns} data={makeRows(2)} enableRowSelection />);
+      const input = screen.getByTestId('row-checkbox-0');
+      const label = input.closest('label');
+      expect(label).not.toBeNull();
+      expect(label?.className).toContain('p-2.5');
+      expect(label?.className).toContain('cursor-pointer');
+    });
+
+    it('toggles selection when the padded label is clicked, without firing onRowClick', () => {
+      const onRowClick = vi.fn();
+      const onSelectionChange = vi.fn();
+      const data = makeRows(2);
+      render(
+        <DataTable
+          columns={testColumns}
+          data={data}
+          enableRowSelection
+          onRowClick={onRowClick}
+          onSelectionChange={onSelectionChange}
+        />,
+      );
+      const label = screen.getByTestId('row-checkbox-0').closest('label')!;
+      fireEvent.click(label);
+      expect(onSelectionChange).toHaveBeenCalledWith([data[0]]);
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
+  });
+
   describe('themed checkbox (#1288)', () => {
     it('header checkbox uses the themed primitive (input + adjacent indicator icon)', () => {
       render(

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 import { DataTable } from './data-table';
 import type { ColumnDef } from '@tanstack/react-table';
 
@@ -643,6 +643,48 @@ describe('DataTable', () => {
       expect(screen.queryByTestId('virtual-scroll-container')).not.toBeInTheDocument();
       expect(screen.queryByTestId('window-scroll-container')).not.toBeInTheDocument();
       expect(screen.getByTestId('auto-fit-container')).toBeInTheDocument();
+    });
+
+    it('recomputes page size when the viewport is resized', () => {
+      // requestAnimationFrame → run synchronously so the resize handler flushes in-test
+      const rafSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          cb(0);
+          return 0;
+        });
+      // initial: available = 1000 - 200 - 40 - 56 - 24 = 680 → floor(680/48)=14 → ceil(30/14)=3 pages
+      setViewport(1000, 200);
+      render(<DataTable columns={testColumns} data={makeRows(30)} autoFit />);
+      expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+
+      // shrink viewport: available = 700 - 200 - 40 - 56 - 24 = 380 → floor(380/48)=7 → ceil(30/7)=5 pages
+      act(() => {
+        Object.defineProperty(window, 'innerHeight', { value: 700, configurable: true });
+        window.dispatchEvent(new Event('resize'));
+      });
+      expect(screen.getByText(/Page 1 of 5/)).toBeInTheDocument();
+
+      rafSpy.mockRestore();
+    });
+
+    it('clamps the page index back into range when data shrinks', () => {
+      setViewport(1000, 200); // 14 rows/page → 3 pages for 30 rows
+      const { rerender } = render(<DataTable columns={testColumns} data={makeRows(30)} autoFit />);
+
+      // navigate to the last page (3 of 3)
+      const next = () => {
+        const buttons = screen.getAllByRole('button');
+        fireEvent.click(buttons[buttons.length - 1]);
+      };
+      next(); // page 2
+      next(); // page 3
+      expect(screen.getByText(/Page 3 of 3/)).toBeInTheDocument();
+
+      // shrink data to a single page → clamp effect resets the index; single page hides the footer
+      rerender(<DataTable columns={testColumns} data={makeRows(5)} autoFit />);
+      expect(screen.getByText('container-5')).toBeInTheDocument();
+      expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -280,6 +280,10 @@ describe('DataTable', () => {
       // ascending → arrow-up, neutral icon gone
       expect(nameHeader.querySelector('svg.lucide-arrow-up')).toBeInTheDocument();
       expect(nameHeader.querySelector('svg.lucide-arrow-up-down')).not.toBeInTheDocument();
+      // descending → arrow-down replaces arrow-up
+      fireEvent.click(nameHeader);
+      expect(nameHeader.querySelector('svg.lucide-arrow-down')).toBeInTheDocument();
+      expect(nameHeader.querySelector('svg.lucide-arrow-up')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -686,6 +686,28 @@ describe('DataTable', () => {
       expect(screen.getByText('container-5')).toBeInTheDocument();
       expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument();
     });
+
+    it('renders selection checkboxes alongside pagination in autoFit mode', () => {
+      setViewport(1000, 200); // 14 rows/page → 3 pages for 30 rows
+      const onSelectionChange = vi.fn();
+      const data = makeRows(30);
+      render(
+        <DataTable
+          columns={testColumns}
+          data={data}
+          autoFit
+          enableRowSelection
+          onSelectionChange={onSelectionChange}
+        />,
+      );
+      const container = screen.getByTestId('auto-fit-container');
+      expect(container.querySelector('[data-testid="select-all-checkbox"]')).toBeInTheDocument();
+      expect(screen.getByTestId('row-checkbox-0')).toBeInTheDocument();
+      expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+      // toggling a row checkbox selects that row
+      fireEvent.click(screen.getByTestId('row-checkbox-0'));
+      expect(onSelectionChange).toHaveBeenCalledWith([data[0]]);
+    });
   });
 
   describe('horizontal scroll (minTableWidth)', () => {

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -255,6 +255,34 @@ describe('DataTable', () => {
     });
   });
 
+  describe('sort direction indicator', () => {
+    it('marks sortable headers aria-sort="none" before any sort', () => {
+      render(<DataTable columns={testColumns} data={makeRows(5)} />);
+      const nameHeader = screen.getByText('Name').closest('th');
+      expect(nameHeader).toHaveAttribute('aria-sort', 'none');
+    });
+
+    it('sets aria-sort ascending then descending when toggling a header', () => {
+      render(<DataTable columns={testColumns} data={makeRows(5)} />);
+      const nameHeader = screen.getByText('Name').closest('th')!;
+      fireEvent.click(nameHeader);
+      expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
+      fireEvent.click(nameHeader);
+      expect(nameHeader).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('swaps the neutral icon for a directional arrow on the active column', () => {
+      render(<DataTable columns={testColumns} data={makeRows(5)} />);
+      const nameHeader = screen.getByText('Name').closest('th')!;
+      // inactive → neutral up/down icon
+      expect(nameHeader.querySelector('svg.lucide-arrow-up-down')).toBeInTheDocument();
+      fireEvent.click(nameHeader);
+      // ascending → arrow-up, neutral icon gone
+      expect(nameHeader.querySelector('svg.lucide-arrow-up')).toBeInTheDocument();
+      expect(nameHeader.querySelector('svg.lucide-arrow-up-down')).not.toBeInTheDocument();
+    });
+  });
+
   describe('server-side pagination mode', () => {
     it('renders server pagination controls when serverPagination is provided', () => {
       const onPageChange = vi.fn();

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DataTable } from './data-table';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -579,6 +579,92 @@ describe('DataTable', () => {
       fireEvent.click(label);
       expect(onSelectionChange).toHaveBeenCalledWith([data[0]]);
       expect(onRowClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('autoFit mode', () => {
+    let rectSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    const setViewport = (innerHeight: number, top: number) => {
+      Object.defineProperty(window, 'innerHeight', { value: innerHeight, configurable: true });
+      rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({
+          top,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          width: 0,
+          height: 0,
+          x: 0,
+          y: top,
+          toJSON: () => ({}),
+        } as DOMRect);
+    };
+
+    afterEach(() => {
+      rectSpy?.mockRestore();
+      rectSpy = undefined;
+      Object.defineProperty(window, 'innerHeight', { value: 768, configurable: true });
+    });
+
+    it('computes page size from the available viewport height', () => {
+      // available = 1000 - 200 - 40 - 56 - 24 = 680 → floor(680 / 48) = 14 rows/page
+      setViewport(1000, 200);
+      render(<DataTable columns={testColumns} data={makeRows(30)} autoFit />);
+      expect(screen.getByTestId('auto-fit-container')).toBeInTheDocument();
+      expect(screen.getByText('container-14')).toBeInTheDocument();
+      expect(screen.queryByText('container-15')).not.toBeInTheDocument();
+      expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument(); // ceil(30/14) = 3
+    });
+
+    it('paginates to the next page of rows', () => {
+      setViewport(1000, 200); // 14 rows/page
+      render(<DataTable columns={testColumns} data={makeRows(30)} autoFit />);
+      const buttons = screen.getAllByRole('button');
+      fireEvent.click(buttons[buttons.length - 1]); // next page
+      expect(screen.getByText('container-15')).toBeInTheDocument();
+      expect(screen.queryByText('container-14')).not.toBeInTheDocument();
+      expect(screen.getByText(/Page 2 of 3/)).toBeInTheDocument();
+    });
+
+    it('floors page size to a minimum of 5 rows on very short viewports', () => {
+      // available = 200 - 180 - 40 - 56 - 24 = -100 → max(5, floor(-100/48)) = 5
+      setViewport(200, 180);
+      render(<DataTable columns={testColumns} data={makeRows(12)} autoFit />);
+      expect(screen.getByText('container-5')).toBeInTheDocument();
+      expect(screen.queryByText('container-6')).not.toBeInTheDocument();
+      expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument(); // ceil(12/5) = 3
+    });
+
+    it('does not virtualize or window-scroll in autoFit mode', () => {
+      setViewport(1000, 200);
+      render(<DataTable columns={testColumns} data={makeRows(100)} autoFit />);
+      expect(screen.queryByTestId('virtual-scroll-container')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('window-scroll-container')).not.toBeInTheDocument();
+      expect(screen.getByTestId('auto-fit-container')).toBeInTheDocument();
+    });
+  });
+
+  describe('horizontal scroll (minTableWidth)', () => {
+    let rectSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    afterEach(() => {
+      rectSpy?.mockRestore();
+      rectSpy = undefined;
+      Object.defineProperty(window, 'innerHeight', { value: 768, configurable: true });
+    });
+
+    it('applies overflow-x-auto and a min-width on the table when minTableWidth is set', () => {
+      Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true });
+      rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({ top: 100, toJSON: () => ({}) } as DOMRect);
+      render(<DataTable columns={testColumns} data={makeRows(5)} autoFit minTableWidth={860} />);
+      const container = screen.getByTestId('auto-fit-container');
+      expect(container.className).toContain('overflow-x-auto');
+      const table = container.querySelector('table');
+      expect(table?.style.minWidth).toBe('860px');
     });
   });
 

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -15,7 +15,7 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { cn } from '@/shared/lib/utils';
 import { Checkbox } from '@/shared/components/ui/checkbox';
-import { ArrowUpDown, ChevronLeft, ChevronRight, ArrowUp } from 'lucide-react';
+import { ArrowUpDown, ChevronLeft, ChevronRight, ArrowUp, ArrowDown } from 'lucide-react';
 
 const ROW_HEIGHT = 48;
 const OVERSCAN = 10;
@@ -259,26 +259,45 @@ export function DataTable<T>({
     <thead className={cn('[&_tr]:border-b', useVirtual && 'sticky top-0 z-10 bg-card')}>
       {table.getHeaderGroups().map((headerGroup) => (
         <tr key={headerGroup.id} className="border-b transition-colors hover:bg-muted/50">
-          {headerGroup.headers.map((header) => (
-            <th
-              key={header.id}
-              style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}
-              className={cn(
-                'h-10 px-4 text-left align-middle font-medium text-muted-foreground',
-                header.column.getCanSort() && 'cursor-pointer select-none'
-              )}
-              onClick={header.column.getToggleSortingHandler()}
-            >
-              <div className="flex items-center gap-2">
-                {header.isPlaceholder
-                  ? null
-                  : flexRender(header.column.columnDef.header, header.getContext())}
-                {header.column.getCanSort() && (
-                  <ArrowUpDown className="h-4 w-4" />
+          {headerGroup.headers.map((header) => {
+            const canSort = header.column.getCanSort();
+            const sorted = header.column.getIsSorted(); // 'asc' | 'desc' | false
+            return (
+              <th
+                key={header.id}
+                style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}
+                aria-sort={
+                  !canSort
+                    ? undefined
+                    : sorted === 'asc'
+                      ? 'ascending'
+                      : sorted === 'desc'
+                        ? 'descending'
+                        : 'none'
+                }
+                className={cn(
+                  'h-10 px-4 text-left align-middle font-medium',
+                  canSort && 'cursor-pointer select-none',
+                  sorted ? 'text-foreground' : 'text-muted-foreground',
                 )}
-              </div>
-            </th>
-          ))}
+                onClick={header.column.getToggleSortingHandler()}
+              >
+                <div className="flex items-center gap-2">
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(header.column.columnDef.header, header.getContext())}
+                  {canSort &&
+                    (sorted === 'asc' ? (
+                      <ArrowUp className="h-4 w-4 text-foreground" />
+                    ) : sorted === 'desc' ? (
+                      <ArrowDown className="h-4 w-4 text-foreground" />
+                    ) : (
+                      <ArrowUpDown className="h-4 w-4 text-muted-foreground/40" />
+                    ))}
+                </div>
+              </th>
+            );
+          })}
         </tr>
       ))}
     </thead>

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -261,7 +261,7 @@ export function DataTable<T>({
         <tr key={headerGroup.id} className="border-b transition-colors hover:bg-muted/50">
           {headerGroup.headers.map((header) => {
             const canSort = header.column.getCanSort();
-            const sorted = header.column.getIsSorted(); // 'asc' | 'desc' | false
+            const sorted = header.column.getIsSorted(); // false when the column is not sorted
             return (
               <th
                 key={header.id}

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import {
   useReactTable,
   getCoreRowModel,
@@ -11,6 +11,8 @@ import {
   type ColumnFiltersState,
   type RowSelectionState,
   type Row,
+  type PaginationState,
+  type Updater,
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { cn } from '@/shared/lib/utils';
@@ -22,6 +24,10 @@ const OVERSCAN = 10;
 const VIRTUAL_THRESHOLD = 50;
 const SCROLL_CONTAINER_HEIGHT = 600;
 const SCROLL_TO_TOP_THRESHOLD = 20;
+const AUTO_FIT_HEADER_PX = 40; // sticky header row (h-10)
+const AUTO_FIT_FOOTER_PX = 56; // pagination footer reserve
+const AUTO_FIT_MARGIN_PX = 24; // breathing room above the viewport bottom
+const MIN_AUTO_ROWS = 5; // never page smaller than this
 
 export interface ServerPaginationProps {
   total: number;
@@ -53,6 +59,17 @@ interface DataTableProps<T> {
    * dataset is bounded to a few hundred rows.
    */
   windowScroll?: boolean;
+  /**
+   * Paginate with a page size computed to fill the available viewport
+   * height. Recomputes on resize and when `data` changes. Mutually
+   * exclusive with `windowScroll`, virtualization, and `serverPagination`.
+   */
+  autoFit?: boolean;
+  /**
+   * Minimum table width in px. When the container is narrower the table
+   * overflows horizontally (themed scrollbar) instead of squashing columns.
+   */
+  minTableWidth?: number;
 }
 
 export function DataTable<T>({
@@ -72,10 +89,15 @@ export function DataTable<T>({
   getRowId: getRowIdProp,
   selectedRowIds,
   windowScroll,
+  autoFit,
+  minTableWidth,
 }: DataTableProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [pageIndex, setPageIndex] = useState(0);
+  const [autoPageSize, setAutoPageSize] = useState(MIN_AUTO_ROWS);
+  const autoFitWrapperRef = useRef<HTMLDivElement>(null);
 
   // Sync controlled selection from parent (e.g. clear all checkboxes)
   useEffect(() => {
@@ -88,10 +110,13 @@ export function DataTable<T>({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const isServerPaginated = !!serverPagination;
-  const useWindowScroll = !!windowScroll && !isServerPaginated;
+  const useAutoFit = !!autoFit && !isServerPaginated;
+  const useWindowScroll = !!windowScroll && !isServerPaginated && !useAutoFit;
   const useVirtual = !useWindowScroll
+    && !useAutoFit
     && !isServerPaginated
     && (virtualScrolling ?? data.length > VIRTUAL_THRESHOLD);
+  const useClientPagination = !useVirtual && !useWindowScroll && !isServerPaginated;
 
   // Build the checkbox column when row selection is enabled
   const selectionColumn = useMemo<ColumnDef<T, any> | null>(() => {
@@ -152,9 +177,22 @@ export function DataTable<T>({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    ...(useVirtual || isServerPaginated || useWindowScroll ? {} : { getPaginationRowModel: getPaginationRowModel() }),
+    ...(useClientPagination ? { getPaginationRowModel: getPaginationRowModel() } : {}),
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
+    ...(useAutoFit
+      ? {
+          onPaginationChange: (updater: Updater<PaginationState>) => {
+            setPageIndex((prev) => {
+              const next =
+                typeof updater === 'function'
+                  ? updater({ pageIndex: prev, pageSize: autoPageSize })
+                  : updater;
+              return next.pageIndex;
+            });
+          },
+        }
+      : {}),
     ...(enableRowSelection
       ? {
           enableRowSelection: (row) => {
@@ -169,8 +207,9 @@ export function DataTable<T>({
       sorting,
       columnFilters,
       ...(enableRowSelection ? { rowSelection } : {}),
+      ...(useAutoFit ? { pagination: { pageIndex, pageSize: autoPageSize } } : {}),
     },
-    ...(useVirtual || isServerPaginated || useWindowScroll ? {} : { initialState: { pagination: { pageSize } } }),
+    ...(useClientPagination && !useAutoFit ? { initialState: { pagination: { pageSize } } } : {}),
     ...(getRowIdProp ? { getRowId: (row: T) => getRowIdProp(row) } : {}),
   });
 
@@ -187,6 +226,45 @@ export function DataTable<T>({
       table.getColumn(searchKey)?.setFilterValue(externalSearchValue);
     }
   }, [externalSearchValue, searchKey, table]);
+
+  // Auto-fit: compute a page size that fills the available viewport height.
+  const recomputeAutoPageSize = useCallback(() => {
+    if (!useAutoFit) return;
+    const el = autoFitWrapperRef.current;
+    if (!el) return;
+    const top = el.getBoundingClientRect().top;
+    const available =
+      window.innerHeight - top - AUTO_FIT_HEADER_PX - AUTO_FIT_FOOTER_PX - AUTO_FIT_MARGIN_PX;
+    const size = Math.max(MIN_AUTO_ROWS, Math.floor(available / ROW_HEIGHT));
+    setAutoPageSize((prev) => (prev === size ? prev : size));
+  }, [useAutoFit]);
+
+  useLayoutEffect(() => {
+    recomputeAutoPageSize();
+  }, [recomputeAutoPageSize, data]);
+
+  useEffect(() => {
+    if (!useAutoFit) return;
+    let raf = 0;
+    const onResize = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(recomputeAutoPageSize);
+    };
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      cancelAnimationFrame(raf);
+    };
+  }, [useAutoFit, recomputeAutoPageSize]);
+
+  // Keep pageIndex in range when the page size or data shrinks.
+  useEffect(() => {
+    if (!useAutoFit) return;
+    const pageCount = table.getPageCount();
+    if (pageCount > 0 && pageIndex > pageCount - 1) {
+      setPageIndex(pageCount - 1);
+    }
+  }, [useAutoFit, autoPageSize, data, pageIndex, table]);
 
   const { rows } = table.getRowModel();
 
@@ -240,6 +318,37 @@ export function DataTable<T>({
     : 0;
   const canServerPrev = serverPagination ? serverPagination.page > 1 : false;
   const canServerNext = serverPagination ? serverPagination.page < serverPageCount : false;
+
+  const tableStyle = minTableWidth ? { minWidth: minTableWidth } : undefined;
+
+  const renderClientPagination = () => {
+    if (table.getPageCount() <= 1) return null;
+    return (
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()} ({data.length} total)
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            aria-label="Next page"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    );
+  };
 
   const renderRow = (row: Row<T>) => (
     <tr
@@ -367,9 +476,33 @@ export function DataTable<T>({
         </div>
       )}
 
-      {useWindowScroll ? (
-        <div className="rounded-md border" data-testid="window-scroll-container">
-          <table className="w-full caption-bottom text-sm">
+      {useAutoFit ? (
+        <>
+          <div
+            ref={autoFitWrapperRef}
+            className="overflow-x-auto rounded-md border"
+            data-testid="auto-fit-container"
+          >
+            <table className="w-full caption-bottom text-sm" style={tableStyle}>
+              {renderHeader()}
+              <tbody className="[&_tr:last-child]:border-0">
+                {table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row) => renderRow(row))
+                ) : (
+                  <tr>
+                    <td colSpan={allColumns.length} className="h-24 text-center text-muted-foreground">
+                      No results.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+          {renderClientPagination()}
+        </>
+      ) : useWindowScroll ? (
+        <div className="overflow-x-auto rounded-md border" data-testid="window-scroll-container">
+          <table className="w-full caption-bottom text-sm" style={tableStyle}>
             {renderHeader()}
             <tbody className="[&_tr:last-child]:border-0">
               {rows.length ? (
@@ -396,7 +529,7 @@ export function DataTable<T>({
             aria-label="Data table with virtual scrolling"
             data-testid="virtual-scroll-container"
           >
-            <table className="w-full caption-bottom text-sm">
+            <table className="w-full caption-bottom text-sm" style={tableStyle}>
               {renderHeader()}
               <tbody className="[&_tr:last-child]:border-0">
                 {rows.length ? (
@@ -451,8 +584,8 @@ export function DataTable<T>({
         </div>
       ) : (
         <>
-          <div className="rounded-md border">
-            <table className="w-full caption-bottom text-sm">
+          <div className="overflow-x-auto rounded-md border">
+            <table className="w-full caption-bottom text-sm" style={tableStyle}>
               {renderHeader()}
               <tbody className="[&_tr:last-child]:border-0">
                 {table.getRowModel().rows.length ? (
@@ -468,34 +601,7 @@ export function DataTable<T>({
             </table>
           </div>
 
-          {isServerPaginated ? (
-            renderServerPagination()
-          ) : (
-            table.getPageCount() > 1 && (
-              <div className="flex items-center justify-between">
-                <p className="text-sm text-muted-foreground">
-                  Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
-                  {' '}({data.length} total)
-                </p>
-                <div className="flex items-center gap-2">
-                  <button
-                    className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
-                    onClick={() => table.previousPage()}
-                    disabled={!table.getCanPreviousPage()}
-                  >
-                    <ChevronLeft className="h-4 w-4" />
-                  </button>
-                  <button
-                    className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 text-sm hover:bg-accent disabled:opacity-50"
-                    onClick={() => table.nextPage()}
-                    disabled={!table.getCanNextPage()}
-                  >
-                    <ChevronRight className="h-4 w-4" />
-                  </button>
-                </div>
-              </div>
-            )
-          )}
+          {isServerPaginated ? renderServerPagination() : renderClientPagination()}
         </>
       )}
     </div>

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -480,7 +480,7 @@ export function DataTable<T>({
         <>
           <div
             ref={autoFitWrapperRef}
-            className="overflow-x-auto rounded-md border"
+            className="scrollbar-themed overflow-x-auto rounded-md border"
             data-testid="auto-fit-container"
           >
             <table className="w-full caption-bottom text-sm" style={tableStyle}>
@@ -501,7 +501,7 @@ export function DataTable<T>({
           {renderClientPagination()}
         </>
       ) : useWindowScroll ? (
-        <div className="overflow-x-auto rounded-md border" data-testid="window-scroll-container">
+        <div className="scrollbar-themed overflow-x-auto rounded-md border" data-testid="window-scroll-container">
           <table className="w-full caption-bottom text-sm" style={tableStyle}>
             {renderHeader()}
             <tbody className="[&_tr:last-child]:border-0">
@@ -584,7 +584,7 @@ export function DataTable<T>({
         </div>
       ) : (
         <>
-          <div className="overflow-x-auto rounded-md border">
+          <div className="scrollbar-themed overflow-x-auto rounded-md border">
             <table className="w-full caption-bottom text-sm" style={tableStyle}>
               {renderHeader()}
               <tbody className="[&_tr:last-child]:border-0">

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -98,19 +98,24 @@ export function DataTable<T>({
     if (!enableRowSelection) return null;
     return {
       id: '_selection',
-      size: 40,
+      size: 52,
       enableSorting: false,
       header: ({ table: tbl }) => {
         const allPageSelected = tbl.getIsAllPageRowsSelected();
         const somePageSelected = tbl.getIsSomePageRowsSelected();
         return (
-          <Checkbox
-            data-testid="select-all-checkbox"
-            aria-label="Select all on page"
-            checked={allPageSelected}
-            indeterminate={somePageSelected && !allPageSelected}
-            onChange={tbl.getToggleAllPageRowsSelectedHandler()}
-          />
+          <label
+            className="-m-2.5 inline-flex cursor-pointer items-center justify-center p-2.5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Checkbox
+              data-testid="select-all-checkbox"
+              aria-label="Select all on page"
+              checked={allPageSelected}
+              indeterminate={somePageSelected && !allPageSelected}
+              onChange={tbl.getToggleAllPageRowsSelectedHandler()}
+            />
+          </label>
         );
       },
       cell: ({ row }) => {
@@ -118,15 +123,20 @@ export function DataTable<T>({
         const isSelected = row.getIsSelected();
         const isDisabled = !isSelected && maxSelection !== undefined && selectedCount >= maxSelection;
         return (
-          <Checkbox
-            data-testid={`row-checkbox-${row.id}`}
-            aria-label={`Select row ${row.id}`}
-            checked={isSelected}
-            disabled={isDisabled}
-            title={isDisabled ? `Maximum of ${maxSelection} containers can be compared at once` : undefined}
-            onChange={row.getToggleSelectedHandler()}
+          <label
+            className="-m-2.5 inline-flex cursor-pointer items-center justify-center p-2.5"
             onClick={(e) => e.stopPropagation()}
-          />
+          >
+            <Checkbox
+              data-testid={`row-checkbox-${row.id}`}
+              aria-label={`Select row ${row.id}`}
+              checked={isSelected}
+              disabled={isDisabled}
+              title={isDisabled ? `Maximum of ${maxSelection} containers can be compared at once` : undefined}
+              onChange={row.getToggleSelectedHandler()}
+              onClick={(e) => e.stopPropagation()}
+            />
+          </label>
         );
       },
     };

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -134,7 +134,6 @@ export function DataTable<T>({
               disabled={isDisabled}
               title={isDisabled ? `Maximum of ${maxSelection} containers can be compared at once` : undefined}
               onChange={row.getToggleSelectedHandler()}
-              onClick={(e) => e.stopPropagation()}
             />
           </label>
         );


### PR DESCRIPTION
## Summary

Six UI refinements to the Workload Explorer list, implemented TDD via the spec/plan in `docs/superpowers/`:

- **Auto-fit pagination** — the list now pages instead of window-scrolling; page size is computed to fill the viewport height (recomputes on resize / filter changes, min 5 rows). New reusable `DataTable` `autoFit` mode.
- **Horizontal scroll on narrow widths** — new `DataTable` `minTableWidth` prop (explorer passes `860`); wraps tables in `overflow-x-auto` so columns no longer squash.
- **Search above filters** — `WorkloadSmartSearch` moved above the endpoint/stack/group/state dropdowns (order: search → dropdowns → chips → table).
- **Compact Group column** — text badge replaced with a labelled icon: amber `Cog` (System) / slate `Box` (Workload), narrower column, `title`/`aria-label`/`sr-only` for a11y.
- **Bigger checkbox hit-box** — selection checkbox wrapped in a padded `<label>` (~36px target) without changing the visible box; selection column widened 40→52.
- **Sort-direction indicator** — active sortable header shows `ArrowUp`/`ArrowDown` (emphasized), inactive shows a faint neutral icon, plus `aria-sort`.

Reusable changes live in `frontend/src/shared/components/tables/data-table.tsx`; page changes in `frontend/src/features/containers/pages/workload-explorer.tsx`. No changes to data fetching, compare mode, CSV export, filter semantics, or grouping logic. No new dependencies.

Spec: `docs/superpowers/specs/2026-05-29-workload-explorer-ui-refinements-design.md`

## Test Plan

- [x] `data-table.test.tsx` — sort indicator, enlarged hit-box, autoFit page-size math + next-page + min-5 floor + resize-recompute + shrink-clamp, horizontal scroll, autoFit-with-row-selection (56 tests)
- [x] `workload-explorer.test.tsx` — search-above-filters ordering, Group icon a11y, `autoFit`/`minTableWidth` props passed (52 tests)
- [x] Full frontend suite green (2014/2014), typecheck clean, lint clean, `build` succeeds
- [ ] Manual: confirm in-browser that the list pages and re-fits on resize, narrow window shows a horizontal scrollbar, Group icons + tooltips render, checkbox is easy to click, and sort arrows reflect direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)