### PR TITLE
feat(home): Overall Health pane with inner stat tiles in a 4:1 row

### DIFF
--- a/frontend/src/features/core/pages/home.test.tsx
+++ b/frontend/src/features/core/pages/home.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import HomePage from './home';
@@ -86,10 +86,18 @@ vi.mock('@/shared/components/data-display/tilt-card', () => ({
 vi.mock('@/shared/components/data-display/spotlight-card', () => ({
   SpotlightCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
+// Motion wrappers are mocked to plain divs, but they FORWARD className so the
+// 4:1 grid layout (grid-cols-5 / col-span-4 / col-span-1) stays assertable.
 vi.mock('@/shared/components/layout/motion-page', () => ({
-  MotionPage: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  MotionReveal: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  MotionStagger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  MotionPage: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  MotionReveal: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  MotionStagger: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
 }));
 vi.mock('@/shared/components/ui/refresh-controls', () => ({
   RefreshControls: () => <button data-testid="mock-refresh" />,
@@ -184,7 +192,43 @@ describe('HomePage', () => {
     } as any);
   });
 
-  it('renders KPI cards when data is loaded', () => {
+  it('renders the Overall Health hero with its inner stat tiles, not the removed KPI cards', () => {
+    mockUseDashboardFull.mockReturnValue({
+      data: makeDashboardData(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+    mockUseContainers.mockReturnValue({
+      data: [makeContainer({ id: 'r1', name: 'r1', healthStatus: 'healthy' })],
+      isLoading: false,
+      isError: false,
+    } as any);
+
+    renderPage();
+
+    // The Overall Health pane now carries the same inner stat tiles as the
+    // Health & Monitoring hero.
+    const hero = screen.getByTestId('fleet-health-hero');
+    expect(within(hero).getByText('Running')).toBeInTheDocument();
+    expect(within(hero).getByText('Healthy')).toBeInTheDocument();
+    expect(within(hero).getByText('Unhealthy')).toBeInTheDocument();
+    expect(within(hero).getByText('No Healthcheck')).toBeInTheDocument();
+
+    // Security Findings stays on Home...
+    expect(screen.getByText('Security Findings')).toBeInTheDocument();
+
+    // ...but the standalone Endpoints / Running / Stopped / Stacks KPI cards
+    // are removed — those numbers now live inside the health pane.
+    expect(screen.queryByText('Endpoints')).not.toBeInTheDocument();
+    expect(screen.queryByText('Running Containers')).not.toBeInTheDocument();
+    expect(screen.queryByText('Stopped Containers')).not.toBeInTheDocument();
+    expect(screen.queryByText('Stacks')).not.toBeInTheDocument();
+  });
+
+  it('lays out Overall Health and Security Findings in a 4:1 grid', () => {
     mockUseDashboardFull.mockReturnValue({
       data: makeDashboardData(),
       isLoading: false,
@@ -196,11 +240,21 @@ describe('HomePage', () => {
 
     renderPage();
 
-    expect(screen.getByText('Endpoints')).toBeInTheDocument();
-    expect(screen.getByText('Running Containers')).toBeInTheDocument();
-    expect(screen.getByText('Stopped Containers')).toBeInTheDocument();
-    expect(screen.getByText('Stacks')).toBeInTheDocument();
-    expect(screen.getByText('Security Findings')).toBeInTheDocument();
+    const hero = screen.getByTestId('fleet-health-hero');
+    // Both halves share one 5-column grid...
+    expect(hero.closest('[class*="grid-cols-5"]')).not.toBeNull();
+    // ...the health pane spans 4 columns...
+    const healthCol = hero.closest('[class*="col-span-4"]');
+    expect(healthCol).not.toBeNull();
+    // ...and Security Findings spans the remaining 1.
+    const securityCol = screen.getByText('Security Findings').closest('[class*="col-span-1"]');
+    expect(securityCol).not.toBeNull();
+
+    // Equal-height guard (review finding #1): both columns carry h-full so the
+    // shorter Security card stretches to match the taller health pane and the
+    // 4:1 row reads as one deliberate band rather than two mismatched cards.
+    expect(healthCol?.className).toContain('h-full');
+    expect(securityCol?.className).toContain('h-full');
   });
 
   it('does not render Recent Containers section (#801)', () => {
@@ -234,7 +288,7 @@ describe('HomePage', () => {
     expect(screen.getByText('Connection refused')).toBeInTheDocument();
   });
 
-  it('shows skeleton cards when loading', () => {
+  it('does not render the removed KPI cards while loading', () => {
     mockUseDashboardFull.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -250,7 +304,7 @@ describe('HomePage', () => {
     expect(screen.queryByText('Endpoints')).not.toBeInTheDocument();
   });
 
-  it('renders the Overall Health Score card on row 2 with 9 healthy / 1 unhealthy (green)', () => {
+  it('renders the Overall Health Score with 9 healthy / 1 unhealthy (green)', () => {
     mockUseDashboardFull.mockReturnValue({
       data: makeDashboardData(),
       isLoading: false,

--- a/frontend/src/features/core/pages/home.tsx
+++ b/frontend/src/features/core/pages/home.tsx
@@ -1,12 +1,12 @@
 import { lazy, Suspense, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Server, Boxes, PackageOpen, Layers, AlertTriangle, Star, ShieldAlert } from 'lucide-react';
+import { AlertTriangle, Star, ShieldAlert } from 'lucide-react';
 import { useDashboardFull } from '@/features/core/hooks/use-dashboard-full';
 import { useContainers, useFavoriteContainers } from '@/features/containers/hooks/use-containers';
 import { calculateHealthStats } from '@/shared/lib/health-score';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
-import { HealthScoreCard } from '@/shared/components/data-display/health-score-card';
+import { FleetHealthSummary } from '@/features/ai-intelligence/components/fleet-health-summary';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { SkeletonKpi, SkeletonChart } from '@/shared/components/feedback/skeleton';
@@ -40,10 +40,8 @@ export default function HomePage() {
   const { interval, setInterval } = useAutoRefresh(30);
   const favoriteIds = useFavoritesStore((s) => s.favoriteIds);
   const { data: favoriteContainers = [] } = useFavoriteContainers(favoriteIds);
-  // KPI history is included in the unified /api/dashboard/full response — no separate call needed
-  const kpiHistory = fullData?.kpiHistory;
 
-  // Containers feed the Overall Health Score row (row 2). Uses the same
+  // Containers feed the Overall Health Score row. Uses the same
   // helpers as the Health & Monitoring page so the two views never disagree.
   const {
     data: containers,
@@ -78,44 +76,6 @@ export default function HomePage() {
       total: stack.containerCount,
     }));
   }, [resourcesData]);
-
-  // Derive sparkline arrays from KPI history snapshots
-  const sparklines = useMemo(() => {
-    if (!kpiHistory || kpiHistory.length < 2) {
-      return { endpoints: [], running: [], stopped: [], stacks: [] };
-    }
-    return {
-      endpoints: kpiHistory.map((s) => s.endpoints),
-      running: kpiHistory.map((s) => s.running),
-      stopped: kpiHistory.map((s) => s.stopped),
-      stacks: kpiHistory.map((s) => s.stacks),
-    };
-  }, [kpiHistory]);
-
-  // Compute hover detail strings from history
-  const hoverDetails = useMemo(() => {
-    if (!kpiHistory || kpiHistory.length === 0) {
-      return { endpoints: undefined, running: undefined, stopped: undefined, stacks: undefined };
-    }
-    const latest = kpiHistory[kpiHistory.length - 1];
-    const oneHourAgo = kpiHistory.length > 12 ? kpiHistory[kpiHistory.length - 13] : kpiHistory[0];
-
-    function detail(key: 'endpoints' | 'running' | 'stopped' | 'stacks') {
-      const values = kpiHistory!.map((s) => s[key]);
-      const peak = Math.max(...values);
-      const avg = Math.round(values.reduce((a, b) => a + b, 0) / values.length);
-      const delta = latest[key] - oneHourAgo[key];
-      const sign = delta >= 0 ? '+' : '';
-      return `Last hour: ${sign}${delta} | Peak: ${peak} | Avg: ${avg}`;
-    }
-
-    return {
-      endpoints: detail('endpoints'),
-      running: detail('running'),
-      stopped: detail('stopped'),
-      stacks: detail('stacks'),
-    };
-  }, [kpiHistory]);
 
   if (isError) {
     return (
@@ -157,70 +117,29 @@ export default function HomePage() {
         </div>
       </div>
 
-      {/* KPI Cards */}
-      {isLoading ? (
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-5">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <SkeletonKpi key={i} />
-          ))}
-        </div>
-      ) : data ? (
-        <MotionStagger className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-5" stagger={0.05}>
-          <MotionReveal className="h-full">
-            <TiltCard>
-              <KpiCard
-                label="Endpoints"
-                value={data.kpis.endpoints}
-                icon={<Server className="h-5 w-5" />}
-                trendValue={`${data.kpis.endpointsUp} up`}
-                trend={data.kpis.endpointsDown > 0 ? 'down' : 'up'}
-                sparklineData={sparklines.endpoints}
-                sparklineColor="var(--color-chart-1)"
-                hoverDetail={hoverDetails.endpoints}
-              />
-            </TiltCard>
-          </MotionReveal>
-          <MotionReveal className="h-full">
-            <TiltCard>
-              <KpiCard
-                label="Running Containers"
-                value={data.kpis.running}
-                icon={<Boxes className="h-5 w-5" />}
-                trendValue={`of ${data.kpis.total} total`}
-                trend="neutral"
-                sparklineData={sparklines.running}
-                sparklineColor="var(--color-chart-2)"
-                hoverDetail={hoverDetails.running}
-              />
-            </TiltCard>
-          </MotionReveal>
-          <MotionReveal className="h-full">
-            <TiltCard>
-              <KpiCard
-                label="Stopped Containers"
-                value={data.kpis.stopped}
-                icon={<PackageOpen className="h-5 w-5" />}
-                trend={data.kpis.stopped > 0 ? 'down' : 'neutral'}
-                trendValue={data.kpis.stopped > 0 ? `${data.kpis.stopped} stopped` : 'none'}
-                sparklineData={sparklines.stopped}
-                sparklineColor="var(--color-chart-3)"
-                hoverDetail={hoverDetails.stopped}
-              />
-            </TiltCard>
-          </MotionReveal>
-          <MotionReveal className="h-full">
-            <TiltCard>
-              <KpiCard
-                label="Stacks"
-                value={data.kpis.stacks}
-                icon={<Layers className="h-5 w-5" />}
-                sparklineData={sparklines.stacks}
-                sparklineColor="var(--color-chart-4)"
-                hoverDetail={hoverDetails.stacks}
-              />
-            </TiltCard>
-          </MotionReveal>
-          <MotionReveal className="h-full">
+      {/* Overall Health Score (4 fr) + Security Findings (1 fr) — single hero
+          row that answers "is everything OK?" at a glance. The health pane
+          reuses FleetHealthSummary so Home shows the same score and inner stat
+          tiles as the Health & Monitoring page and the two can never drift. */}
+      <MotionStagger className="grid grid-cols-1 gap-8 lg:grid-cols-5" stagger={0.05}>
+        <MotionReveal className="h-full lg:col-span-4">
+          {isContainersError ? (
+            <EmptyState
+              variant="error"
+              icon={AlertTriangle}
+              title="Failed to load fleet health"
+              description="Could not compute the Overall Health Score from container data."
+            />
+          ) : (
+            <SpotlightCard>
+              <FleetHealthSummary stats={healthStats} isLoading={isLoadingContainers} />
+            </SpotlightCard>
+          )}
+        </MotionReveal>
+        <MotionReveal className="h-full lg:col-span-1">
+          {isLoading ? (
+            <SkeletonKpi className="h-full" />
+          ) : data ? (
             <TiltCard>
               <button
                 type="button"
@@ -237,35 +156,9 @@ export default function HomePage() {
                 />
               </button>
             </TiltCard>
-          </MotionReveal>
-        </MotionStagger>
-      ) : null}
-
-      {/* Overall Health Score — single hero row that answers "is everything OK?"
-          without a click. Same component as Health & Monitoring so the two
-          pages can never drift apart. */}
-      {isContainersError ? (
-        <EmptyState
-          variant="error"
-          icon={AlertTriangle}
-          title="Failed to load fleet health"
-          description="Could not compute the Overall Health Score from container data."
-        />
-      ) : isLoadingContainers ? (
-        <div data-testid="health-score-skeleton">
-          <SkeletonKpi />
-        </div>
-      ) : healthStats ? (
-        <MotionStagger stagger={0.05}>
-          <MotionReveal>
-            <SpotlightCard>
-              <div className="rounded-lg border bg-card p-6 shadow-sm">
-                <HealthScoreCard stats={healthStats} />
-              </div>
-            </SpotlightCard>
-          </MotionReveal>
-        </MotionStagger>
-      ) : null}
+          ) : null}
+        </MotionReveal>
+      </MotionStagger>
 
       {/* Pinned Favorites */}
       {favoriteContainers.length > 0 && (


### PR DESCRIPTION
## Summary
- Home's Overall Health pane now renders via `FleetHealthSummary` (the same component as Health & Monitoring) instead of the bare `HealthScoreCard`, so the smaller inner KPI tiles — **Running / Healthy / Unhealthy / No Healthcheck** — now appear on Home.
- Removed the standalone **Endpoints / Running Containers / Stopped Containers / Stacks** KPI cards (those numbers now live inside the health pane), plus the now-dead `kpiHistory` / `sparklines` / `hoverDetails` derivations and unused icon imports they fed.
- **Security Findings** moved beside the health pane in a single **4:1** hero row (`lg:grid-cols-5`, health `col-span-4`, security `col-span-1`); both columns are `h-full` so the shorter Security card stretches to match the taller health pane. Stacks vertically on mobile. Same click-through to `/security/audit`.

## Test Plan
- [x] `vitest` (home page): 7 passed — covers inner tiles present, four removed cards absent, 4:1 grid layout, equal-height guard, error state, 90% green-band score, subtitle, no Recent Containers (#801)
- [x] `tsc --noEmit`: 0 errors
- [x] `eslint --max-warnings=0`: clean
- [ ] Visual check of the new Home hero row in the running app

## Notes
- The `useDashboardFull` hook still fetches `kpiHistoryHours=24`; that param is shared with the `login.tsx` / `use-prefetch.ts` prefetch paths, so it's intentionally left as-is (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)