### PR TITLE
feat(ai): migrate LLM Latency Breakdown table to shared DataTable

### DIFF
--- a/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.test.tsx
@@ -92,4 +92,38 @@ describe('LlmLatencyBreakdown', () => {
     expect(peers).toContain('api.anthropic.com');
     expect(peers).toContain('api.openai.com');
   });
+
+  it('renders the breakdown via the shared DataTable with per-peer rows and columns', async () => {
+    mockApiGet.mockImplementation(async (_path: string, params: Record<string, unknown>) => {
+      const host = params?.netPeerName as string;
+      if (host === 'api.anthropic.com') {
+        return {
+          traces: [
+            { traceId: 't1', duration: 1200, attributes: {} },
+            { traceId: 't2', duration: 1100, attributes: {} },
+          ],
+        };
+      }
+      return { traces: [] };
+    });
+
+    renderWithProviders(<LlmLatencyBreakdown peers={['api.anthropic.com']} />);
+
+    await waitFor(() => {
+      // The shared DataTable shell is mounted and the peer row has populated.
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+      // The peer is keyed as a DataTable row (getRowId => row.peer).
+      expect(screen.getByTestId('table-row-api.anthropic.com')).toBeInTheDocument();
+    });
+
+    // Column headers are preserved.
+    expect(screen.getByText('Provider')).toBeInTheDocument();
+    expect(screen.getByText('Calls')).toBeInTheDocument();
+    expect(screen.getByText('p50 (ms)')).toBeInTheDocument();
+    expect(screen.getByText('p95 (ms)')).toBeInTheDocument();
+    expect(screen.getByText('p99 (ms)')).toBeInTheDocument();
+
+    // Calls cell reflects the two spans returned for the peer.
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.tsx
+++ b/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useQueries } from '@tanstack/react-query';
+import { type ColumnDef } from '@tanstack/react-table';
 import {
   BarChart,
   Bar,
@@ -11,6 +12,7 @@ import {
   YAxis,
 } from 'recharts';
 import { api } from '@/shared/lib/api';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { NoTraceDataCallout } from '@/features/observability/components/no-trace-data-callout';
 
 /**
@@ -32,6 +34,16 @@ interface PeerSpan {
   duration?: number;
   duration_ms?: number;
   attributes?: Record<string, unknown>;
+}
+
+interface BreakdownRow {
+  peer: string;
+  p50: number;
+  p95: number;
+  p99: number;
+  calls: number;
+  network: number;
+  model: number;
 }
 
 interface LlmLatencyBreakdownProps {
@@ -98,7 +110,7 @@ export function LlmLatencyBreakdown({ peers, fromIso, toIso }: LlmLatencyBreakdo
   const isLoading = queries.some((q) => q.isLoading);
   const allSpans = queries.flatMap((q) => q.data ?? []);
 
-  const chartData = useMemo(() => {
+  const chartData = useMemo<BreakdownRow[]>(() => {
     return peerList
       .map((peer, idx) => {
         const spans = queries[idx]?.data ?? [];
@@ -141,6 +153,36 @@ export function LlmLatencyBreakdown({ peers, fromIso, toIso }: LlmLatencyBreakdo
       .filter((row) => row.calls > 0);
   }, [peerList, queries]);
 
+  const columns = useMemo<ColumnDef<BreakdownRow, unknown>[]>(() => [
+    {
+      accessorKey: 'peer',
+      header: 'Provider',
+      cell: ({ getValue }) => (
+        <span className="font-mono text-xs">{getValue<string>()}</span>
+      ),
+    },
+    {
+      accessorKey: 'calls',
+      header: () => <span className="block text-right">Calls</span>,
+      cell: ({ getValue }) => <span className="block text-right">{getValue<number>()}</span>,
+    },
+    {
+      accessorKey: 'p50',
+      header: () => <span className="block text-right">p50 (ms)</span>,
+      cell: ({ getValue }) => <span className="block text-right">{getValue<number>().toFixed(0)}</span>,
+    },
+    {
+      accessorKey: 'p95',
+      header: () => <span className="block text-right">p95 (ms)</span>,
+      cell: ({ getValue }) => <span className="block text-right">{getValue<number>().toFixed(0)}</span>,
+    },
+    {
+      accessorKey: 'p99',
+      header: () => <span className="block text-right">p99 (ms)</span>,
+      cell: ({ getValue }) => <span className="block text-right">{getValue<number>().toFixed(0)}</span>,
+    },
+  ], []);
+
   if (!isLoading && allSpans.length === 0) {
     return (
       <NoTraceDataCallout
@@ -170,29 +212,14 @@ export function LlmLatencyBreakdown({ peers, fromIso, toIso }: LlmLatencyBreakdo
         </ResponsiveContainer>
       </div>
 
-      <div className="mt-4 overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-              <th className="px-2 py-1.5 font-medium">Provider</th>
-              <th className="px-2 py-1.5 font-medium text-right">Calls</th>
-              <th className="px-2 py-1.5 font-medium text-right">p50 (ms)</th>
-              <th className="px-2 py-1.5 font-medium text-right">p95 (ms)</th>
-              <th className="px-2 py-1.5 font-medium text-right">p99 (ms)</th>
-            </tr>
-          </thead>
-          <tbody>
-            {chartData.map((row) => (
-              <tr key={row.peer} className="border-b last:border-0">
-                <td className="px-2 py-1.5 font-mono text-xs">{row.peer}</td>
-                <td className="px-2 py-1.5 text-right">{row.calls}</td>
-                <td className="px-2 py-1.5 text-right">{row.p50.toFixed(0)}</td>
-                <td className="px-2 py-1.5 text-right">{row.p95.toFixed(0)}</td>
-                <td className="px-2 py-1.5 text-right">{row.p99.toFixed(0)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <div className="mt-4">
+        <DataTable
+          columns={columns}
+          data={chartData}
+          hideSearch
+          pageSize={100}
+          getRowId={(row) => row.peer}
+        />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

Migrates the hand-rolled `<table>` in the LLM Latency Breakdown panel (`frontend/src/features/ai-intelligence/components/llm-latency-breakdown.tsx`) to the shared `DataTable` component.

- Replaced the manual `<thead>/<tbody>` markup with a memoized `ColumnDef[]` over a new `BreakdownRow` type.
- Preserved every column and its rendering: **Provider** (left, monospace `font-mono text-xs`), **Calls**, **p50 (ms)**, **p95 (ms)**, **p99 (ms)** (all right-aligned, `.toFixed(0)` formatting on the percentiles).
- `hideSearch` (the original had no filter input) and `getRowId={(row) => row.peer}` for stable row keys (matches the original `key={row.peer}`).
- Rows were not clickable, so no `onRowClick`.

### autoFit decision
**Omitted.** This is a small, fixed breakdown bounded by the configured LLM peer list (default 5, realistically a handful) embedded directly beneath the stacked bar chart — not a full-page scroll table. A fixed `pageSize={100}` keeps every peer row on a single page with no pagination footer (`DataTable` only renders the footer when `getPageCount() > 1`), exactly matching the prior "show all rows" behaviour.

### Caveats
- The original had no `min-w-[Npx]`, so no `minTableWidth` is carried; `DataTable` already wraps the table in a `scrollbar-themed overflow-x-auto` container, so horizontal overflow on narrow viewports is preserved.
- Header styling shifts slightly from the original `text-xs uppercase tracking-wide` to `DataTable`'s standard `font-medium text-muted-foreground` header row; column labels and alignment are unchanged.

## Testing
- `npx vitest run src/features/ai-intelligence/components/llm-latency-breakdown.test.tsx` — 3 passed (added a test asserting the shared `DataTable` renders with the preserved columns and a per-peer row).
- `npm run typecheck -w frontend` — clean.
- `eslint` on both changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)