### PR TITLE
feat(security): migrate Observed Destinations table to shared DataTable

### DIFF
--- a/frontend/src/features/security/components/observed-destinations-panel.test.tsx
+++ b/frontend/src/features/security/components/observed-destinations-panel.test.tsx
@@ -74,6 +74,34 @@ describe('ObservedDestinationsPanel', () => {
     expect(screen.getByText('17')).toBeInTheDocument();
   });
 
+  it('renders the rows inside the shared DataTable', async () => {
+    mockApiGet.mockResolvedValue({
+      destinations: [
+        {
+          peer: '10.0.0.5',
+          port: 443,
+          callCount: 17,
+          firstSeen: '2026-05-14T11:00:00Z',
+          lastSeen: '2026-05-14T12:00:00Z',
+          verdict: 'allow',
+          reason: 'RFC1918',
+        },
+      ],
+    });
+
+    renderWithProviders(<ObservedDestinationsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    });
+    // Column headers carried over from the hand-rolled table.
+    expect(screen.getByText('Peer')).toBeInTheDocument();
+    expect(screen.getByText('Calls')).toBeInTheDocument();
+    expect(screen.getByText('Verdict')).toBeInTheDocument();
+    // Row rendered through the shared table.
+    expect(screen.getByTestId('table-row-0')).toBeInTheDocument();
+  });
+
   it('passes endpointId to the API when provided', async () => {
     mockApiGet.mockResolvedValue({ destinations: [] });
 

--- a/frontend/src/features/security/components/observed-destinations-panel.tsx
+++ b/frontend/src/features/security/components/observed-destinations-panel.tsx
@@ -1,7 +1,10 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { type ColumnDef } from '@tanstack/react-table';
 import { Globe } from 'lucide-react';
 import { api } from '@/shared/lib/api';
 import { cn } from '@/shared/lib/utils';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { NoTraceDataCallout } from '@/features/observability/components/no-trace-data-callout';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
@@ -59,6 +62,59 @@ export function ObservedDestinationsPanel({ endpointId }: Props) {
 
   const destinations = data?.destinations ?? [];
 
+  const columns = useMemo<ColumnDef<ObservedDestinationDto, unknown>[]>(() => [
+    {
+      accessorKey: 'peer',
+      header: 'Peer',
+      cell: ({ getValue }) => <span className="font-mono text-xs">{getValue<string>()}</span>,
+    },
+    {
+      accessorKey: 'port',
+      header: 'Port',
+      cell: ({ getValue }) => {
+        const port = getValue<number | null>();
+        return <span className="text-muted-foreground">{port ?? '—'}</span>;
+      },
+    },
+    {
+      accessorKey: 'callCount',
+      header: () => <span className="block text-right">Calls</span>,
+      cell: ({ getValue }) => <span className="block text-right">{getValue<number>()}</span>,
+    },
+    {
+      accessorKey: 'firstSeen',
+      header: 'First seen',
+      cell: ({ getValue }) => (
+        <span className="text-xs text-muted-foreground">{fmt(getValue<string>())}</span>
+      ),
+    },
+    {
+      accessorKey: 'lastSeen',
+      header: 'Last seen',
+      cell: ({ getValue }) => (
+        <span className="text-xs text-muted-foreground">{fmt(getValue<string>())}</span>
+      ),
+    },
+    {
+      accessorKey: 'verdict',
+      header: 'Verdict',
+      cell: ({ row }) => {
+        const { verdict, reason } = row.original;
+        return (
+          <span
+            className={cn(
+              'inline-flex rounded-full px-2 py-0.5 text-xs font-medium uppercase',
+              verdictClass(verdict),
+            )}
+            title={reason ?? undefined}
+          >
+            {verdict}
+          </span>
+        );
+      },
+    },
+  ], []);
+
   return (
     <SpotlightCard>
     <section className="rounded-lg border bg-card p-6 shadow-sm" data-testid="observed-destinations-panel">
@@ -90,42 +146,12 @@ export function ObservedDestinationsPanel({ endpointId }: Props) {
       )}
 
       {!isError && !isLoading && destinations.length > 0 && (
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[900px] text-sm">
-            <thead>
-              <tr className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
-                <th className="px-3 py-2.5 font-medium">Peer</th>
-                <th className="px-3 py-2.5 font-medium">Port</th>
-                <th className="px-3 py-2.5 font-medium text-right">Calls</th>
-                <th className="px-3 py-2.5 font-medium">First seen</th>
-                <th className="px-3 py-2.5 font-medium">Last seen</th>
-                <th className="px-3 py-2.5 font-medium">Verdict</th>
-              </tr>
-            </thead>
-            <tbody>
-              {destinations.map((row) => (
-                <tr key={`${row.peer}:${row.port ?? ''}`} className="border-b last:border-0">
-                  <td className="px-3 py-2.5 font-mono text-xs">{row.peer}</td>
-                  <td className="px-3 py-2.5 text-muted-foreground">{row.port ?? '—'}</td>
-                  <td className="px-3 py-2.5 text-right">{row.callCount}</td>
-                  <td className="px-3 py-2.5 text-xs text-muted-foreground">{fmt(row.firstSeen)}</td>
-                  <td className="px-3 py-2.5 text-xs text-muted-foreground">{fmt(row.lastSeen)}</td>
-                  <td className="px-3 py-2.5">
-                    <span
-                      className={cn(
-                        'inline-flex rounded-full px-2 py-0.5 text-xs font-medium uppercase',
-                        verdictClass(row.verdict),
-                      )}
-                      title={row.reason ?? undefined}
-                    >
-                      {row.verdict}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <DataTable
+          columns={columns}
+          data={destinations}
+          hideSearch
+          minTableWidth={900}
+        />
       )}
     </section>
     </SpotlightCard>


### PR DESCRIPTION
## Summary

Migrates the hand-rolled `<table>` in the Observed Destinations panel (`frontend/src/features/security/components/observed-destinations-panel.tsx`, #1240) to the shared `DataTable`, matching the pattern from the Users table migration. The panel now inherits consistent table styling, header sorting, and the themed horizontal scrollbar for free.

## What changed

- Replaced the raw `<table>…</table>` with `<DataTable>` driven by a memoized `ColumnDef[]`.
- Preserved every cell rendering detail:
  - **Peer** — monospace
  - **Port** — muted, `—` fallback when `null`
  - **Calls** — right-aligned (header + cell)
  - **First seen / Last seen** — `toLocaleString` via the existing `fmt` helper, muted xs text
  - **Verdict** — pill badge with the same `verdictClass` colors and `title={reason}` tooltip
- Kept the surrounding `SpotlightCard` + section chrome, the loading / error (with Retry) / empty (`NoTraceDataCallout`) states untouched.
- `hideSearch` — the panel has no search of its own.
- `minTableWidth={900}` carries over the prior `min-w-[900px]`.

## autoFit decision

**Omitted.** This is a panel rendered below the Security Audit findings table on the Security Audit page, not the sole primary content filling the viewport, so it uses fixed-page (client) pagination per the migration guidance.

## Caveats / tradeoffs

- DataTable enables client-side sorting by default; the previous table was unsorted. This is an additive UX improvement and column rendering is unchanged.
- DataTable paginates at 10 rows/page (default) once there are more than 10 destinations, whereas the old table rendered all rows inline. For a 24h destination list this is a reasonable bound and the pagination controls only appear when needed.

## Tests

Updated `observed-destinations-panel.test.tsx`: existing empty-state / row / endpointId tests retained, plus a new test asserting the shared `DataTable` (`data-testid="data-table"`) renders with the carried-over headers and a `table-row-*`.

- `npx vitest run …/observed-destinations-panel.test.tsx` — 4 passed
- `npm run typecheck -w frontend` — clean
- `eslint` on both files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)