### PR TITLE
feat(workload-search): autofocus the search bar when the page opens

### DIFF
--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -598,6 +598,7 @@ export default function WorkloadExplorerPage() {
                 knownStackNames={knownStackNames}
                 onFiltered={setSearchFilteredContainers}
                 totalCount={filteredContainers.length}
+                autoFocus
               />
 
               <div className="flex items-center gap-4 flex-wrap">

--- a/frontend/src/shared/components/forms/workload-smart-search.test.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.test.tsx
@@ -74,6 +74,16 @@ describe('WorkloadSmartSearch', () => {
     expect(screen.getByPlaceholderText(/filter by name/i)).toBeInTheDocument();
   });
 
+  it('focuses the search input on mount when autoFocus is set', () => {
+    renderComponent({ autoFocus: true });
+    expect(document.activeElement).toBe(screen.getByRole('textbox'));
+  });
+
+  it('does not focus the search input on mount by default', () => {
+    renderComponent();
+    expect(document.activeElement).not.toBe(screen.getByRole('textbox'));
+  });
+
   it('renders with custom placeholder', () => {
     renderComponent({ placeholder: 'Custom placeholder' });
     expect(screen.getByPlaceholderText('Custom placeholder')).toBeInTheDocument();

--- a/frontend/src/shared/components/forms/workload-smart-search.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.tsx
@@ -26,6 +26,8 @@ export interface WorkloadSmartSearchProps {
   onFiltered: (containers: Container[]) => void;
   totalCount: number;
   placeholder?: string;
+  /** Focus the search input on mount (e.g. when the page first opens). */
+  autoFocus?: boolean;
 }
 
 /** Apply AI filter results by matching containerNames against the containers list (case-insensitive). */
@@ -41,6 +43,7 @@ export function WorkloadSmartSearch({
   onFiltered,
   totalCount,
   placeholder = 'Filter by name, image, state, stack... or press Enter for AI search',
+  autoFocus = false,
 }: WorkloadSmartSearchProps) {
   const navigate = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -72,6 +75,12 @@ export function WorkloadSmartSearch({
     },
     [containers, onFiltered],
   );
+
+  // Focus the input on mount when requested, so opening the page drops the
+  // caret straight into the search bar.
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
 
   // Re-apply filter when upstream containers change (dropdown filter changed)
   useEffect(() => {


### PR DESCRIPTION
## What

Opening the Workload Explorer now drops the caret straight into the smart search input, so you can start typing immediately.

- Adds an opt-in `autoFocus?: boolean` prop to `WorkloadSmartSearch` — focuses the input on mount via the existing `inputRef` (default `false`, so no other call site changes behavior).
- Sets `autoFocus` on the Workload Explorer's search instance.

```diff
+  /** Focus the search input on mount (e.g. when the page first opens). */
+  autoFocus?: boolean;
...
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
```

## Tests

- Added two cases: focuses on mount when `autoFocus` set, and does *not* focus by default. Full file: **29 passed**.
- `tsc --noEmit` clean; eslint clean; full pre-push suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)