### PR TITLE
feat(containers): migrate Container Comparison matrices to shared DataTable

### DIFF
--- a/frontend/src/features/containers/components/container-comparison-view.test.tsx
+++ b/frontend/src/features/containers/components/container-comparison-view.test.tsx
@@ -173,4 +173,98 @@ describe('ContainerComparisonView', () => {
     await userEvent.click(screen.getByRole('button', { name: '24h' }));
     expect(onTimeRangeChange).toHaveBeenCalledWith('24h');
   });
+
+  it('renders the summary matrix on the shared DataTable with one column per container', () => {
+    const containers = [
+      makeContainer({ id: 'c1', name: 'web-app', state: 'running', image: 'nginx:1.25' }),
+      makeContainer({ id: 'c2', name: 'api', state: 'exited', image: 'node:20' }),
+    ];
+
+    render(
+      wrap(
+        createElement(ContainerComparisonView, {
+          containers,
+          tab: 'summary',
+          onTabChange: vi.fn(),
+          timeRange: '1h',
+          onTimeRangeChange: vi.fn(),
+          onRemove: vi.fn(),
+        }),
+      ),
+    );
+
+    // The shared DataTable is in play, rendered as a window-scroll matrix.
+    expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    expect(screen.getByTestId('window-scroll-container')).toBeInTheDocument();
+
+    // Leading row-label column header plus a dynamic header per container
+    // (the names appear both in the pills and as column headers).
+    expect(screen.getByRole('columnheader', { name: 'Attribute' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'web-app' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'api' })).toBeInTheDocument();
+
+    // Attribute rows transposed onto the matrix, with per-container values.
+    expect(screen.getByRole('cell', { name: 'State' })).toBeInTheDocument();
+    expect(screen.getByText('running')).toBeInTheDocument();
+    expect(screen.getByText('exited')).toBeInTheDocument();
+    expect(screen.getByText('nginx:1.25')).toBeInTheDocument();
+    expect(screen.getByText('node:20')).toBeInTheDocument();
+  });
+
+  it('renders the config matrix with a dynamic per-container column for each label key', () => {
+    const containers = [
+      makeContainer({ id: 'c1', name: 'web-app', labels: { 'com.docker.stack': 'prod', tier: 'frontend' } }),
+      makeContainer({ id: 'c2', name: 'api', labels: { 'com.docker.stack': 'prod', tier: 'backend' } }),
+    ];
+
+    render(
+      wrap(
+        createElement(ContainerComparisonView, {
+          containers,
+          tab: 'config',
+          onTabChange: vi.fn(),
+          timeRange: '1h',
+          onTimeRangeChange: vi.fn(),
+          onRemove: vi.fn(),
+        }),
+      ),
+    );
+
+    expect(screen.getByTestId('data-table')).toBeInTheDocument();
+
+    // Leading "Label" column + one header per compared container.
+    expect(screen.getByRole('columnheader', { name: 'Label' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'web-app' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'api' })).toBeInTheDocument();
+
+    // Each unique label key becomes a row; the differing values both render in
+    // their respective per-container columns.
+    expect(screen.getByRole('cell', { name: 'com.docker.stack' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'tier' })).toBeInTheDocument();
+    expect(screen.getByText('frontend')).toBeInTheDocument();
+    expect(screen.getByText('backend')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no labels to compare', () => {
+    const containers = [
+      makeContainer({ id: 'c1', name: 'web-app', labels: {} }),
+      makeContainer({ id: 'c2', name: 'api', labels: {} }),
+    ];
+
+    render(
+      wrap(
+        createElement(ContainerComparisonView, {
+          containers,
+          tab: 'config',
+          onTabChange: vi.fn(),
+          timeRange: '1h',
+          onTimeRangeChange: vi.fn(),
+          onRemove: vi.fn(),
+        }),
+      ),
+    );
+
+    expect(screen.getByText('No labels to compare')).toBeInTheDocument();
+    expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/containers/components/container-comparison-view.tsx
+++ b/frontend/src/features/containers/components/container-comparison-view.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import {
   LineChart,
   Line,
@@ -8,9 +8,11 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
+import { type ColumnDef } from '@tanstack/react-table';
 import { X, BarChart3, GitCompareArrows, Info, Clock } from 'lucide-react';
 import { type Container } from '@/features/containers/hooks/use-containers';
 import { useComparisonMetrics, type ComparisonTarget } from '@/features/containers/hooks/use-container-comparison';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { formatDate, cn } from '@/shared/lib/utils';
 
 export const COMPARISON_CHART_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444'];
@@ -160,120 +162,207 @@ function ComparisonChart({
   );
 }
 
-function SummaryTable({ containers }: { containers: Container[] }) {
+// ─── Comparison matrices on the shared DataTable ────────────────────────────
+//
+// These two views are comparison MATRICES, not paginated lists: rows are
+// metric/config KEYS and columns are the compared CONTAINERS (dynamic). To run
+// them through the shared DataTable we transpose the data — one row object per
+// attribute/label key, one dynamic column per container (keyed by container id)
+// plus a leading "label" column. We omit `autoFit` (these are bounded matrices
+// inside a comparison view, not a viewport-filling list) and pass `windowScroll`
+// so every row stays visible at once, matching the original always-show-all
+// behavior. Sorting is disabled on every column — reordering metric rows or
+// container columns would be meaningless here.
+//
+// Tradeoff: DataTable renders a uniform `<tr>` and exposes no per-row className
+// hook, so ConfigDiff's "values differ" highlight (previously a row-level
+// `bg-yellow-500/5`) is reproduced at the cell level instead (each cell in a
+// differing row carries the tint). The visual intent — flagging label rows that
+// diverge across containers — is preserved.
+
+/** A header cell carrying the chart-line color dot + the container name. */
+function containerColumnHeader(container: Container, index: number): ReactNode {
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b text-left">
-            <th className="pb-2 pr-4 font-medium text-muted-foreground">Attribute</th>
-            {containers.map((c, i) => (
-              <th key={c.id} className="pb-2 pr-4 font-medium">
-                <div className="flex items-center gap-2">
-                  <div
-                    className="h-2.5 w-2.5 rounded-full"
-                    style={{ backgroundColor: COMPARISON_CHART_COLORS[i] }}
-                  />
-                  {c.name}
-                </div>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y">
-          <tr>
-            <td className="py-2 pr-4 text-muted-foreground">State</td>
-            {containers.map((c) => (
-              <td key={c.id} className="py-2 pr-4">
-                <span
-                  className={cn(
-                    'rounded-full px-2 py-0.5 text-xs font-medium',
-                    c.state === 'running'
-                      ? 'bg-emerald-500/10 text-emerald-500'
-                      : c.state === 'exited'
-                        ? 'bg-red-500/10 text-red-500'
-                        : 'bg-gray-500/10 text-gray-500',
-                  )}
-                >
-                  {c.state}
-                </span>
-              </td>
-            ))}
-          </tr>
-          <tr>
-            <td className="py-2 pr-4 text-muted-foreground">Status</td>
-            {containers.map((c) => (
-              <td key={c.id} className="py-2 pr-4">{c.status}</td>
-            ))}
-          </tr>
-          <tr>
-            <td className="py-2 pr-4 text-muted-foreground">Image</td>
-            {containers.map((c) => (
-              <td key={c.id} className="py-2 pr-4">
-                <span className="font-mono text-xs">{c.image}</span>
-              </td>
-            ))}
-          </tr>
-          <tr>
-            <td className="py-2 pr-4 text-muted-foreground">Endpoint</td>
-            {containers.map((c) => (
-              <td key={c.id} className="py-2 pr-4">{c.endpointName}</td>
-            ))}
-          </tr>
-          <tr>
-            <td className="py-2 pr-4 text-muted-foreground">Health</td>
-            {containers.map((c) => (
-              <td key={c.id} className="py-2 pr-4">
-                {c.healthStatus ? (
-                  <span
-                    className={cn(
-                      'rounded-full px-2 py-0.5 text-xs font-medium',
-                      c.healthStatus === 'healthy'
-                        ? 'bg-emerald-500/10 text-emerald-500'
-                        : 'bg-red-500/10 text-red-500',
-                    )}
-                  >
-                    {c.healthStatus}
-                  </span>
-                ) : (
-                  <span className="text-muted-foreground">—</span>
-                )}
-              </td>
-            ))}
-          </tr>
-          <tr>
-            <td className="py-2 pr-4 text-muted-foreground">Networks</td>
-            {containers.map((c) => (
-              <td key={c.id} className="py-2 pr-4">
-                {c.networks.length > 0
-                  ? c.networks
-                      .map((net) =>
-                        c.networkIPs?.[net] ? `${net} (${c.networkIPs[net]})` : net,
-                      )
-                      .join(', ')
-                  : '—'}
-              </td>
-            ))}
-          </tr>
-          <tr>
-            <td className="py-2 pr-4 text-muted-foreground">Created</td>
-            {containers.map((c) => (
-              <td key={c.id} className="py-2 pr-4">
-                {formatDate(new Date(c.created * 1000).toISOString())}
-              </td>
-            ))}
-          </tr>
-        </tbody>
-      </table>
+    <div className="flex items-center gap-2">
+      <div
+        className="h-2.5 w-2.5 rounded-full"
+        style={{ backgroundColor: COMPARISON_CHART_COLORS[index] }}
+      />
+      {container.name}
     </div>
   );
 }
 
+interface SummaryRow {
+  /** Stable row identity — the attribute name. */
+  attribute: string;
+  /** Cell renderer per compared container, keyed by container id. */
+  cells: Record<string, ReactNode>;
+}
+
+function SummaryTable({ containers }: { containers: Container[] }) {
+  const rows = useMemo<SummaryRow[]>(() => {
+    const cellsFor = (render: (c: Container) => ReactNode): Record<string, ReactNode> =>
+      Object.fromEntries(containers.map((c) => [c.id, render(c)]));
+
+    return [
+      {
+        attribute: 'State',
+        cells: cellsFor((c) => (
+          <span
+            className={cn(
+              'rounded-full px-2 py-0.5 text-xs font-medium',
+              c.state === 'running'
+                ? 'bg-emerald-500/10 text-emerald-500'
+                : c.state === 'exited'
+                  ? 'bg-red-500/10 text-red-500'
+                  : 'bg-gray-500/10 text-gray-500',
+            )}
+          >
+            {c.state}
+          </span>
+        )),
+      },
+      { attribute: 'Status', cells: cellsFor((c) => c.status) },
+      {
+        attribute: 'Image',
+        cells: cellsFor((c) => <span className="font-mono text-xs">{c.image}</span>),
+      },
+      { attribute: 'Endpoint', cells: cellsFor((c) => c.endpointName) },
+      {
+        attribute: 'Health',
+        cells: cellsFor((c) =>
+          c.healthStatus ? (
+            <span
+              className={cn(
+                'rounded-full px-2 py-0.5 text-xs font-medium',
+                c.healthStatus === 'healthy'
+                  ? 'bg-emerald-500/10 text-emerald-500'
+                  : 'bg-red-500/10 text-red-500',
+              )}
+            >
+              {c.healthStatus}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          ),
+        ),
+      },
+      {
+        attribute: 'Networks',
+        cells: cellsFor((c) =>
+          c.networks.length > 0
+            ? c.networks
+                .map((net) => (c.networkIPs?.[net] ? `${net} (${c.networkIPs[net]})` : net))
+                .join(', ')
+            : '—',
+        ),
+      },
+      {
+        attribute: 'Created',
+        cells: cellsFor((c) => formatDate(new Date(c.created * 1000).toISOString())),
+      },
+    ];
+  }, [containers]);
+
+  const columns = useMemo<ColumnDef<SummaryRow, unknown>[]>(() => {
+    const attributeColumn: ColumnDef<SummaryRow, unknown> = {
+      id: 'attribute',
+      header: 'Attribute',
+      enableSorting: false,
+      cell: ({ row }) => <span className="text-muted-foreground">{row.original.attribute}</span>,
+    };
+
+    const containerColumns: ColumnDef<SummaryRow, unknown>[] = containers.map((c, i) => ({
+      id: c.id,
+      header: () => containerColumnHeader(c, i),
+      enableSorting: false,
+      cell: ({ row }) => row.original.cells[c.id] ?? null,
+    }));
+
+    return [attributeColumn, ...containerColumns];
+  }, [containers]);
+
+  return (
+    <DataTable
+      columns={columns}
+      data={rows}
+      hideSearch
+      windowScroll
+      getRowId={(row) => row.attribute}
+    />
+  );
+}
+
+interface ConfigRow {
+  /** Stable row identity — the label key. */
+  label: string;
+  /** Raw label value per compared container, keyed by container id. */
+  values: Record<string, string>;
+  /** True when every compared container shares the same value for this key. */
+  allSame: boolean;
+}
+
 function ConfigDiff({ containers }: { containers: Container[] }) {
   // Collect all unique label keys
-  const allLabelKeys = Array.from(
-    new Set(containers.flatMap((c) => Object.keys(c.labels))),
-  ).sort();
+  const allLabelKeys = useMemo(
+    () => Array.from(new Set(containers.flatMap((c) => Object.keys(c.labels)))).sort(),
+    [containers],
+  );
+
+  const rows = useMemo<ConfigRow[]>(
+    () =>
+      allLabelKeys.map((key) => {
+        const values = Object.fromEntries(containers.map((c) => [c.id, c.labels[key] || '']));
+        const valueList = containers.map((c) => values[c.id]);
+        const allSame = valueList.every((v) => v === valueList[0]);
+        return { label: key, values, allSame };
+      }),
+    [allLabelKeys, containers],
+  );
+
+  const columns = useMemo<ColumnDef<ConfigRow, unknown>[]>(() => {
+    const labelColumn: ColumnDef<ConfigRow, unknown> = {
+      id: 'label',
+      header: 'Label',
+      enableSorting: false,
+      // The "values differ" highlight lived on the row in the old markup;
+      // DataTable has no per-row className hook, so it's tinted per-cell here.
+      cell: ({ row }) => (
+        <span
+          className={cn(
+            'font-mono text-xs text-muted-foreground',
+            !row.original.allSame && 'bg-yellow-500/5',
+          )}
+        >
+          {row.original.label}
+        </span>
+      ),
+    };
+
+    const containerColumns: ColumnDef<ConfigRow, unknown>[] = containers.map((c, i) => ({
+      id: c.id,
+      header: () => containerColumnHeader(c, i),
+      enableSorting: false,
+      cell: ({ row }) => {
+        const val = row.original.values[c.id];
+        const highlight = !row.original.allSame;
+        return (
+          <span
+            className={cn(
+              'font-mono text-xs',
+              highlight && 'bg-yellow-500/5',
+              highlight && val && 'font-medium text-yellow-600 dark:text-yellow-400',
+            )}
+          >
+            {val || <span className="text-muted-foreground">—</span>}
+          </span>
+        );
+      },
+    }));
+
+    return [labelColumn, ...containerColumns];
+  }, [containers]);
 
   if (allLabelKeys.length === 0) {
     return (
@@ -284,51 +373,13 @@ function ConfigDiff({ containers }: { containers: Container[] }) {
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b text-left">
-            <th className="pb-2 pr-4 font-medium text-muted-foreground">Label</th>
-            {containers.map((c, i) => (
-              <th key={c.id} className="pb-2 pr-4 font-medium">
-                <div className="flex items-center gap-2">
-                  <div
-                    className="h-2.5 w-2.5 rounded-full"
-                    style={{ backgroundColor: COMPARISON_CHART_COLORS[i] }}
-                  />
-                  {c.name}
-                </div>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y">
-          {allLabelKeys.map((key) => {
-            const values = containers.map((c) => c.labels[key] || '');
-            const allSame = values.every((v) => v === values[0]);
-
-            return (
-              <tr key={key} className={allSame ? '' : 'bg-yellow-500/5'}>
-                <td className="py-1.5 pr-4 font-mono text-xs text-muted-foreground">
-                  {key}
-                </td>
-                {values.map((val, i) => (
-                  <td
-                    key={containers[i].id}
-                    className={cn(
-                      'py-1.5 pr-4 font-mono text-xs',
-                      !allSame && val ? 'text-yellow-600 dark:text-yellow-400 font-medium' : '',
-                    )}
-                  >
-                    {val || <span className="text-muted-foreground">—</span>}
-                  </td>
-                ))}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
+    <DataTable
+      columns={columns}
+      data={rows}
+      hideSearch
+      windowScroll
+      getRowId={(row) => row.label}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

Migrates **both** hand-rolled `<table>`s in `container-comparison-view.tsx` (the **Summary** status matrix and the **Configuration / label-diff** matrix) onto the shared `DataTable`.

These views are comparison **matrices**, not paginated lists — rows are attribute/label **keys** and columns are the compared **containers**. So the migration transposes the data and builds a **dynamic** `ColumnDef[]`:

- a leading row-label column (`Attribute` for the summary, `Label` for the config diff), and
- **one column per compared container**, each with a stable `id` set to the container id and a header carrying the chart-line color dot + container name.

Each row object holds its key plus a `Record<containerId, value>` map; the per-container column cell looks its value up by id, preserving the exact values/cells the old markup rendered (state/health pills, mono image text, network IP formatting, label values, em-dash empties).

### DataTable options
- `windowScroll` — keeps **every** matrix row visible at once (no pagination, no inner scrollbar), matching the original always-show-all behavior.
- `hideSearch` — matrices aren't searched.
- `enableSorting: false` on every column — reordering metric rows or container columns would be meaningless.
- **`autoFit` omitted** intentionally (these are bounded matrices inside a comparison view, not a viewport-filling list).
- `getRowId` set to the attribute/label key for stable row identity.

The component's public props are unchanged; the empty-state ("No labels to compare") path is preserved.

## Tradeoff (note)
This is an unusual but acceptable use of `DataTable` (containers-as-columns rather than rows-as-records). `DataTable` renders a uniform `<tr>` and exposes **no per-row `className` hook**, so `ConfigDiff`'s "values differ" row highlight (previously `bg-yellow-500/5` on the `<tr>`) is reproduced **at the cell level** — each cell in a differing row carries the tint, and differing values keep the amber bold treatment. The visual intent (flagging label rows that diverge across containers) is preserved.

## Tests
- All 5 pre-existing tests still pass.
- Added 3 tests: the Summary matrix renders on the shared `DataTable` (`data-table` + `window-scroll-container` testids) with the leading label column **and a dynamic header per container**, transposed attribute rows render their per-container values; the Config matrix renders a dynamic per-container column for each label key with differing values in their respective columns; and the empty-state path renders no table.

## Verification
- `vitest run container-comparison-view.test.tsx` → 8 passed (run via threads pool; the default forks pool hit a transient worker-startup timeout in this sandbox, unrelated to the change).
- `npm run typecheck -w frontend` → clean.
- `eslint` on both changed files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)