### PR TITLE
feat(workload-search): right-align example chips and exit field on Escape

### DIFF
--- a/frontend/src/shared/components/forms/workload-smart-search.test.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.test.tsx
@@ -212,6 +212,25 @@ describe('WorkloadSmartSearch', () => {
     expect(lastCall).toHaveLength(3);
   });
 
+  it('Escape exits the field (blurs the input)', () => {
+    renderComponent();
+    const input = screen.getByRole('textbox');
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it('right-aligns the example chips via ml-auto on the first chip', () => {
+    renderComponent();
+    // ml-auto on the leading chip pushes the row to the right when it fits and
+    // collapses to a left-aligned scrollable row when the chips overflow.
+    expect(screen.getByRole('button', { name: 'state:running' })).toHaveClass('ml-auto');
+  });
+
   it('clicking a filter chip sets query and filters', () => {
     const { onFiltered } = renderComponent();
     fireEvent.click(screen.getByRole('button', { name: 'state:running' }));

--- a/frontend/src/shared/components/forms/workload-smart-search.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.tsx
@@ -128,6 +128,8 @@ export function WorkloadSmartSearch({
         handleAiSearch();
       } else if (e.key === 'Escape') {
         handleClear();
+        // Exit the field on Escape so keyboard users can leave the search.
+        inputRef.current?.blur();
       }
     },
     [handleAiSearch, handleClear],
@@ -234,7 +236,7 @@ export function WorkloadSmartSearch({
             }}
             className="absolute inset-y-0 left-11 right-3 flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           >
-            {FILTER_CHIPS.map((chip) => (
+            {FILTER_CHIPS.map((chip, i) => (
               <button
                 key={chip.label}
                 onClick={() => handleFilterChipClick(chip.label)}
@@ -242,6 +244,10 @@ export function WorkloadSmartSearch({
                   'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-border/60 bg-card/80 px-2 py-0.5 text-xs font-medium',
                   'text-muted-foreground backdrop-blur-sm transition-colors duration-200',
                   'hover:bg-primary/10 hover:text-primary hover:border-primary/30',
+                  // Right-align the chip row: ml-auto on the first chip absorbs
+                  // free space so chips sit at the right when they fit, and
+                  // collapses to a left-aligned scrollable row when they overflow.
+                  i === 0 && 'ml-auto',
                 )}
               >
                 {chip.label}


### PR DESCRIPTION
## What

Two small UX tweaks to the Workload Explorer smart search bar:

1. **Right-align the in-field example chips** — `ml-auto` on the first chip pushes the row flush right when the chips fit, and collapses to a left-aligned scrollable row when they overflow (so no chip is ever clipped/unreachable).
2. **Escape exits the field** — the Escape handler now `blur()`s the input in addition to clearing it, so keyboard users can leave the search.

```diff
       } else if (e.key === 'Escape') {
         handleClear();
+        inputRef.current?.blur();
       }
```
```diff
-            {FILTER_CHIPS.map((chip) => (
+            {FILTER_CHIPS.map((chip, i) => (
               <button
                 ...
+                  i === 0 && 'ml-auto',
```

## Verification

**Live** (Playwright, /workloads, 1440px):
- Chips: first chip has `ml-auto`, `gapOnLeft: 177px` / `gapOnRight: 0px` → flush right. ✅
- Escape: focus the input → press Escape → `activeElement` becomes `BODY`. ✅

**Tests:** added two cases (`Escape exits the field (blurs the input)`, `right-aligns the example chips via ml-auto on the first chip`). Full file: **27 passed**. `tsc --noEmit` clean; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)