### PR TITLE
fix(test): llm-observability expects 3 DataTables after latency-breakdown migration

### DIFF
--- a/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
@@ -195,9 +195,11 @@ describe('LlmObservabilityPage', () => {
     } as ReturnType<typeof useLlmTraces>);
 
     renderPage();
-    // One DataTable for Model Breakdown, one for Recent Traces
-    expect(screen.getAllByTestId('data-table')).toHaveLength(2);
-    // No per-table search is rendered (both pass hideSearch)
+    // Three shared DataTables on this page: Model Breakdown + Recent Traces (this
+    // page), plus the embedded LlmLatencyBreakdown component, which became a
+    // DataTable in its own migration (#1339).
+    expect(screen.getAllByTestId('data-table')).toHaveLength(3);
+    // No per-table search is rendered (all pass hideSearch)
     expect(screen.queryByTestId('data-table-search')).toBeNull();
   });
 


### PR DESCRIPTION
Cross-PR integration fix discovered when verifying the integrated `dev` after merging the table-migration batch.

#1341 asserted exactly **2** `data-table` testids on the LLM Observability page. Once **#1339** migrated the embedded `LlmLatencyBreakdown` component to `DataTable`, the page legitimately renders **3**. Per the project's no-mock-internal-components rule, the test now reflects the real DOM (count → 3) rather than mocking the child.

Full frontend suite: **2032 passing**. Pure test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)