### PR TITLE
feat(webhooks): migrate Webhooks table to shared DataTable

### DIFF
--- a/frontend/src/features/core/pages/webhooks.test.tsx
+++ b/frontend/src/features/core/pages/webhooks.test.tsx
@@ -87,6 +87,16 @@ describe('WebhooksPanel', () => {
     expect(screen.getAllByText('insight.created').length).toBeGreaterThan(0);
   });
 
+  it('renders deliveries in a DataTable', () => {
+    render(<WebhooksPanel />);
+
+    expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    // Delivery row content rendered by the DataTable
+    expect(screen.getByText('delivered')).toBeInTheDocument();
+    expect(screen.getByText('200')).toBeInTheDocument();
+    expect(screen.getByText('1/5')).toBeInTheDocument();
+  });
+
   it('creates a webhook from form input', async () => {
     render(<WebhooksPanel />);
 

--- a/frontend/src/features/core/pages/webhooks.tsx
+++ b/frontend/src/features/core/pages/webhooks.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
+import { type ColumnDef } from '@tanstack/react-table';
 import { Loader2, PlugZap, Plus, TestTube2, Trash2, Activity, Radio, RefreshCw, Webhook as WebhookIcon } from 'lucide-react';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { SkeletonText } from '@/shared/components/feedback/skeleton';
+import { DataTable } from '@/shared/components/tables/data-table';
 import {
   useCreateWebhook,
   useDeleteWebhook,
@@ -14,6 +16,7 @@ import {
   useWebhooks,
   streamDashboardEvents,
   type Webhook,
+  type WebhookDelivery,
 } from '@/features/core/hooks/use-webhooks';
 import { formatDate } from '@/shared/lib/utils';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
@@ -104,6 +107,44 @@ export function WebhooksPanel() {
     if (filter === 'disabled') return all.filter((w) => w.enabled === 0);
     return all;
   }, [filter, webhooksQuery.data]);
+
+  const deliveries = useMemo(
+    () => deliveriesQuery.data?.deliveries ?? [],
+    [deliveriesQuery.data],
+  );
+
+  const deliveryColumns = useMemo<ColumnDef<WebhookDelivery, unknown>[]>(() => [
+    {
+      accessorKey: 'event_type',
+      header: 'Event',
+      cell: ({ getValue }) => <span className="text-xs">{getValue<string>()}</span>,
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ getValue }) => <span className="text-xs capitalize">{getValue<string>()}</span>,
+    },
+    {
+      accessorKey: 'http_status',
+      header: 'HTTP',
+      cell: ({ getValue }) => <span className="text-xs">{getValue<number | null>() ?? '-'}</span>,
+    },
+    {
+      id: 'attempt',
+      header: 'Attempt',
+      enableSorting: false,
+      cell: ({ row }) => (
+        <span className="text-xs">{row.original.attempt}/{row.original.max_attempts}</span>
+      ),
+    },
+    {
+      accessorKey: 'created_at',
+      header: 'Created',
+      cell: ({ getValue }) => (
+        <span className="text-xs text-muted-foreground">{formatDate(getValue<string>())}</span>
+      ),
+    },
+  ], []);
 
   const beginCreate = () => {
     setEditingId(null);
@@ -394,33 +435,17 @@ export function WebhooksPanel() {
               <div className="h-9 animate-pulse rounded bg-muted" />
               <div className="h-9 animate-pulse rounded bg-muted" />
             </div>
+          ) : deliveries.length === 0 ? (
+            <p className="mt-2 text-xs text-muted-foreground">No deliveries recorded yet.</p>
           ) : (
-            <div className="mt-3 overflow-x-auto">
-              <table className="w-full min-w-[640px] text-sm">
-                <thead>
-                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-                    <th className="px-2 py-2 font-medium">Event</th>
-                    <th className="px-2 py-2 font-medium">Status</th>
-                    <th className="px-2 py-2 font-medium">HTTP</th>
-                    <th className="px-2 py-2 font-medium">Attempt</th>
-                    <th className="px-2 py-2 font-medium">Created</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(deliveriesQuery.data?.deliveries ?? []).map((delivery) => (
-                    <tr key={delivery.id} className="border-b last:border-0">
-                      <td className="px-2 py-2 text-xs">{delivery.event_type}</td>
-                      <td className="px-2 py-2 text-xs capitalize">{delivery.status}</td>
-                      <td className="px-2 py-2 text-xs">{delivery.http_status ?? '-'}</td>
-                      <td className="px-2 py-2 text-xs">{delivery.attempt}/{delivery.max_attempts}</td>
-                      <td className="px-2 py-2 text-xs text-muted-foreground">{formatDate(delivery.created_at)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {(deliveriesQuery.data?.deliveries ?? []).length === 0 && (
-                <p className="mt-2 text-xs text-muted-foreground">No deliveries recorded yet.</p>
-              )}
+            <div className="mt-3">
+              <DataTable
+                columns={deliveryColumns}
+                data={deliveries}
+                getRowId={(delivery) => delivery.id}
+                hideSearch
+                minTableWidth={640}
+              />
             </div>
           )}
         </section>


### PR DESCRIPTION
## Summary

Migrates the **Delivery Monitor** table on the Webhooks page (`frontend/src/features/core/pages/webhooks.tsx`, formerly the hand-rolled `<table>` ~line 399) to the shared `DataTable` component. This is the only `<table>` in the file — the webhook list above it is a card list, not a table, so it was left unchanged.

### Columns (all preserved)
| Header | Source | Rendering |
|---|---|---|
| Event | `event_type` | text-xs |
| Status | `status` | text-xs, capitalized |
| HTTP | `http_status` | `?? '-'` fallback |
| Attempt | `attempt`/`max_attempts` | computed, non-sortable |
| Created | `created_at` | `formatDate(...)`, muted |

- `minTableWidth={640}` preserves the original `min-w-[640px]`.
- `getRowId` keyed on `delivery.id` (matches the original `key`).
- `hideSearch` — the original table had no search/filter control of its own, so none is added.
- Empty state preserved: the original "No deliveries recorded yet." copy is still shown when there are no deliveries (rendered instead of DataTable's generic "No results.").
- No row actions and rows were not clickable, so no `onRowClick`.

### autoFit decision: OMITTED
The Delivery Monitor table is **not** the single primary content of the page. It sits inside a `SpotlightCard` sharing its grid row (`xl:grid-cols-2`) with the **Live Event Feed** card, and the page above it also hosts the webhook list and the create/edit form. Since it shares vertical space with sibling content, `autoFit` is omitted and the table uses default fixed-page client pagination.

### Tests
- `npx vitest run src/features/core/pages/webhooks.test.tsx` — **5/5 pass** (added a test asserting the DataTable renders with delivery cell content).
- `npm run typecheck -w frontend` — **clean**.
- `npx eslint webhooks.tsx webhooks.test.tsx` — **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)