### PR TITLE
feat(security): migrate Security Audit table to shared DataTable

### DIFF
--- a/frontend/src/features/security/pages/security-audit.test.tsx
+++ b/frontend/src/features/security/pages/security-audit.test.tsx
@@ -64,6 +64,15 @@ describe('SecurityAuditPage', () => {
     expect(screen.getByText('warning')).toBeInTheDocument();
   });
 
+  it('renders the shared DataTable with column headers', () => {
+    renderWithClient(<SecurityAuditPage />);
+
+    expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /Capabilities Added/ })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /Privileged/ })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /Severity/ })).toBeInTheDocument();
+  });
+
   it('renders the search input', () => {
     renderWithClient(<SecurityAuditPage />);
     expect(screen.getByPlaceholderText('Search containers by name or image...')).toBeInTheDocument();

--- a/frontend/src/features/security/pages/security-audit.tsx
+++ b/frontend/src/features/security/pages/security-audit.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from 'react';
+import { type ColumnDef } from '@tanstack/react-table';
 import { Search, ShieldAlert } from 'lucide-react';
-import { useSecurityAudit } from '@/features/security/hooks/use-security-audit';
+import { useSecurityAudit, type SecurityAuditEntry } from '@/features/security/hooks/use-security-audit';
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { cn } from '@/shared/lib/utils';
 import { ObservedDestinationsPanel } from '@/features/security/components/observed-destinations-panel';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
@@ -99,6 +101,141 @@ export default function SecurityAuditPage() {
       });
   }, [entries, searchQuery, selectedSeverity, selectedIgnored, selectedStack]);
 
