### PR TITLE
feat(sidebar): reorganize main menu into intent-based groups

### DIFF
--- a/docs/ai-instructions/ui-design-system.md
+++ b/docs/ai-instructions/ui-design-system.md
@@ -47,7 +47,7 @@ Each theme defines: semantic colors, sidebar colors, 5 chart colors, border radi
 
 - **Bento grids** — `auto-rows-[minmax(180px,1fr)]`, 1-4 column responsive
 - **Hero cards** — 2-column span for primary KPIs with animated counters + sparklines
-- **Sidebar** — Collapsible (60px/16rem), glassmorphic, 4 nav groups, hidden scrollbar (thin on hover)
+- **Sidebar** — Collapsible (60px/16rem), glassmorphic, 6 intent-based nav groups (Overview, Monitoring, Diagnostics, Intelligence, Security, Operations) with Settings pinned separately at the foot, hidden scrollbar (thin on hover)
 - **Header** — Fixed top: breadcrumbs, Ctrl+K command palette, theme toggle, user menu
 
 ## Animation Standards

--- a/frontend/src/features/core/components/layout/sidebar.test.tsx
+++ b/frontend/src/features/core/components/layout/sidebar.test.tsx
@@ -26,6 +26,26 @@ function renderSidebar() {
   );
 }
 
