### PR TITLE
fix(workloads): fit table to viewport (no dead scroll) + drop obsolete row actions

### DIFF
--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -942,10 +942,10 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
     return typeof col?.header === 'string' ? col.header : undefined;
   }
 
-  it('renders columns in order Name, Stackname, State, Endpoint, Imagename, Group, Actions', () => {
+  it('renders columns in order Name, Stackname, State, Endpoint, Imagename, Group (no Actions column)', () => {
     render(<WorkloadExplorerPage />);
     const ids = mockColumns?.map((c) => c.id ?? c.accessorKey);
-    expect(ids).toEqual(['name', 'stack', 'state', 'endpointName', 'image', 'group', 'actions']);
+    expect(ids).toEqual(['name', 'stack', 'state', 'endpointName', 'image', 'group']);
   });
 
   it('renames the stack and image headers to Stackname and Imagename', () => {
@@ -972,7 +972,7 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
 
   it('passes minTableWidth to the DataTable for horizontal scrolling', () => {
     render(<WorkloadExplorerPage />);
-    expect(screen.getByTestId('workloads-table')).toHaveAttribute('data-min-table-width', '860');
+    expect(screen.getByTestId('workloads-table')).toHaveAttribute('data-min-table-width', '770');
   });
 
   it('Imagename cell renders only the segment after the last "/" with the full path on title', () => {

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useCallback } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { type ColumnDef, type RowSelectionState } from '@tanstack/react-table';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import { AlertTriangle, Box, Boxes, Cog, Download, Eye, GitCompareArrows, ScrollText, X } from 'lucide-react';
+import { AlertTriangle, Box, Boxes, Cog, Download, GitCompareArrows, X } from 'lucide-react';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { useContainers, type Container } from '@/features/containers/hooks/use-containers';
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
@@ -391,43 +391,6 @@ export default function WorkloadExplorerPage() {
         );
       },
     },
-    {
-      id: 'actions',
-      header: () => <span className="sr-only">Actions</span>,
-      size: 90,
-      enableSorting: false,
-      cell: ({ row }) => {
-        const container = row.original;
-        return (
-          <div className="flex items-center justify-end gap-1 opacity-0 transition-opacity duration-150 group-hover/row:opacity-100 group-focus-within/row:opacity-100 max-sm:opacity-100">
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                navigate(`/containers/${container.endpointId}/${container.id}`);
-              }}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-accent"
-              aria-label={`View details for ${container.name}`}
-              title="View details"
-            >
-              <Eye className="h-3.5 w-3.5 text-muted-foreground" />
-            </button>
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                navigate(`/containers/${container.endpointId}/${container.id}?tab=logs`);
-              }}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-accent"
-              aria-label={`View logs for ${container.name}`}
-              title="View logs"
-            >
-              <ScrollText className="h-3.5 w-3.5 text-muted-foreground" />
-            </button>
-          </div>
-        );
-      },
-    },
   ], [navigate, knownStackNames, selectedEndpoint, selectedGroup, selectedState]);
 
   if (isError) {
@@ -703,7 +666,7 @@ export default function WorkloadExplorerPage() {
                 data={searchFilteredContainers ?? filteredContainers}
                 hideSearch
                 autoFit
-                minTableWidth={860}
+                minTableWidth={770}
                 enableRowSelection
                 maxSelection={MAX_COMPARE}
                 onSelectionChange={handleSelectionChange}

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -584,6 +584,7 @@ describe('DataTable', () => {
 
   describe('autoFit mode', () => {
     let rectSpy: ReturnType<typeof vi.spyOn> | undefined;
+    let gcsSpy: ReturnType<typeof vi.spyOn> | undefined;
 
     const setViewport = (innerHeight: number, top: number) => {
       Object.defineProperty(window, 'innerHeight', { value: innerHeight, configurable: true });
@@ -605,6 +606,8 @@ describe('DataTable', () => {
     afterEach(() => {
       rectSpy?.mockRestore();
       rectSpy = undefined;
+      gcsSpy?.mockRestore();
+      gcsSpy = undefined;
       Object.defineProperty(window, 'innerHeight', { value: 768, configurable: true });
     });
 
@@ -707,6 +710,45 @@ describe('DataTable', () => {
       // toggling a row checkbox selects that row
       fireEvent.click(screen.getByTestId('row-checkbox-0'));
       expect(onSelectionChange).toHaveBeenCalledWith([data[0]]);
+    });
+
+    it('reserves the scroll container bottom padding so the page itself does not scroll', () => {
+      // The scroll container (e.g. the app <main>) reserves bottom padding as
+      // clearance for fixed chrome (mobile nav, floating action bars). autoFit
+      // must treat that padding as unavailable so the table ends above it.
+      // viewport 1000, container top 200, padding-bottom 144:
+      //   ignoring padding → 1000 - 200 - 40 - 56 - 24 = 680 → 14 rows/page
+      //   reserving padding → (1000 - 144) - 200 - 120 = 536 → floor(536/48) = 11 rows
+      Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true });
+      rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+        top: 200,
+        bottom: 1000,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 200,
+        toJSON: () => ({}),
+      } as DOMRect);
+      const realGcs = window.getComputedStyle.bind(window);
+      gcsSpy = vi.spyOn(window, 'getComputedStyle').mockImplementation(((
+        elt: Element,
+        pseudo?: string | null,
+      ) => {
+        if (elt instanceof HTMLElement && elt.hasAttribute('data-scroll-host')) {
+          return { overflowY: 'auto', paddingBottom: '144px' } as unknown as CSSStyleDeclaration;
+        }
+        return realGcs(elt, pseudo ?? undefined);
+      }) as typeof window.getComputedStyle);
+
+      render(
+        <div data-scroll-host>
+          <DataTable columns={testColumns} data={makeRows(30)} autoFit />
+        </div>,
+      );
+      expect(screen.getByText('container-11')).toBeInTheDocument();
+      expect(screen.queryByText('container-12')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -29,6 +29,32 @@ const AUTO_FIT_FOOTER_PX = 56; // pagination footer reserve
 const AUTO_FIT_MARGIN_PX = 24; // breathing room above the viewport bottom
 const MIN_AUTO_ROWS = 5; // never page smaller than this
 
+/** Nearest ancestor that scrolls vertically (overflow-y auto/scroll), or null. */
+function getVerticalScrollParent(node: HTMLElement): HTMLElement | null {
+  let el = node.parentElement;
+  while (el) {
+    const { overflowY } = getComputedStyle(el);
+    if (overflowY === 'auto' || overflowY === 'scroll') return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Usable bottom edge (px from the viewport top) for content inside `el`'s scroll
+ * container. The container often reserves bottom padding as clearance for fixed
+ * chrome (mobile nav, floating action bars); that padding is unavailable, so we
+ * subtract it. Without it, autoFit sizes the table flush to the viewport and the
+ * reserved padding spills past it, leaving the page with a small dead scroll.
+ * Falls back to the viewport height when nothing scrolls.
+ */
+function getScrollableBottom(el: HTMLElement): number {
+  const scrollParent = getVerticalScrollParent(el);
+  if (!scrollParent) return window.innerHeight;
+  const padBottom = parseFloat(getComputedStyle(scrollParent).paddingBottom) || 0;
+  return Math.min(window.innerHeight, scrollParent.getBoundingClientRect().bottom - padBottom);
+}
+
 export interface ServerPaginationProps {
   total: number;
   page: number;
@@ -234,7 +260,7 @@ export function DataTable<T>({
     if (!el) return;
     const top = el.getBoundingClientRect().top;
     const available =
-      window.innerHeight - top - AUTO_FIT_HEADER_PX - AUTO_FIT_FOOTER_PX - AUTO_FIT_MARGIN_PX;
+      getScrollableBottom(el) - top - AUTO_FIT_HEADER_PX - AUTO_FIT_FOOTER_PX - AUTO_FIT_MARGIN_PX;
     const size = Math.max(MIN_AUTO_ROWS, Math.floor(available / ROW_HEIGHT));
     setAutoPageSize((prev) => (prev === size ? prev : size));
   }, [useAutoFit]);


### PR DESCRIPTION
## Summary

Two fixes for the **Workload Explorer** page.

### 1. No more dead scroll
The table uses `autoFit`, which sized itself flush to `window.innerHeight` while ignoring the scroll container's reserved bottom padding (clearance for the fixed mobile nav / floating action bar). That padding spilled past the viewport, leaving the page with a small scroll into empty space.

`autoFit` now finds its vertical scroll container and reserves its computed `padding-bottom`, so the table ends *above* the padding zone and the page no longer scrolls — pagination absorbs the overflow. It reads the actual computed padding, so it self-corrects across breakpoints. Blast radius is contained: Workload Explorer is the only `autoFit` consumer.

> Note: the page header was *not* the cause — `autoFit` already subtracts the header height dynamically, so a smaller header just yields more rows; the overflow below it is independent.

### 2. Removed obsolete actions column
Dropped the far-right **View details / View logs** column — rows are already clickable to the detail page and the name chip navigates too. Also dropped the now-unused `Eye` / `ScrollText` imports and refit `minTableWidth` 860 → 770 to reclaim the freed width (the `w-full` table redistributes it to the auto-width columns).

## Tests (TDD: failing test → fix → green)
- New: *"autoFit reserves the scroll container bottom padding so the page itself does not scroll"*
- Updated: column-set test (no `actions`) and `minTableWidth` test (770)
- ✅ Full frontend suite **1996 passed** · `typecheck` clean · `eslint` clean

## Verification note
Verified via the unit test that simulates the scroll-container-padding scenario plus the full suite — not a live browser (no dev server running). Happy to attach before/after screenshots if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)