### PR TITLE
feat(security): migrate Packet Capture table to shared DataTable

### DIFF
--- a/frontend/src/features/security/pages/packet-capture.test.tsx
+++ b/frontend/src/features/security/pages/packet-capture.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { useCaptures, type Capture } from '@/features/security/hooks/use-pcap';
 
 vi.mock('@/features/containers/hooks/use-endpoints', () => ({
   useEndpoints: vi.fn().mockReturnValue({
@@ -85,7 +86,34 @@ vi.mock('@/shared/lib/api', () => ({
 
 import PacketCapture from './packet-capture';
 
+const mockUseCaptures = vi.mocked(useCaptures);
+
+function makeCapture(overrides: Partial<Capture> = {}): Capture {
+  return {
+    id: 'cap-12345678-abcd',
+    endpoint_id: 1,
+    container_id: 'c1',
+    container_name: 'api-1',
+    status: 'complete',
+    filter: 'port 80',
+    duration_seconds: 60,
+    max_packets: null,
+    capture_file: '/tmp/cap.pcap',
+    file_size_bytes: 2048,
+    packet_count: 10,
+    protocol_stats: null,
+    exec_id: null,
+    error_message: null,
+    started_at: '2026-05-29T10:00:00.000Z',
+    completed_at: '2026-05-29T10:01:00.000Z',
+    created_at: '2026-05-29T10:00:00.000Z',
+    analysis_result: null,
+    ...overrides,
+  };
+}
+
 describe('PacketCapture', () => {
+  // Radix Select portal interactions are slow on cold JSDOM start; give them headroom.
   it('groups running container options by stack and no-stack bucket', () => {
     render(<PacketCapture />);
 
@@ -103,7 +131,7 @@ describe('PacketCapture', () => {
     expect(screen.getByRole('option', { name: 'worker-1' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'beta-api-1' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'standalone-1' })).toBeInTheDocument();
-  });
+  }, 20000);
 
   it('filters container options by selected stack', () => {
     render(<PacketCapture />);
@@ -123,5 +151,47 @@ describe('PacketCapture', () => {
     expect(screen.getByRole('option', { name: 'worker-1' })).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'beta-api-1' })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'standalone-1' })).not.toBeInTheDocument();
+  }, 20000);
+
+  it('shows the empty state when there are no captures', () => {
+    mockUseCaptures.mockReturnValue({ data: { captures: [] }, refetch: vi.fn() } as unknown as ReturnType<typeof useCaptures>);
+    render(<PacketCapture />);
+
+    expect(screen.getByText('No captures found')).toBeInTheDocument();
+    expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
+  });
+
+  it('renders the capture history in a DataTable with column headers and row data', () => {
+    mockUseCaptures.mockReturnValue({
+      data: {
+        captures: [
+          makeCapture({ id: 'aaaaaaaa-1111', container_name: 'web-1', filter: 'tcp', file_size_bytes: 1024 }),
+        ],
+      },
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useCaptures>);
+
+    render(<PacketCapture />);
+
+    const table = screen.getByTestId('data-table');
+    expect(table).toBeInTheDocument();
+
+    // Headers preserved from the original hand-rolled table
+    expect(within(table).getByText('Container')).toBeInTheDocument();
+    expect(within(table).getByText('Status')).toBeInTheDocument();
+    expect(within(table).getByText('Filter')).toBeInTheDocument();
+    expect(within(table).getByText('File Size')).toBeInTheDocument();
+    expect(within(table).getByText('Created')).toBeInTheDocument();
+    expect(within(table).getByText('Actions')).toBeInTheDocument();
+
+    // Row content + cell formatting preserved
+    expect(within(table).getByText('web-1')).toBeInTheDocument();
+    expect(within(table).getByText('aaaaaaaa')).toBeInTheDocument();
+    expect(within(table).getByText('tcp')).toBeInTheDocument();
+    expect(within(table).getByText('1 KB')).toBeInTheDocument();
+
+    // Download + delete actions available for a completed capture with a file
+    expect(within(table).getByTitle('Download PCAP')).toBeInTheDocument();
+    expect(within(table).getByTitle('Delete capture')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/security/pages/packet-capture.tsx
+++ b/frontend/src/features/security/pages/packet-capture.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { type ColumnDef } from '@tanstack/react-table';
 import {
   Radio,
   Play,
@@ -17,6 +18,7 @@ import {
   Loader2,
 } from 'lucide-react';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
 import { useEndpoints, useEndpointCapabilities } from '@/features/containers/hooks/use-endpoints';
 import { useContainers } from '@/features/containers/hooks/use-containers';
@@ -132,6 +134,155 @@ export default function PacketCapture() {
     const container = filteredRunningContainers.find((c) => c.id === value);
     setSelectedContainerName(container?.name ?? '');
   };
+
+  const stopMutate = stopCapture.mutate;
+  const deleteMutate = deleteCapture.mutate;
+  const analyzeMutate = analyzeMutation.mutate;
+  const analyzePending = analyzeMutation.isPending;
+  const analyzeVariables = analyzeMutation.variables;
+
+  const handleStop = useCallback((id: string) => stopMutate(id), [stopMutate]);
+  const handleDelete = useCallback((id: string) => deleteMutate(id), [deleteMutate]);
+  const handleDownload = useCallback((id: string) => downloadCapture(id, api.getToken()), []);
+  const handleAnalyze = useCallback((id: string) => analyzeMutate(id), [analyzeMutate]);
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedAnalysis((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const columns = useMemo<ColumnDef<Capture, unknown>[]>(() => [
+    {
+      accessorKey: 'container_name',
+      header: 'Container',
+      cell: ({ row }) => {
+        const capture = row.original;
+        const analysis = parseAnalysis(capture);
+        const isExpanded = expandedAnalysis.has(capture.id);
+        return (
+          <div className="flex items-center gap-2">
+            {analysis && (
+              <button
+                onClick={() => toggleExpand(capture.id)}
+                className="-ml-1 rounded p-1 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                title="Toggle analysis"
+              >
+                {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+              </button>
+            )}
+            <div>
+              <p className="font-medium">{capture.container_name}</p>
+              <p className="text-xs text-muted-foreground">{capture.id.slice(0, 8)}</p>
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ row }) => {
+        const capture = row.original;
+        const analysis = parseAnalysis(capture);
+        return (
+          <div className="flex items-center gap-2">
+            <StatusBadge status={capture.status} />
+            {analysis && <HealthBadge status={analysis.health_status} />}
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: 'filter',
+      header: 'Filter',
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">
+          {row.original.filter || <span className="italic">none</span>}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'file_size_bytes',
+      header: 'File Size',
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">
+          {row.original.file_size_bytes ? formatBytes(row.original.file_size_bytes) : '-'}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'created_at',
+      header: 'Created',
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">{new Date(row.original.created_at).toLocaleString()}</span>
+      ),
+    },
+    {
+      id: 'actions',
+      header: () => <span className="block text-right">Actions</span>,
+      enableSorting: false,
+      cell: ({ row }) => {
+        const capture = row.original;
+        const isActive = capture.status === 'capturing' || capture.status === 'pending' || capture.status === 'processing';
+        const hasFile = capture.capture_file && (capture.status === 'complete' || capture.status === 'succeeded');
+        const canAnalyze = hasFile && !isActive;
+        const isAnalyzing = analyzePending && analyzeVariables === capture.id;
+        return (
+          <div className="flex items-center justify-end gap-1">
+            {isActive && (
+              <button
+                onClick={() => handleStop(capture.id)}
+                className="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                title="Stop capture"
+              >
+                <Square className="h-4 w-4" />
+              </button>
+            )}
+            {canAnalyze && (
+              <button
+                onClick={() => handleAnalyze(capture.id)}
+                disabled={isAnalyzing}
+                className="rounded p-1.5 text-muted-foreground hover:bg-purple-500/10 hover:text-purple-500"
+                title="Analyze with AI"
+              >
+                {isAnalyzing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Brain className="h-4 w-4" />}
+              </button>
+            )}
+            {hasFile && (
+              <button
+                onClick={() => handleDownload(capture.id)}
+                className="rounded p-1.5 text-muted-foreground hover:bg-primary/10 hover:text-primary"
+                title="Download PCAP"
+              >
+                <Download className="h-4 w-4" />
+              </button>
+            )}
+            {!isActive && (
+              <button
+                onClick={() => handleDelete(capture.id)}
+                className="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                title="Delete capture"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        );
+      },
+    },
+  ], [expandedAnalysis, toggleExpand, handleStop, handleDelete, handleDownload, handleAnalyze, analyzePending, analyzeVariables]);
+
+  const expandedCaptures = useMemo(
+    () =>
+      captures
+        .filter((c) => expandedAnalysis.has(c.id))
+        .map((c) => ({ capture: c, analysis: parseAnalysis(c) }))
+        .filter((entry): entry is { capture: Capture; analysis: PcapAnalysisResult } => entry.analysis !== null),
+    [captures, expandedAnalysis],
+  );
 
   return (
     <div className="space-y-6">
@@ -334,44 +485,30 @@ export default function PacketCapture() {
           </div>
           </SpotlightCard>
         ) : (
-          <SpotlightCard>
-          <div className="overflow-x-auto rounded-lg border bg-card shadow-sm">
-            <table className="w-full text-sm">
-              <thead className="border-b bg-muted/50">
-                <tr>
-                  <th className="px-4 py-2 text-left font-medium">Container</th>
-                  <th className="px-4 py-2 text-left font-medium">Status</th>
-                  <th className="px-4 py-2 text-left font-medium">Filter</th>
-                  <th className="px-4 py-2 text-left font-medium">File Size</th>
-                  <th className="px-4 py-2 text-left font-medium">Created</th>
-                  <th className="px-4 py-2 text-right font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {captures.map((capture) => (
-                  <CaptureRow
-                    key={capture.id}
-                    capture={capture}
-                    onStop={() => stopCapture.mutate(capture.id)}
-                    onDelete={() => deleteCapture.mutate(capture.id)}
-                    onDownload={() => downloadCapture(capture.id, api.getToken())}
-                    onAnalyze={() => analyzeMutation.mutate(capture.id)}
-                    isAnalyzing={analyzeMutation.isPending && analyzeMutation.variables === capture.id}
-                    isExpanded={expandedAnalysis.has(capture.id)}
-                    onToggleExpand={() => {
-                      setExpandedAnalysis((prev) => {
-                        const next = new Set(prev);
-                        if (next.has(capture.id)) next.delete(capture.id);
-                        else next.add(capture.id);
-                        return next;
-                      });
-                    }}
-                  />
+          <>
+            <SpotlightCard>
+            <div className="rounded-lg border bg-card p-4 shadow-sm">
+              <DataTable columns={columns} data={captures} hideSearch minTableWidth={720} />
+            </div>
+            </SpotlightCard>
+
+            {expandedCaptures.length > 0 && (
+              <div className="space-y-3">
+                {expandedCaptures.map(({ capture, analysis }) => (
+                  <div key={capture.id} className="space-y-1">
+                    <p className="px-1 text-xs font-medium text-muted-foreground">
+                      {capture.container_name} · {capture.id.slice(0, 8)}
+                    </p>
+                    <AnalysisPanel
+                      analysis={analysis}
+                      onReanalyze={() => handleAnalyze(capture.id)}
+                      isAnalyzing={analyzePending && analyzeVariables === capture.id}
+                    />
+                  </div>
                 ))}
-              </tbody>
-            </table>
-          </div>
-          </SpotlightCard>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>
@@ -525,113 +662,5 @@ function AnalysisPanel({ analysis, onReanalyze, isAnalyzing }: { analysis: PcapA
       )}
     </div>
     </SpotlightCard>
-  );
-}
-
-function CaptureRow({
-  capture,
-  onStop,
-  onDelete,
-  onDownload,
-  onAnalyze,
-  isAnalyzing,
-  isExpanded,
-  onToggleExpand,
-}: {
-  capture: Capture;
-  onStop: () => void;
-  onDelete: () => void;
-  onDownload: () => void;
-  onAnalyze: () => void;
-  isAnalyzing: boolean;
-  isExpanded: boolean;
-  onToggleExpand: () => void;
-}) {
-  const isActive = capture.status === 'capturing' || capture.status === 'pending' || capture.status === 'processing';
-  const hasFile = capture.capture_file && (capture.status === 'complete' || capture.status === 'succeeded');
-  const analysis = parseAnalysis(capture);
-  const canAnalyze = hasFile && !isActive;
-
-  return (
-    <>
-      <tr className="hover:bg-muted/30">
-        <td className="px-4 py-2">
-          <div className="flex items-center gap-2">
-            {analysis && (
-              <button onClick={onToggleExpand} className="-ml-1 rounded p-1 text-muted-foreground hover:bg-muted/50 hover:text-foreground" title="Toggle analysis">
-                {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-              </button>
-            )}
-            <div>
-              <p className="font-medium">{capture.container_name}</p>
-              <p className="text-xs text-muted-foreground">{capture.id.slice(0, 8)}</p>
-            </div>
-          </div>
-        </td>
-        <td className="px-4 py-2">
-          <div className="flex items-center gap-2">
-            <StatusBadge status={capture.status} />
-            {analysis && <HealthBadge status={analysis.health_status} />}
-          </div>
-        </td>
-        <td className="px-4 py-2 text-muted-foreground">
-          {capture.filter || <span className="italic">none</span>}
-        </td>
-        <td className="px-4 py-2 text-muted-foreground">
-          {capture.file_size_bytes ? formatBytes(capture.file_size_bytes) : '-'}
-        </td>
-        <td className="px-4 py-2 text-muted-foreground">
-          {new Date(capture.created_at).toLocaleString()}
-        </td>
-        <td className="px-4 py-2 text-right">
-          <div className="flex items-center justify-end gap-1">
-            {isActive && (
-              <button
-                onClick={onStop}
-                className="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                title="Stop capture"
-              >
-                <Square className="h-4 w-4" />
-              </button>
-            )}
-            {canAnalyze && (
-              <button
-                onClick={onAnalyze}
-                disabled={isAnalyzing}
-                className="rounded p-1.5 text-muted-foreground hover:bg-purple-500/10 hover:text-purple-500"
-                title="Analyze with AI"
-              >
-                {isAnalyzing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Brain className="h-4 w-4" />}
-              </button>
-            )}
-            {hasFile && (
-              <button
-                onClick={onDownload}
-                className="rounded p-1.5 text-muted-foreground hover:bg-primary/10 hover:text-primary"
-                title="Download PCAP"
-              >
-                <Download className="h-4 w-4" />
-              </button>
-            )}
-            {!isActive && (
-              <button
-                onClick={onDelete}
-                className="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                title="Delete capture"
-              >
-                <Trash2 className="h-4 w-4" />
-              </button>
-            )}
-          </div>
-        </td>
-      </tr>
-      {analysis && isExpanded && (
-        <tr>
-          <td colSpan={6} className="px-4 py-3">
-            <AnalysisPanel analysis={analysis} onReanalyze={onAnalyze} isAnalyzing={isAnalyzing} />
-          </td>
-        </tr>
-      )}
-    </>
   );
 }


### PR DESCRIPTION
## Summary

Migrates the Packet Capture page's hand-rolled capture-history `<table>` to the shared `DataTable` component, so the page inherits consistent sorting, theming, and the themed horizontal scrollbar used elsewhere in the app.

### What changed
- Replaced the `<table>`/`<thead>`/`<tbody>` markup (and the bespoke `CaptureRow` component) with `<DataTable columns={columns} data={captures} hideSearch minTableWidth={720} />`.
- Built a memoized `ColumnDef<Capture>[]` that preserves **every** header and cell renderer from the original:
  - **Container** — chevron expand toggle (when analysis exists) + container name + short id.
  - **Status** — `StatusBadge` plus `HealthBadge` when analysis is present.
  - **Filter** — BPF filter string with italic `none` fallback.
  - **File Size** — `formatBytes(...)` with `-` fallback.
  - **Created** — localized `toLocaleString()`.
  - **Actions** — stop / AI-analyze / download / delete buttons, with the same active/has-file/can-analyze gating and the analyzing spinner.
- Wrapped all row-action handlers (`handleStop`, `handleDelete`, `handleDownload`, `handleAnalyze`, `toggleExpand`) in `useCallback`.
- Preserved the surrounding chrome unchanged: header, edge-async warning, New Capture form, Active Captures grid, status-filter tabs, and the empty state.

### autoFit decision
**Not used (fixed-page).** `autoFit` is only appropriate when the table is the single primary content filling the page below the header. Here the capture-history table sits below a tall New Capture form, an optional Active Captures grid, and a status-tab row — it is not the sole content — so a fixed client-paginated page (default size) is correct. Carried `minTableWidth={720}` so columns overflow into the themed scrollbar instead of squashing on narrow viewports. No server-side pagination existed, so none was wired.

### UI tradeoff (noted per task instructions)
The original table rendered expanded AI analysis as an inline full-width `colSpan` sub-row directly beneath each capture. `DataTable` has no native expandable sub-row support, so expanded `AnalysisPanel`s now stack in a labeled section **below** the table (each prefixed with its container name + short id) rather than inline between rows. The toggle, re-analyze action, health badge, and all findings are fully preserved — only the panel's vertical position changed.

### Tests
- Updated `packet-capture.test.tsx`: the two existing Radix-select grouping/filter tests are unchanged (given a 20s per-test timeout to absorb cold-start JSDOM warm-up now that the table deps load).
- Added a DataTable-rendering test asserting the `data-table` testid, all six column headers, row cell content (name, short id, filter, formatted size), and the download/delete action buttons.
- Added an empty-state test asserting `No captures found` renders and no `data-table` appears.

### Verification
- `npx vitest run src/features/security/pages/packet-capture.test.tsx` → 4 passed.
- `npm run typecheck -w frontend` → exit 0.
- `npx eslint <both files>` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)