### PR TITLE
feat(settings): migrate Infrastructure settings table to shared DataTable

### DIFF
--- a/frontend/src/features/core/components/settings/tab-infrastructure.test.tsx
+++ b/frontend/src/features/core/components/settings/tab-infrastructure.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+
+// Mock the backup hooks so the component can render without a real query client / network
+const refetch = vi.fn();
+const createMutate = vi.fn();
+const deleteMutate = vi.fn();
+const downloadPortainerBackup = vi.fn();
+
+let mockBackups: { filename: string; size: number; createdAt: string }[] = [];
+let mockIsLoading = false;
+let mockDeletePending = false;
+
+vi.mock('@/features/core/hooks/use-portainer-backups', () => ({
+  usePortainerBackups: () => ({ data: { backups: mockBackups }, isLoading: mockIsLoading, refetch }),
+  useCreatePortainerBackup: () => ({ mutate: createMutate, isPending: false }),
+  useDeletePortainerBackup: () => ({ mutate: deleteMutate, isPending: mockDeletePending }),
+  downloadPortainerBackup: (filename: string) => downloadPortainerBackup(filename),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { PortainerBackupManagement } from './tab-infrastructure';
+
+const sampleBackups = [
+  { filename: 'portainer-backup-2026-05-01.tar.gz', size: 1024 * 1024, createdAt: '2026-05-01T10:00:00Z' },
+  { filename: 'portainer-backup-2026-05-02.tar.gz', size: 2 * 1024 * 1024, createdAt: '2026-05-02T10:00:00Z' },
+];
+
+describe('PortainerBackupManagement (DataTable migration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBackups = [...sampleBackups];
+    mockIsLoading = false;
+    mockDeletePending = false;
+  });
+
+  it('renders the shared DataTable with backup rows', () => {
+    render(<PortainerBackupManagement />);
+
+    // The shared DataTable root marker confirms the migration
+    expect(screen.getByTestId('data-table')).toBeInTheDocument();
+
+    // Column headers preserved
+    expect(screen.getByText('Filename')).toBeInTheDocument();
+    expect(screen.getByText('Size')).toBeInTheDocument();
+    expect(screen.getByText('Created')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+
+    // Each backup is rendered with its formatted size
+    expect(screen.getByText('portainer-backup-2026-05-01.tar.gz')).toBeInTheDocument();
+    expect(screen.getByText('portainer-backup-2026-05-02.tar.gz')).toBeInTheDocument();
+    expect(screen.getByText('1 MB')).toBeInTheDocument();
+    expect(screen.getByText('2 MB')).toBeInTheDocument();
+  });
+
+  it('does not render the DataTable when there are no backups (empty state preserved)', () => {
+    mockBackups = [];
+    render(<PortainerBackupManagement />);
+
+    expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
+    expect(screen.getByText('No Portainer backups yet')).toBeInTheDocument();
+  });
+
+  it('triggers download for the correct file from a row action', () => {
+    render(<PortainerBackupManagement />);
+
+    const firstRow = screen.getByText('portainer-backup-2026-05-01.tar.gz').closest('tr')!;
+    fireEvent.click(within(firstRow).getByText('Download'));
+
+    expect(downloadPortainerBackup).toHaveBeenCalledWith('portainer-backup-2026-05-01.tar.gz');
+  });
+
+  it('triggers delete for the correct file from a row action', () => {
+    render(<PortainerBackupManagement />);
+
+    const secondRow = screen.getByText('portainer-backup-2026-05-02.tar.gz').closest('tr')!;
+    fireEvent.click(within(secondRow).getByText('Delete'));
+
+    expect(deleteMutate).toHaveBeenCalledWith('portainer-backup-2026-05-02.tar.gz', expect.any(Object));
+  });
+
+  it('refreshes the backup list when Refresh is clicked', async () => {
+    render(<PortainerBackupManagement />);
+
+    fireEvent.click(screen.getByText('Refresh'));
+
+    await waitFor(() => {
+      expect(refetch).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/features/core/components/settings/tab-infrastructure.tsx
+++ b/frontend/src/features/core/components/settings/tab-infrastructure.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { type ColumnDef } from '@tanstack/react-table';
 import {
   Archive,
   BarChart3,
@@ -18,7 +19,9 @@ import {
   useCreatePortainerBackup,
   useDeletePortainerBackup,
   downloadPortainerBackup,
+  type PortainerBackupFile,
 } from '@/features/core/hooks/use-portainer-backups';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { formatBytes } from '@/shared/lib/utils';
 import { toast } from 'sonner';
 
@@ -72,7 +75,7 @@ export function InfrastructureTab({ editedValues, originalValues, onChange, isSa
   );
 }
 
-function PortainerBackupManagement() {
+export function PortainerBackupManagement() {
   const { data, isLoading, refetch } = usePortainerBackups();
   const createBackup = useCreatePortainerBackup();
   const deleteBackupMut = useDeletePortainerBackup();
@@ -94,27 +97,90 @@ function PortainerBackupManagement() {
     });
   };
 
-  const handleDownload = async (filename: string) => {
+  const handleDownload = useCallback(async (filename: string) => {
     try {
       await downloadPortainerBackup(filename);
     } catch (err) {
       toast.error(`Download failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
-  };
+  }, []);
 
-  const handleDelete = (filename: string) => {
-    setDeletingFile(filename);
-    deleteBackupMut.mutate(filename, {
-      onSuccess: () => {
-        toast.success(`Deleted ${filename}`);
-        setDeletingFile(null);
+  const handleDelete = useCallback(
+    (filename: string) => {
+      setDeletingFile(filename);
+      deleteBackupMut.mutate(filename, {
+        onSuccess: () => {
+          toast.success(`Deleted ${filename}`);
+          setDeletingFile(null);
+        },
+        onError: (err) => {
+          toast.error(`Delete failed: ${err.message}`);
+          setDeletingFile(null);
+        },
+      });
+    },
+    [deleteBackupMut],
+  );
+
+  const columns = useMemo<ColumnDef<PortainerBackupFile, unknown>[]>(
+    () => [
+      {
+        accessorKey: 'filename',
+        header: 'Filename',
+        cell: ({ getValue }) => <span className="font-mono text-xs">{getValue<string>()}</span>,
       },
-      onError: (err) => {
-        toast.error(`Delete failed: ${err.message}`);
-        setDeletingFile(null);
+      {
+        accessorKey: 'size',
+        header: 'Size',
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground">{formatBytes(getValue<number>())}</span>
+        ),
       },
-    });
-  };
+      {
+        accessorKey: 'createdAt',
+        header: 'Created',
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground">
+            {new Date(getValue<string>()).toLocaleString()}
+          </span>
+        ),
+      },
+      {
+        id: 'actions',
+        header: () => <span className="block text-right">Actions</span>,
+        enableSorting: false,
+        cell: ({ row }) => {
+          const backup = row.original;
+          return (
+            <div className="flex items-center justify-end gap-2">
+              <button
+                onClick={() => handleDownload(backup.filename)}
+                className="flex items-center gap-1.5 rounded-md border border-input bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-accent"
+                title="Download"
+              >
+                <Download className="h-3.5 w-3.5" />
+                Download
+              </button>
+              <button
+                onClick={() => handleDelete(backup.filename)}
+                disabled={deletingFile === backup.filename}
+                className="flex items-center gap-1.5 rounded-md border border-destructive/30 bg-background px-2.5 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                title="Delete"
+              >
+                {deletingFile === backup.filename ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="h-3.5 w-3.5" />
+                )}
+                Delete
+              </button>
+            </div>
+          );
+        },
+      },
+    ],
+    [handleDownload, handleDelete, deletingFile],
+  );
 
   return (
     <div className="space-y-6">
@@ -205,53 +271,8 @@ function PortainerBackupManagement() {
             </p>
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="px-4 py-2.5 font-medium">Filename</th>
-                  <th className="px-4 py-2.5 font-medium">Size</th>
-                  <th className="px-4 py-2.5 font-medium">Created</th>
-                  <th className="px-4 py-2.5 font-medium text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {backups.map((backup) => (
-                  <tr key={backup.filename} className="border-b last:border-0">
-                    <td className="px-4 py-3 font-mono text-xs">{backup.filename}</td>
-                    <td className="px-4 py-3 text-muted-foreground">{formatBytes(backup.size)}</td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {new Date(backup.createdAt).toLocaleString()}
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <div className="flex items-center justify-end gap-2">
-                        <button
-                          onClick={() => handleDownload(backup.filename)}
-                          className="flex items-center gap-1.5 rounded-md border border-input bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-accent"
-                          title="Download"
-                        >
-                          <Download className="h-3.5 w-3.5" />
-                          Download
-                        </button>
-                        <button
-                          onClick={() => handleDelete(backup.filename)}
-                          disabled={deletingFile === backup.filename}
-                          className="flex items-center gap-1.5 rounded-md border border-destructive/30 bg-background px-2.5 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                          title="Delete"
-                        >
-                          {deletingFile === backup.filename ? (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <Trash2 className="h-3.5 w-3.5" />
-                          )}
-                          Delete
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="p-4">
+            <DataTable columns={columns} data={backups} hideSearch />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Migrates the hand-rolled backup-files `<table>` in the Infrastructure settings tab (`tab-infrastructure.tsx`) to the shared `DataTable` component, continuing the table-consolidation effort.

- Replaced the manual `<table>/<thead>/<tbody>` markup in `PortainerBackupManagement` with `<DataTable>` driven by a memoized `ColumnDef[]`.
- Columns preserve every original header and cell rendering: **Filename** (mono), **Size** (`formatBytes`), **Created** (`toLocaleString`), and a right-aligned **Actions** column.
- The per-row **Download** and **Delete** controls (including the in-flight spinner + disabled state via `deletingFile`) are carried over verbatim; their handlers are now `useCallback`-memoized so the column defs stay stable.
- The loading skeleton and the rich "No Portainer backups yet" empty state remain in the parent pane chrome — `DataTable` only renders once there are rows, matching the previous behavior.

### Design decisions / tradeoffs
- **`autoFit` omitted** — this is a fixed-page settings sub-panel, not a full-height list, so the default client pagination is used (per the migration guidance for settings sub-panels).
- **`minTableWidth` not set** — the original table had no `min-w-[Npx]` constraint, so none is carried.
- **`hideSearch`** — the original table had no search box; search is suppressed to preserve behavior.
- Actions sorting is disabled (`enableSorting: false`); the data columns gain DataTable's standard click-to-sort, a minor additive improvement.

### Tests
Added `tab-infrastructure.test.tsx` (5 tests): asserts the shared `DataTable` renders with backup rows + headers + formatted sizes, the empty state is preserved when there are no backups, and the Download/Delete/Refresh row actions fire against the correct file. Hooks and `downloadPortainerBackup` are mocked at the module boundary.

### Verification
- `npx vitest run src/features/core/components/settings/tab-infrastructure.test.tsx` — 5 passed
- `npm run typecheck -w frontend` — clean
- `eslint` on both changed files — clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)