### PR TITLE
feat(settings): migrate AI/LLM settings table to shared DataTable

### DIFF
--- a/frontend/src/features/core/components/settings/tab-ai-llm.test.tsx
+++ b/frontend/src/features/core/components/settings/tab-ai-llm.test.tsx
@@ -97,3 +97,33 @@ describe('LlmSettingsSection — Test Connection token sanitisation', () => {
     expect(body.token).toBe('sk-real-token');
   });
 });
+
+describe('LlmSettingsSection — model use-case reference table (DataTable)', () => {
+  it('renders the model use-case table via the shared DataTable when expanded', () => {
+    render(
+      <LlmSettingsSection
+        values={baseValues}
+        originalValues={baseValues}
+        onChange={vi.fn()}
+        disabled={false}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    // Table is collapsed by default; the "All models" toggle reveals it.
+    fireEvent.click(screen.getByRole('button', { name: /all models/i }));
+
+    // Shared DataTable rendered (carries data-testid="data-table").
+    const table = screen.getByTestId('data-table');
+    expect(table).toBeInTheDocument();
+
+    // The "Label" / "Description" headers are unique to the table.
+    expect(screen.getByText('Label')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+
+    // Known reference rows render inside the table.
+    expect(screen.getByText('qwen3:32b')).toBeInTheDocument();
+    expect(screen.getByText('phi-4')).toBeInTheDocument();
+    expect(screen.getAllByText('Gold Standard').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/features/core/components/settings/tab-ai-llm.tsx
+++ b/frontend/src/features/core/components/settings/tab-ai-llm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef, lazy, Suspense } from 'react';
+import type { ColumnDef } from '@tanstack/react-table';
 import {
   AlertTriangle,
   Bot,
@@ -65,6 +66,7 @@ import { useUpdateSetting, useDeleteSetting } from '@/features/core/hooks/use-se
 import { usePromptHistory, useRollbackPrompt, type PromptVersion } from '@/features/ai-intelligence/hooks/use-prompt-versions';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { cn, formatBytes } from '@/shared/lib/utils';
 import { api } from '@/shared/lib/api';
 import { toast } from 'sonner';
@@ -73,6 +75,9 @@ import type { LlmModel, LlmTestPromptResponse } from '@/features/ai-intelligence
 
 const LazyAiFeedbackPanel = lazy(() => import('@/features/core/pages/settings-ai-feedback').then((m) => ({ default: m.AiFeedbackPanel })));
 import { getModelUseCase, MODEL_USE_CASE_TABLE } from './model-use-cases';
+
+/** Row shape of the model use-case reference table (rendered via DataTable). */
+type ModelUseCaseRow = (typeof MODEL_USE_CASE_TABLE)[number];
 
 /** Keys that belong to LLM configuration (excluded from parent auto-save). */
 export const LLM_SETTING_KEYS = DEFAULT_SETTINGS.llm.map((s) => s.key);
@@ -306,6 +311,38 @@ export function LlmSettingsSection({ values, originalValues, onChange, disabled 
 
   const activeBackendUrl = apiUrl || 'No URL set';
 
+  // Reference table of model use-cases (DataTable). Static data → no autoFit
+  // (this is a fixed sub-panel, not a full page), no search, no row clicks.
+  // text-xs cell classNames preserve the original compact look.
+  const useCaseColumns = useMemo<ColumnDef<ModelUseCaseRow, unknown>[]>(() => [
+    {
+      accessorKey: 'models',
+      header: 'Model',
+      enableSorting: false,
+      cell: ({ getValue }) => (
+        <span className="font-mono text-xs text-foreground">{getValue<string>()}</span>
+      ),
+    },
+    {
+      accessorKey: 'label',
+      header: 'Label',
+      enableSorting: false,
+      cell: ({ row }) => (
+        <span className={cn('text-xs font-semibold whitespace-nowrap', row.original.color)}>
+          {row.original.label}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'description',
+      header: 'Description',
+      enableSorting: false,
+      cell: ({ getValue }) => (
+        <span className="hidden text-xs text-muted-foreground sm:inline">{getValue<string>()}</span>
+      ),
+    },
+  ], []);
+
   return (
     <div className="rounded-lg border bg-card">
       <div className="flex items-center justify-between p-4 border-b border-border">
@@ -521,25 +558,14 @@ export function LlmSettingsSection({ values, originalValues, onChange, disabled 
             );
           })()}
           {showUseCaseTable && (
-            <div className="mt-2 rounded-md border border-border/50 bg-muted/20 overflow-hidden">
-              <table className="w-full text-xs">
-                <thead>
-                  <tr className="border-b border-border/50 bg-muted/40">
-                    <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Model</th>
-                    <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Label</th>
-                    <th className="px-3 py-1.5 text-left font-medium text-muted-foreground hidden sm:table-cell">Description</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {MODEL_USE_CASE_TABLE.map((row) => (
-                    <tr key={row.models} className="border-b border-border/30 last:border-0">
-                      <td className="px-3 py-1.5 font-mono text-foreground">{row.models}</td>
-                      <td className={cn('px-3 py-1.5 font-semibold whitespace-nowrap', row.color)}>{row.label}</td>
-                      <td className="px-3 py-1.5 text-muted-foreground hidden sm:table-cell">{row.description}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+            <div className="mt-2">
+              <DataTable
+                columns={useCaseColumns}
+                data={MODEL_USE_CASE_TABLE}
+                getRowId={(row) => row.models}
+                hideSearch
+                windowScroll
+              />
             </div>
           )}
         </div>

--- a/frontend/src/features/core/components/settings/tab-ai-llm.tsx
+++ b/frontend/src/features/core/components/settings/tab-ai-llm.tsx
@@ -335,7 +335,9 @@ export function LlmSettingsSection({ values, originalValues, onChange, disabled 
     },
     {
       accessorKey: 'description',
-      header: 'Description',
+      // Hide the header too on narrow viewports so it doesn't sit above empty
+      // cells (the original column collapsed entirely below `sm`).
+      header: () => <span className="hidden sm:inline">Description</span>,
       enableSorting: false,
       cell: ({ getValue }) => (
         <span className="hidden text-xs text-muted-foreground sm:inline">{getValue<string>()}</span>


### PR DESCRIPTION
## Summary

Migrates the hand-rolled model use-case reference `<table>` in the LLM Configuration settings sub-panel (`tab-ai-llm.tsx`, inside `LlmSettingsSection`) to the shared `DataTable` component, continuing the table-migration effort.

- Memoized `ColumnDef[]` (3 columns) preserving every header and cell rendering from the original:
  - **Model** — `font-mono text-xs text-foreground`
  - **Label** — `text-xs font-semibold whitespace-nowrap` with the per-row use-case `color` class
  - **Description** — `hidden text-xs text-muted-foreground sm:inline` (preserves the original `hidden sm:table-cell` responsive hide via inner content)
- Compact `text-xs` look kept via per-cell `className`s.
- `getRowId` keyed on `models` (matching the original `key={row.models}`).
- This is a static reference list, so `windowScroll` is used to render all rows with no pager / inner scrollbar (preserving the original "show everything at once" behaviour). No `onRowClick` (rows were never clickable). No `searchKey` (`hideSearch`).

### autoFit decision
**OMITTED.** Per the guidance, this is a fixed settings sub-panel (not a full page), so `autoFit` is not used. `windowScroll` is used instead to keep all 20 reference rows visible without pagination.

### Caveats / tradeoffs
- DataTable's default cell chrome is `px-4 py-3` (vs. the original `px-3 py-1.5`), and the header row is `h-10 text-sm` (vs. the original `text-xs px-3 py-1.5`). The shared component does not expose per-cell padding/header-size overrides, so the table is slightly taller/roomier than before. Cell *text* sizing is preserved at `text-xs`; only the spacing differs marginally. This is consistent with adopting the shared component and was judged an acceptable visual tradeoff for a low-traffic reference table.
- The outer `bg-muted/20` tint and `border-border/50` wrapper were dropped in favour of DataTable's own `rounded-md border` container (it supplies its own border), avoiding a double border.

## Tests
Added a test asserting the shared `DataTable` renders when the "All models" reference table is expanded (checks `data-testid="data-table"`, the `Label`/`Description` headers, and known rows `qwen3:32b` / `phi-4` / `Gold Standard`).

- `npx vitest run src/features/core/components/settings/tab-ai-llm.test.tsx` → **3 passed**
- `npm run typecheck -w frontend` → **clean**
- `npx eslint` on both changed files → **clean (exit 0)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)