### PR TITLE
feat(infra): fit Fleet Endpoints & Stacks tables to viewport (autoFit)

### DIFF
--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -421,6 +421,18 @@ describe('InfrastructurePage — fleet section', () => {
     // DataTable search input should be present
     expect(screen.getByTestId('data-table-search')).toBeInTheDocument();
   });
+
+  it('fleet table view fits the viewport (autoFit)', () => {
+    useUiStore.setState({ pageViewModes: { fleet: 'table' } });
+    mockEndpoints([
+      makeEndpoint({ id: 1, name: 'alpha-env' }),
+      makeEndpoint({ id: 2, name: 'beta-env' }),
+    ]);
+
+    renderPage();
+
+    expect(screen.getByTestId('auto-fit-container')).toBeInTheDocument();
+  });
 });
 
 describe('InfrastructurePage — stack section', () => {
@@ -487,6 +499,18 @@ describe('InfrastructurePage — stack section', () => {
     // DataTable search input should be present (one for fleet which is empty, one for stacks)
     const searchInputs = screen.getAllByTestId('data-table-search');
     expect(searchInputs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stacks table view fits the viewport (autoFit)', () => {
+    useUiStore.setState({ pageViewModes: { stacks: 'table' } });
+    mockStacks([
+      makeStack({ id: 1, name: 'alpha-stack' }),
+      makeStack({ id: 2, name: 'beta-stack' }),
+    ]);
+
+    renderPageWithInitialParams('/infrastructure?tab=stacks');
+
+    expect(screen.getByTestId('auto-fit-container')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -1041,7 +1041,7 @@ export default function InfrastructurePage() {
               data={filteredEndpoints}
               searchKey="name"
               searchPlaceholder="Search endpoints..."
-              pageSize={15}
+              autoFit
               onRowClick={(row) => handleEndpointClick(row.id)}
             />
           </div>
@@ -1207,7 +1207,7 @@ export default function InfrastructurePage() {
               data={filteredStacks}
               searchKey="name"
               searchPlaceholder="Search stacks..."
-              pageSize={15}
+              autoFit
               onRowClick={handleStackClick}
             />
           </div>


### PR DESCRIPTION
## Summary
Extends the Workload Explorer fit-to-viewport behavior (#1326) to the Infrastructure page's two single-primary tables.

- **Fleet → Endpoints** (table view) and **Stacks** (table view) now use `autoFit`, so the table sizes its page to the viewport and pagination handles overflow instead of a fixed `pageSize={15}` that left the page scrolling.
- **Intentionally left scrollable** (per design discussion): the Kubernetes tab (3 stacked tables) and the Images page (table below charts) — `autoFit` assumes a single primary table and would fight those layouts.

First in a series applying "no dead page scroll" across the app's tables.

## Tests
- New: *"fleet table view fits the viewport (autoFit)"* and *"stacks table view fits the viewport (autoFit)"* — assert the `auto-fit-container` renders in table mode (verified RED→GREEN).
- ✅ fleet-overview suite 60 passed · `typecheck` clean · `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)