### PR TITLE
feat(topology): render only connected handles on nodes

### DIFF
--- a/docs/superpowers/plans/2026-05-30-topology-prune-unused-handles.md
+++ b/docs/superpowers/plans/2026-05-30-topology-prune-unused-handles.md
@@ -1,0 +1,197 @@
+# Topology — Prune Unused Connection Points Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render only the React Flow handles each topology node actually uses (derived from the edge list), instead of all four, on both container and network nodes.
+
+**Architecture:** A pure helper `collectUsedHandles(edges)` maps each nodeId → set of used handle directions. Phase 4 of `topology-graph.tsx` injects `usedHandles: HandleDirection[]` onto each `node.data` after edges are built. `ContainerNode` / `NetworkNode` render a `<Handle>` only when its id is in `usedHandles` (fallback: render all four when `usedHandles` is `undefined`).
+
+**Tech Stack:** React 19, `@xyflow/react`, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-topology-prune-unused-handles-design.md`
+
+---
+
+## Conventions
+- Worktree: `/home/simon/Documents/ai-portainer-dashboard/.claude/worktrees/feature+topology-prune-unused-handles`, branch `feature/topology-prune-unused-handles` (off `origin/dev` 65cf3383).
+- Run frontend tests from `frontend/`: `cd frontend && npx vitest run <path>` (NOT worktree root → jsdom error). `--pool=threads` if workers fail.
+- Never `git add -A`/`-u` (node_modules symlinks). Never `--no-verify`. Husky pre-commit prints a big `npm ci --dry-run` dump — harmless; pipe commits to a file and grep, don't cat.
+
+## File Structure
+- Modify `frontend/src/features/containers/components/network/topology-graph.tsx` — export `HandleDirection`, add `collectUsedHandles`, inject `usedHandles` in Phase 4.
+- Modify `container-node.tsx`, `network-node.tsx` — conditional handle render.
+- Modify `topology-graph.test.ts` — tests for `collectUsedHandles`.
+
+---
+
+## Task 1: `collectUsedHandles` helper + export `HandleDirection`
+
+**Files:** Modify `topology-graph.tsx`; Test `topology-graph.test.ts`.
+
+- [ ] **Step 1: Failing tests.** In `topology-graph.test.ts`, add `collectUsedHandles` and `type HandleDirection` to the existing `from './topology-graph'` import block (alongside `getBestHandles`). Append this top-level block at the END of the file (after the final line):
+
+```ts
+describe('collectUsedHandles', () => {
+  it('records sourceHandle on source and targetHandle on target', () => {
+    const m = collectUsedHandles([
+      { source: 'a', target: 'b', sourceHandle: 'right', targetHandle: 'left' },
+    ]);
+    expect([...(m.get('a') ?? [])]).toEqual(['right']);
+    expect([...(m.get('b') ?? [])]).toEqual(['left']);
+  });
+
+  it('keeps both handles for a node used as source and target', () => {
+    const m = collectUsedHandles([
+      { source: 'a', target: 'b', sourceHandle: 'right', targetHandle: 'left' },
+      { source: 'c', target: 'a', sourceHandle: 'bottom', targetHandle: 'top' },
+    ]);
+    expect([...(m.get('a') ?? [])].sort()).toEqual(['right', 'top']);
+  });
+
+  it('dedupes repeated handles', () => {
+    const m = collectUsedHandles([
+      { source: 'a', target: 'b', sourceHandle: 'right', targetHandle: 'left' },
+      { source: 'a', target: 'd', sourceHandle: 'right', targetHandle: 'left' },
+    ]);
+    expect([...(m.get('a') ?? [])]).toEqual(['right']);
+  });
+
+  it('ignores null/undefined handles', () => {
+    const m = collectUsedHandles([
+      { source: 'a', target: 'b', sourceHandle: null, targetHandle: undefined },
+    ]);
+    expect(m.has('a')).toBe(false);
+    expect(m.has('b')).toBe(false);
+  });
+
+  it('returns no entry for nodes with no edges', () => {
+    const m = collectUsedHandles([]);
+    expect(m.size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Verify fail.** `cd frontend && npx vitest run src/features/containers/components/network/topology-graph.test.ts` → FAIL (import error: `collectUsedHandles` not exported).
+
+- [ ] **Step 3: Implement.** In `topology-graph.tsx`, the line `type HandleDirection = 'top' | 'right' | 'bottom' | 'left';` (in the `// --- Handle helpers` section) → add `export`:
+
+```ts
+export type HandleDirection = 'top' | 'right' | 'bottom' | 'left';
+```
+
+Then add, right after the `getBestHandles` function (before `// --- End handle helpers ---`):
+
+```ts
+/**
+ * Map each node id to the set of handle directions some edge attaches to
+ * (as source or target). Lets nodes render only their connected handles. Pure.
+ */
+export function collectUsedHandles(
+  edges: Array<{ source: string; target: string; sourceHandle?: string | null; targetHandle?: string | null }>,
+): Map<string, Set<HandleDirection>> {
+  const used = new Map<string, Set<HandleDirection>>();
+  const add = (nodeId: string, handle?: string | null) => {
+    if (!handle) return;
+    if (!used.has(nodeId)) used.set(nodeId, new Set());
+    used.get(nodeId)!.add(handle as HandleDirection);
+  };
+  for (const e of edges) {
+    add(e.source, e.sourceHandle);
+    add(e.target, e.targetHandle);
+  }
+  return used;
+}
+```
+
+- [ ] **Step 4: Verify pass + typecheck.** `cd frontend && npx vitest run src/features/containers/components/network/topology-graph.test.ts && npx tsc --noEmit` → PASS, no errors.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add frontend/src/features/containers/components/network/topology-graph.tsx frontend/src/features/containers/components/network/topology-graph.test.ts
+git commit -m "feat(topology): add collectUsedHandles helper
+
+Pure helper mapping each node id to the handle directions its edges use.
+Export HandleDirection for reuse. No behavior change yet."
+```
+
+---
+
+## Task 2: Inject `usedHandles` into node data (Phase 4)
+
+**Files:** Modify `topology-graph.tsx`.
+
+- [ ] **Step 1: Implement.** In the Phase 4 `useMemo` (`const { nodes: initialNodes, edges: initialEdges } = useMemo(...)`), find the final `return { nodes, edges };` (currently line ~612). Immediately BEFORE it, insert:
+
+```ts
+    // Render only the handles edges actually attach to (prune orphan dots).
+    const usedHandles = collectUsedHandles(edges);
+    for (const node of nodes) {
+      (node.data as Record<string, unknown>).usedHandles = [...(usedHandles.get(node.id) ?? [])];
+    }
+
+```
+
+- [ ] **Step 2: Typecheck + existing tests.** `cd frontend && npx tsc --noEmit && npx vitest run src/features/containers` → clean, all pass (no behavior asserted yet; this just adds data).
+
+- [ ] **Step 3: Commit.**
+```bash
+git add frontend/src/features/containers/components/network/topology-graph.tsx
+git commit -m "feat(topology): inject usedHandles onto node data
+
+Phase 4 tags each node with the handle directions its edges use, so node
+components can render only connected handles."
+```
+
+---
+
+## Task 3: Filter handles in ContainerNode and NetworkNode
+
+**Files:** Modify `container-node.tsx`, `network-node.tsx`.
+
+- [ ] **Step 1: ContainerNode.** Replace the body of `frontend/src/features/containers/components/network/container-node.tsx` so the four `<Handle>` are conditional. Add after the existing `const related = ...` line:
+
+```ts
+  const usedHandles = (data as any).usedHandles as Array<'top' | 'right' | 'bottom' | 'left'> | undefined;
+  const showHandle = (id: 'top' | 'right' | 'bottom' | 'left') =>
+    usedHandles === undefined || usedHandles.includes(id);
+```
+
+Then change each handle line to be guarded (keep `type="source"`, ids, className unchanged):
+```tsx
+      {showHandle('top') && <Handle id="top" type="source" position={Position.Top} className="!bg-gray-400" />}
+      {showHandle('right') && <Handle id="right" type="source" position={Position.Right} className="!bg-gray-400" />}
+```
+…and likewise the `bottom` and `left` handles further down.
+
+- [ ] **Step 2: NetworkNode.** Same change in `network-node.tsx` — add the identical `usedHandles` / `showHandle` lines after its `const related = ...`, and guard its four handles (keep `type="target"`):
+```tsx
+      {showHandle('top') && <Handle id="top" type="target" position={Position.Top} className="!bg-gray-400" />}
+      {showHandle('right') && <Handle id="right" type="target" position={Position.Right} className="!bg-gray-400" />}
+```
+…and `bottom` / `left`.
+
+- [ ] **Step 3: Typecheck + full containers suite.** `cd frontend && npx tsc --noEmit && npx vitest run src/features/containers` → clean, all pass.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add frontend/src/features/containers/components/network/container-node.tsx frontend/src/features/containers/components/network/network-node.tsx
+git commit -m "feat(topology): render only connected handles on nodes
+
+Container and network nodes now render a handle only when an edge attaches
+to it (data.usedHandles), removing orphan connection dots. Falls back to all
+four handles when usedHandles is absent."
+```
+
+---
+
+## Task 4: Verify
+
+- [ ] **Step 1:** `cd frontend && npx vitest run` → all pass.
+- [ ] **Step 2:** `cd frontend && npx tsc --noEmit && npm run lint -w frontend` → clean.
+- [ ] **Step 3: Manual** (run skill / `npm run dev`): open Topology, confirm each node shows dots only where lines meet it, no line snaps to a node center, isolated nodes show no dots, RPC overlay still connects. Screenshot for PR.
+- [ ] **Step 4:** Finish via `superpowers:finishing-a-development-branch` → PR to `dev`.
+
+## Self-review notes
+- Spec coverage: helper (T1) ✓, inject (T2) ✓, both node components (T3) ✓, fallback-when-undefined (T3) ✓, tests (T1) ✓, verify+manual (T4) ✓.
+- Naming consistent: `collectUsedHandles`, `HandleDirection`, `usedHandles`, `showHandle` used identically across tasks.
+- Node-component DOM tests intentionally omitted (bare `<Handle>` needs ReactFlowProvider) — per spec; coverage via pure helper + manual check.

--- a/docs/superpowers/specs/2026-05-30-topology-prune-unused-handles-design.md
+++ b/docs/superpowers/specs/2026-05-30-topology-prune-unused-handles-design.md
@@ -1,0 +1,160 @@
+# Network Topology — Prune Unused Connection Points
+
+**Date:** 2026-05-30
+**Branch:** `feature/topology-prune-unused-handles`
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+In the Network Topology view, `ContainerNode` and `NetworkNode` each render **all
+four** React Flow handles (top / right / bottom / left) as small gray dots
+(`!bg-gray-400`), unconditionally. Every edge, however, attaches to only **one**
+handle per node — the direction is chosen by `getBestHandles()` from the angle
+between the two node centers. The result is that most nodes display two or three
+"dangling" connection dots that attach to nothing, cluttering the graph.
+
+## Goal
+
+Render only the connection points that an edge actually uses. A node keeps a gray
+dot exactly where a line meets it; orphan dots disappear. Applies to **both**
+container and network nodes.
+
+## Constraint (load-bearing)
+
+React Flow attaches an edge to a specific handle by matching the edge's
+`sourceHandle` / `targetHandle` string to a `<Handle id=...>` rendered inside the
+node. If that handle is not in the DOM, the edge silently falls back to the node
+origin and renders wrong. Therefore handles cannot be removed blindly — we must
+render exactly the set of handle ids that the edges reference for each node.
+
+## Background: current implementation
+
+In `frontend/src/features/containers/components/network/`:
+
+- `container-node.tsx` — renders 4 `<Handle type="source" id="top|right|bottom|left">`.
+- `network-node.tsx` — renders 4 `<Handle type="target" id="top|right|bottom|left">`.
+- `topology-graph.tsx` Phase 4 builds the React Flow `nodes` first, then the
+  `edges`. Each edge sets `sourceHandle` / `targetHandle` from
+  `getBestHandles(sourcePos, targetPos)` (returns one of `top|right|bottom|left`).
+  This covers both the structural container↔network edges and the RPC-overlay
+  edges (`showObservedTraffic`).
+
+Because the edges already know which handle each node uses, the used set is fully
+derivable from the assembled edge list — no new geometry needed.
+
+## Design
+
+### 1. Derive the used-handle set from edges (pure helper)
+
+Add to `topology-graph.tsx`, exported for testing:
+
+```ts
+export type HandleDirection = 'top' | 'right' | 'bottom' | 'left';
+
+/**
+ * Map each node id to the set of handle directions that at least one edge
+ * attaches to (as source or target). Used to render only connected handles.
+ */
+export function collectUsedHandles(
+  edges: Array<{ source: string; target: string; sourceHandle?: string | null; targetHandle?: string | null }>,
+): Map<string, Set<HandleDirection>> {
+  const used = new Map<string, Set<HandleDirection>>();
+  const add = (nodeId: string, handle?: string | null) => {
+    if (!handle) return;
+    if (!used.has(nodeId)) used.set(nodeId, new Set());
+    used.get(nodeId)!.add(handle as HandleDirection);
+  };
+  for (const e of edges) {
+    add(e.source, e.sourceHandle);
+    add(e.target, e.targetHandle);
+  }
+  return used;
+}
+```
+
+`HandleDirection` is currently a local `type` in `topology-graph.tsx`; it becomes
+exported so the helper and tests can reference it. This naturally handles a
+container that is both an edge source (structural / RPC-from) and an edge target
+(RPC-to): both its handle ids are retained.
+
+### 2. Inject `usedHandles` into node data (Phase 4 post-pass)
+
+After both `nodes` and `edges` are built in the Phase 4 `useMemo` (edges are built
+last today, so no reordering is needed), run one pass:
+
+```ts
+const usedHandles = collectUsedHandles(edges);
+for (const node of nodes) {
+  (node.data as Record<string, unknown>).usedHandles = [...(usedHandles.get(node.id) ?? [])];
+}
+```
+
+`usedHandles` is a plain `HandleDirection[]` on `node.data`. A node with no edges
+gets `[]` (renders zero handles — correct, nothing attaches).
+
+### 3. Filter handles in the node components
+
+`ContainerNode` and `NetworkNode` read `data.usedHandles` and render a `<Handle>`
+only when its id is included. Kept dots are unchanged (`!bg-gray-400`). The
+shape, label, selection/related rings, and all other markup stay identical.
+
+```ts
+// shared idea, applied in each component with its own handle `type`
+const usedHandles = (data as any).usedHandles as HandleDirection[] | undefined;
+const showHandle = (id: HandleDirection) => usedHandles === undefined || usedHandles.includes(id);
+```
+
+- **Container** handles are `type="source"`; **network** handles are
+  `type="target"` — unchanged.
+- **Fallback:** when `usedHandles` is `undefined`, render all four (preserves
+  today's behavior for any caller that doesn't supply the field). Only an explicit
+  array (including `[]`) filters.
+
+The four `<Handle>` elements become conditional (`{showHandle('top') && <Handle .../>}`)
+in their existing positions; nothing else in the components changes.
+
+## What does NOT change
+
+Edge routing, `getBestHandles` / `getHandleForAngle`, the RPC overlay, ELK layout,
+viewport, and node positions are all untouched. This is purely a reduction in how
+many handle dots each node renders.
+
+## Testing
+
+Per the project's mandatory-tests rule:
+
+- **`topology-graph.test.ts`** — unit-test `collectUsedHandles` (pure):
+  - a structural edge records `sourceHandle` on the source and `targetHandle` on
+    the target;
+  - a node referenced as both source and target keeps both handle ids;
+  - RPC-style edges contribute their handles the same way;
+  - a `null`/`undefined` handle is ignored;
+  - a node with no edges has no entry (caller treats missing as `[]`).
+- The existing `getBestHandles` / `getHandleForAngle` tests stay green
+  (`HandleDirection` becoming exported is non-breaking).
+- Node-component DOM render tests are intentionally out of scope: a bare
+  `<Handle>` requires `ReactFlowProvider` context and the existing suite stubs
+  `TopologyGraph` in the page test rather than mounting React Flow. Coverage rests
+  on the pure helper plus manual visual verification in the running app.
+
+Full frontend suite must stay green: `cd frontend && npx vitest run`.
+
+## Documentation
+
+`docs/architecture.md` already describes the topology view; no content there is
+invalidated by this change (handles are an internal rendering detail). No
+`.env.example` or `CLAUDE.md` changes. If the architecture note benefits from a
+one-line mention that nodes render only connected handles, add it; otherwise no
+doc change is required.
+
+## Risks & mitigations
+
+- **Missing-handle fallback to node origin** — mitigated by deriving the used set
+  directly from the same edge objects React Flow consumes, so every referenced
+  handle id is guaranteed to be rendered.
+- **A future edge type that sets a handle not in the four directions** — the
+  helper passes the string through as-is; the node component only knows four
+  positions, so an unknown id simply wouldn't render. Acceptable: all current
+  edges use `getBestHandles`, which only returns the four cardinal directions.
+- **Visual regression** — verify in the running app that every line still meets a
+  dot and no line snaps to a node center.

--- a/frontend/src/features/containers/components/network/container-node.tsx
+++ b/frontend/src/features/containers/components/network/container-node.tsx
@@ -1,5 +1,6 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import { cn } from '@/shared/lib/utils';
+import { shouldShowHandle, type HandleDirection } from './handle-visibility';
 
 const stateColors: Record<string, string> = {
   running: 'bg-emerald-500 border-emerald-600',
@@ -14,14 +15,12 @@ export function ContainerNode({ data }: NodeProps) {
   const image = (data as any).image || '';
   const selected = Boolean((data as any).selected);
   const related = Boolean((data as any).related);
-  const usedHandles = (data as any).usedHandles as Array<'top' | 'right' | 'bottom' | 'left'> | undefined;
-  const showHandle = (id: 'top' | 'right' | 'bottom' | 'left') =>
-    usedHandles === undefined || usedHandles.includes(id);
+  const usedHandles = (data as any).usedHandles as HandleDirection[] | undefined;
 
   return (
     <div className="flex flex-col items-center gap-1">
-      {showHandle('top') && <Handle id="top" type="source" position={Position.Top} className="!bg-gray-400" />}
-      {showHandle('right') && <Handle id="right" type="source" position={Position.Right} className="!bg-gray-400" />}
+      {shouldShowHandle(usedHandles, 'top') && <Handle id="top" type="source" position={Position.Top} className="!bg-gray-400" />}
+      {shouldShowHandle(usedHandles, 'right') && <Handle id="right" type="source" position={Position.Right} className="!bg-gray-400" />}
       <div
         className={cn(
           'h-10 w-10 rounded-full border-2 flex items-center justify-center text-white text-xs font-bold transition-all duration-200',
@@ -40,8 +39,8 @@ export function ContainerNode({ data }: NodeProps) {
       <div className="text-[10px] text-muted-foreground max-w-[100px] truncate">
         {image}
       </div>
-      {showHandle('bottom') && <Handle id="bottom" type="source" position={Position.Bottom} className="!bg-gray-400" />}
-      {showHandle('left') && <Handle id="left" type="source" position={Position.Left} className="!bg-gray-400" />}
+      {shouldShowHandle(usedHandles, 'bottom') && <Handle id="bottom" type="source" position={Position.Bottom} className="!bg-gray-400" />}
+      {shouldShowHandle(usedHandles, 'left') && <Handle id="left" type="source" position={Position.Left} className="!bg-gray-400" />}
     </div>
   );
 }

--- a/frontend/src/features/containers/components/network/container-node.tsx
+++ b/frontend/src/features/containers/components/network/container-node.tsx
@@ -14,11 +14,14 @@ export function ContainerNode({ data }: NodeProps) {
   const image = (data as any).image || '';
   const selected = Boolean((data as any).selected);
   const related = Boolean((data as any).related);
+  const usedHandles = (data as any).usedHandles as Array<'top' | 'right' | 'bottom' | 'left'> | undefined;
+  const showHandle = (id: 'top' | 'right' | 'bottom' | 'left') =>
+    usedHandles === undefined || usedHandles.includes(id);
 
   return (
     <div className="flex flex-col items-center gap-1">
-      <Handle id="top" type="source" position={Position.Top} className="!bg-gray-400" />
-      <Handle id="right" type="source" position={Position.Right} className="!bg-gray-400" />
+      {showHandle('top') && <Handle id="top" type="source" position={Position.Top} className="!bg-gray-400" />}
+      {showHandle('right') && <Handle id="right" type="source" position={Position.Right} className="!bg-gray-400" />}
       <div
         className={cn(
           'h-10 w-10 rounded-full border-2 flex items-center justify-center text-white text-xs font-bold transition-all duration-200',
@@ -37,8 +40,8 @@ export function ContainerNode({ data }: NodeProps) {
       <div className="text-[10px] text-muted-foreground max-w-[100px] truncate">
         {image}
       </div>
-      <Handle id="bottom" type="source" position={Position.Bottom} className="!bg-gray-400" />
-      <Handle id="left" type="source" position={Position.Left} className="!bg-gray-400" />
+      {showHandle('bottom') && <Handle id="bottom" type="source" position={Position.Bottom} className="!bg-gray-400" />}
+      {showHandle('left') && <Handle id="left" type="source" position={Position.Left} className="!bg-gray-400" />}
     </div>
   );
 }

--- a/frontend/src/features/containers/components/network/handle-visibility.test.ts
+++ b/frontend/src/features/containers/components/network/handle-visibility.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowHandle } from './handle-visibility';
+
+describe('shouldShowHandle', () => {
+  it('shows every handle when usedHandles is undefined (fallback)', () => {
+    expect(shouldShowHandle(undefined, 'top')).toBe(true);
+    expect(shouldShowHandle(undefined, 'right')).toBe(true);
+    expect(shouldShowHandle(undefined, 'bottom')).toBe(true);
+    expect(shouldShowHandle(undefined, 'left')).toBe(true);
+  });
+
+  it('shows no handle when usedHandles is an empty array', () => {
+    expect(shouldShowHandle([], 'top')).toBe(false);
+    expect(shouldShowHandle([], 'right')).toBe(false);
+    expect(shouldShowHandle([], 'bottom')).toBe(false);
+    expect(shouldShowHandle([], 'left')).toBe(false);
+  });
+
+  it('shows only the handles listed in usedHandles', () => {
+    expect(shouldShowHandle(['top', 'left'], 'top')).toBe(true);
+    expect(shouldShowHandle(['top', 'left'], 'left')).toBe(true);
+    expect(shouldShowHandle(['top', 'left'], 'right')).toBe(false);
+    expect(shouldShowHandle(['top', 'left'], 'bottom')).toBe(false);
+  });
+});

--- a/frontend/src/features/containers/components/network/handle-visibility.ts
+++ b/frontend/src/features/containers/components/network/handle-visibility.ts
@@ -1,0 +1,17 @@
+/** A React Flow handle position on a topology node. */
+export type HandleDirection = 'top' | 'right' | 'bottom' | 'left';
+
+/**
+ * Whether a node should render the handle in direction `id`.
+ *
+ * `usedHandles` is the set of directions edges actually attach to for this node
+ * (injected onto node data by the topology graph). When it is `undefined` — no
+ * data supplied — all handles render as a safe fallback; an explicit empty array
+ * renders none. Pure; exported for testing.
+ */
+export function shouldShowHandle(
+  usedHandles: HandleDirection[] | undefined,
+  id: HandleDirection,
+): boolean {
+  return usedHandles === undefined || usedHandles.includes(id);
+}

--- a/frontend/src/features/containers/components/network/network-node.tsx
+++ b/frontend/src/features/containers/components/network/network-node.tsx
@@ -1,5 +1,6 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import { cn } from '@/shared/lib/utils';
+import { shouldShowHandle, type HandleDirection } from './handle-visibility';
 
 export function NetworkNode({ data }: NodeProps) {
   const label = (data as any).label || 'Unknown';
@@ -7,14 +8,12 @@ export function NetworkNode({ data }: NodeProps) {
   const subnet = (data as any).subnet || '';
   const selected = Boolean((data as any).selected);
   const related = Boolean((data as any).related);
-  const usedHandles = (data as any).usedHandles as Array<'top' | 'right' | 'bottom' | 'left'> | undefined;
-  const showHandle = (id: 'top' | 'right' | 'bottom' | 'left') =>
-    usedHandles === undefined || usedHandles.includes(id);
+  const usedHandles = (data as any).usedHandles as HandleDirection[] | undefined;
 
   return (
     <div className="flex flex-col items-center gap-1">
-      {showHandle('top') && <Handle id="top" type="target" position={Position.Top} className="!bg-gray-400" />}
-      {showHandle('right') && <Handle id="right" type="target" position={Position.Right} className="!bg-gray-400" />}
+      {shouldShowHandle(usedHandles, 'top') && <Handle id="top" type="target" position={Position.Top} className="!bg-gray-400" />}
+      {shouldShowHandle(usedHandles, 'right') && <Handle id="right" type="target" position={Position.Right} className="!bg-gray-400" />}
       <div
         className={cn(
           'h-12 w-12 rotate-45 border-2 border-blue-500 bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center transition-all duration-200',
@@ -37,8 +36,8 @@ export function NetworkNode({ data }: NodeProps) {
       {subnet && (
         <div className="text-[10px] text-muted-foreground">{subnet}</div>
       )}
-      {showHandle('bottom') && <Handle id="bottom" type="target" position={Position.Bottom} className="!bg-gray-400" />}
-      {showHandle('left') && <Handle id="left" type="target" position={Position.Left} className="!bg-gray-400" />}
+      {shouldShowHandle(usedHandles, 'bottom') && <Handle id="bottom" type="target" position={Position.Bottom} className="!bg-gray-400" />}
+      {shouldShowHandle(usedHandles, 'left') && <Handle id="left" type="target" position={Position.Left} className="!bg-gray-400" />}
     </div>
   );
 }

--- a/frontend/src/features/containers/components/network/network-node.tsx
+++ b/frontend/src/features/containers/components/network/network-node.tsx
@@ -7,11 +7,14 @@ export function NetworkNode({ data }: NodeProps) {
   const subnet = (data as any).subnet || '';
   const selected = Boolean((data as any).selected);
   const related = Boolean((data as any).related);
+  const usedHandles = (data as any).usedHandles as Array<'top' | 'right' | 'bottom' | 'left'> | undefined;
+  const showHandle = (id: 'top' | 'right' | 'bottom' | 'left') =>
+    usedHandles === undefined || usedHandles.includes(id);
 
   return (
     <div className="flex flex-col items-center gap-1">
-      <Handle id="top" type="target" position={Position.Top} className="!bg-gray-400" />
-      <Handle id="right" type="target" position={Position.Right} className="!bg-gray-400" />
+      {showHandle('top') && <Handle id="top" type="target" position={Position.Top} className="!bg-gray-400" />}
+      {showHandle('right') && <Handle id="right" type="target" position={Position.Right} className="!bg-gray-400" />}
       <div
         className={cn(
           'h-12 w-12 rotate-45 border-2 border-blue-500 bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center transition-all duration-200',
@@ -34,8 +37,8 @@ export function NetworkNode({ data }: NodeProps) {
       {subnet && (
         <div className="text-[10px] text-muted-foreground">{subnet}</div>
       )}
-      <Handle id="bottom" type="target" position={Position.Bottom} className="!bg-gray-400" />
-      <Handle id="left" type="target" position={Position.Left} className="!bg-gray-400" />
+      {showHandle('bottom') && <Handle id="bottom" type="target" position={Position.Bottom} className="!bg-gray-400" />}
+      {showHandle('left') && <Handle id="left" type="target" position={Position.Left} className="!bg-gray-400" />}
     </div>
   );
 }

--- a/frontend/src/features/containers/components/network/topology-graph.test.ts
+++ b/frontend/src/features/containers/components/network/topology-graph.test.ts
@@ -11,6 +11,8 @@ import {
   sortStacks,
   getHandleForAngle,
   getBestHandles,
+  collectUsedHandles,
+  type HandleDirection,
   formatRate,
   ROOT_LAYOUT_OPTIONS,
   GROUP_LAYOUT_OPTIONS,
@@ -663,5 +665,44 @@ describe('formatRate', () => {
 
   it('rounds correctly for fractional KB', () => {
     expect(formatRate(1536)).toBe('1.5KB/s');
+  });
+});
+
+describe('collectUsedHandles', () => {
+  it('records sourceHandle on source and targetHandle on target', () => {
+    const m = collectUsedHandles([
+      { source: 'a', target: 'b', sourceHandle: 'right', targetHandle: 'left' },
+    ]);
+    expect([...(m.get('a') ?? [])]).toEqual(['right']);
+    expect([...(m.get('b') ?? [])]).toEqual(['left']);
+  });
+
+  it('keeps both handles for a node used as source and target', () => {
+    const m = collectUsedHandles([
+      { source: 'a', target: 'b', sourceHandle: 'right', targetHandle: 'left' },
+      { source: 'c', target: 'a', sourceHandle: 'bottom', targetHandle: 'top' },
+    ]);
+    expect([...(m.get('a') ?? [])].sort()).toEqual(['right', 'top']);
+  });
+
+  it('dedupes repeated handles', () => {
+    const m = collectUsedHandles([
+      { source: 'a', target: 'b', sourceHandle: 'right', targetHandle: 'left' },
+      { source: 'a', target: 'd', sourceHandle: 'right', targetHandle: 'left' },
+    ]);
+    expect([...(m.get('a') ?? [])]).toEqual(['right']);
+  });
+
+  it('ignores null/undefined handles', () => {
+    const m = collectUsedHandles([
+      { source: 'a', target: 'b', sourceHandle: null, targetHandle: undefined },
+    ]);
+    expect(m.has('a')).toBe(false);
+    expect(m.has('b')).toBe(false);
+  });
+
+  it('returns no entry for nodes with no edges', () => {
+    const m = collectUsedHandles([]);
+    expect(m.size).toBe(0);
   });
 });

--- a/frontend/src/features/containers/components/network/topology-graph.tsx
+++ b/frontend/src/features/containers/components/network/topology-graph.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/features/containers/hooks/use-elk-layout';
 import { useUiStore } from '@/stores/ui-store';
 import { TopologyLegend } from './topology-legend';
+import type { HandleDirection } from './handle-visibility';
 
 export interface ContainerData {
   id: string;
@@ -211,7 +212,10 @@ export function sortStacks(
 
 // --- Handle helpers (pure functions, exported for testing) ---
 
-export type HandleDirection = 'top' | 'right' | 'bottom' | 'left';
+// HandleDirection lives in ./handle-visibility (a leaf module the node
+// components import without pulling in this file). Re-exported here so existing
+// callers/tests can keep importing it from topology-graph.
+export type { HandleDirection };
 
 /** Map an angle (radians, 0 = right, counter-clockwise negative) to the closest handle direction. */
 export function getHandleForAngle(angle: number): HandleDirection {

--- a/frontend/src/features/containers/components/network/topology-graph.tsx
+++ b/frontend/src/features/containers/components/network/topology-graph.tsx
@@ -211,7 +211,7 @@ export function sortStacks(
 
 // --- Handle helpers (pure functions, exported for testing) ---
 
-type HandleDirection = 'top' | 'right' | 'bottom' | 'left';
+export type HandleDirection = 'top' | 'right' | 'bottom' | 'left';
 
 /** Map an angle (radians, 0 = right, counter-clockwise negative) to the closest handle direction. */
 export function getHandleForAngle(angle: number): HandleDirection {
@@ -239,6 +239,26 @@ export function getBestHandles(
     left: 'right',
   };
   return { sourceHandle, targetHandle: opposites[sourceHandle] };
+}
+
+/**
+ * Map each node id to the set of handle directions some edge attaches to
+ * (as source or target). Lets nodes render only their connected handles. Pure.
+ */
+export function collectUsedHandles(
+  edges: Array<{ source: string; target: string; sourceHandle?: string | null; targetHandle?: string | null }>,
+): Map<string, Set<HandleDirection>> {
+  const used = new Map<string, Set<HandleDirection>>();
+  const add = (nodeId: string, handle?: string | null) => {
+    if (!handle) return;
+    if (!used.has(nodeId)) used.set(nodeId, new Set());
+    used.get(nodeId)!.add(handle as HandleDirection);
+  };
+  for (const e of edges) {
+    add(e.source, e.sourceHandle);
+    add(e.target, e.targetHandle);
+  }
+  return used;
 }
 
 // --- End handle helpers ---

--- a/frontend/src/features/containers/components/network/topology-graph.tsx
+++ b/frontend/src/features/containers/components/network/topology-graph.tsx
@@ -662,6 +662,12 @@ export function TopologyGraph({
       }
     }
 
+    // Render only the handles edges actually attach to (prune orphan dots).
+    const usedHandles = collectUsedHandles(edges);
+    for (const node of nodes) {
+      (node.data as Record<string, unknown>).usedHandles = [...(usedHandles.get(node.id) ?? [])];
+    }
+
     return { nodes, edges };
   }, [blueprints, externalNets, layoutPositions, containers, networks, networkRates, relatedSet, selectedNodeId, potatoMode, showObservedTraffic, observedEdges]);
 


### PR DESCRIPTION
## Summary

In the Network Topology view, container and network nodes rendered all four React Flow connection handles (top/right/bottom/left) as gray dots, always — but each edge attaches to only one handle per node (chosen by `getBestHandles()` from the angle between node centers). Most nodes therefore showed two or three orphan dots connected to nothing. This PR renders only the handles an edge actually uses.

- **`collectUsedHandles(edges)`** — new pure, exported helper in `topology-graph.tsx` mapping each node id → the set of handle directions its edges attach to (as source or target). Covers structural container↔network edges and the RPC overlay.
- **Phase 4 injection** — after edges are built, each node is tagged with `data.usedHandles: HandleDirection[]` (`[]` for nodes with no edges).
- **`ContainerNode` / `NetworkNode`** — render a `<Handle>` only when its id is in `data.usedHandles`. Fallback: render all four when `usedHandles` is `undefined` (preserves prior behavior for any caller that doesn't supply it).

The set of rendered handles is always a **superset** of the handle ids edges reference (both derive from the same `edges` array), so no edge can point at a missing handle — edge routing, `getBestHandles`, layout, and the RPC overlay are unchanged. Net effect: each line still meets its node at one gray dot; the orphan dots are gone. Isolated nodes (no connections) render zero dots.

Design spec: `docs/superpowers/specs/2026-05-30-topology-prune-unused-handles-design.md`
Plan: `docs/superpowers/plans/2026-05-30-topology-prune-unused-handles.md`

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint -w frontend` — clean
- [x] Full frontend suite — 2074 passed (212 files); 5 new `collectUsedHandles` unit tests
- [ ] Manual: open Network Topology, confirm each node shows dots only where lines meet it, no line snaps to a node center, isolated nodes show no dots, and the RPC/observed-traffic overlay still connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)