### PR TITLE
feat(ai): migrate LLM Observability tables to shared DataTable

### DIFF
--- a/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
@@ -182,6 +182,25 @@ describe('LlmObservabilityPage', () => {
     expect(screen.getByText('error')).toBeTruthy();
   });
 
+  it('renders both shared DataTables when stats and traces have data', () => {
+    vi.mocked(useLlmStats).mockReturnValue({
+      data: mockStats,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as ReturnType<typeof useLlmStats>);
+    vi.mocked(useLlmTraces).mockReturnValue({
+      data: mockTraces,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as ReturnType<typeof useLlmTraces>);
+
+    renderPage();
+    // One DataTable for Model Breakdown, one for Recent Traces
+    expect(screen.getAllByTestId('data-table')).toHaveLength(2);
+    // No per-table search is rendered (both pass hideSearch)
+    expect(screen.queryByTestId('data-table-search')).toBeNull();
+  });
+
   it('blurs query column by default and reveals on toggle', () => {
     vi.mocked(useLlmTraces).mockReturnValue({
       data: mockTraces,
@@ -192,16 +211,20 @@ describe('LlmObservabilityPage', () => {
     renderPage();
     const queryCell = screen.getByText('What containers are using the most memory?');
 
-    // Privacy mode is ON by default — cell should have blur class
-    expect(queryCell.closest('td')?.className).toContain('blur-sm');
+    // Privacy mode is ON by default — the query cell content should have the blur class
+    expect(queryCell.className).toContain('blur-sm');
 
     // Click the Privacy toggle button to reveal
     fireEvent.click(screen.getByText('Privacy'));
-    expect(queryCell.closest('td')?.className).not.toContain('blur-sm');
+    expect(
+      screen.getByText('What containers are using the most memory?').className
+    ).not.toContain('blur-sm');
 
     // Click again to re-blur
     fireEvent.click(screen.getByText('Privacy'));
-    expect(queryCell.closest('td')?.className).toContain('blur-sm');
+    expect(
+      screen.getByText('What containers are using the most memory?').className
+    ).toContain('blur-sm');
   });
 
   it('renders skeleton cards during loading', () => {

--- a/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { type ColumnDef } from '@tanstack/react-table';
 import { LlmLatencyBreakdown } from '@/features/ai-intelligence/components/llm-latency-breakdown';
 import { useLlmTraces, useLlmStats, type LlmTrace } from '@/features/ai-intelligence/hooks/use-llm-observability';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
@@ -7,6 +8,7 @@ import { AutoRefreshToggle } from '@/shared/components/ui/auto-refresh-toggle';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { TiltCard } from '@/shared/components/data-display/tilt-card';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { SkeletonKpi, SkeletonList } from '@/shared/components/feedback/skeleton';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { cn, formatDate } from '@/shared/lib/utils';
@@ -19,6 +21,8 @@ import {
   Eye,
   EyeOff,
 } from 'lucide-react';
+
+type ModelBreakdownRow = { model: string; count: number; tokens: number };
 
 type TimeRange = 1 | 6 | 24 | 168;
 
@@ -46,6 +50,64 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 function TracesTable({ traces, isLoading, privacyMode }: { traces: LlmTrace[]; isLoading: boolean; privacyMode: boolean }) {
+  const columns = useMemo<ColumnDef<LlmTrace, unknown>[]>(() => [
+    {
+      accessorKey: 'created_at',
+      header: 'Time',
+      cell: ({ getValue }) => (
+        <span className="whitespace-nowrap text-muted-foreground">{formatDate(getValue<string>())}</span>
+      ),
+    },
+    {
+      accessorKey: 'model',
+      header: 'Model',
+      cell: ({ getValue }) => (
+        <span className="whitespace-nowrap font-mono text-xs">{getValue<string>()}</span>
+      ),
+    },
+    {
+      accessorKey: 'user_query',
+      header: 'Query',
+      cell: ({ row }) => {
+        const query = row.original.user_query;
+        return (
+          <span
+            className={cn(
+              'block max-w-[300px] truncate select-none',
+              privacyMode && 'blur-sm hover:blur-none transition-[filter] duration-200'
+            )}
+            title={privacyMode ? undefined : (query ?? undefined)}
+          >
+            {query || '—'}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: 'total_tokens',
+      header: () => <span className="block w-full text-right">Tokens</span>,
+      cell: ({ getValue }) => (
+        <div className="text-right whitespace-nowrap font-mono">{getValue<number>().toLocaleString()}</div>
+      ),
+    },
+    {
+      accessorKey: 'latency_ms',
+      header: () => <span className="block w-full text-right">Latency</span>,
+      cell: ({ getValue }) => (
+        <div className="text-right whitespace-nowrap font-mono">{getValue<number>().toLocaleString()}ms</div>
+      ),
+    },
+    {
+      accessorKey: 'status',
+      header: () => <span className="block w-full text-center">Status</span>,
+      cell: ({ getValue }) => (
+        <div className="text-center">
+          <StatusBadge status={getValue<string>()} />
+        </div>
+      ),
+    },
+  ], [privacyMode]);
+
   if (isLoading) {
     return <SkeletonList rows={4} />;
   }
@@ -60,51 +122,66 @@ function TracesTable({ traces, isLoading, privacyMode }: { traces: LlmTrace[]; i
     );
   }
 
-  return (
-    <div className="rounded-lg border bg-card overflow-hidden">
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b bg-muted/50">
-              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Time</th>
-              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Model</th>
-              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Query</th>
-              <th className="px-4 py-3 text-right font-medium text-muted-foreground">Tokens</th>
-              <th className="px-4 py-3 text-right font-medium text-muted-foreground">Latency</th>
-              <th className="px-4 py-3 text-center font-medium text-muted-foreground">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {traces.map((trace) => (
-              <tr key={trace.id} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
-                <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
-                  {formatDate(trace.created_at)}
-                </td>
-                <td className="px-4 py-3 whitespace-nowrap font-mono text-xs">
-                  {trace.model}
-                </td>
-                <td className={cn(
-                  'px-4 py-3 max-w-[300px] truncate select-none',
-                  privacyMode && 'blur-sm hover:blur-none transition-[filter] duration-200'
-                )} title={privacyMode ? undefined : (trace.user_query ?? undefined)}>
-                  {trace.user_query || '—'}
-                </td>
-                <td className="px-4 py-3 text-right whitespace-nowrap font-mono">
-                  {trace.total_tokens.toLocaleString()}
-                </td>
-                <td className="px-4 py-3 text-right whitespace-nowrap font-mono">
-                  {trace.latency_ms.toLocaleString()}ms
-                </td>
-                <td className="px-4 py-3 text-center">
-                  <StatusBadge status={trace.status} />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
+  return <DataTable columns={columns} data={traces} hideSearch getRowId={(trace) => String(trace.id)} />;
+}
+
+function ModelBreakdownTable({
+  modelBreakdown,
+  totalModelQueries,
+  maxModelQueries,
+}: {
+  modelBreakdown: ModelBreakdownRow[];
+  totalModelQueries: number;
+  maxModelQueries: number;
+}) {
+  const columns = useMemo<ColumnDef<ModelBreakdownRow, unknown>[]>(() => [
+    {
+      accessorKey: 'model',
+      header: 'Model',
+      cell: ({ getValue }) => (
+        <span className="inline-flex rounded-md bg-muted/50 px-2 py-1 font-mono text-xs">
+          {getValue<string>()}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'count',
+      header: () => <span className="block w-full text-right">Queries</span>,
+      cell: ({ getValue }) => (
+        <div className="text-right font-medium">{getValue<number>().toLocaleString()}</div>
+      ),
+    },
+    {
+      accessorKey: 'tokens',
+      header: () => <span className="block w-full text-right">Tokens</span>,
+      cell: ({ getValue }) => (
+        <div className="text-right font-medium">{getValue<number>().toLocaleString()}</div>
+      ),
+    },
+    {
+      id: 'share',
+      header: 'Share',
+      enableSorting: false,
+      cell: ({ row }) => {
+        const model = row.original;
+        const queryShare = totalModelQueries > 0 ? Math.round((model.count / totalModelQueries) * 100) : 0;
+        const density = maxModelQueries > 0 ? Math.round((model.count / maxModelQueries) * 100) : 0;
+        return (
+          <div className="flex min-w-36 items-center gap-2">
+            <div className="h-2 w-24 overflow-hidden rounded-full bg-muted" aria-label={`${model.model} share`}>
+              <div
+                className="h-full rounded-full bg-primary"
+                style={{ width: `${Math.max(4, density)}%` }}
+              />
+            </div>
+            <span className="text-xs text-muted-foreground">{queryShare}%</span>
+          </div>
+        );
+      },
+    },
+  ], [totalModelQueries, maxModelQueries]);
+
+  return <DataTable columns={columns} data={modelBreakdown} hideSearch getRowId={(model) => model.model} />;
 }
 
 export default function LlmObservabilityPage() {
@@ -226,46 +303,11 @@ export default function LlmObservabilityPage() {
           {modelBreakdown.length === 0 ? (
             <p className="text-sm text-muted-foreground">No model data available.</p>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b">
-                    <th className="px-3 pb-2 pt-1 text-left font-medium text-muted-foreground">Model</th>
-                    <th className="px-3 pb-2 pt-1 text-right font-medium text-muted-foreground">Queries</th>
-                    <th className="px-3 pb-2 pt-1 text-right font-medium text-muted-foreground">Tokens</th>
-                    <th className="px-3 pb-2 pt-1 text-left font-medium text-muted-foreground">Share</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {modelBreakdown.map((model) => {
-                    const queryShare = totalModelQueries > 0 ? Math.round((model.count / totalModelQueries) * 100) : 0;
-                    const density = maxModelQueries > 0 ? Math.round((model.count / maxModelQueries) * 100) : 0;
-                    return (
-                      <tr key={model.model} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
-                        <td className="px-3 py-2.5">
-                          <span className="inline-flex rounded-md bg-muted/50 px-2 py-1 font-mono text-xs">
-                            {model.model}
-                          </span>
-                        </td>
-                        <td className="px-3 py-2.5 text-right font-medium">{model.count.toLocaleString()}</td>
-                        <td className="px-3 py-2.5 text-right font-medium">{model.tokens.toLocaleString()}</td>
-                        <td className="px-3 py-2.5">
-                          <div className="flex min-w-36 items-center gap-2">
-                            <div className="h-2 w-24 overflow-hidden rounded-full bg-muted" aria-label={`${model.model} share`}>
-                              <div
-                                className="h-full rounded-full bg-primary"
-                                style={{ width: `${Math.max(4, density)}%` }}
-                              />
-                            </div>
-                            <span className="text-xs text-muted-foreground">{queryShare}%</span>
-                          </div>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+            <ModelBreakdownTable
+              modelBreakdown={modelBreakdown}
+              totalModelQueries={totalModelQueries}
+              maxModelQueries={maxModelQueries}
+            />
           )}
         </div>
         </SpotlightCard>


### PR DESCRIPTION
## Summary

Migrates **both** hand-rolled `<table>`s on the LLM Observability page (`frontend/src/features/ai-intelligence/pages/llm-observability.tsx`) to the shared `DataTable` component.

- **Recent Traces table** → `DataTable` with a memoized `ColumnDef[]` (Time, Model, Query, Tokens, Latency, Status). Preserves: `formatDate` time rendering, mono model text, the privacy-blur on the Query column (`blur-sm hover:blur-none`, title revealed only when privacy is off), right-aligned mono Tokens/Latency, centered `StatusBadge`. Keeps the surrounding skeleton (`SkeletonList`) and `EmptyState` ("No LLM traces yet") exactly as before.
- **Model Breakdown table** → `DataTable` with its own memoized `ColumnDef[]` (Model badge, Queries, Tokens, Share). Preserves the share progress bar (`aria-label="<model> share"`) and the percentage label, right-aligned counts, and the "No model data available." fallback.

Each table gets its own separate `ColumnDef[]`; alignment is preserved via per-column header/cell wrappers since `DataTable` renders left-aligned headers by default.

## Decisions / tradeoffs

- **autoFit: OMITTED for both tables.** Both tables share the page with KPI cards, the Model Breakdown card, and the LLM Latency Breakdown chart — neither is a single primary table filling the page below the header, so per the migration guidance autoFit is not appropriate. They render with default client pagination (both datasets are small: traces capped at 50, model breakdown is a handful of rows).
- **`hideSearch` on both** — neither original table had a per-table search box.
- **No `minTableWidth`** — neither original `<table>` had a `min-w-[Npx]` constraint.
- **No `onRowClick`** — rows were not clickable in either original table.
- **`getRowId`** wired to `trace.id` / `model.model` for stable keys.
- Columns are now sortable (a `DataTable` default). This is an additive UX improvement and does not change any rendering.
- One test assertion updated: the privacy-blur class now lives on the query cell's inner content `<span>` (the cell `<td>` is owned by `DataTable`), so the test checks the span's className instead of `closest('td')`. Behavior is identical.

## Tests

- Added a test asserting **both** `DataTable`s render (`getAllByTestId('data-table')` has length 2) and that no per-table search input is shown.
- Existing tests (KPI cards, model breakdown rows, traces rows, status badges, privacy toggle, skeletons, empty state) all preserved and passing.
- Local results: target test file **10/10 passing**; `npm run typecheck -w frontend` clean; eslint clean on both touched files. The full pre-push frontend suite passed **1997/1997**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)