### PR TITLE
feat(settings): migrate Monitoring settings table to shared DataTable

### DIFF
--- a/frontend/src/features/core/components/settings/tab-monitoring.test.tsx
+++ b/frontend/src/features/core/components/settings/tab-monitoring.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { NotificationTestButtons } from './tab-monitoring';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { NotificationTestButtons, NotificationHistoryPanel } from './tab-monitoring';
 
 // Mock the api module
 vi.mock('@/shared/lib/api', () => ({
   api: {
     post: vi.fn(),
+    get: vi.fn(),
   },
 }));
 
@@ -102,6 +103,89 @@ describe('NotificationTestButtons', () => {
 
     // Resolve and cleanup
     resolvePromise({ success: true });
+  });
+});
+
+describe('NotificationHistoryPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const sampleEntries = [
+    {
+      id: 1,
+      channel: 'discord' as const,
+      event_type: 'container.health',
+      title: 'Container unhealthy',
+      body: 'web-1 reported an unhealthy status check',
+      severity: 'warning',
+      status: 'sent' as const,
+      error: null,
+      container_name: 'web-1',
+      created_at: '2026-05-29T10:00:00.000Z',
+    },
+    {
+      id: 2,
+      channel: 'email' as const,
+      event_type: 'anomaly.detected',
+      title: 'Anomaly detected',
+      body: 'CPU spike on api-2',
+      severity: 'critical',
+      status: 'failed' as const,
+      error: 'SMTP connection refused',
+      container_name: 'api-2',
+      created_at: '2026-05-29T09:30:00.000Z',
+    },
+  ];
+
+  it('should render the DataTable with notification history rows', { timeout: 15000 }, async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      entries: sampleEntries,
+      total: sampleEntries.length,
+      limit: 200,
+      offset: 0,
+    });
+
+    render(<NotificationHistoryPanel />);
+
+    // DataTable mounts once data loads
+    await waitFor(() => {
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    });
+
+    // Headers preserved from the migrated table (scoped to the table —
+    // "Channel"/"Status" also appear as filter labels above it)
+    const table = within(screen.getByTestId('data-table'));
+    expect(table.getByText('Time')).toBeInTheDocument();
+    expect(table.getByText('Channel')).toBeInTheDocument();
+    expect(table.getByText('Status')).toBeInTheDocument();
+    expect(table.getByText('Event')).toBeInTheDocument();
+    expect(table.getByText('Message')).toBeInTheDocument();
+    expect(table.getByText('Error')).toBeInTheDocument();
+
+    // Cell rendering preserved (titles, statuses, error fallback)
+    expect(screen.getByText('Container unhealthy')).toBeInTheDocument();
+    expect(screen.getByText('Anomaly detected')).toBeInTheDocument();
+    expect(screen.getByText('sent')).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByText('SMTP connection refused')).toBeInTheDocument();
+  });
+
+  it('should show the empty state when there is no history', { timeout: 15000 }, async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      entries: [],
+      total: 0,
+      limit: 200,
+      offset: 0,
+    });
+
+    render(<NotificationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No notification history found')).toBeInTheDocument();
+    });
+    // DataTable should not render when there are no entries
+    expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/features/core/components/settings/tab-monitoring.tsx
+++ b/frontend/src/features/core/components/settings/tab-monitoring.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { type ColumnDef } from '@tanstack/react-table';
 import {
   Activity,
   AlertTriangle,
@@ -10,6 +11,7 @@ import {
 } from 'lucide-react';
 import { SettingsSection, DEFAULT_SETTINGS, type SettingsTabProps } from './shared';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { cn } from '@/shared/lib/utils';
 import { api } from '@/shared/lib/api';
 import { toast } from 'sonner';
@@ -204,6 +206,76 @@ export function NotificationHistoryPanel() {
   const sentCount = filteredEntries.filter((entry) => entry.status === 'sent').length;
   const failedCount = filteredEntries.filter((entry) => entry.status === 'failed').length;
 
+  const columns = useMemo<ColumnDef<NotificationHistoryEntry, unknown>[]>(() => [
+    {
+      accessorKey: 'created_at',
+      header: 'Time',
+      cell: ({ getValue }) => (
+        <span className="text-xs text-muted-foreground">
+          {new Date(getValue<string>()).toLocaleString()}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'channel',
+      header: 'Channel',
+      cell: ({ getValue }) => (
+        <span className="inline-flex rounded-full bg-muted px-2 py-1 text-xs capitalize">
+          {getValue<string>()}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ getValue }) => {
+        const status = getValue<string>();
+        return (
+          <span
+            className={cn(
+              'inline-flex rounded-full px-2 py-1 text-xs font-medium',
+              status === 'sent'
+                ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
+                : 'bg-red-500/15 text-red-700 dark:text-red-400'
+            )}
+          >
+            {status}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: 'title',
+      header: 'Event',
+      cell: ({ row }) => (
+        <>
+          <p className="font-medium">{row.original.title}</p>
+          <p className="text-xs text-muted-foreground">{row.original.event_type}</p>
+        </>
+      ),
+    },
+    {
+      accessorKey: 'body',
+      header: 'Message',
+      enableSorting: false,
+      cell: ({ getValue }) => (
+        <div className="max-w-[380px] text-xs text-muted-foreground">
+          <p className="line-clamp-2">{getValue<string>()}</p>
+        </div>
+      ),
+    },
+    {
+      accessorKey: 'error',
+      header: 'Error',
+      enableSorting: false,
+      cell: ({ getValue }) => (
+        <div className="max-w-[280px] text-xs text-red-700 dark:text-red-400">
+          {getValue<string | null>() ?? 'None'}
+        </div>
+      ),
+    },
+  ], []);
+
   return (
     <div className="rounded-lg border bg-card">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b p-4">
@@ -295,55 +367,14 @@ export function NotificationHistoryPanel() {
           <p className="mt-1 text-sm text-muted-foreground">Try adjusting channel, status, or date filters.</p>
         </div>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[900px] text-sm">
-            <thead>
-              <tr className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
-                <th className="px-4 py-2.5 font-medium">Time</th>
-                <th className="px-4 py-2.5 font-medium">Channel</th>
-                <th className="px-4 py-2.5 font-medium">Status</th>
-                <th className="px-4 py-2.5 font-medium">Event</th>
-                <th className="px-4 py-2.5 font-medium">Message</th>
-                <th className="px-4 py-2.5 font-medium">Error</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredEntries.map((entry) => (
-                <tr key={entry.id} className="border-b last:border-0">
-                  <td className="px-4 py-3 text-xs text-muted-foreground">
-                    {new Date(entry.created_at).toLocaleString()}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className="inline-flex rounded-full bg-muted px-2 py-1 text-xs capitalize">
-                      {entry.channel}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={cn(
-                        'inline-flex rounded-full px-2 py-1 text-xs font-medium',
-                        entry.status === 'sent'
-                          ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
-                          : 'bg-red-500/15 text-red-700 dark:text-red-400'
-                      )}
-                    >
-                      {entry.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <p className="font-medium">{entry.title}</p>
-                    <p className="text-xs text-muted-foreground">{entry.event_type}</p>
-                  </td>
-                  <td className="max-w-[380px] px-4 py-3 text-xs text-muted-foreground">
-                    <p className="line-clamp-2">{entry.body}</p>
-                  </td>
-                  <td className="max-w-[280px] px-4 py-3 text-xs text-red-700 dark:text-red-400">
-                    {entry.error ?? 'None'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="p-4">
+          <DataTable
+            columns={columns}
+            data={filteredEntries}
+            getRowId={(entry) => String(entry.id)}
+            hideSearch
+            minTableWidth={900}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Migrates the hand-rolled notification-history `<table>` in the Monitoring settings tab (`tab-monitoring.tsx`, `NotificationHistoryPanel`) to the shared `DataTable` component.

- Columns are a memoized `ColumnDef[]` that preserves **every** header and cell rendering from the original markup:
  - **Time** — localized timestamp
  - **Channel** — capitalized pill badge
  - **Status** — sent/failed colored pill (emerald/red)
  - **Event** — title (bold) + event_type (muted)
  - **Message** — `line-clamp-2`, `max-w-[380px]`
  - **Error** — red text, `max-w-[280px]`, `None` fallback
- `getRowId` keeps the stable per-entry `id` key.
- The existing error / loading / empty branches are unchanged, so the custom "No notification history found" empty state and skeleton are preserved. `DataTable` only mounts in the populated branch.

## Decisions / tradeoffs

- **autoFit omitted** — this is a fixed-page settings sub-panel (not a full-height page), matching the `users.tsx` reference. Client pagination kicks in past the default page size, which is acceptable for settings.
- **`minTableWidth={900}`** carries over the original `min-w-[900px]` so columns overflow horizontally (themed scrollbar) rather than squashing.
- **No `onRowClick`** — rows were never clickable.
- Sorting is now available on Time/Channel/Status/Event headers (DataTable default); Message and Error have `enableSorting: false`. This is a minor additive enhancement, not a behavior regression.

## Tests

Added a `NotificationHistoryPanel` describe block (mocks `api.get`):
- asserts the `DataTable` renders with all six headers (scoped via `within` since Channel/Status also appear as filter labels) and preserved cell content (titles, status pills, error text).
- asserts the custom empty state still shows and `DataTable` does **not** mount when there's no history.

## Verification

- `npx vitest run src/features/core/components/settings/tab-monitoring.test.tsx` — 11 passed
- `npm run typecheck -w frontend` — clean
- `eslint` on both files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)