+  const columns = useMemo<ColumnDef<SecurityAuditEntry, unknown>[]>(() => [
+    {
+      id: 'container',
+      accessorKey: 'containerName',
+      header: 'Container',
+      cell: ({ row }) => {
+        const entry = row.original;
+        return (
+          <div className={cn(entry.ignored && 'opacity-70')}>
+            <div className="font-medium">{entry.containerName}</div>
+            <div className="text-xs text-muted-foreground">{entry.image}</div>
+          </div>
+        );
+      },
+    },
+    {
+      id: 'stack',
+      accessorKey: 'stackName',
+      header: 'Stack',
+      cell: ({ row }) => (
+        <span className={cn('text-muted-foreground', row.original.ignored && 'opacity-70')}>
+          {row.original.stackName ?? '—'}
+        </span>
+      ),
+    },
+    {
+      id: 'endpoint',
+      accessorKey: 'endpointName',
+      header: 'Endpoint',
+      cell: ({ row }) => (
+        <span className={cn('text-muted-foreground', row.original.ignored && 'opacity-70')}>
+          {row.original.endpointName}
+        </span>
+      ),
+    },
+    {
+      id: 'capabilities',
+      header: 'Capabilities Added',
+      enableSorting: false,
+      cell: ({ row }) => {
+        const entry = row.original;
+        return (
+          <div className={cn('flex flex-wrap gap-1.5', entry.ignored && 'opacity-70')}>
+            {entry.posture.capAdd.length === 0 ? (
+              <span className="inline-flex rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">None</span>
+            ) : (
+              entry.posture.capAdd.map((capability) => (
+                <span
+                  key={capability}
+                  className={cn('inline-flex rounded-full px-2 py-0.5 text-xs font-medium', capabilityBadgeClass(capability))}
+                >
+                  {capability}
+                </span>
+              ))
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      id: 'privileged',
+      header: 'Privileged',
+      accessorFn: (entry) => entry.posture.privileged,
+      cell: ({ row }) => {
+        const entry = row.original;
+        return (
+          <span
+            className={cn(
+              'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+              entry.ignored && 'opacity-70',
+              entry.posture.privileged
+                ? 'bg-red-500/15 text-red-700 dark:text-red-400'
+                : 'bg-muted text-muted-foreground',
+            )}
+          >
+            {entry.posture.privileged ? 'Yes' : 'No'}
+          </span>
+        );
+      },
+    },
+    {
+      id: 'networkPid',
+      header: 'Network/PID',
+      enableSorting: false,
+      cell: ({ row }) => {
+        const entry = row.original;
+        return (
+          <span className={cn('text-xs text-muted-foreground', entry.ignored && 'opacity-70')}>
+            net={entry.posture.networkMode ?? '—'} | pid={entry.posture.pidMode ?? '—'}
+          </span>
+        );
+      },
+    },
+    {
+      id: 'severity',
+      accessorKey: 'severity',
+      header: 'Severity',
+      sortingFn: (a, b) => severityRank(a.original.severity) - severityRank(b.original.severity),
+      cell: ({ row }) => {
+        const entry = row.original;
+        return (
+          <span
+            className={cn(
+              'inline-flex rounded-full px-2 py-0.5 text-xs font-medium uppercase',
+              entry.ignored && 'opacity-70',
+              severityBadgeClass(entry.severity),
+            )}
+          >
+            {entry.severity}
+          </span>
+        );
+      },
+    },
+    {
+      id: 'ignored',
+      accessorKey: 'ignored',
+      header: 'Ignored',
+      cell: ({ row }) => {
+        const entry = row.original;
+        return (
+          <span
+            className={cn(
+              'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+              entry.ignored
+                ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+                : 'bg-muted text-muted-foreground',
+            )}
+          >
+            {entry.ignored ? 'Ignored' : 'Active'}
+          </span>
+        );
+      },
+    },
+  ], []);
+
   return (
     <div className="space-y-4">
       <div>
@@ -193,85 +330,12 @@ export default function SecurityAuditPage() {
             <p className="mt-1 text-sm text-muted-foreground">Try adjusting your search or filters.</p>
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[1100px] text-sm">
-              <thead>
-                <tr className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="px-3 py-2.5 font-medium">Container</th>
-                  <th className="px-3 py-2.5 font-medium">Stack</th>
-                  <th className="px-3 py-2.5 font-medium">Endpoint</th>
-                  <th className="px-3 py-2.5 font-medium">Capabilities Added</th>
-                  <th className="px-3 py-2.5 font-medium">Privileged</th>
-                  <th className="px-3 py-2.5 font-medium">Network/PID</th>
-                  <th className="px-3 py-2.5 font-medium">Severity</th>
-                  <th className="px-3 py-2.5 font-medium">Ignored</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredEntries.map((entry) => (
-                  <tr
-                    key={`${entry.endpointId}:${entry.containerId}`}
-                    className={cn('border-b last:border-0', entry.ignored && 'opacity-70')}
-                  >
-                    <td className="px-3 py-3">
-                      <div className="font-medium">{entry.containerName}</div>
-                      <div className="text-xs text-muted-foreground">{entry.image}</div>
-                    </td>
-                    <td className="px-3 py-3 text-muted-foreground">{entry.stackName ?? '—'}</td>
-                    <td className="px-3 py-3 text-muted-foreground">{entry.endpointName}</td>
-                    <td className="px-3 py-3">
-                      <div className="flex flex-wrap gap-1.5">
-                        {entry.posture.capAdd.length === 0 ? (
-                          <span className="inline-flex rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">None</span>
-                        ) : (
-                          entry.posture.capAdd.map((capability) => (
-                            <span
-                              key={capability}
-                              className={cn('inline-flex rounded-full px-2 py-0.5 text-xs font-medium', capabilityBadgeClass(capability))}
-                            >
-                              {capability}
-                            </span>
-                          ))
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-3 py-3">
-                      <span
-                        className={cn(
-                          'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
-                          entry.posture.privileged
-                            ? 'bg-red-500/15 text-red-700 dark:text-red-400'
-                            : 'bg-muted text-muted-foreground',
-                        )}
-                      >
-                        {entry.posture.privileged ? 'Yes' : 'No'}
-                      </span>
-                    </td>
-                    <td className="px-3 py-3 text-xs text-muted-foreground">
-                      net={entry.posture.networkMode ?? '—'} | pid={entry.posture.pidMode ?? '—'}
-                    </td>
-                    <td className="px-3 py-3">
-                      <span className={cn('inline-flex rounded-full px-2 py-0.5 text-xs font-medium uppercase', severityBadgeClass(entry.severity))}>
-                        {entry.severity}
-                      </span>
-                    </td>
-                    <td className="px-3 py-3">
-                      <span
-                        className={cn(
-                          'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
-                          entry.ignored
-                            ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
-                            : 'bg-muted text-muted-foreground',
-                        )}
-                      >
-                        {entry.ignored ? 'Ignored' : 'Active'}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <DataTable
+            columns={columns}
+            data={filteredEntries}
+            hideSearch
+            minTableWidth={1100}
+          />
         )}
       </section>
       </SpotlightCard>


### PR DESCRIPTION
## Summary

Migrates the Security Audit page's hand-rolled HTML `<table>` to the shared `DataTable` component.

- All eight columns preserved (Container, Stack, Endpoint, Capabilities Added, Privileged, Network/PID, Severity, Ignored) via a memoized `ColumnDef[]`, including every badge / capability cell renderer and the `opacity-70` dimming for ignored rows (moved onto cell content, since `DataTable` does not expose a per-row className).
- Page-owned search box, the four `ThemedSelect` filters, the "N containers shown" summary, and the loading / empty / error states are all unchanged. `hideSearch` is passed so `DataTable` does not add a second search input.
- The custom severity-then-name sort is preserved on the data passed in, and a matching `sortingFn` is attached to the Severity column so header-click sorting stays correct.

### autoFit / serverPagination decision

- **No `serverPagination`** — the audit endpoint (`/api/security/audit[/:endpointId]`) returns all entries in one response; the page never did server/manual pagination. Client pagination (default) is used.
- **No `autoFit`** — the table shares the page with the filter card above and the Observed Destinations panel below, so it is not the single primary content filling the page. `autoFit` is also mutually exclusive with the shared layout here.
- **`minTableWidth={1100}`** carried over from the original `min-w-[1100px]`.
- **No `onRowClick`** — original rows were not clickable.

## Testing

- `npx vitest run src/features/security/pages/security-audit.test.tsx` — 6 passed (added a test asserting the `DataTable` renders with its column headers).
- `npm run typecheck -w frontend` — clean.
- `eslint` on both changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)