### PR TITLE
fix(workload): compact Workload Explorer spacing to cut header scroll

### DIFF
--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -431,6 +431,14 @@ describe('WorkloadExplorerPage', () => {
     expect(screen.getAllByTestId('workload-pane')).toHaveLength(1);
   });
 
+  it('uses compact pane padding so the header/filters/table fit without scrolling', () => {
+    mockQueryString = 'endpoint=1';
+    render(<WorkloadExplorerPage />);
+    // p-4 (not p-6) trims vertical chrome so the page fits within standard
+    // laptop viewport heights without forcing a scroll.
+    expect(screen.getByTestId('workload-pane')).toHaveClass('p-4');
+  });
+
   it('renders state filter dropdown', () => {
     mockQueryString = 'endpoint=1';
     render(<WorkloadExplorerPage />);

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -472,7 +472,7 @@ export default function WorkloadExplorerPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
@@ -590,7 +590,7 @@ export default function WorkloadExplorerPage() {
             <SpotlightCard>
             <div
               data-testid="workload-pane"
-              className="rounded-lg border bg-card p-6 shadow-sm space-y-4"
+              className="rounded-lg border bg-card p-4 shadow-sm space-y-4"
             >
               {/* Smart search */}
               <WorkloadSmartSearch


### PR DESCRIPTION
## What

The Workload Explorer overflowed the viewport at standard laptop heights, forcing a small vertical scroll. This tightens two spacing values to recover ~24px:

| Change | Location | Before → After |
|---|---|---|
| Page root gap | `workload-explorer.tsx` | `space-y-6` → `space-y-4` |
| Merged filter+table pane padding | `workload-explorer.tsx` | `p-6` → `p-4` |

The page **title and "Browse and manage containers…" subtitle are kept intact** — this is the "spacing only" approach (no header text changes).

## Why

The header + page chrome pushed the table just past the fold. Trimming the page rhythm and pane padding keeps the header, filters, and table within the viewport without touching content.

## Tests

- Added `uses compact pane padding so the header/filters/table fit without scrolling` to `workload-explorer.test.tsx`, asserting the pane carries `p-4` (mirrors the existing pane class-assertion test for issue #1163).
- Full page suite: **59 passed**.

## Notes

- No linked issue — this was a direct UI fix request; happy to open one if the workflow needs it.
- Out of scope but worth flagging: the shared app shell (`app-layout.tsx`) gives the scroll area a large `pb-36` (144px) bottom padding for floating-bar / mobile-nav clearance. That's a global, intentional contributor to scroll on tall pages; left untouched here.
- Not visually re-measured before/after: the dev server (port 5273) was down during this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)