### PR TITLE
feat(settings): migrate General settings table to shared DataTable

### DIFF
--- a/frontend/src/features/core/components/settings/tab-general.test.tsx
+++ b/frontend/src/features/core/components/settings/tab-general.test.tsx
@@ -1,12 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GeneralTab } from './tab-general';
 
+const cacheStatsRef: { data: unknown } = { data: undefined };
+
 vi.mock('@/features/core/hooks/use-cache-admin', () => ({
-  useCacheStats: () => ({ data: undefined }),
+  useCacheStats: () => cacheStatsRef,
   useCacheClear: () => ({ mutate: vi.fn(), isPending: false }),
 }));
+
+beforeEach(() => {
+  cacheStatsRef.data = undefined;
+});
 
 function renderTab() {
   const queryClient = new QueryClient({
@@ -28,5 +34,55 @@ describe('GeneralTab — caching model note (#1312)', () => {
     expect(note).toHaveTextContent(/clicking/i);
     expect(note).toHaveTextContent(/refresh/i);
     expect(note).toHaveTextContent(/non-admin clicks fall back to a plain refresh/i);
+  });
+});
+
+describe('GeneralTab — cached entry keys table (DataTable migration)', () => {
+  it('renders the cache entries inside a DataTable', () => {
+    cacheStatsRef.data = {
+      size: 2,
+      l1Size: 1,
+      l2Size: 1,
+      hits: 10,
+      misses: 2,
+      hitRate: '83%',
+      backend: 'multi-layer',
+      entries: [
+        { key: 'portainer:containers', expiresIn: 30 },
+        { key: 'portainer:images', expiresIn: 60 },
+      ],
+    };
+
+    renderTab();
+
+    const table = screen.getByTestId('data-table');
+    expect(table).toBeInTheDocument();
+
+    // Headers preserved from the original hand-rolled table
+    expect(within(table).getByText('Key')).toBeInTheDocument();
+    expect(within(table).getByText('Expires In (TTL)')).toBeInTheDocument();
+
+    // Cell rendering preserved (key + TTL with the "s" suffix)
+    expect(within(table).getByText('portainer:containers')).toBeInTheDocument();
+    expect(within(table).getByText('portainer:images')).toBeInTheDocument();
+    expect(within(table).getByText('30s')).toBeInTheDocument();
+    expect(within(table).getByText('60s')).toBeInTheDocument();
+  });
+
+  it('does not render the cache entries table when there are no entries', () => {
+    cacheStatsRef.data = {
+      size: 0,
+      l1Size: 0,
+      l2Size: 0,
+      hits: 0,
+      misses: 0,
+      hitRate: 'N/A',
+      backend: 'memory-only',
+      entries: [],
+    };
+
+    renderTab();
+
+    expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/core/components/settings/tab-general.tsx
+++ b/frontend/src/features/core/components/settings/tab-general.tsx
@@ -1,5 +1,13 @@
+import { useMemo } from 'react';
+import { type ColumnDef } from '@tanstack/react-table';
 import { Loader2, RefreshCw, Settings2 } from 'lucide-react';
+import { DataTable } from '@/shared/components/tables/data-table';
 import { useCacheStats, useCacheClear } from '@/features/core/hooks/use-cache-admin';
+
+interface CacheEntryRow {
+  key: string;
+  expiresIn: number;
+}
 
 export interface CacheStatsSummary {
   backend: 'multi-layer' | 'memory-only';
@@ -34,6 +42,26 @@ export function GeneralTab({ theme }: GeneralTabProps) {
   const { data: cacheStats } = useCacheStats();
   const cacheClear = useCacheClear();
   const redisSystemInfo = getRedisSystemInfo(cacheStats);
+
+  const cacheEntryColumns = useMemo<ColumnDef<CacheEntryRow, unknown>[]>(
+    () => [
+      {
+        accessorKey: 'key',
+        header: 'Key',
+        cell: ({ getValue }) => (
+          <span className="font-mono text-xs">{getValue<string>()}</span>
+        ),
+      },
+      {
+        accessorKey: 'expiresIn',
+        header: () => <span className="block text-right">Expires In (TTL)</span>,
+        cell: ({ getValue }) => (
+          <span className="block text-right text-muted-foreground">{getValue<number>()}s</span>
+        ),
+      },
+    ],
+    [],
+  );
 
   return (
     <div className="space-y-6">
@@ -115,22 +143,14 @@ export function GeneralTab({ theme }: GeneralTabProps) {
                       Internal cache identifiers used by the backend for stored query results.
                     </p>
                   </div>
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b bg-muted/50">
-                        <th className="p-3 text-left font-medium">Key</th>
-                        <th className="p-3 text-right font-medium">Expires In (TTL)</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {cacheStats.entries.map((entry) => (
-                        <tr key={entry.key} className="border-b last:border-0">
-                          <td className="p-3 font-mono text-xs">{entry.key}</td>
-                          <td className="p-3 text-right text-muted-foreground">{entry.expiresIn}s</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                  <div className="p-3">
+                    <DataTable
+                      columns={cacheEntryColumns}
+                      data={cacheStats.entries}
+                      getRowId={(entry) => entry.key}
+                      hideSearch
+                    />
+                  </div>
                 </div>
               </div>
             )}


### PR DESCRIPTION
Migrates the hand-rolled "Cached Entry Keys" table in the General settings sub-panel to the shared DataTable component (part of the app-wide table standardization).

- Columns: Key (mono) and Expires In (TTL); behavior preserved, still gated behind a non-empty cache-entries list.
- autoFit omitted — it's a settings sub-panel sharing the page with other sections, so default fixed-page pagination is used.
- 3 tests pass; typecheck and eslint clean.

(This branch's agent hit a transient local git-auth blip and couldn't push; pushed manually from the main checkout.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)