+/**
+ * Reads the rendered nav into an ordered list of { title, items } groups so
+ * tests can assert both grouping and order. Each group is a direct `div.mb-2`
+ * child of <nav>; the title is the header button's first span, items are <li>s.
+ */
+function getNavGroups() {
+  const nav = screen.getByRole('navigation');
+  const groupDivs = Array.from(nav.children).filter((el) =>
+    el.classList.contains('mb-2'),
+  ) as HTMLElement[];
+  return groupDivs.map((group) => {
+    const header = group.querySelector(':scope > button');
+    const title = header?.querySelector('span')?.textContent?.trim() ?? '';
+    const items = Array.from(group.querySelectorAll('li')).map((li) =>
+      (li.textContent ?? '').trim(),
+    );
+    return { title, items };
+  });
+}
+
 describe('Sidebar', () => {
   beforeEach(() => {
     useUiStore.persist?.clearStorage?.();
@@ -98,19 +118,82 @@ describe('Sidebar', () => {
     expect(screen.getByTestId('sidebar-active-indicator')).toBeInTheDocument();
   });
 
-  it('renders all navigation groups', () => {
+  it('renders the intent-based navigation groups in order', () => {
     mockUseRemediationActions.mockReturnValue({
       data: [],
     } as any);
 
     renderSidebar();
 
-    expect(screen.getByText('Overview')).toBeInTheDocument();
-    expect(screen.getByText('Containers')).toBeInTheDocument();
-    expect(screen.getByText('Intelligence')).toBeInTheDocument();
-    expect(screen.getByText('Operations')).toBeInTheDocument();
+    expect(getNavGroups().map((g) => g.title)).toEqual([
+      'Overview',
+      'Monitoring',
+      'Diagnostics',
+      'Intelligence',
+      'Security',
+      'Operations',
+    ]);
+    // Old grab-bag groups are gone.
+    expect(screen.queryByText('Containers')).not.toBeInTheDocument();
     expect(screen.queryByText('Backups')).not.toBeInTheDocument();
     expect(screen.getByText(/Settings/i)).toBeInTheDocument();
+  });
+
+  it('places Remediation under Operations, not Intelligence (observer-first: actions are separated)', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+
+    renderSidebar();
+
+    const groups = getNavGroups();
+    const intelligence = groups.find((g) => g.title === 'Intelligence');
+    const operations = groups.find((g) => g.title === 'Operations');
+    expect(intelligence?.items).not.toContain('Remediation');
+    expect(operations?.items).toContain('Remediation');
+  });
+
+  it('consolidates the two monitoring views under the Monitoring group', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+
+    renderSidebar();
+
+    const monitoring = getNavGroups().find((g) => g.title === 'Monitoring');
+    expect(monitoring?.items).toEqual(['Health & Monitoring', 'Metrics Dashboard']);
+  });
+
+  it('keeps the two log views adjacent under Diagnostics', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+
+    renderSidebar();
+
+    const diagnostics = getNavGroups().find((g) => g.title === 'Diagnostics');
+    const items = diagnostics?.items ?? [];
+    const logViewer = items.indexOf('Log Viewer');
+    const edgeLogs = items.indexOf('Edge Agent Logs');
+    expect(logViewer).toBeGreaterThanOrEqual(0);
+    expect(edgeLogs).toBeGreaterThanOrEqual(0);
+    expect(Math.abs(logViewer - edgeLogs)).toBe(1);
+  });
+
+  it('gives Security its own group containing the Security Audit view', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+
+    renderSidebar();
+
+    const security = getNavGroups().find((g) => g.title === 'Security');
+    expect(security?.items).toContain('Security Audit');
+  });
+
+  it('pins the Settings link below the nav groups, not inside one', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+
+    renderSidebar();
+
+    // Settings remains reachable...
+    expect(screen.getByRole('button', { name: /Settings/i })).toBeInTheDocument();
+    // ...but is no longer an item inside any of the titled groups.
+    for (const group of getNavGroups()) {
+      expect(group.items).not.toContain('Settings');
+    }
   });
 
   it('renders collapse toggle button', () => {

--- a/frontend/src/features/core/components/layout/sidebar.tsx
+++ b/frontend/src/features/core/components/layout/sidebar.tsx
@@ -46,6 +46,11 @@ interface NavGroup {
   items: NavItem[];
 }
 
+// Grouped by operator intent: what's running -> is it healthy -> why ->
+// ask the AI -> security posture -> act. Remediation is the one mutating
+// workflow and lives alone under Operations to keep the observer-first
+// separation between looking and acting. Settings is pinned separately
+// (see `settingsItem`), out of the themed groups.
 const navigation: NavGroup[] = [
   {
     title: 'Overview',
@@ -53,40 +58,52 @@ const navigation: NavGroup[] = [
       { label: 'Home', to: '/', icon: LayoutDashboard },
       { label: 'Workload Explorer', to: '/workloads', icon: Boxes },
       { label: 'Infrastructure', to: '/infrastructure', icon: Server },
+      { label: 'Image Footprint', to: '/images', icon: PackageOpen },
     ],
   },
   {
-    title: 'Containers',
+    title: 'Monitoring',
     items: [
       { label: 'Health & Monitoring', to: '/health', icon: HeartPulse },
-      { label: 'Image Footprint', to: '/images', icon: PackageOpen },
+      { label: 'Metrics Dashboard', to: '/metrics', icon: BarChart3 },
+    ],
+  },
+  {
+    title: 'Diagnostics',
+    items: [
+      { label: 'Trace Explorer', to: '/traces', icon: GitBranch },
+      { label: 'eBPF Coverage', to: '/ebpf-coverage', icon: Bug },
       { label: 'Network Topology', to: '/topology', icon: Network },
+      { label: 'Packet Capture', to: '/packet-capture', icon: Radio },
+      { label: 'Log Viewer', to: '/logs', icon: ScrollText },
+      { label: 'Edge Agent Logs', to: '/edge-logs', icon: FileSearch },
     ],
   },
   {
     title: 'Intelligence',
     items: [
-      { label: 'Metrics Dashboard', to: '/metrics', icon: BarChart3 },
-      { label: 'Trace Explorer', to: '/traces', icon: GitBranch },
-      { label: 'eBPF Coverage', to: '/ebpf-coverage', icon: Bug },
       { label: 'LLM Assistant', to: '/assistant', icon: MessageSquare },
       { label: 'LLM Observability', to: '/llm-observability', icon: Activity },
-      { label: 'Remediation', to: '/remediation', icon: Shield },
+    ],
+  },
+  {
+    title: 'Security',
+    items: [
+      { label: 'Security Audit', to: '/security/audit', icon: Shield },
+      { label: 'Vulnerabilities', to: '/security/vulnerabilities', icon: ShieldAlert },
     ],
   },
   {
     title: 'Operations',
     items: [
-      { label: 'Log Viewer', to: '/logs', icon: ScrollText },
-      { label: 'Security Audit', to: '/security/audit', icon: Shield },
-      { label: 'Vulnerabilities', to: '/security/vulnerabilities', icon: ShieldAlert },
-      { label: 'Edge Agent Logs', to: '/edge-logs', icon: FileSearch },
-      { label: 'Packet Capture', to: '/packet-capture', icon: Radio },
+      { label: 'Remediation', to: '/remediation', icon: Shield },
       { label: 'Reports', to: '/reports', icon: FileBarChart },
-      { label: 'Settings', to: '/settings', icon: Settings },
     ],
   },
 ];
+
+// Pinned at the foot of the sidebar, separated from the themed groups.
+const settingsItem: NavItem = { label: 'Settings', to: '/settings', icon: Settings };
 
 function AnimatedBadge({ count }: { count: number }) {
   const prevCountRef = useRef(count);
@@ -156,6 +173,110 @@ function ScrollGradient({ navRef }: { navRef: React.RefObject<HTMLElement | null
   );
 }
 
+function NavLink({
+  item,
+  isActive,
+  collapsed,
+  reducedMotion,
+  pendingCount,
+  onPrefetch,
+  onNavigate,
+}: {
+  item: NavItem;
+  isActive: boolean;
+  collapsed: boolean;
+  reducedMotion: boolean | null;
+  pendingCount: number;
+  onPrefetch?: () => void;
+  onNavigate: () => void;
+}) {
+  const link = (
+    <button
+      type="button"
+      className={cn(
+        'relative flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm font-medium transition-colors duration-200',
+        isActive
+          ? 'text-sidebar-accent-foreground'
+          : 'text-sidebar-foreground hover:bg-sidebar-background/45 hover:text-sidebar-accent-foreground',
+        collapsed && 'justify-center px-0'
+      )}
+      onMouseEnter={onPrefetch}
+      onFocus={onPrefetch}
+      onClick={onNavigate}
+    >
+      <>
+        {isActive && (
+          <motion.span
+            layoutId="sidebar-active-pill"
+            data-testid="sidebar-active-indicator"
+            className="absolute inset-0 -z-10 rounded-md bg-sidebar-background/55 shadow-sm ring-1 ring-sidebar-border/60 backdrop-blur-sm"
+            transition={
+              reducedMotion
+                ? { duration: 0 }
+                : { type: 'spring', stiffness: 400, damping: 30 }
+            }
+          />
+        )}
+        <motion.span
+          className="shrink-0"
+          layout={!reducedMotion}
+          transition={
+            reducedMotion
+              ? { duration: 0 }
+              : { type: 'spring', stiffness: 300, damping: 25 }
+          }
+        >
+          <item.icon className="h-4 w-4" />
+        </motion.span>
+        <AnimatePresence>
+          {!collapsed && (
+            <motion.span
+              className="flex flex-1 items-center gap-1 truncate"
+              initial={reducedMotion ? false : { opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={
+                reducedMotion
+                  ? { duration: 0 }
+                  : { duration: 0.1, ease: 'easeOut' }
+              }
+            >
+              <span className="truncate">{item.label}</span>
+              {item.to === '/remediation' ? (
+                <AnimatedBadge count={pendingCount} />
+              ) : item.badge != null && item.badge > 0 ? (
+                <AnimatedBadge count={item.badge} />
+              ) : null}
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </>
+    </button>
+  );
+
+  return (
+    <li>
+      {collapsed ? (
+        <TooltipPrimitive.Root>
+          <TooltipPrimitive.Trigger asChild>{link}</TooltipPrimitive.Trigger>
+          <TooltipPrimitive.Portal>
+            <TooltipPrimitive.Content
+              side="right"
+              sideOffset={8}
+              className="z-50 rounded-md bg-popover px-3 py-1.5 text-xs font-medium text-popover-foreground shadow-md"
+            >
+              {item.label}
+              <TooltipPrimitive.Arrow className="fill-popover" />
+            </TooltipPrimitive.Content>
+          </TooltipPrimitive.Portal>
+        </TooltipPrimitive.Root>
+      ) : (
+        link
+      )}
+    </li>
+  );
+}
+
 export function Sidebar() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -203,6 +324,17 @@ export function Sidebar() {
       return !item.hidden;
     }),
   }));
+
+  const isItemActive = (to: string) =>
+    to === '/' ? location.pathname === '/' : location.pathname.startsWith(to);
+
+  const handleNavigate = (to: string) => {
+    if (to === '/') {
+      window.location.assign('/');
+      return;
+    }
+    navigate(to, { state: { source: 'sidebar-nav', ts: Date.now() } });
+  };
 
   return (
     <TooltipPrimitive.Provider delayDuration={200}>
@@ -287,101 +419,18 @@ export function Sidebar() {
                   )}
                 >
                   <ul className="space-y-0.5 overflow-hidden px-2">
-                    {group.items.map((item) => {
-                      const isActive = item.to === '/'
-                        ? location.pathname === '/'
-                        : location.pathname.startsWith(item.to);
-                      const link = (
-                        <button
-                          type="button"
-                          className={cn(
-                            'relative flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm font-medium transition-colors duration-200',
-                            isActive
-                              ? 'text-sidebar-accent-foreground'
-                              : 'text-sidebar-foreground hover:bg-sidebar-background/45 hover:text-sidebar-accent-foreground',
-                            sidebarCollapsed && 'justify-center px-0'
-                          )}
-                          onMouseEnter={prefetchMap[item.to]}
-                          onFocus={prefetchMap[item.to]}
-                          onClick={() => {
-                            if (item.to === '/') {
-                              window.location.assign('/');
-                              return;
-                            }
-                            navigate(item.to, { state: { source: 'sidebar-nav', ts: Date.now() } });
-                          }}
-                        >
-                          <>
-                            {isActive && (
-                              <motion.span
-                                layoutId="sidebar-active-pill"
-                                data-testid="sidebar-active-indicator"
-                                className="absolute inset-0 -z-10 rounded-md bg-sidebar-background/55 shadow-sm ring-1 ring-sidebar-border/60 backdrop-blur-sm"
-                                transition={
-                                  reducedMotion
-                                    ? { duration: 0 }
-                                    : { type: 'spring', stiffness: 400, damping: 30 }
-                                }
-                              />
-                            )}
-                            <motion.span
-                              className="shrink-0"
-                              layout={!reducedMotion}
-                              transition={
-                                reducedMotion
-                                  ? { duration: 0 }
-                                  : { type: 'spring', stiffness: 300, damping: 25 }
-                              }
-                            >
-                              <item.icon className="h-4 w-4" />
-                            </motion.span>
-                            <AnimatePresence>
-                              {!sidebarCollapsed && (
-                                <motion.span
-                                  className="flex flex-1 items-center gap-1 truncate"
-                                  initial={reducedMotion ? false : { opacity: 0 }}
-                                  animate={{ opacity: 1 }}
-                                  exit={{ opacity: 0 }}
-                                  transition={
-                                    reducedMotion
-                                      ? { duration: 0 }
-                                      : { duration: 0.1, ease: 'easeOut' }
-                                  }
-                                >
-                                  <span className="truncate">{item.label}</span>
-                                  {item.to === '/remediation' ? (
-                                    <AnimatedBadge count={pendingCount} />
-                                  ) : item.badge != null && item.badge > 0 ? (
-                                    <AnimatedBadge count={item.badge} />
-                                  ) : null}
-                                </motion.span>
-                              )}
-                            </AnimatePresence>
-                          </>
-                        </button>
-                      );
-                      return (
-                        <li key={item.to}>
-                          {sidebarCollapsed ? (
-                            <TooltipPrimitive.Root>
-                              <TooltipPrimitive.Trigger asChild>{link}</TooltipPrimitive.Trigger>
-                              <TooltipPrimitive.Portal>
-                                <TooltipPrimitive.Content
-                                  side="right"
-                                  sideOffset={8}
-                                  className="z-50 rounded-md bg-popover px-3 py-1.5 text-xs font-medium text-popover-foreground shadow-md"
-                                >
-                                  {item.label}
-                                  <TooltipPrimitive.Arrow className="fill-popover" />
-                                </TooltipPrimitive.Content>
-                              </TooltipPrimitive.Portal>
-                            </TooltipPrimitive.Root>
-                          ) : (
-                            link
-                          )}
-                        </li>
-                      );
-                    })}
+                    {group.items.map((item) => (
+                      <NavLink
+                        key={item.to}
+                        item={item}
+                        isActive={isItemActive(item.to)}
+                        collapsed={sidebarCollapsed}
+                        reducedMotion={reducedMotion}
+                        pendingCount={pendingCount}
+                        onPrefetch={prefetchMap[item.to]}
+                        onNavigate={() => handleNavigate(item.to)}
+                      />
+                    ))}
                   </ul>
                 </div>
               </div>
@@ -389,6 +438,20 @@ export function Sidebar() {
           })}
           <ScrollGradient navRef={navRef} />
         </nav>
+
+        {/* Settings — pinned at the foot, separated from the themed groups */}
+        <div className="border-t border-border/30 px-2 pt-2">
+          <ul className="space-y-0.5">
+            <NavLink
+              item={settingsItem}
+              isActive={isItemActive(settingsItem.to)}
+              collapsed={sidebarCollapsed}
+              reducedMotion={reducedMotion}
+              pendingCount={pendingCount}
+              onNavigate={() => handleNavigate(settingsItem.to)}
+            />
+          </ul>
+        </div>
 
         {/* Collapse toggle */}
         <div className="p-2">


### PR DESCRIPTION
## Why

The sidebar menu ordering felt off. The prior grouping (Overview / Containers / Intelligence / Operations) scattered related tools across groups and — most notably — buried **Remediation**, the app's only container-mutating action, inside the read-only *Intelligence* group, cutting against the project's observer-first principle.

## What

Regrouped the sidebar by **operator intent**: *what's running → is it healthy → why → ask the AI → security posture → act*, with configuration pinned at the foot.

| Group | Items |
|---|---|
| **Overview** | Home, Workload Explorer, Infrastructure, Image Footprint |
| **Monitoring** | Health & Monitoring, Metrics Dashboard |
| **Diagnostics** | Trace Explorer, eBPF Coverage, Network Topology, Packet Capture, Log Viewer, Edge Agent Logs |
| **Intelligence** | LLM Assistant, LLM Observability |
| **Security** | Security Audit, Vulnerabilities* |
| **Operations** | Remediation•, Reports |
| _pinned, separated_ | Settings |

<sub>* Vulnerabilities stays Harbor-gated. • Remediation keeps its live pending-action badge.</sub>

Key moves:
- **Remediation → Operations** — the one mutating workflow is separated from the read-only insights (observer-first).
- **Monitoring consolidated** — Health & Monitoring and Metrics Dashboard were split across two groups; now together.
- **New Diagnostics group** — reunites the deep-dive tools, including the two log views (previously four rows apart) now adjacent.
- **Security promoted** to its own group instead of being buried in a catch-all.
- **Settings pinned** at the foot below a separator.
- Extracted a small `NavLink` component so the item markup (active pill, badge, collapsed tooltip) is shared between the groups and the pinned Settings link — **behavior unchanged**.

Out of scope: the mobile bottom-tab nav (`mobile-bottom-nav.tsx`) is a separately-curated experience and was intentionally left unchanged.

## Tests

Added/updated structural tests (TDD — verified RED before GREEN) asserting the new group order, Remediation's relocation out of Intelligence, monitoring consolidation, adjacent log views, the Security group, and pinned Settings.

- `frontend` sidebar tests: **13/13 pass**
- layout suite: **67/67 pass**
- `tsc --noEmit` clean, ESLint clean

Docs: updated `docs/ai-instructions/ui-design-system.md` (sidebar spec: 4 → 6 groups + pinned Settings).

_No linked issue — this originated from a direct UX request._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
