### PR TITLE
feat(layout): symmetric sidebar inset after activity-feed removal

### DIFF
--- a/frontend/src/features/core/components/layout/sidebar.test.tsx
+++ b/frontend/src/features/core/components/layout/sidebar.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Sidebar, getSidebarBottomClass } from './sidebar';
+import { Sidebar } from './sidebar';
 import { useUiStore } from '@/stores/ui-store';
 
 vi.mock('@/features/operations/hooks/use-remediation', () => ({
@@ -35,8 +35,16 @@ describe('Sidebar', () => {
     });
   });
 
-  it('uses collapsed-feed spacing for sidebar bottom offset', () => {
-    expect(getSidebarBottomClass()).toBe('md:bottom-12');
+  it('uses a symmetric 1rem inset on top, left, and bottom', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+    renderSidebar();
+    const sidebar = screen.getByTestId('sidebar');
+    expect(sidebar.className).toContain('top-4');
+    expect(sidebar.className).toContain('left-4');
+    expect(sidebar.className).toContain('bottom-4');
+    // no leftover activity-feed bottom clearance
+    expect(sidebar.className).not.toContain('bottom-12');
+    expect(sidebar.className).not.toContain('bottom-2');
   });
 
   it('shows pending remediation count as badge', () => {

--- a/frontend/src/features/core/components/layout/sidebar.tsx
+++ b/frontend/src/features/core/components/layout/sidebar.tsx
@@ -46,10 +46,6 @@ interface NavGroup {
   items: NavItem[];
 }
 
-export function getSidebarBottomClass(): 'md:bottom-12' {
-  return 'md:bottom-12';
-}
-
 const navigation: NavGroup[] = [
   {
     title: 'Overview',
@@ -214,9 +210,8 @@ export function Sidebar() {
         data-testid="sidebar"
         data-animated-bg={hasAnimatedBg || undefined}
         className={cn(
-          'fixed left-4 top-4 bottom-2 z-30 flex flex-col rounded-2xl bg-sidebar-background/80 backdrop-blur-xl shadow-lg ring-1 ring-black/5 dark:ring-white/10',
+          'fixed left-4 top-4 bottom-4 z-30 flex flex-col rounded-2xl bg-sidebar-background/80 backdrop-blur-xl shadow-lg ring-1 ring-black/5 dark:ring-white/10',
           !potatoMode && 'transition-[width,background-color] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
-          getSidebarBottomClass(),
           sidebarCollapsed ? 'w-16' : 'w-64'
         )}
       >


### PR DESCRIPTION
## Summary

Follow-up to the activity-feed removal. The sidebar still carried `md:bottom-12` — the bottom-bar analog of the main content's `md:pb-12` that cleared the (now-removed) activity feed. With the feed gone, that left a 3rem dead gap below the sidebar, while the main content already ends at the 1rem line — so the two bottoms no longer aligned.

**Change:** sidebar inset `left-4 top-4 bottom-2` (+ `md:bottom-12`) → **`left-4 top-4 bottom-4`** — equal 1rem on top, left, and bottom (a bit larger), so its bottom lines up with the Workload Explorer content/table bottom.

- Removed the now-dead `getSidebarBottomClass()` helper.
- Replaced its unit test with a regression test asserting the symmetric inset (`top-4`/`left-4`/`bottom-4`, no `bottom-12`/`bottom-2`).
- No table code change needed: the main content's matching feed-clearance padding (`md:pb-12`) was already removed with the feed, so the table area already ends at the 1rem line.

## Test Plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test -w frontend` — 1995/1995 pass (incl. new symmetric-inset test)
- [x] `npm run build -w frontend` succeeds
- [ ] Manual: confirm equal top/left/bottom spacing around the sidebar, and that the Workload Explorer table card bottom lines up with the sidebar bottom (if the auto-fit table leaves a small gap, a follow-up can trim its ~24px breathing room)

🤖 Generated with [Claude Code](https://claude.com/claude-code)