### PR TITLE
fix(table): autoFit pages off measured row height, not the 48px estimate

### DIFF
--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -750,6 +750,36 @@ describe('DataTable', () => {
       expect(screen.getByText('container-11')).toBeInTheDocument();
       expect(screen.queryByText('container-12')).not.toBeInTheDocument();
     });
+
+    it('divides by the measured row height, not the ROW_HEIGHT constant', () => {
+      // Rows render taller than the ROW_HEIGHT (48) assumption once cell
+      // padding + font metrics are applied (~53px in real tables). autoFit must
+      // page off the *measured* height, otherwise it fits too many rows and the
+      // page scrolls by ~(rows × overshoot)px. Here body rows report 53px:
+      //   available = 1000 - 200 - 40 - 56 - 24 = 680
+      //   floor(680 / 53) = 12 rows/page  (a 48 assumption would show 14)
+      Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true });
+      rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: HTMLElement) {
+          const height = this.tagName === 'TR' ? 53 : 0;
+          return {
+            top: 200,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            width: 0,
+            height,
+            x: 0,
+            y: 200,
+            toJSON: () => ({}),
+          } as DOMRect;
+        });
+
+      render(<DataTable columns={testColumns} data={makeRows(30)} autoFit />);
+      expect(screen.getByText('container-12')).toBeInTheDocument();
+      expect(screen.queryByText('container-13')).not.toBeInTheDocument();
+    });
   });
 
   describe('horizontal scroll (minTableWidth)', () => {

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -268,7 +268,15 @@ export function DataTable<T>({
     const top = el.getBoundingClientRect().top;
     const available =
       getScrollableBottom(el) - top - AUTO_FIT_HEADER_PX - AUTO_FIT_FOOTER_PX - AUTO_FIT_MARGIN_PX;
-    const size = Math.max(MIN_AUTO_ROWS, Math.floor(available / ROW_HEIGHT));
+    // Divide by the *measured* body-row height, not the ROW_HEIGHT estimate.
+    // Cell padding + font metrics make real rows taller than the constant
+    // (~53px vs 48px); using the estimate fits too many rows and the page
+    // scrolls by ~(rows × overshoot)px. Falls back to ROW_HEIGHT before the
+    // first row paints (height 0).
+    const firstRow = el.querySelector('tbody tr');
+    const measured = firstRow?.getBoundingClientRect().height ?? 0;
+    const rowHeight = measured > 0 ? measured : ROW_HEIGHT;
+    const size = Math.max(MIN_AUTO_ROWS, Math.floor(available / rowHeight));
     setAutoPageSize((prev) => (prev === size ? prev : size));
   }, [useAutoFit]);
 


### PR DESCRIPTION
## What

`DataTable` autoFit mode computed page size by dividing available viewport height by a hardcoded `ROW_HEIGHT = 48`, but rows actually render at **~53px** (`td` `py-3` padding + `text-sm` cell). Fix: measure the first body row's real height and divide by that, falling back to `ROW_HEIGHT` before the first row paints.

```diff
-    const size = Math.max(MIN_AUTO_ROWS, Math.floor(available / ROW_HEIGHT));
+    const firstRow = el.querySelector('tbody tr');
+    const measured = firstRow?.getBoundingClientRect().height ?? 0;
+    const rowHeight = measured > 0 ? measured : ROW_HEIGHT;
+    const size = Math.max(MIN_AUTO_ROWS, Math.floor(available / rowHeight));
```

## Why

The ~5px-per-row error accumulates: it's absorbed by the 24px safety margin on short viewports, but grows with row count on taller screens, so autoFit fits too many rows and the page scrolls. This is the residual Workload Explorer scroll reported after #1348 (which adjusted header spacing — a symptom, not the cause).

A hardcoded `48->53` would also be wrong, since row height is content-dependent (a plain-text autoFit table renders ~45px rows). Measuring is the only correct fix.

## Scope

Affects every `autoFit` table — fixes **Workload Explorer** and **Fleet Overview** (its two autoFit tables).

## Verification

**Live before -> after** (Workload Explorer, 40 rows, width 1440), `main` scroll overflow:

| viewport | before | after |
|---|---|---|
| 760px | 23px | **0px** |
| 1040px | 8px | **0px** |
| 1200px | 60px | **0px** |
| 1300px | 66px | **0px** |

**Tests** (TDD — added a failing test that reproduces the overshoot, then fixed to green):
- New: `divides by the measured row height, not the ROW_HEIGHT constant` in `data-table.test.tsx`.
- Full frontend suite: **2047 passed** (212 files); `tsc --noEmit` clean; eslint clean.

## Note

PR #1348 (merged header-spacing change) is now redundant as a fix but harmless — it slightly compacts the page. Can revert separately if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)