### PR TITLE
feat(infrastructure): unified smart search + per-tab filters

### DIFF
--- a/docs/superpowers/plans/2026-05-30-infrastructure-smart-search.md
+++ b/docs/superpowers/plans/2026-05-30-infrastructure-smart-search.md
@@ -1,0 +1,1103 @@
+# Infrastructure Smart Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Infrastructure page one Workload-Explorer-style smart search bar per tab (with clickable example chips), regroup each tab's filter dropdowns onto the search toolbar, remove the redundant per-table search boxes, and add a smart search bar to the Kubernetes tab.
+
+**Architecture:** Upgrade the existing `FleetSearch` component (add `examples` + `autoFocus` props and the in-field chip overlay) and reuse it on all three tabs. Endpoints/stacks keep filtering through the existing `fleet-search-filter.ts`; a new `k8s-search-filter.ts` filters pods/deployments/services. Each `DataTable` gets `hideSearch` so the smart bar is the only search input.
+
+**Tech Stack:** React 19, TypeScript (strict), Vitest + @testing-library/react (jsdom), Tailwind, `@tanstack/react-table` (DataTable), Radix Tabs.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-infrastructure-smart-search-design.md`
+
+**Branch / worktree:** `worktree-feature+infrastructure-smart-search` at `.claude/worktrees/feature+infrastructure-smart-search` (off `origin/dev`). All `npx vitest`/`npm` commands run from the `frontend/` subdirectory of that worktree.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `frontend/src/features/containers/components/fleet/fleet-search.tsx` | Reusable smart search bar (query state, debounce, clear, count badge) + new example chips & autofocus | Modify |
+| `frontend/src/features/containers/components/fleet/fleet-search.test.tsx` | Unit tests for `FleetSearch` | Modify |
+| `frontend/src/features/containers/lib/k8s-search-filter.ts` | Parse `namespace:`/`status:`/free-text query; filter K8s resource lists | Create |
+| `frontend/src/features/containers/lib/k8s-search-filter.test.ts` | Unit tests for the K8s filter | Create |
+| `frontend/src/features/containers/pages/fleet-overview.tsx` | Infrastructure page: regroup toolbars, wire `examples`/`autoFocus`, add K8s search + filter, `hideSearch` on all tables | Modify |
+| `frontend/src/features/containers/pages/fleet-overview.test.tsx` | Page integration tests | Modify |
+
+No new dependencies. No backend/API changes.
+
+---
+
+## Task 1: Upgrade `FleetSearch` with example chips, autofocus, and Escape-to-blur
+
+**Files:**
+- Modify: `frontend/src/features/containers/components/fleet/fleet-search.tsx`
+- Test: `frontend/src/features/containers/components/fleet/fleet-search.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests inside the existing `describe('FleetSearch', ...)` block in `fleet-search.test.tsx` (before its closing `});`):
+
+```tsx
+  it('renders example chips when examples provided and field is empty', () => {
+    renderSearch({ examples: ['name:prod', 'status:up'] });
+    expect(screen.getByRole('group', { name: /example searches/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'name:prod' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'status:up' })).toBeInTheDocument();
+  });
+
+  it('hides example chips once a query is typed', () => {
+    renderSearch({ examples: ['name:prod'] });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'x' } });
+    expect(screen.queryByRole('button', { name: 'name:prod' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the example group when no examples are given', () => {
+    renderSearch();
+    expect(screen.queryByRole('group', { name: /example searches/i })).not.toBeInTheDocument();
+  });
+
+  it('clicking an example chip fills the query and calls onSearch immediately', () => {
+    const { onSearch } = renderSearch({ examples: ['status:up'] });
+    fireEvent.click(screen.getByRole('button', { name: 'status:up' }));
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('status:up');
+    // Immediate (not debounced): assert before advancing timers.
+    expect(onSearch).toHaveBeenCalledWith('status:up');
+  });
+
+  it('focuses the input on mount when autoFocus is set', () => {
+    renderSearch({ autoFocus: true });
+    expect(document.activeElement).toBe(screen.getByRole('textbox'));
+  });
+
+  it('does not focus the input on mount by default', () => {
+    renderSearch();
+    expect(document.activeElement).not.toBe(screen.getByRole('textbox'));
+  });
+
+  it('Escape clears the query and blurs the input', () => {
+    const { onSearch } = renderSearch();
+    const input = screen.getByRole('textbox');
+    input.focus();
+    fireEvent.change(input, { target: { value: 'test' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect((input as HTMLInputElement).value).toBe('');
+    expect(onSearch).toHaveBeenCalledWith('');
+    expect(document.activeElement).not.toBe(input);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/features/containers/components/fleet/fleet-search.test.tsx`
+Expected: FAIL — the new tests error (e.g. "Unable to find role group", `examples`/`autoFocus` have no effect, Escape does not blur).
+
+- [ ] **Step 3: Replace the component implementation**
+
+Replace the entire contents of `frontend/src/features/containers/components/fleet/fleet-search.tsx` with:
+
+```tsx
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { Search, X } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+
+export interface FleetSearchProps {
+  onSearch: (query: string) => void;
+  totalCount: number;
+  filteredCount: number;
+  placeholder?: string;
+  label: string;
+  /** Example query chips shown inside the field while it is empty. */
+  examples?: string[];
+  /** Focus the input on mount (e.g. when the page first opens). */
+  autoFocus?: boolean;
+}
+
+export function FleetSearch({
+  onSearch,
+  totalCount,
+  filteredCount,
+  placeholder = 'Search...',
+  label,
+  examples,
+  autoFocus = false,
+}: FleetSearchProps) {
+  const [query, setQuery] = useState('');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const dispatchSearch = useCallback(
+    (value: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onSearch(value);
+      }, 300);
+    },
+    [onSearch],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setQuery(value);
+      dispatchSearch(value);
+    },
+    [dispatchSearch],
+  );
+
+  const handleClear = useCallback(() => {
+    setQuery('');
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    onSearch('');
+  }, [onSearch]);
+
+  const handleExampleClick = useCallback(
+    (value: string) => {
+      setQuery(value);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      onSearch(value);
+      inputRef.current?.focus();
+    },
+    [onSearch],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Escape') {
+        handleClear();
+        // Exit the field on Escape so keyboard users can leave the search.
+        inputRef.current?.blur();
+      }
+    },
+    [handleClear],
+  );
+
+  const isFiltered = query.length > 0 && filteredCount !== totalCount;
+  const showExamples = !query && !!examples && examples.length > 0;
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="relative flex-1">
+        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
+          <Search className="h-4 w-4 text-muted-foreground" />
+        </div>
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className={cn(
+            'w-full rounded-xl border bg-card/80 py-3 pl-11 pr-9 text-sm backdrop-blur-sm',
+            'placeholder:text-muted-foreground/50',
+            'focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50',
+            'transition-all duration-200',
+            // While example chips overlay the empty field, hide the placeholder
+            // text (kept in the DOM for a11y/tests) so the two don't collide.
+            showExamples && 'placeholder:text-transparent',
+          )}
+          aria-label={label}
+        />
+        {showExamples && (
+          <div
+            role="group"
+            aria-label="Example searches"
+            onClick={(e) => {
+              // A click on the empty strip (not a chip) focuses the input.
+              if (e.target === e.currentTarget) {
+                inputRef.current?.focus();
+              }
+            }}
+            className="absolute inset-y-0 left-11 right-3 flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          >
+            {examples.map((ex, i) => (
+              <button
+                key={ex}
+                type="button"
+                onClick={() => handleExampleClick(ex)}
+                className={cn(
+                  'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-border/60 bg-card/80 px-2 py-0.5 text-xs font-medium',
+                  'text-muted-foreground backdrop-blur-sm transition-colors duration-200',
+                  'hover:bg-primary/10 hover:text-primary hover:border-primary/30',
+                  // Right-align the chip row: ml-auto on the first chip absorbs
+                  // free space so chips sit right when they fit, and collapse to
+                  // a left-aligned scrollable row when they overflow.
+                  i === 0 && 'ml-auto',
+                )}
+              >
+                {ex}
+              </button>
+            ))}
+          </div>
+        )}
+        {query && (
+          <button
+            onClick={handleClear}
+            className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      {isFiltered && (
+        <span className="shrink-0 text-sm text-muted-foreground" data-testid="fleet-search-count">
+          {filteredCount} of {totalCount}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/features/containers/components/fleet/fleet-search.test.tsx`
+Expected: PASS — all original + 7 new tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/containers/components/fleet/fleet-search.tsx frontend/src/features/containers/components/fleet/fleet-search.test.tsx
+git commit -m "feat(fleet-search): add example chips, autoFocus, and Escape-to-blur"
+```
+
+---
+
+## Task 2: K8s search filter module
+
+**Files:**
+- Create: `frontend/src/features/containers/lib/k8s-search-filter.ts`
+- Test: `frontend/src/features/containers/lib/k8s-search-filter.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/features/containers/lib/k8s-search-filter.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseK8sQuery, filterK8sResources } from './k8s-search-filter';
+
+const items = [
+  { name: 'nginx-abc', namespace: 'default', status: 'Running' },
+  { name: 'redis-xyz', namespace: 'cache', status: 'Pending' },
+  { name: 'nginx-old', namespace: 'kube-system', status: 'Running' },
+  { name: 'api-svc', namespace: 'default' }, // no status (e.g. a service)
+];
+
+describe('parseK8sQuery', () => {
+  it('returns an empty object for a blank query', () => {
+    expect(parseK8sQuery('   ')).toEqual({});
+  });
+
+  it('extracts namespace and status tokens and free text', () => {
+    expect(parseK8sQuery('namespace:default status:running nginx')).toEqual({
+      namespace: 'default',
+      status: 'running',
+      text: 'nginx',
+    });
+  });
+
+  it('treats bare words as free text (joined)', () => {
+    expect(parseK8sQuery('nginx web')).toEqual({ text: 'nginx web' });
+  });
+
+  it('ignores field tokens with an empty value', () => {
+    expect(parseK8sQuery('namespace: nginx')).toEqual({ text: 'nginx' });
+  });
+});
+
+describe('filterK8sResources', () => {
+  it('returns all items for a blank query', () => {
+    expect(filterK8sResources(items, '  ')).toHaveLength(4);
+  });
+
+  it('matches free text against the name (case-insensitive substring)', () => {
+    const r = filterK8sResources(items, 'NGINX');
+    expect(r.map((i) => i.name)).toEqual(['nginx-abc', 'nginx-old']);
+  });
+
+  it('matches namespace exactly (case-insensitive)', () => {
+    const r = filterK8sResources(items, 'namespace:DEFAULT');
+    expect(r.map((i) => i.name)).toEqual(['nginx-abc', 'api-svc']);
+  });
+
+  it('matches status as a case-insensitive substring', () => {
+    const r = filterK8sResources(items, 'status:running');
+    expect(r.map((i) => i.name)).toEqual(['nginx-abc', 'nginx-old']);
+  });
+
+  it('excludes resources without a status when a status token is given', () => {
+    const r = filterK8sResources(items, 'status:running');
+    expect(r.some((i) => i.name === 'api-svc')).toBe(false);
+  });
+
+  it('combines tokens with AND', () => {
+    const r = filterK8sResources(items, 'namespace:kube-system nginx');
+    expect(r.map((i) => i.name)).toEqual(['nginx-old']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/containers/lib/k8s-search-filter.test.ts`
+Expected: FAIL — cannot resolve `./k8s-search-filter`.
+
+- [ ] **Step 3: Create the implementation**
+
+Create `frontend/src/features/containers/lib/k8s-search-filter.ts`:
+
+```ts
+/**
+ * Smart-search filter for Kubernetes resource lists (pods, deployments,
+ * services) shown on the Infrastructure page. Supports `namespace:` and
+ * `status:` field tokens plus free-text matched against the resource name.
+ * Resources without a `status` field (e.g. services) never match a `status:`
+ * token, which is the intended behavior.
+ */
+export interface K8sSearchableResource {
+  name: string;
+  namespace?: string;
+  status?: string;
+}
+
+export interface ParsedK8sQuery {
+  namespace?: string;
+  status?: string;
+  text?: string;
+}
+
+export function parseK8sQuery(query: string): ParsedK8sQuery {
+  const parsed: ParsedK8sQuery = {};
+  const freeText: string[] = [];
+
+  for (const token of query.trim().split(/\s+/).filter(Boolean)) {
+    const match = /^(namespace|status):(.*)$/i.exec(token);
+    if (match) {
+      const value = match[2].toLowerCase();
+      if (!value) continue;
+      if (match[1].toLowerCase() === 'namespace') parsed.namespace = value;
+      else parsed.status = value;
+    } else {
+      freeText.push(token.toLowerCase());
+    }
+  }
+
+  if (freeText.length > 0) parsed.text = freeText.join(' ');
+  return parsed;
+}
+
+export function filterK8sResources<T extends K8sSearchableResource>(
+  items: T[],
+  query: string,
+): T[] {
+  const { namespace, status, text } = parseK8sQuery(query);
+  if (!namespace && !status && !text) return items;
+
+  return items.filter((item) => {
+    if (namespace && (item.namespace ?? '').toLowerCase() !== namespace) return false;
+    if (status) {
+      if (item.status === undefined) return false;
+      if (!item.status.toLowerCase().includes(status)) return false;
+    }
+    if (text && !item.name.toLowerCase().includes(text)) return false;
+    return true;
+  });
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/features/containers/lib/k8s-search-filter.test.ts`
+Expected: PASS — all 11 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/containers/lib/k8s-search-filter.ts frontend/src/features/containers/lib/k8s-search-filter.test.ts
+git commit -m "feat(infrastructure): add k8s resource search filter"
+```
+
+---
+
+## Task 3: Fleet tab — regroup toolbar, wire examples + autoFocus, drop table search
+
+**Files:**
+- Modify: `frontend/src/features/containers/pages/fleet-overview.tsx` (Fleet tab JSX, ~`:894`–`:1050`)
+- Test: `frontend/src/features/containers/pages/fleet-overview.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a new describe block at the end of `fleet-overview.test.tsx` (before the file's final close). It reuses the existing `mockEndpoints`/`mockStacks`/`renderPage`/`makeEndpoint` helpers:
+
+```tsx
+describe('Infrastructure smart search — Fleet tab', () => {
+  beforeEach(() => {
+    useUiStore.setState({} as any, false); // no-op guard; keeps store import used
+    mockStacks([]);
+  });
+
+  it('renders endpoint example chips inside the search bar', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' }), makeEndpoint({ id: 2, name: 'prod-2', status: 'down' })]);
+    renderPage();
+    expect(screen.getByRole('button', { name: 'name:prod' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'status:up' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'type:edge' })).toBeInTheDocument();
+  });
+
+  it('shows only one search input in Fleet table view (no DataTable search box)', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' }), makeEndpoint({ id: 2, name: 'prod-2' })]);
+    renderPage();
+    fireEvent.click(screen.getByTitle('Table view'));
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+  });
+});
+```
+
+> Note: the existing top-of-file `beforeEach` already resets mocks; `useUiStore` is already imported at the top of the file. If a lint "unused import" arises, remove the no-op line and instead keep the existing default mock setup.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/fleet-overview.test.tsx -t "Fleet tab"`
+Expected: FAIL — chip buttons not found; table view shows 2 textboxes (FleetSearch + DataTable search).
+
+- [ ] **Step 3: Regroup the Fleet toolbar and wire the new props**
+
+In `fleet-overview.tsx`, replace the Fleet tab block that currently spans the toolbar row, the filter-chip bar, and the standalone search (the JSX from the opening `<section aria-labelledby="fleet-heading" ...>` down to the end of the `{/* Endpoint search */}` block) with the following. Concretely, replace this current code:
+
+```tsx
+      <section aria-labelledby="fleet-heading" className="space-y-4">
+        <h2 id="fleet-heading" className="sr-only">Fleet Overview</h2>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          {!isLoading && endpoints && (
+            <div className="flex flex-wrap items-center gap-3">
+              {/* Endpoint status filter */}
+              {endpointStatusOptions.length > 2 && (
+```
+
+…through the end of the endpoint-search block:
+
+```tsx
+        {/* Endpoint search */}
+        {!isLoading && endpoints && endpoints.length > 0 && (
+          <FleetSearch
+            onSearch={handleEndpointSearch}
+            totalCount={endpoints.length}
+            filteredCount={filteredEndpoints.length}
+            placeholder="Search endpoints... (name:prod status:up type:edge)"
+            label="Search endpoints"
+          />
+        )}
+```
+
+with this new version (search bar moves into a shared toolbar row with the dropdowns/count/view-toggle; the filter-chip bar stays below):
+
+```tsx
+      <section aria-labelledby="fleet-heading" className="space-y-4">
+        <h2 id="fleet-heading" className="sr-only">Fleet Overview</h2>
+        {!isLoading && endpoints && endpoints.length > 0 && (
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
+            <div className="lg:flex-1">
+              <FleetSearch
+                onSearch={handleEndpointSearch}
+                totalCount={endpoints.length}
+                filteredCount={filteredEndpoints.length}
+                placeholder="Search endpoints... (name:prod status:up type:edge)"
+                label="Search endpoints"
+                examples={['name:prod', 'status:up', 'type:edge']}
+                autoFocus
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              {/* Endpoint status filter */}
+              {endpointStatusOptions.length > 2 && (
+                <div className="flex items-center gap-1.5">
+                  <label htmlFor="endpoint-status-filter" className="text-xs text-muted-foreground">Status</label>
+                  <ThemedSelect
+                    id="endpoint-status-filter"
+                    value={endpointStatusFilter}
+                    onValueChange={setEndpointStatusFilter}
+                    options={endpointStatusOptions}
+                    className="w-[150px]"
+                  />
+                </div>
+              )}
+              {/* Endpoint type filter (only if multiple types) */}
+              {endpointTypeOptions.length > 0 && (
+                <div className="flex items-center gap-1.5">
+                  <label htmlFor="endpoint-type-filter" className="text-xs text-muted-foreground">Type</label>
+                  <ThemedSelect
+                    id="endpoint-type-filter"
+                    value={endpointTypeFilter}
+                    onValueChange={setEndpointTypeFilter}
+                    options={endpointTypeOptions}
+                    className="w-[170px]"
+                  />
+                </div>
+              )}
+              <span className="text-sm text-muted-foreground" data-testid="fleet-filtered-count">
+                {filteredEndpoints.length}{filteredEndpoints.length !== (endpoints?.length ?? 0) ? ` of ${endpoints?.length}` : ''} endpoint{filteredEndpoints.length !== 1 ? 's' : ''}
+              </span>
+              <div className="flex items-center rounded-lg border p-1">
+                <button
+                  onClick={() => setFleetViewMode('grid')}
+                  className={cn(
+                    'inline-flex items-center justify-center rounded-md p-2 transition-colors',
+                    fleetViewMode === 'grid'
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                  title="Grid view"
+                >
+                  <LayoutGrid className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => setFleetViewMode('table')}
+                  className={cn(
+                    'inline-flex items-center justify-center rounded-md p-2 transition-colors',
+                    fleetViewMode === 'table'
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                  title="Table view"
+                >
+                  <List className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Endpoint filter chips */}
+        {!isLoading && hasActiveEndpointFilter && (
+          <FilterChipBar
+            filters={activeEndpointFilters}
+            onRemove={handleRemoveEndpointFilter}
+            onClearAll={handleClearAllEndpointFilters}
+          />
+        )}
+```
+
+- [ ] **Step 4: Drop the Fleet table's built-in search**
+
+In the same file, in the Fleet `fleetViewMode === 'table'` branch, replace:
+
+```tsx
+            <DataTable
+              columns={endpointColumns}
+              data={filteredEndpoints}
+              searchKey="name"
+              searchPlaceholder="Search endpoints..."
+              autoFit
+              onRowClick={(row) => handleEndpointClick(row.id)}
+            />
+```
+
+with:
+
+```tsx
+            <DataTable
+              columns={endpointColumns}
+              data={filteredEndpoints}
+              hideSearch
+              autoFit
+              onRowClick={(row) => handleEndpointClick(row.id)}
+            />
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/fleet-overview.test.tsx`
+Expected: PASS — new Fleet-tab tests green AND all pre-existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/features/containers/pages/fleet-overview.tsx frontend/src/features/containers/pages/fleet-overview.test.tsx
+git commit -m "feat(infrastructure): regroup Fleet toolbar with smart search, drop table search"
+```
+
+---
+
+## Task 4: Stacks tab — regroup toolbar, wire examples, drop table search
+
+**Files:**
+- Modify: `frontend/src/features/containers/pages/fleet-overview.tsx` (Stacks tab JSX, ~`:1054`–`:1216`)
+- Test: `frontend/src/features/containers/pages/fleet-overview.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a new describe block at the end of `fleet-overview.test.tsx`:
+
+```tsx
+describe('Infrastructure smart search — Stacks tab', () => {
+  beforeEach(() => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' })]);
+    mockStacks([makeStack({ id: 1, name: 'traefik' }), makeStack({ id: 2, name: 'grafana' })]);
+  });
+
+  it('renders stack example chips inside the search bar', () => {
+    renderPage();
+    fireEvent.click(screen.getByTestId('tab-stacks'));
+    expect(screen.getByRole('button', { name: 'name:traefik' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'status:active' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'endpoint:prod' })).toBeInTheDocument();
+  });
+
+  it('shows only one search input in Stacks table view', () => {
+    renderPage();
+    fireEvent.click(screen.getByTestId('tab-stacks'));
+    fireEvent.click(screen.getByTitle('Table view'));
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/fleet-overview.test.tsx -t "Stacks tab"`
+Expected: FAIL — chips not found; table view shows 2 textboxes.
+
+- [ ] **Step 3: Regroup the Stacks toolbar and wire examples**
+
+In `fleet-overview.tsx`, in the Stacks tab, replace the current toolbar wrapper, the controls block, and the standalone stack-search block. Replace this current code:
+
+```tsx
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2">
+            {stackEndpointFilterParam !== ALL_FILTER && (
+```
+
+…down through the end of the stack-search block:
+
+```tsx
+        {/* Stack search */}
+        {!isLoading && dropdownFilteredStacks.length > 0 && (
+          <FleetSearch
+            onSearch={setStackSearchQuery}
+            totalCount={dropdownFilteredStacks.length}
+            filteredCount={filteredStacks.length}
+            placeholder="Search stacks... (name:traefik status:active endpoint:prod)"
+            label="Search stacks"
+          />
+        )}
+```
+
+with this new version (the endpoint pill keeps its own row; the search bar joins the dropdowns/count/view-toggle in one toolbar row; the chip bar stays below):
+
+```tsx
+        <div className="flex items-center gap-2">
+          {stackEndpointFilterParam !== ALL_FILTER && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+              {endpoints?.find(ep => ep.id === Number(stackEndpointFilterParam))?.name ?? `Endpoint ${stackEndpointFilterParam}`}
+              <button
+                onClick={() => setStackEndpointFilter(ALL_FILTER)}
+                className="ml-0.5 rounded-full hover:bg-primary/20"
+                aria-label="Clear endpoint filter"
+                data-testid="clear-stack-filter"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          )}
+        </div>
+        {!isLoading && stacksWithEndpoints.length > 0 && (
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
+            {dropdownFilteredStacks.length > 0 && (
+              <div className="lg:flex-1">
+                <FleetSearch
+                  onSearch={setStackSearchQuery}
+                  totalCount={dropdownFilteredStacks.length}
+                  filteredCount={filteredStacks.length}
+                  placeholder="Search stacks... (name:traefik status:active endpoint:prod)"
+                  label="Search stacks"
+                  examples={['name:traefik', 'status:active', 'endpoint:prod']}
+                />
+              </div>
+            )}
+            <div className="flex flex-wrap items-center gap-3">
+              {/* Stack status filter */}
+              {stackStatusOptions.length > 2 && (
+                <div className="flex items-center gap-1.5">
+                  <label htmlFor="stack-status-filter" className="text-xs text-muted-foreground">Status</label>
+                  <ThemedSelect
+                    id="stack-status-filter"
+                    value={stackStatusFilter}
+                    onValueChange={setStackStatusFilter}
+                    options={stackStatusOptions}
+                    className="w-[160px]"
+                  />
+                </div>
+              )}
+              {/* Stack endpoint filter (only if multiple endpoints have stacks) */}
+              {stackEndpointOptions.length > 0 && (
+                <div className="flex items-center gap-1.5">
+                  <label htmlFor="stack-endpoint-filter" className="text-xs text-muted-foreground">Endpoint</label>
+                  <ThemedSelect
+                    id="stack-endpoint-filter"
+                    value={stackEndpointFilterParam}
+                    onValueChange={setStackEndpointFilter}
+                    options={stackEndpointOptions}
+                    className="w-[180px]"
+                  />
+                </div>
+              )}
+              <span className="text-sm text-muted-foreground" data-testid="stacks-filtered-count">
+                {filteredStacks.length}{hasActiveStackFilter ? ` of ${stacksWithEndpoints.length}` : ''} stack{filteredStacks.length !== 1 ? 's' : ''}
+              </span>
+              <div className="flex items-center rounded-lg border p-1">
+                <button
+                  onClick={() => setStacksViewMode('grid')}
+                  className={cn(
+                    'inline-flex items-center justify-center rounded-md p-2 transition-colors',
+                    stacksViewMode === 'grid'
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                  title="Grid view"
+                >
+                  <LayoutGrid className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => setStacksViewMode('table')}
+                  className={cn(
+                    'inline-flex items-center justify-center rounded-md p-2 transition-colors',
+                    stacksViewMode === 'table'
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                  title="Table view"
+                >
+                  <List className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Stack filter chips */}
+        {!isLoading && hasActiveStackFilter && (
+          <FilterChipBar
+            filters={activeStackFilters}
+            onRemove={handleRemoveStackFilter}
+            onClearAll={handleClearAllStackFilters}
+          />
+        )}
+```
+
+- [ ] **Step 4: Drop the Stacks table's built-in search**
+
+In the Stacks `stacksViewMode` table branch, replace:
+
+```tsx
+            <DataTable
+              columns={stackColumns}
+              data={filteredStacks}
+              searchKey="name"
+              searchPlaceholder="Search stacks..."
+              autoFit
+              onRowClick={handleStackClick}
+            />
+```
+
+with:
+
+```tsx
+            <DataTable
+              columns={stackColumns}
+              data={filteredStacks}
+              hideSearch
+              autoFit
+              onRowClick={handleStackClick}
+            />
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/fleet-overview.test.tsx`
+Expected: PASS — Stacks-tab tests green, all prior tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/features/containers/pages/fleet-overview.tsx frontend/src/features/containers/pages/fleet-overview.test.tsx
+git commit -m "feat(infrastructure): regroup Stacks toolbar with smart search, drop table search"
+```
+
+---
+
+## Task 5: Kubernetes tab — add smart search, wire filter, drop per-table search
+
+**Files:**
+- Modify: `frontend/src/features/containers/pages/fleet-overview.tsx` (imports, K8s state/memos near `:289`–`:328`, K8s tab JSX `:1220`–`:1301`)
+- Test: `frontend/src/features/containers/pages/fleet-overview.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+The page test does not yet mock the Kubernetes hooks. Add this mock alongside the other `vi.mock(...)` calls at the top of `fleet-overview.test.tsx` (after the `use-stacks` mock at line 19):
+
+```tsx
+vi.mock('@/features/kubernetes/hooks/use-kubernetes', () => ({
+  useK8sPods: vi.fn(() => ({ data: [], isLoading: false, refetch: vi.fn(), isFetching: false })),
+  useK8sDeployments: vi.fn(() => ({ data: [], isLoading: false })),
+  useK8sServices: vi.fn(() => ({ data: [], isLoading: false })),
+  useK8sNamespaces: vi.fn(() => ({ data: [] })),
+}));
+```
+
+Add this import with the other hook imports near line 38:
+
+```tsx
+import { useK8sPods } from '@/features/kubernetes/hooks/use-kubernetes';
+```
+
+Then append a new describe block at the end of the file:
+
+```tsx
+describe('Infrastructure smart search — Kubernetes tab', () => {
+  const pod = (name: string, namespace: string, status: string) => ({
+    id: `${namespace}/${name}`, name, namespace, images: [], state: 'running',
+    status, restarts: 0, created: 0, endpointId: 1, endpointName: 'prod-1',
+    labels: {}, containers: [], resourceType: 'pod',
+  });
+
+  beforeEach(() => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' })]);
+    mockStacks([]);
+    vi.mocked(useK8sPods).mockReturnValue({
+      data: [pod('nginx-1', 'default', 'Running'), pod('redis-1', 'cache', 'Pending')],
+      isLoading: false, refetch: vi.fn(), isFetching: false,
+    } as any);
+  });
+
+  it('renders a Kubernetes search bar with example chips', () => {
+    renderPage();
+    fireEvent.click(screen.getByTestId('tab-kubernetes'));
+    expect(screen.getByRole('textbox', { name: /search kubernetes resources/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'namespace:kube-system' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'status:running' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'nginx' })).toBeInTheDocument();
+  });
+
+  it('filters the pods table by the search query', async () => {
+    renderPage();
+    fireEvent.click(screen.getByTestId('tab-kubernetes'));
+    expect(screen.getByText('nginx-1')).toBeInTheDocument();
+    expect(screen.getByText('redis-1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'nginx' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('redis-1')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('nginx-1')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/fleet-overview.test.tsx -t "Kubernetes tab"`
+Expected: FAIL — no K8s search textbox / chips; both pods still shown after clicking the chip.
+
+- [ ] **Step 3: Add the filter import**
+
+In `fleet-overview.tsx`, add this import near the other `lib` imports (top of file):
+
+```tsx
+import { filterK8sResources } from '@/features/containers/lib/k8s-search-filter';
+```
+
+- [ ] **Step 4: Add K8s search state and filtered memos**
+
+In `fleet-overview.tsx`, just after the K8s hook destructuring (the `useK8sNamespaces()` block ending around line 328), add:
+
+```tsx
+  const [k8sSearchQuery, setK8sSearchQuery] = useState('');
+  const filteredK8sPods = useMemo(
+    () => filterK8sResources(k8sPods ?? [], k8sSearchQuery),
+    [k8sPods, k8sSearchQuery],
+  );
+  const filteredK8sDeployments = useMemo(
+    () => filterK8sResources(k8sDeployments ?? [], k8sSearchQuery),
+    [k8sDeployments, k8sSearchQuery],
+  );
+  const filteredK8sServices = useMemo(
+    () => filterK8sResources(k8sServices ?? [], k8sSearchQuery),
+    [k8sServices, k8sSearchQuery],
+  );
+  const k8sTotalCount =
+    (k8sPods?.length ?? 0) + (k8sDeployments?.length ?? 0) + (k8sServices?.length ?? 0);
+  const k8sFilteredCount =
+    filteredK8sPods.length + filteredK8sDeployments.length + filteredK8sServices.length;
+```
+
+- [ ] **Step 5: Insert the K8s search bar after the summary bar**
+
+In the Kubernetes tab JSX, immediately after the closing of the `{/* K8s summary bar */}` `</SpotlightCard>` and before the `{/* Pods table */}` block, insert:
+
+```tsx
+        {/* K8s smart search */}
+        {!k8sPodsLoading && k8sTotalCount > 0 && (
+          <FleetSearch
+            onSearch={setK8sSearchQuery}
+            totalCount={k8sTotalCount}
+            filteredCount={k8sFilteredCount}
+            placeholder="Search resources... (namespace:kube-system status:running nginx)"
+            label="Search Kubernetes resources"
+            examples={['namespace:kube-system', 'status:running', 'nginx']}
+          />
+        )}
+```
+
+- [ ] **Step 6: Point the three tables at filtered data and hide their search**
+
+In the Kubernetes tab, replace the Pods `DataTable`:
+
+```tsx
+            <DataTable
+              columns={k8sPodColumns}
+              data={k8sPods ?? []}
+              searchKey="name"
+              searchPlaceholder="Search pods..."
+              pageSize={15}
+            />
+```
+
+with:
+
+```tsx
+            <DataTable
+              columns={k8sPodColumns}
+              data={filteredK8sPods}
+              hideSearch
+              pageSize={15}
+            />
+```
+
+Replace the Deployments `DataTable`:
+
+```tsx
+            <DataTable
+              columns={k8sDeploymentColumns}
+              data={k8sDeployments}
+              searchKey="name"
+              searchPlaceholder="Search deployments..."
+              pageSize={15}
+            />
+```
+
+with:
+
+```tsx
+            <DataTable
+              columns={k8sDeploymentColumns}
+              data={filteredK8sDeployments}
+              hideSearch
+              pageSize={15}
+            />
+```
+
+Replace the Services `DataTable`:
+
+```tsx
+            <DataTable
+              columns={k8sServiceColumns}
+              data={k8sServices}
+              searchKey="name"
+              searchPlaceholder="Search services..."
+              pageSize={15}
+            />
+```
+
+with:
+
+```tsx
+            <DataTable
+              columns={k8sServiceColumns}
+              data={filteredK8sServices}
+              hideSearch
+              pageSize={15}
+            />
+```
+
+> The deployments/services sections keep their existing `k8sDeployments && k8sDeployments.length > 0` (and services equivalent) render guards — those gate on the *unfiltered* presence of data so a section doesn't vanish mid-search; the filtered arrays only affect the rows shown.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/features/containers/pages/fleet-overview.test.tsx`
+Expected: PASS — Kubernetes-tab tests green, all prior tests still pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/features/containers/pages/fleet-overview.tsx frontend/src/features/containers/pages/fleet-overview.test.tsx
+git commit -m "feat(infrastructure): add smart search to Kubernetes tab"
+```
+
+---
+
+## Task 6: Full verification and docs
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-30-infrastructure-smart-search-design.md` (mark status done) — optional
+
+- [ ] **Step 1: Typecheck the frontend workspace**
+
+Run: `npm run typecheck -w frontend`
+Expected: no errors. (Common issue: `filterK8sResources(k8sDeployments ?? [], ...)` — `K8sDeployment` has no `status` field, which is fine because `K8sSearchableResource.status` is optional; if TS complains about excess/missing properties, confirm the generic constraint reads `status?: string`.)
+
+- [ ] **Step 2: Lint the frontend workspace**
+
+Run: `npm run lint -w frontend`
+Expected: no errors for the changed files. Fix any unused-import or formatting issues inline.
+
+- [ ] **Step 3: Run the full frontend test suite**
+
+Run: `cd frontend && npx vitest run`
+Expected: all tests pass (baseline was green; the 4 touched files now include the new cases).
+
+- [ ] **Step 4: Update the spec status (optional)**
+
+Edit the `**Status:**` line of the spec to `Implemented`.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore(infrastructure): verify smart-search build, mark spec implemented"
+```
+
+- [ ] **Step 6: Hand back for review**
+
+Report the diff summary and suggest the requesting-code-review skill / opening a PR (`feature/infrastructure-smart-search` → `dev`). Rename the branch from `worktree-feature+infrastructure-smart-search` to `feature/infrastructure-smart-search` before pushing if a PR is desired.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- One smart bar per tab, WE-style + chips → Task 1 (component) + Tasks 3/4/5 (wiring `examples`).
+- Remove redundant DataTable search → `hideSearch` in Tasks 3 (fleet), 4 (stacks), 5 (3× k8s).
+- Regroup filters onto the search toolbar → Tasks 3 & 4 (single `lg:flex-row` toolbar).
+- K8s smart search across pods/deployments/services → Task 2 (filter) + Task 5 (wiring, combined count).
+- Autofocus like Workload Explorer → Task 1 (`autoFocus` prop) + Task 3 (applied to the default Fleet tab only, to avoid focus-steal on tab switches).
+- Escape-to-blur → Task 1.
+- Tests for all → Tasks 1, 2, 3, 4, 5; full-suite gate in Task 6.
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code; every run step shows the exact command and expected result.
+
+**Type consistency:** `FleetSearchProps` adds `examples?: string[]` and `autoFocus?: boolean` (Task 1) and they're passed in Tasks 3/4/5. `filterK8sResources<T extends K8sSearchableResource>` / `parseK8sQuery` names match between Task 2 definition and Task 5 usage. `hideSearch` is the real `DataTableProps` prop (verified in `data-table.tsx:74`). K8s hook/type names (`useK8sPods`, `K8sPod`, fields `name`/`namespace`/`status`) match `use-kubernetes.ts`.

--- a/docs/superpowers/specs/2026-05-30-infrastructure-smart-search-design.md
+++ b/docs/superpowers/specs/2026-05-30-infrastructure-smart-search-design.md
@@ -1,0 +1,221 @@
+# Infrastructure page: unified smart search + per-tab filters
+
+**Date:** 2026-05-30
+**Branch:** `feature/infrastructure-smart-search` (off `dev`)
+**Status:** Approved design — pending spec review
+
+## Overview
+
+The Infrastructure page (`frontend/src/features/containers/pages/fleet-overview.tsx`)
+has three tabs — **Fleet Overview**, **Stack Overview**, **Kubernetes**. Today the
+Fleet and Stacks tabs each render *two* search inputs in table view (a smart
+`FleetSearch` bar plus the `DataTable`'s own built-in search box), and the
+Kubernetes tab has no smart search or filter at all — just three tables, each with
+its own built-in search.
+
+This work consolidates each tab to a **single** Workload-Explorer-style smart
+search bar (rounded, full-width, with clickable example chips), regroups the
+existing filter dropdowns onto the same toolbar row as that search bar, and adds a
+smart search bar to the Kubernetes tab that filters pods, deployments, and
+services together.
+
+## Goals
+
+- One smart search bar per tab, styled like the Workload Explorer search
+  (`WorkloadSmartSearch`): `rounded-xl`, full-width, left search icon, and an
+  in-field row of clickable **example chips** shown while the field is empty.
+- Remove the now-redundant `DataTable` built-in search box on every Infrastructure
+  table (Fleet table, Stacks table, K8s pods/deployments/services tables).
+- Regroup each tab's filter dropdowns + result count + view toggle onto a single
+  toolbar row together with the smart search bar.
+- Add a smart search bar to the Kubernetes tab that filters all three resource
+  tables by name, `namespace:`, and `status:`.
+
+## Non-Goals (out of scope)
+
+- No changes to the Workload Explorer page or to `WorkloadSmartSearch` itself.
+- No AI/LLM natural-language search mode on the Infrastructure page (the
+  Workload Explorer's AI chips/mode are **not** ported here).
+- No backend or API changes.
+- No change to the URL-persisted dropdown filters' semantics (status/type/endpoint
+  filters keep their existing URL params and behavior).
+
+## Current state (verified on `dev`)
+
+- `fleet-overview.tsx`
+  - Fleet tab: filter row with status/type `ThemedSelect` dropdowns + count +
+    grid/table view toggle (`:899`–`:957`); `FilterChipBar` (`:960`); `FleetSearch`
+    endpoint search (`:969`–`:977`); table view `DataTable` with
+    `searchKey="name"` + `searchPlaceholder="Search endpoints..."` (`:1040`–`:1047`).
+  - Stacks tab: analogous layout; `FleetSearch` stack search (`:1144`–`:1152`);
+    table view `DataTable` with built-in search (`:1206`–`:1213`).
+  - K8s tab: counts summary bar (`:1224`–`:1247`) + three `DataTable`s for pods
+    (`:1260`), deployments (`:1276`), services (`:1292`), each with its own
+    `searchKey`/`searchPlaceholder`. No smart search, no dropdown filter.
+- `components/fleet/fleet-search.tsx` — `FleetSearch`: local `query` state, 300ms
+  debounce, clear button, Escape-to-clear, count badge. Props: `onSearch`,
+  `totalCount`, `filteredCount`, `placeholder`, `label`. Used **only** by
+  `fleet-overview.tsx` (two call sites).
+- `lib/fleet-search-filter.ts` — smart filter for endpoints/stacks
+  (`name:`, `status:`, `type:`, `endpoint:`, free text). Unchanged by this work.
+- `shared/components/forms/workload-smart-search.tsx` — the visual reference for
+  the chip overlay (in-field, right-aligned via `ml-auto` on the first chip,
+  horizontally scrollable, hidden scrollbar) and Escape-to-blur behavior.
+
+## Approach
+
+**Chosen: upgrade the existing `FleetSearch`** to carry the Workload-Explorer look
+and example chips, then reuse it on all three tabs. Rejected alternatives: building
+a new shared `SmartSearchBar` primitive (larger blast radius, touches Workload
+Explorer — out of scope) and reusing `WorkloadSmartSearch` directly (hard-coupled
+to containers and an AI mode that does not apply here).
+
+`FleetSearch` already owns query state, debounce, clear, count badge, and Escape
+handling, so the upgrade is additive.
+
+## Design
+
+### 1. `FleetSearch` component upgrade (`components/fleet/fleet-search.tsx`)
+
+New optional props:
+
+```ts
+export interface FleetSearchProps {
+  onSearch: (query: string) => void;
+  totalCount: number;
+  filteredCount: number;
+  placeholder?: string;
+  label?: string;
+  examples?: string[];     // NEW: chip labels shown in-field when empty
+  autoFocus?: boolean;     // NEW: focus the input on mount
+}
+```
+
+Behavior changes:
+
+- **Styling:** input becomes `rounded-xl`, full-width (`w-full`), `bg-card/80`
+  `backdrop-blur-sm`, `py-3`, `pl-11` (left search icon), right-side padding for the
+  clear button / count badge — matching `WorkloadSmartSearch`'s input.
+- **Example chips:** when `query` is empty and `examples` is non-empty, render a
+  right-aligned, horizontally-scrollable chip row overlaid inside the input
+  (absolute, `inset-y-0 left-11 right-3`, `ml-auto` on the first chip, hidden
+  scrollbar) mirroring `WorkloadSmartSearch`. The chip row is a
+  `role="group"` labelled "Example searches". Clicking the empty strip focuses the
+  input. The placeholder text is hidden (`placeholder:text-transparent`) while
+  chips are shown, but kept in the DOM for a11y.
+- **Chip click:** sets the query to the chip label and immediately invokes
+  `onSearch(label)` (no debounce wait), so the filter applies at once.
+- **Escape:** clears the query **and** blurs the input (today it only clears).
+- Existing debounce (300ms on typed input), clear button, and count badge are
+  preserved.
+
+`FleetSearch` remains presentation + query-state only; the actual filtering stays
+in the page (via `fleet-search-filter.ts` for endpoints/stacks, and the new
+`k8s-search-filter.ts` for K8s).
+
+### 2. Fleet Overview tab
+
+Regroup into a single responsive toolbar row:
+
+```
+[ smart search bar (flex-1) ] [ Status ▾ ] [ Type ▾ ] [ "N of M endpoints" ] [ grid/table toggle ]
+```
+
+- On large screens the search bar takes the remaining width and the dropdowns +
+  count + view toggle sit to its right; on small screens they stack
+  (`flex-col gap-2 lg:flex-row lg:items-center`).
+- `FilterChipBar` (active-filter chips) stays on its own row directly below.
+- Example chips: `name:prod`, `status:up`, `type:edge`.
+- Table view: remove the `DataTable` built-in search (drop `searchKey` /
+  `searchPlaceholder`, or pass an explicit disable prop — see §5). The table is
+  already fed the smart-search-filtered `filteredEndpoints`.
+
+### 3. Stack Overview tab
+
+Same toolbar regrouping as Fleet:
+
+```
+[ smart search bar (flex-1) ] [ Status ▾ ] [ Endpoint ▾ ] [ "N of M stacks" ] [ grid/table toggle ]
+```
+
+- Example chips: `name:traefik`, `status:active`, `endpoint:prod`.
+- Keep the existing standalone endpoint pill (`:1059`–`:1071`) and `FilterChipBar`.
+- Table view: remove the `DataTable` built-in search; table is fed
+  `filteredStacks`.
+
+### 4. Kubernetes tab
+
+Add one smart search bar between the counts summary bar and the first table.
+
+- New page state `k8sSearchQuery` (local component state, consistent with how
+  endpoint/stack search queries are held; not URL-persisted).
+- New module `lib/k8s-search-filter.ts`:
+
+  ```ts
+  export interface K8sSearchableResource {
+    name: string;
+    namespace?: string;
+    status?: string;   // pods: phase; deployments: derived status; absent for services
+  }
+  export function parseK8sQuery(q: string): { namespace?: string; status?: string; text?: string };
+  export function filterK8sResources<T extends K8sSearchableResource>(items: T[], query: string): T[];
+  ```
+
+  - Supports `namespace:<ns>` and `status:<value>` field tokens plus free text
+    matched against `name` (case-insensitive, substring). Empty/blank query
+    returns all items. A `status:` token simply never matches resources without a
+    `status` field (e.g. services), which is the intended behavior.
+- Apply `filterK8sResources` to `k8sPods`, `k8sDeployments`, and `k8sServices`
+  before passing each to its `DataTable`; remove all three `DataTable` built-in
+  searches.
+- Example chips: `namespace:kube-system`, `status:running`, `nginx`.
+- Count display: the counts summary bar keeps showing per-type **totals** (an
+  at-a-glance cluster overview, unaffected by the query). The search bar's own
+  count badge shows the **combined** filtered total: pass `totalCount` = pods +
+  deployments + services totals and `filteredCount` = the sum of the three
+  filtered lengths, so the badge reads "N of M" when a query is active.
+
+### 5. `DataTable` built-in search removal
+
+The smart bar now owns search on every Infrastructure table, so the per-table
+search box is redundant. Verify how `DataTable` toggles its search box:
+
+- If omitting `searchKey`/`searchPlaceholder` already hides the search box, drop
+  those props.
+- If `DataTable` renders search whenever data has the key, add/confirm an explicit
+  opt-out prop (e.g. `searchable={false}`) and use it.
+
+This is the one implementation detail to confirm against `DataTable`'s API before
+editing; the rest of the design does not depend on the outcome.
+
+## Testing
+
+- `components/fleet/fleet-search.test.tsx` (extend):
+  - renders example chips when `examples` provided and field empty; hidden once a
+    query is typed;
+  - clicking a chip sets the query and calls `onSearch` with the chip label;
+  - `autoFocus` focuses the input on mount;
+  - Escape clears the query **and** blurs the input;
+  - existing debounce/clear/count-badge tests still pass.
+- `lib/k8s-search-filter.test.ts` (new):
+  - `parseK8sQuery` extracts `namespace:` / `status:` tokens and free text;
+  - `filterK8sResources` matches by name substring (case-insensitive), by
+    namespace, by status; combines tokens (AND); returns all on empty query;
+    `status:` token excludes status-less resources (services).
+- `pages/fleet-overview.test.tsx` (update):
+  - Fleet/Stacks toolbar renders the search bar and the filter dropdowns on the
+    same toolbar (regrouped layout);
+  - in table view there is exactly **one** search input per tab (no `DataTable`
+    search box);
+  - Kubernetes tab renders the smart search bar and typing a query filters the
+    pods/deployments/services tables;
+  - existing filter/pagination/tab tests still pass.
+
+All work follows TDD (red → green → refactor). No `--no-verify`.
+
+## Docs to update on completion
+
+- This spec (source of truth for the change).
+- `CLAUDE.md` / `docs/architecture.md` only if a public contract changes — this is
+  an internal frontend refactor, so likely a brief note at most.
+- No `.env.example` changes (no new config).

--- a/docs/superpowers/specs/2026-05-30-infrastructure-smart-search-design.md
+++ b/docs/superpowers/specs/2026-05-30-infrastructure-smart-search-design.md
@@ -163,8 +163,9 @@ Add one smart search bar between the counts summary bar and the first table.
 
   - Supports `namespace:<ns>` and `status:<value>` field tokens plus free text
     matched against `name` (case-insensitive, substring). Empty/blank query
-    returns all items. A `status:` token simply never matches resources without a
-    `status` field (e.g. services), which is the intended behavior.
+    returns all items. A `status:` token only narrows resources that have a
+    `status` field (pods); resources without a `status` field (e.g. deployments,
+    services) pass through unaffected — they are not excluded.
 - Apply `filterK8sResources` to `k8sPods`, `k8sDeployments`, and `k8sServices`
   before passing each to its `DataTable`; remove all three `DataTable` built-in
   searches.
@@ -201,7 +202,7 @@ editing; the rest of the design does not depend on the outcome.
   - `parseK8sQuery` extracts `namespace:` / `status:` tokens and free text;
   - `filterK8sResources` matches by name substring (case-insensitive), by
     namespace, by status; combines tokens (AND); returns all on empty query;
-    `status:` token excludes status-less resources (services).
+    `status:` token passes through status-less resources (services/deployments) unaffected.
 - `pages/fleet-overview.test.tsx` (update):
   - Fleet/Stacks toolbar renders the search bar and the filter dropdowns on the
     same toolbar (regrouped layout);

--- a/docs/superpowers/specs/2026-05-30-infrastructure-smart-search-design.md
+++ b/docs/superpowers/specs/2026-05-30-infrastructure-smart-search-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-30
 **Branch:** `feature/infrastructure-smart-search` (off `dev`)
-**Status:** Approved design — pending spec review
+**Status:** Implemented
 
 ## Overview
 

--- a/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
@@ -102,6 +102,12 @@ describe('FleetSearch', () => {
     expect(screen.queryByTestId('fleet-search-count')).not.toBeInTheDocument();
   });
 
+  it('hides the count badge when showCount is false', () => {
+    renderSearch({ totalCount: 10, filteredCount: 3, showCount: false });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'prod' } });
+    expect(screen.queryByTestId('fleet-search-count')).not.toBeInTheDocument();
+  });
+
   it('shows filtered count when search reduces results', () => {
     renderSearch({ totalCount: 10, filteredCount: 3 });
     const input = screen.getByRole('textbox');

--- a/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
@@ -130,4 +130,51 @@ describe('FleetSearch', () => {
     renderSearch({ placeholder: 'Custom placeholder' });
     expect(screen.getByPlaceholderText('Custom placeholder')).toBeInTheDocument();
   });
+
+  it('renders example chips when examples provided and field is empty', () => {
+    renderSearch({ examples: ['name:prod', 'status:up'] });
+    expect(screen.getByRole('group', { name: /example searches/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'name:prod' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'status:up' })).toBeInTheDocument();
+  });
+
+  it('hides example chips once a query is typed', () => {
+    renderSearch({ examples: ['name:prod'] });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'x' } });
+    expect(screen.queryByRole('button', { name: 'name:prod' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the example group when no examples are given', () => {
+    renderSearch();
+    expect(screen.queryByRole('group', { name: /example searches/i })).not.toBeInTheDocument();
+  });
+
+  it('clicking an example chip fills the query and calls onSearch immediately', () => {
+    const { onSearch } = renderSearch({ examples: ['status:up'] });
+    fireEvent.click(screen.getByRole('button', { name: 'status:up' }));
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('status:up');
+    // Immediate (not debounced): assert before advancing timers.
+    expect(onSearch).toHaveBeenCalledWith('status:up');
+  });
+
+  it('focuses the input on mount when autoFocus is set', () => {
+    renderSearch({ autoFocus: true });
+    expect(document.activeElement).toBe(screen.getByRole('textbox'));
+  });
+
+  it('does not focus the input on mount by default', () => {
+    renderSearch();
+    expect(document.activeElement).not.toBe(screen.getByRole('textbox'));
+  });
+
+  it('Escape clears the query and blurs the input', () => {
+    const { onSearch } = renderSearch();
+    const input = screen.getByRole('textbox');
+    input.focus();
+    fireEvent.change(input, { target: { value: 'test' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect((input as HTMLInputElement).value).toBe('');
+    expect(onSearch).toHaveBeenCalledWith('');
+    expect(document.activeElement).not.toBe(input);
+  });
 });

--- a/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
@@ -97,17 +97,6 @@ describe('FleetSearch', () => {
     expect(onSearch).toHaveBeenCalledWith('');
   });
 
-  it('Escape key clears input', () => {
-    const { onSearch } = renderSearch();
-    const input = screen.getByRole('textbox');
-
-    fireEvent.change(input, { target: { value: 'test' } });
-    fireEvent.keyDown(input, { key: 'Escape' });
-
-    expect((input as HTMLInputElement).value).toBe('');
-    expect(onSearch).toHaveBeenCalledWith('');
-  });
-
   it('does not show count when not filtering', () => {
     renderSearch({ totalCount: 10, filteredCount: 10 });
     expect(screen.queryByTestId('fleet-search-count')).not.toBeInTheDocument();

--- a/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
@@ -162,6 +162,23 @@ describe('FleetSearch', () => {
     expect(document.activeElement).not.toBe(screen.getByRole('textbox'));
   });
 
+  it('seeds the input from initialValue', () => {
+    renderSearch({ initialValue: 'web' });
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('web');
+  });
+
+  it('hides example chips when seeded with a non-empty initialValue', () => {
+    renderSearch({ initialValue: 'web', examples: ['name:prod'] });
+    expect(screen.queryByRole('button', { name: 'name:prod' })).not.toBeInTheDocument();
+  });
+
+  it('calls onAutoFocused after autoFocus moves focus into the input', () => {
+    const onAutoFocused = vi.fn();
+    renderSearch({ autoFocus: true, onAutoFocused });
+    expect(onAutoFocused).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(screen.getByRole('textbox'));
+  });
+
   it('Escape clears the query and blurs the input', () => {
     const { onSearch } = renderSearch();
     const input = screen.getByRole('textbox');

--- a/frontend/src/features/containers/components/fleet/fleet-search.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.tsx
@@ -8,6 +8,10 @@ export interface FleetSearchProps {
   filteredCount: number;
   placeholder?: string;
   label: string;
+  /** Example query chips shown inside the field while it is empty. */
+  examples?: string[];
+  /** Focus the input on mount (e.g. when the page first opens). */
+  autoFocus?: boolean;
 }
 
 export function FleetSearch({
@@ -16,9 +20,12 @@ export function FleetSearch({
   filteredCount,
   placeholder = 'Search...',
   label,
+  examples,
+  autoFocus = false,
 }: FleetSearchProps) {
   const [query, setQuery] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const dispatchSearch = useCallback(
     (value: string) => {
@@ -36,6 +43,10 @@ export function FleetSearch({
     };
   }, []);
 
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
+
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
@@ -51,37 +62,86 @@ export function FleetSearch({
     onSearch('');
   }, [onSearch]);
 
+  const handleExampleClick = useCallback(
+    (value: string) => {
+      setQuery(value);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      onSearch(value);
+      inputRef.current?.focus();
+    },
+    [onSearch],
+  );
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Escape') {
         handleClear();
+        // Exit the field on Escape so keyboard users can leave the search.
+        inputRef.current?.blur();
       }
     },
     [handleClear],
   );
 
   const isFiltered = query.length > 0 && filteredCount !== totalCount;
+  const showExamples = !query && !!examples && examples.length > 0;
 
   return (
     <div className="flex items-center gap-3">
       <div className="relative flex-1">
-        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
           <Search className="h-4 w-4 text-muted-foreground" />
         </div>
         <input
+          ref={inputRef}
           type="text"
           value={query}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           className={cn(
-            'w-full rounded-lg border bg-card/80 py-2 pl-10 pr-9 text-sm',
+            'w-full rounded-xl border bg-card/80 py-3 pl-11 pr-9 text-sm backdrop-blur-sm',
             'placeholder:text-muted-foreground/50',
             'focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50',
             'transition-all duration-200',
+            // While example chips overlay the empty field, hide the placeholder
+            // text (kept in the DOM for a11y/tests) so the two don't collide.
+            showExamples && 'placeholder:text-transparent',
           )}
           aria-label={label}
         />
+        {showExamples && (
+          <div
+            role="group"
+            aria-label="Example searches"
+            onClick={(e) => {
+              // A click on the empty strip (not a chip) focuses the input.
+              if (e.target === e.currentTarget) {
+                inputRef.current?.focus();
+              }
+            }}
+            className="absolute inset-y-0 left-11 right-3 flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          >
+            {examples.map((ex, i) => (
+              <button
+                key={ex}
+                type="button"
+                onClick={() => handleExampleClick(ex)}
+                className={cn(
+                  'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-border/60 bg-card/80 px-2 py-0.5 text-xs font-medium',
+                  'text-muted-foreground backdrop-blur-sm transition-colors duration-200',
+                  'hover:bg-primary/10 hover:text-primary hover:border-primary/30',
+                  // Right-align the chip row: ml-auto on the first chip absorbs
+                  // free space so chips sit right when they fit, and collapse to
+                  // a left-aligned scrollable row when they overflow.
+                  i === 0 && 'ml-auto',
+                )}
+              >
+                {ex}
+              </button>
+            ))}
+          </div>
+        )}
         {query && (
           <button
             onClick={handleClear}

--- a/frontend/src/features/containers/components/fleet/fleet-search.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.tsx
@@ -14,6 +14,10 @@ export interface FleetSearchProps {
   autoFocus?: boolean;
   /** Show the filtered count badge when isFiltered. Defaults to true. */
   showCount?: boolean;
+  /** Seed the input value on mount (e.g. from a URL-persisted query). */
+  initialValue?: string;
+  /** Called once after autoFocus moves focus into the input. */
+  onAutoFocused?: () => void;
 }
 
 export function FleetSearch({
@@ -25,8 +29,10 @@ export function FleetSearch({
   examples,
   autoFocus = false,
   showCount = true,
+  initialValue,
+  onAutoFocused,
 }: FleetSearchProps) {
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(initialValue ?? '');
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -47,8 +53,11 @@ export function FleetSearch({
   }, []);
 
   useEffect(() => {
-    if (autoFocus) inputRef.current?.focus();
-  }, [autoFocus]);
+    if (autoFocus) {
+      inputRef.current?.focus();
+      onAutoFocused?.();
+    }
+  }, [autoFocus, onAutoFocused]);
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/features/containers/components/fleet/fleet-search.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.tsx
@@ -12,6 +12,8 @@ export interface FleetSearchProps {
   examples?: string[];
   /** Focus the input on mount (e.g. when the page first opens). */
   autoFocus?: boolean;
+  /** Show the filtered count badge when isFiltered. Defaults to true. */
+  showCount?: boolean;
 }
 
 export function FleetSearch({
@@ -22,6 +24,7 @@ export function FleetSearch({
   label,
   examples,
   autoFocus = false,
+  showCount = true,
 }: FleetSearchProps) {
   const [query, setQuery] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -100,7 +103,7 @@ export function FleetSearch({
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           className={cn(
-            'w-full rounded-xl border bg-card/80 py-3 pl-11 pr-9 text-sm backdrop-blur-sm',
+            'w-full rounded-xl border bg-card/80 py-3 pl-11 pr-9 text-[16px] sm:text-sm backdrop-blur-sm',
             'placeholder:text-muted-foreground/50',
             'focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50',
             'transition-all duration-200',
@@ -155,7 +158,7 @@ export function FleetSearch({
           </button>
         )}
       </div>
-      {isFiltered && (
+      {isFiltered && showCount && (
         <span className="shrink-0 text-sm text-muted-foreground" data-testid="fleet-search-count">
           {filteredCount} of {totalCount}
         </span>

--- a/frontend/src/features/containers/components/fleet/fleet-search.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.tsx
@@ -111,6 +111,8 @@ export function FleetSearch({
           aria-label={label}
         />
         {showExamples && (
+          // Chips stay mounted while the field is empty (including while it is
+          // focused) so they remain keyboard-reachable, mirroring WorkloadSmartSearch.
           <div
             role="group"
             aria-label="Example searches"
@@ -144,6 +146,7 @@ export function FleetSearch({
         )}
         {query && (
           <button
+            type="button"
             onClick={handleClear}
             className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
             aria-label="Clear search"

--- a/frontend/src/features/containers/lib/k8s-search-filter.test.ts
+++ b/frontend/src/features/containers/lib/k8s-search-filter.test.ts
@@ -51,14 +51,16 @@ describe('filterK8sResources', () => {
     expect(r).toHaveLength(0); // 'kube-system' is not an exact match for 'kube'
   });
 
-  it('matches status as a case-insensitive substring', () => {
+  it('narrows resources that have a status, by case-insensitive substring', () => {
     const r = filterK8sResources(items, 'status:running');
-    expect(r.map((i) => i.name)).toEqual(['nginx-abc', 'nginx-old']);
+    // The two Running pods match; redis (Pending) is dropped; api-svc has no
+    // status so the status token is ignored for it and it passes through.
+    expect(r.map((i) => i.name)).toEqual(['nginx-abc', 'nginx-old', 'api-svc']);
   });
 
-  it('excludes resources without a status when a status token is given', () => {
+  it('passes status-less resources through a status token (does not exclude them)', () => {
     const r = filterK8sResources(items, 'status:running');
-    expect(r.some((i) => i.name === 'api-svc')).toBe(false);
+    expect(r.some((i) => i.name === 'api-svc')).toBe(true);
   });
 
   it('combines tokens with AND', () => {

--- a/frontend/src/features/containers/lib/k8s-search-filter.test.ts
+++ b/frontend/src/features/containers/lib/k8s-search-filter.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { parseK8sQuery, filterK8sResources } from './k8s-search-filter';
+
+const items = [
+  { name: 'nginx-abc', namespace: 'default', status: 'Running' },
+  { name: 'redis-xyz', namespace: 'cache', status: 'Pending' },
+  { name: 'nginx-old', namespace: 'kube-system', status: 'Running' },
+  { name: 'api-svc', namespace: 'default' }, // no status (e.g. a service)
+];
+
+describe('parseK8sQuery', () => {
+  it('returns an empty object for a blank query', () => {
+    expect(parseK8sQuery('   ')).toEqual({});
+  });
+
+  it('extracts namespace and status tokens and free text', () => {
+    expect(parseK8sQuery('namespace:default status:running nginx')).toEqual({
+      namespace: 'default',
+      status: 'running',
+      text: 'nginx',
+    });
+  });
+
+  it('treats bare words as free text (joined)', () => {
+    expect(parseK8sQuery('nginx web')).toEqual({ text: 'nginx web' });
+  });
+
+  it('ignores field tokens with an empty value', () => {
+    expect(parseK8sQuery('namespace: nginx')).toEqual({ text: 'nginx' });
+  });
+});
+
+describe('filterK8sResources', () => {
+  it('returns all items for a blank query', () => {
+    expect(filterK8sResources(items, '  ')).toHaveLength(4);
+  });
+
+  it('matches free text against the name (case-insensitive substring)', () => {
+    const r = filterK8sResources(items, 'NGINX');
+    expect(r.map((i) => i.name)).toEqual(['nginx-abc', 'nginx-old']);
+  });
+
+  it('matches namespace exactly (case-insensitive)', () => {
+    const r = filterK8sResources(items, 'namespace:DEFAULT');
+    expect(r.map((i) => i.name)).toEqual(['nginx-abc', 'api-svc']);
+  });
+
+  it('matches status as a case-insensitive substring', () => {
+    const r = filterK8sResources(items, 'status:running');
+    expect(r.map((i) => i.name)).toEqual(['nginx-abc', 'nginx-old']);
+  });
+
+  it('excludes resources without a status when a status token is given', () => {
+    const r = filterK8sResources(items, 'status:running');
+    expect(r.some((i) => i.name === 'api-svc')).toBe(false);
+  });
+
+  it('combines tokens with AND', () => {
+    const r = filterK8sResources(items, 'namespace:kube-system nginx');
+    expect(r.map((i) => i.name)).toEqual(['nginx-old']);
+  });
+});

--- a/frontend/src/features/containers/lib/k8s-search-filter.test.ts
+++ b/frontend/src/features/containers/lib/k8s-search-filter.test.ts
@@ -29,6 +29,10 @@ describe('parseK8sQuery', () => {
   it('ignores field tokens with an empty value', () => {
     expect(parseK8sQuery('namespace: nginx')).toEqual({ text: 'nginx' });
   });
+
+  it('uses the last value when a field token repeats (last-wins)', () => {
+    expect(parseK8sQuery('namespace:a namespace:b')).toEqual({ namespace: 'b' });
+  });
 });
 
 describe('filterK8sResources', () => {

--- a/frontend/src/features/containers/lib/k8s-search-filter.test.ts
+++ b/frontend/src/features/containers/lib/k8s-search-filter.test.ts
@@ -11,6 +11,7 @@ const items = [
 describe('parseK8sQuery', () => {
   it('returns an empty object for a blank query', () => {
     expect(parseK8sQuery('   ')).toEqual({});
+    expect(parseK8sQuery('')).toEqual({});
   });
 
   it('extracts namespace and status tokens and free text', () => {
@@ -43,6 +44,11 @@ describe('filterK8sResources', () => {
   it('matches namespace exactly (case-insensitive)', () => {
     const r = filterK8sResources(items, 'namespace:DEFAULT');
     expect(r.map((i) => i.name)).toEqual(['nginx-abc', 'api-svc']);
+  });
+
+  it('does not match namespace as a substring', () => {
+    const r = filterK8sResources(items, 'namespace:kube');
+    expect(r).toHaveLength(0); // 'kube-system' is not an exact match for 'kube'
   });
 
   it('matches status as a case-insensitive substring', () => {

--- a/frontend/src/features/containers/lib/k8s-search-filter.ts
+++ b/frontend/src/features/containers/lib/k8s-search-filter.ts
@@ -2,8 +2,8 @@
  * Smart-search filter for Kubernetes resource lists (pods, deployments,
  * services) shown on the Infrastructure page. Supports `namespace:` and
  * `status:` field tokens plus free-text matched against the resource name.
- * Resources without a `status` field (e.g. services) never match a `status:`
- * token, which is the intended behavior.
+ * A `status:` token is ignored for resources without a `status` field
+ * (e.g. services); those resources pass through unaffected.
  */
 export interface K8sSearchableResource {
   name: string;
@@ -46,9 +46,10 @@ export function filterK8sResources<T extends K8sSearchableResource>(
 
   return items.filter((item) => {
     if (namespace && (item.namespace ?? '').toLowerCase() !== namespace) return false;
-    if (status) {
-      if (item.status === undefined) return false;
-      if (!item.status.toLowerCase().includes(status)) return false;
+    // A status: token only narrows resources that have a status (pods).
+    // Status-less resources (deployments, services) pass through unaffected.
+    if (status && item.status !== undefined && !item.status.toLowerCase().includes(status)) {
+      return false;
     }
     if (text && !item.name.toLowerCase().includes(text)) return false;
     return true;

--- a/frontend/src/features/containers/lib/k8s-search-filter.ts
+++ b/frontend/src/features/containers/lib/k8s-search-filter.ts
@@ -23,6 +23,7 @@ export function parseK8sQuery(query: string): ParsedK8sQuery {
 
   for (const token of query.trim().split(/\s+/).filter(Boolean)) {
     const match = /^(namespace|status):(.*)$/i.exec(token);
+    // A field token may appear once; a repeat overwrites (last value wins).
     if (match) {
       const value = match[2].toLowerCase();
       if (!value) continue;

--- a/frontend/src/features/containers/lib/k8s-search-filter.ts
+++ b/frontend/src/features/containers/lib/k8s-search-filter.ts
@@ -1,0 +1,56 @@
+/**
+ * Smart-search filter for Kubernetes resource lists (pods, deployments,
+ * services) shown on the Infrastructure page. Supports `namespace:` and
+ * `status:` field tokens plus free-text matched against the resource name.
+ * Resources without a `status` field (e.g. services) never match a `status:`
+ * token, which is the intended behavior.
+ */
+export interface K8sSearchableResource {
+  name: string;
+  namespace?: string;
+  status?: string;
+}
+
+export interface ParsedK8sQuery {
+  namespace?: string;
+  status?: string;
+  text?: string;
+}
+
+export function parseK8sQuery(query: string): ParsedK8sQuery {
+  const parsed: ParsedK8sQuery = {};
+  const freeText: string[] = [];
+
+  for (const token of query.trim().split(/\s+/).filter(Boolean)) {
+    const match = /^(namespace|status):(.*)$/i.exec(token);
+    if (match) {
+      const value = match[2].toLowerCase();
+      if (!value) continue;
+      if (match[1].toLowerCase() === 'namespace') parsed.namespace = value;
+      else parsed.status = value;
+    } else {
+      freeText.push(token.toLowerCase());
+    }
+  }
+
+  if (freeText.length > 0) parsed.text = freeText.join(' ');
+  return parsed;
+}
+
+export function filterK8sResources<T extends K8sSearchableResource>(
+  items: T[],
+  query: string,
+): T[] {
+  const { namespace, status, text } = parseK8sQuery(query);
+  if (!namespace && !status && !text) return items;
+
+  return items.filter((item) => {
+    if (namespace && (item.namespace ?? '').toLowerCase() !== namespace) return false;
+    if (status) {
+      if (item.status === undefined) return false;
+      if (!item.status.toLowerCase().includes(status)) return false;
+    }
+    if (text && !item.name.toLowerCase().includes(text)) return false;
+    return true;
+  });
+}

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -1196,4 +1196,14 @@ describe('Infrastructure smart search — Kubernetes tab', () => {
     });
     expect(screen.getByText('nginx-1')).toBeInTheDocument();
   });
+
+  it('shows an empty state when the K8s search matches nothing', async () => {
+    renderPageWithInitialParams('/infrastructure?tab=kubernetes');
+    fireEvent.change(screen.getByRole('textbox', { name: /search kubernetes resources/i }), {
+      target: { value: 'zzz-no-match' },
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/no matching resources/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -18,6 +18,13 @@ vi.mock('@/features/containers/hooks/use-stacks', () => ({
   useStacks: vi.fn(),
 }));
 
+vi.mock('@/features/kubernetes/hooks/use-kubernetes', () => ({
+  useK8sPods: vi.fn(() => ({ data: [], isLoading: false, refetch: vi.fn(), isFetching: false })),
+  useK8sDeployments: vi.fn(() => ({ data: [], isLoading: false })),
+  useK8sServices: vi.fn(() => ({ data: [], isLoading: false })),
+  useK8sNamespaces: vi.fn(() => ({ data: [] })),
+}));
+
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
   useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn() }),
 }));
@@ -36,6 +43,7 @@ vi.mock('sonner', () => ({
 import { toast } from 'sonner';
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
 import { useStacks } from '@/features/containers/hooks/use-stacks';
+import { useK8sPods } from '@/features/kubernetes/hooks/use-kubernetes';
 import type { Endpoint } from '@/features/containers/hooks/use-endpoints';
 import type { Stack } from '@/features/containers/hooks/use-stacks';
 import { useUiStore } from '@/stores/ui-store';
@@ -1148,5 +1156,43 @@ describe('Infrastructure smart search — Stacks tab', () => {
     renderPageWithInitialParams('/infrastructure?tab=stacks');
     expect(screen.getByRole('textbox', { name: 'Search stacks' })).toBeInTheDocument();
     expect(screen.queryByTestId('data-table-search')).not.toBeInTheDocument();
+  });
+});
+
+describe('Infrastructure smart search — Kubernetes tab', () => {
+  const pod = (name: string, namespace: string, status: string) => ({
+    id: `${namespace}/${name}`, name, namespace, images: [], state: 'running',
+    status, restarts: 0, created: 0, endpointId: 1, endpointName: 'prod-1',
+    labels: {}, containers: [], resourceType: 'pod',
+  });
+
+  beforeEach(() => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' })]);
+    mockStacks([]);
+    vi.mocked(useK8sPods).mockReturnValue({
+      data: [pod('nginx-1', 'default', 'Running'), pod('redis-1', 'cache', 'Pending')],
+      isLoading: false, refetch: vi.fn(), isFetching: false,
+    } as any);
+  });
+
+  it('renders a Kubernetes search bar with example chips', () => {
+    renderPageWithInitialParams('/infrastructure?tab=kubernetes');
+    expect(screen.getByRole('textbox', { name: /search kubernetes resources/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'namespace:kube-system' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'status:running' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'nginx' })).toBeInTheDocument();
+  });
+
+  it('filters the pods table by the search query', async () => {
+    renderPageWithInitialParams('/infrastructure?tab=kubernetes');
+    expect(screen.getByText('nginx-1')).toBeInTheDocument();
+    expect(screen.getByText('redis-1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'nginx' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('redis-1')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('nginx-1')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -1126,11 +1126,4 @@ describe('Infrastructure smart search — Fleet tab', () => {
     expect(screen.getByRole('button', { name: 'status:up' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'type:edge' })).toBeInTheDocument();
   });
-
-  it('shows only one search input in Fleet table view (no DataTable search box)', () => {
-    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' }), makeEndpoint({ id: 2, name: 'prod-2' })]);
-    renderPage();
-    fireEvent.click(screen.getByTitle('Table view'));
-    expect(screen.getAllByRole('textbox')).toHaveLength(1);
-  });
 });

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -488,7 +488,7 @@ describe('InfrastructurePage — stack section', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/workloads?endpoint=1&stack=my-stack');
   });
 
-  it('stacks table view enables search', () => {
+  it('stacks table view enables search via the smart search bar', () => {
     useUiStore.setState({ pageViewModes: { stacks: 'table' } });
     mockStacks([
       makeStack({ id: 1, name: 'alpha-stack' }),
@@ -497,9 +497,9 @@ describe('InfrastructurePage — stack section', () => {
 
     renderPageWithInitialParams('/infrastructure?tab=stacks');
 
-    // DataTable search input should be present (one for fleet which is empty, one for stacks)
-    const searchInputs = screen.getAllByTestId('data-table-search');
-    expect(searchInputs.length).toBeGreaterThanOrEqual(1);
+    // Smart search bar present; DataTable built-in search is removed
+    expect(screen.getByRole('textbox', { name: 'Search stacks' })).toBeInTheDocument();
+    expect(screen.queryByTestId('data-table-search')).not.toBeInTheDocument();
   });
 
   it('stacks table view fits the viewport (autoFit)', () => {
@@ -1125,5 +1125,28 @@ describe('Infrastructure smart search — Fleet tab', () => {
     expect(screen.getByRole('button', { name: 'name:prod' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'status:up' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'type:edge' })).toBeInTheDocument();
+  });
+});
+
+describe('Infrastructure smart search — Stacks tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({ pageViewModes: {} });
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' })]);
+    mockStacks([makeStack({ id: 1, name: 'traefik' }), makeStack({ id: 2, name: 'grafana' })]);
+  });
+
+  it('renders stack example chips inside the search bar', () => {
+    renderPageWithInitialParams('/infrastructure?tab=stacks');
+    expect(screen.getByRole('button', { name: 'name:traefik' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'status:active' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'endpoint:prod' })).toBeInTheDocument();
+  });
+
+  it('shows the smart search bar and no DataTable search in Stacks table view', () => {
+    useUiStore.setState({ pageViewModes: { stacks: 'table' } });
+    renderPageWithInitialParams('/infrastructure?tab=stacks');
+    expect(screen.getByRole('textbox', { name: 'Search stacks' })).toBeInTheDocument();
+    expect(screen.queryByTestId('data-table-search')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -1181,6 +1181,7 @@ describe('Infrastructure smart search — Kubernetes tab', () => {
     expect(screen.getByRole('button', { name: 'namespace:kube-system' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'status:running' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'nginx' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /search kubernetes resources/i })).not.toHaveFocus();
   });
 
   it('filters the pods table by the search query', async () => {

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -1134,6 +1134,13 @@ describe('Infrastructure smart search — Fleet tab', () => {
     expect(screen.getByRole('button', { name: 'status:up' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'type:edge' })).toBeInTheDocument();
   });
+
+  it('seeds the endpoint search from the URL (endpointSearch param)', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' }), makeEndpoint({ id: 2, name: 'web-2' })]);
+    mockStacks([]);
+    renderPageWithInitialParams('/infrastructure?tab=fleet&endpointSearch=prod');
+    expect((screen.getByRole('textbox', { name: 'Search endpoints' }) as HTMLInputElement).value).toBe('prod');
+  });
 });
 
 describe('Infrastructure smart search — Stacks tab', () => {
@@ -1205,5 +1212,10 @@ describe('Infrastructure smart search — Kubernetes tab', () => {
     await waitFor(() => {
       expect(screen.getByText(/no matching resources/i)).toBeInTheDocument();
     });
+  });
+
+  it('seeds the K8s search from the URL (k8sSearch param)', () => {
+    renderPageWithInitialParams('/infrastructure?tab=kubernetes&k8sSearch=nginx');
+    expect((screen.getByRole('textbox', { name: /search kubernetes resources/i }) as HTMLInputElement).value).toBe('nginx');
   });
 });

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -375,7 +375,7 @@ describe('InfrastructurePage — fleet section', () => {
     renderPage();
 
     expect(screen.queryByTestId('grid-pagination')).not.toBeInTheDocument();
-    expect(screen.getByTestId('data-table-search')).toBeInTheDocument();
+    expect(screen.getByTestId('auto-fit-container')).toBeInTheDocument();
   });
 
   it('paginates grid view with 30 items per page', () => {
@@ -409,7 +409,7 @@ describe('InfrastructurePage — fleet section', () => {
     expect(screen.queryByText('env-1')).not.toBeInTheDocument();
   });
 
-  it('fleet table view enables search', () => {
+  it('fleet table view shows the smart search bar (not DataTable search)', () => {
     useUiStore.setState({ pageViewModes: { fleet: 'table' } });
     mockEndpoints([
       makeEndpoint({ id: 1, name: 'alpha-env' }),
@@ -418,8 +418,9 @@ describe('InfrastructurePage — fleet section', () => {
 
     renderPage();
 
-    // DataTable search input should be present
-    expect(screen.getByTestId('data-table-search')).toBeInTheDocument();
+    // FleetSearch input should be present; DataTable search should be hidden
+    expect(screen.getByRole('textbox', { name: 'Search endpoints' })).toBeInTheDocument();
+    expect(screen.queryByTestId('data-table-search')).not.toBeInTheDocument();
   });
 
   it('fleet table view fits the viewport (autoFit)', () => {
@@ -1110,5 +1111,26 @@ describe('InfrastructurePage — stack filter chips', () => {
     expect(screen.queryByTestId('filter-chip-stackStatus')).not.toBeInTheDocument();
     expect(screen.getByText('active-s')).toBeInTheDocument();
     expect(screen.getByText('inactive-s')).toBeInTheDocument();
+  });
+});
+
+describe('Infrastructure smart search — Fleet tab', () => {
+  beforeEach(() => {
+    mockStacks([]);
+  });
+
+  it('renders endpoint example chips inside the search bar', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' }), makeEndpoint({ id: 2, name: 'prod-2', status: 'down' })]);
+    renderPage();
+    expect(screen.getByRole('button', { name: 'name:prod' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'status:up' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'type:edge' })).toBeInTheDocument();
+  });
+
+  it('shows only one search input in Fleet table view (no DataTable search box)', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' }), makeEndpoint({ id: 2, name: 'prod-2' })]);
+    renderPage();
+    fireEvent.click(screen.getByTitle('Table view'));
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
   });
 });

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -213,15 +213,22 @@ export default function InfrastructurePage() {
   const handleTabChange = useCallback((newTab: string) => {
     const resolved = resolveTab(newTab);
     const params: Record<string, string> = { tab: resolved };
-    // Preserve existing filter params when switching tabs
+    // Preserve existing filter + per-tab search params when switching tabs, so
+    // each tab's search text survives a round-trip just like its dropdown filters.
     const endpointStatus = searchParams.get('endpointStatus');
     const endpointType = searchParams.get('endpointType');
     const stackStatus = searchParams.get('stackStatus');
     const stackEndpoint = searchParams.get('stackEndpoint');
+    const endpointSearch = searchParams.get('endpointSearch');
+    const stackSearch = searchParams.get('stackSearch');
+    const k8sSearch = searchParams.get('k8sSearch');
     if (endpointStatus) params.endpointStatus = endpointStatus;
     if (endpointType) params.endpointType = endpointType;
     if (stackStatus) params.stackStatus = stackStatus;
     if (stackEndpoint) params.stackEndpoint = stackEndpoint;
+    if (endpointSearch) params.endpointSearch = endpointSearch;
+    if (stackSearch) params.stackSearch = stackSearch;
+    if (k8sSearch) params.k8sSearch = k8sSearch;
     setSearchParams(params, { replace: true });
   }, [searchParams, setSearchParams]);
 

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -894,8 +894,19 @@ export default function InfrastructurePage() {
         <Tabs.Content value="fleet" className="mt-4">
       <section aria-labelledby="fleet-heading" className="space-y-4">
         <h2 id="fleet-heading" className="sr-only">Fleet Overview</h2>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          {!isLoading && endpoints && (
+        {!isLoading && endpoints && endpoints.length > 0 && (
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
+            <div className="lg:flex-1">
+              <FleetSearch
+                onSearch={handleEndpointSearch}
+                totalCount={endpoints.length}
+                filteredCount={filteredEndpoints.length}
+                placeholder="Search endpoints... (name:prod status:up type:edge)"
+                label="Search endpoints"
+                examples={['name:prod', 'status:up', 'type:edge']}
+                autoFocus
+              />
+            </div>
             <div className="flex flex-wrap items-center gap-3">
               {/* Endpoint status filter */}
               {endpointStatusOptions.length > 2 && (
@@ -953,8 +964,8 @@ export default function InfrastructurePage() {
                 </button>
               </div>
             </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Endpoint filter chips */}
         {!isLoading && hasActiveEndpointFilter && (
@@ -962,17 +973,6 @@ export default function InfrastructurePage() {
             filters={activeEndpointFilters}
             onRemove={handleRemoveEndpointFilter}
             onClearAll={handleClearAllEndpointFilters}
-          />
-        )}
-
-        {/* Endpoint search */}
-        {!isLoading && endpoints && endpoints.length > 0 && (
-          <FleetSearch
-            onSearch={handleEndpointSearch}
-            totalCount={endpoints.length}
-            filteredCount={filteredEndpoints.length}
-            placeholder="Search endpoints... (name:prod status:up type:edge)"
-            label="Search endpoints"
           />
         )}
 
@@ -1040,8 +1040,7 @@ export default function InfrastructurePage() {
             <DataTable
               columns={endpointColumns}
               data={filteredEndpoints}
-              searchKey="name"
-              searchPlaceholder="Search endpoints..."
+              hideSearch
               autoFit
               onRowClick={(row) => handleEndpointClick(row.id)}
             />

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -894,19 +894,23 @@ export default function InfrastructurePage() {
         <Tabs.Content value="fleet" className="mt-4">
       <section aria-labelledby="fleet-heading" className="space-y-4">
         <h2 id="fleet-heading" className="sr-only">Fleet Overview</h2>
-        {!isLoading && endpoints && endpoints.length > 0 && (
+        {!isLoading && endpoints != null && (
           <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
-            <div className="lg:flex-1">
-              <FleetSearch
-                onSearch={handleEndpointSearch}
-                totalCount={endpoints.length}
-                filteredCount={filteredEndpoints.length}
-                placeholder="Search endpoints... (name:prod status:up type:edge)"
-                label="Search endpoints"
-                examples={['name:prod', 'status:up', 'type:edge']}
-                autoFocus
-              />
-            </div>
+            {endpoints.length > 0 && (
+              <div className="lg:flex-1">
+                <FleetSearch
+                  onSearch={handleEndpointSearch}
+                  totalCount={endpoints.length}
+                  filteredCount={filteredEndpoints.length}
+                  placeholder="Search endpoints... (name:prod status:up type:edge)"
+                  label="Search endpoints"
+                  examples={['name:prod', 'status:up', 'type:edge']}
+                  // Focus the search when the Fleet tab (the default landing tab) mounts,
+                  // mirroring the Workload Explorer open-on-page autofocus.
+                  autoFocus
+                />
+              </div>
+            )}
             <div className="flex flex-wrap items-center gap-3">
               {/* Endpoint status filter */}
               {endpointStatusOptions.length > 2 && (

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -1057,8 +1057,8 @@ export default function InfrastructurePage() {
         <Tabs.Content value="stacks" className="mt-4">
       <section aria-labelledby="stacks-heading" className="space-y-4">
         <h2 id="stacks-heading" className="sr-only">Stack Overview</h2>
-        <div className="flex items-center gap-2">
-          {stackEndpointFilterParam !== ALL_FILTER && (
+        {stackEndpointFilterParam !== ALL_FILTER && (
+          <div className="flex items-center gap-2">
             <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
               {endpoints?.find(ep => ep.id === Number(stackEndpointFilterParam))?.name ?? `Endpoint ${stackEndpointFilterParam}`}
               <button
@@ -1070,8 +1070,8 @@ export default function InfrastructurePage() {
                 <X className="h-3 w-3" />
               </button>
             </span>
-          )}
-        </div>
+          </div>
+        )}
         {!isLoading && stacksWithEndpoints.length > 0 && (
           <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
             {dropdownFilteredStacks.length > 0 && (

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { type ColumnDef } from '@tanstack/react-table';
 import * as Tabs from '@radix-ui/react-tabs';
@@ -231,6 +231,13 @@ export default function InfrastructurePage() {
   const stackStatusFilter = searchParams.get('stackStatus') ?? ALL_FILTER;
   const stackEndpointFilterParam = searchParams.get('stackEndpoint') ?? ALL_FILTER;
 
+  const setSearchParam = useCallback((key: string, value: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (value) params.set(key, value);
+    else params.delete(key);
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams]);
+
   const setFleetFilters = useCallback((
     epStatus: string,
     epType: string,
@@ -286,9 +293,14 @@ export default function InfrastructurePage() {
   const stacksViewMode = useUiStore((s) => s.pageViewModes['stacks'] ?? 'grid');
   const setStacksViewMode = (mode: 'grid' | 'table') => setPageViewMode('stacks', mode);
 
-  // Search state
-  const [endpointSearchQuery, setEndpointSearchQuery] = useState('');
-  const [stackSearchQuery, setStackSearchQuery] = useState('');
+  // URL-persisted search queries (derived from searchParams)
+  const endpointSearchQuery = searchParams.get('endpointSearch') ?? '';
+  const stackSearchQuery = searchParams.get('stackSearch') ?? '';
+  const k8sSearchQuery = searchParams.get('k8sSearch') ?? '';
+
+  // Autofocus gate: focus the Fleet search only on first mount, not on every re-entry
+  const fleetSearchAutoFocusedRef = useRef(false);
+  const markFleetSearchAutoFocused = useCallback(() => { fleetSearchAutoFocusedRef.current = true; }, []);
 
   // Shared data — single hook call each, no duplicate requests
   const {
@@ -328,7 +340,6 @@ export default function InfrastructurePage() {
     data: k8sNamespaces,
   } = useK8sNamespaces();
 
-  const [k8sSearchQuery, setK8sSearchQuery] = useState('');
   const filteredK8sPods = useMemo(
     () => filterK8sResources(k8sPods ?? [], k8sSearchQuery),
     [k8sPods, k8sSearchQuery],
@@ -499,9 +510,12 @@ export default function InfrastructurePage() {
   }, [filteredEndpoints, gridPage]);
 
   const handleEndpointSearch = useCallback((query: string) => {
-    setEndpointSearchQuery(query);
+    setSearchParam('endpointSearch', query);
     setGridPage(1);
-  }, []);
+  }, [setSearchParam]);
+
+  const handleStackSearch = useCallback((q: string) => setSearchParam('stackSearch', q), [setSearchParam]);
+  const handleK8sSearch = useCallback((q: string) => setSearchParam('k8sSearch', q), [setSearchParam]);
 
   const handleEndpointClick = (endpointId: number) => {
     navigate(`/workloads?endpoint=${endpointId}`);
@@ -924,9 +938,11 @@ export default function InfrastructurePage() {
                   placeholder="Search endpoints... (name:prod status:up type:edge)"
                   label="Search endpoints"
                   examples={['name:prod', 'status:up', 'type:edge']}
-                  // Focus the search when the Fleet tab (the default landing tab) mounts,
-                  // mirroring the Workload Explorer open-on-page autofocus.
-                  autoFocus
+                  // Focus the search when the Fleet tab first mounts; gate with ref
+                  // so re-mounting (tab switch) does not re-steal focus.
+                  autoFocus={!fleetSearchAutoFocusedRef.current}
+                  onAutoFocused={markFleetSearchAutoFocused}
+                  initialValue={endpointSearchQuery}
                   showCount={false}
                 />
               </div>
@@ -1097,12 +1113,13 @@ export default function InfrastructurePage() {
             {dropdownFilteredStacks.length > 0 && (
               <div className="lg:flex-1">
                 <FleetSearch
-                  onSearch={setStackSearchQuery}
+                  onSearch={handleStackSearch}
                   totalCount={dropdownFilteredStacks.length}
                   filteredCount={filteredStacks.length}
                   placeholder="Search stacks... (name:traefik status:active endpoint:prod)"
                   label="Search stacks"
                   examples={['name:traefik', 'status:active', 'endpoint:prod']}
+                  initialValue={stackSearchQuery}
                   showCount={false}
                 />
               </div>
@@ -1273,12 +1290,13 @@ export default function InfrastructurePage() {
         {/* K8s smart search */}
         {!k8sPodsLoading && !k8sDeploymentsLoading && !k8sServicesLoading && k8sTotalCount > 0 && (
           <FleetSearch
-            onSearch={setK8sSearchQuery}
+            onSearch={handleK8sSearch}
             totalCount={k8sTotalCount}
             filteredCount={k8sFilteredCount}
             placeholder="Search resources... (namespace:kube-system status:running nginx)"
             label="Search Kubernetes resources"
             examples={['namespace:kube-system', 'status:running', 'nginx']}
+            initialValue={k8sSearchQuery}
           />
         )}
 

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -1269,7 +1269,7 @@ export default function InfrastructurePage() {
         </SpotlightCard>
 
         {/* K8s smart search */}
-        {!k8sPodsLoading && k8sTotalCount > 0 && (
+        {!k8sPodsLoading && !k8sDeploymentsLoading && !k8sServicesLoading && k8sTotalCount > 0 && (
           <FleetSearch
             onSearch={setK8sSearchQuery}
             totalCount={k8sTotalCount}

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -927,6 +927,7 @@ export default function InfrastructurePage() {
                   // Focus the search when the Fleet tab (the default landing tab) mounts,
                   // mirroring the Workload Explorer open-on-page autofocus.
                   autoFocus
+                  showCount={false}
                 />
               </div>
             )}
@@ -1102,6 +1103,7 @@ export default function InfrastructurePage() {
                   placeholder="Search stacks... (name:traefik status:active endpoint:prod)"
                   label="Search stacks"
                   examples={['name:traefik', 'status:active', 'endpoint:prod']}
+                  showCount={false}
                 />
               </div>
             )}
@@ -1280,55 +1282,65 @@ export default function InfrastructurePage() {
           />
         )}
 
-        {/* Pods table */}
-        {k8sPodsLoading ? (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <SkeletonChart key={i} size="md" />
-            ))}
-          </div>
+        {k8sSearchQuery && k8sFilteredCount === 0 ? (
+          <EmptyState
+            icon={Search}
+            title="No matching resources"
+            description="Try a different query or clear the search."
+          />
         ) : (
-          <SpotlightCard>
-          <div className="rounded-lg border bg-card p-6 shadow-sm">
-            <h3 className="mb-4 text-sm font-semibold">Pods</h3>
-            <DataTable
-              columns={k8sPodColumns}
-              data={filteredK8sPods}
-              hideSearch
-              pageSize={15}
-            />
-          </div>
-          </SpotlightCard>
-        )}
+          <>
+            {/* Pods table */}
+            {k8sPodsLoading ? (
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <SkeletonChart key={i} size="md" />
+                ))}
+              </div>
+            ) : (
+              <SpotlightCard>
+              <div className="rounded-lg border bg-card p-6 shadow-sm">
+                <h3 className="mb-4 text-sm font-semibold">Pods</h3>
+                <DataTable
+                  columns={k8sPodColumns}
+                  data={filteredK8sPods}
+                  hideSearch
+                  pageSize={15}
+                />
+              </div>
+              </SpotlightCard>
+            )}
 
-        {/* Deployments table */}
-        {!k8sDeploymentsLoading && k8sDeployments && k8sDeployments.length > 0 && (
-          <SpotlightCard>
-          <div className="rounded-lg border bg-card p-6 shadow-sm">
-            <h3 className="mb-4 text-sm font-semibold">Deployments</h3>
-            <DataTable
-              columns={k8sDeploymentColumns}
-              data={filteredK8sDeployments}
-              hideSearch
-              pageSize={15}
-            />
-          </div>
-          </SpotlightCard>
-        )}
+            {/* Deployments table */}
+            {!k8sDeploymentsLoading && k8sDeployments && k8sDeployments.length > 0 && (
+              <SpotlightCard>
+              <div className="rounded-lg border bg-card p-6 shadow-sm">
+                <h3 className="mb-4 text-sm font-semibold">Deployments</h3>
+                <DataTable
+                  columns={k8sDeploymentColumns}
+                  data={filteredK8sDeployments}
+                  hideSearch
+                  pageSize={15}
+                />
+              </div>
+              </SpotlightCard>
+            )}
 
-        {/* Services table */}
-        {!k8sServicesLoading && k8sServices && k8sServices.length > 0 && (
-          <SpotlightCard>
-          <div className="rounded-lg border bg-card p-6 shadow-sm">
-            <h3 className="mb-4 text-sm font-semibold">Services</h3>
-            <DataTable
-              columns={k8sServiceColumns}
-              data={filteredK8sServices}
-              hideSearch
-              pageSize={15}
-            />
-          </div>
-          </SpotlightCard>
+            {/* Services table */}
+            {!k8sServicesLoading && k8sServices && k8sServices.length > 0 && (
+              <SpotlightCard>
+              <div className="rounded-lg border bg-card p-6 shadow-sm">
+                <h3 className="mb-4 text-sm font-semibold">Services</h3>
+                <DataTable
+                  columns={k8sServiceColumns}
+                  data={filteredK8sServices}
+                  hideSearch
+                  pageSize={15}
+                />
+              </div>
+              </SpotlightCard>
+            )}
+          </>
         )}
       </section>
         </Tabs.Content>

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -1057,23 +1057,35 @@ export default function InfrastructurePage() {
         <Tabs.Content value="stacks" className="mt-4">
       <section aria-labelledby="stacks-heading" className="space-y-4">
         <h2 id="stacks-heading" className="sr-only">Stack Overview</h2>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2">
-            {stackEndpointFilterParam !== ALL_FILTER && (
-              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
-                {endpoints?.find(ep => ep.id === Number(stackEndpointFilterParam))?.name ?? `Endpoint ${stackEndpointFilterParam}`}
-                <button
-                  onClick={() => setStackEndpointFilter(ALL_FILTER)}
-                  className="ml-0.5 rounded-full hover:bg-primary/20"
-                  aria-label="Clear endpoint filter"
-                  data-testid="clear-stack-filter"
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </span>
+        <div className="flex items-center gap-2">
+          {stackEndpointFilterParam !== ALL_FILTER && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+              {endpoints?.find(ep => ep.id === Number(stackEndpointFilterParam))?.name ?? `Endpoint ${stackEndpointFilterParam}`}
+              <button
+                onClick={() => setStackEndpointFilter(ALL_FILTER)}
+                className="ml-0.5 rounded-full hover:bg-primary/20"
+                aria-label="Clear endpoint filter"
+                data-testid="clear-stack-filter"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          )}
+        </div>
+        {!isLoading && stacksWithEndpoints.length > 0 && (
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
+            {dropdownFilteredStacks.length > 0 && (
+              <div className="lg:flex-1">
+                <FleetSearch
+                  onSearch={setStackSearchQuery}
+                  totalCount={dropdownFilteredStacks.length}
+                  filteredCount={filteredStacks.length}
+                  placeholder="Search stacks... (name:traefik status:active endpoint:prod)"
+                  label="Search stacks"
+                  examples={['name:traefik', 'status:active', 'endpoint:prod']}
+                />
+              </div>
             )}
-          </div>
-          {!isLoading && stacksWithEndpoints.length > 0 && (
             <div className="flex flex-wrap items-center gap-3">
               {/* Stack status filter */}
               {stackStatusOptions.length > 2 && (
@@ -1131,8 +1143,8 @@ export default function InfrastructurePage() {
                 </button>
               </div>
             </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Stack filter chips */}
         {!isLoading && hasActiveStackFilter && (
@@ -1140,17 +1152,6 @@ export default function InfrastructurePage() {
             filters={activeStackFilters}
             onRemove={handleRemoveStackFilter}
             onClearAll={handleClearAllStackFilters}
-          />
-        )}
-
-        {/* Stack search */}
-        {!isLoading && dropdownFilteredStacks.length > 0 && (
-          <FleetSearch
-            onSearch={setStackSearchQuery}
-            totalCount={dropdownFilteredStacks.length}
-            filteredCount={filteredStacks.length}
-            placeholder="Search stacks... (name:traefik status:active endpoint:prod)"
-            label="Search stacks"
           />
         )}
 
@@ -1209,8 +1210,7 @@ export default function InfrastructurePage() {
             <DataTable
               columns={stackColumns}
               data={filteredStacks}
-              searchKey="name"
-              searchPlaceholder="Search stacks..."
+              hideSearch
               autoFit
               onRowClick={handleStackClick}
             />

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -26,6 +26,7 @@ import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { FleetStatusSummary } from '@/features/containers/components/fleet/fleet-status-summary';
 import { FleetSearch } from '@/features/containers/components/fleet/fleet-search';
 import { filterEndpoints, filterStacks, type StackWithEndpoint } from '@/features/containers/lib/fleet-search-filter';
+import { filterK8sResources } from '@/features/containers/lib/k8s-search-filter';
 import { useK8sPods, useK8sDeployments, useK8sServices, useK8sNamespaces, type K8sPod, type K8sDeployment, type K8sService } from '@/features/kubernetes/hooks/use-kubernetes';
 
 const FLEET_GRID_PAGE_SIZE = 30;
@@ -326,6 +327,24 @@ export default function InfrastructurePage() {
   const {
     data: k8sNamespaces,
   } = useK8sNamespaces();
+
+  const [k8sSearchQuery, setK8sSearchQuery] = useState('');
+  const filteredK8sPods = useMemo(
+    () => filterK8sResources(k8sPods ?? [], k8sSearchQuery),
+    [k8sPods, k8sSearchQuery],
+  );
+  const filteredK8sDeployments = useMemo(
+    () => filterK8sResources(k8sDeployments ?? [], k8sSearchQuery),
+    [k8sDeployments, k8sSearchQuery],
+  );
+  const filteredK8sServices = useMemo(
+    () => filterK8sResources(k8sServices ?? [], k8sSearchQuery),
+    [k8sServices, k8sSearchQuery],
+  );
+  const k8sTotalCount =
+    (k8sPods?.length ?? 0) + (k8sDeployments?.length ?? 0) + (k8sServices?.length ?? 0);
+  const k8sFilteredCount =
+    filteredK8sPods.length + filteredK8sDeployments.length + filteredK8sServices.length;
 
   const isLoading = endpointsLoading || stacksLoading;
   const isFetching = endpointsFetching || stacksFetching;
@@ -1249,6 +1268,18 @@ export default function InfrastructurePage() {
         </div>
         </SpotlightCard>
 
+        {/* K8s smart search */}
+        {!k8sPodsLoading && k8sTotalCount > 0 && (
+          <FleetSearch
+            onSearch={setK8sSearchQuery}
+            totalCount={k8sTotalCount}
+            filteredCount={k8sFilteredCount}
+            placeholder="Search resources... (namespace:kube-system status:running nginx)"
+            label="Search Kubernetes resources"
+            examples={['namespace:kube-system', 'status:running', 'nginx']}
+          />
+        )}
+
         {/* Pods table */}
         {k8sPodsLoading ? (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -1262,9 +1293,8 @@ export default function InfrastructurePage() {
             <h3 className="mb-4 text-sm font-semibold">Pods</h3>
             <DataTable
               columns={k8sPodColumns}
-              data={k8sPods ?? []}
-              searchKey="name"
-              searchPlaceholder="Search pods..."
+              data={filteredK8sPods}
+              hideSearch
               pageSize={15}
             />
           </div>
@@ -1278,9 +1308,8 @@ export default function InfrastructurePage() {
             <h3 className="mb-4 text-sm font-semibold">Deployments</h3>
             <DataTable
               columns={k8sDeploymentColumns}
-              data={k8sDeployments}
-              searchKey="name"
-              searchPlaceholder="Search deployments..."
+              data={filteredK8sDeployments}
+              hideSearch
               pageSize={15}
             />
           </div>
@@ -1294,9 +1323,8 @@ export default function InfrastructurePage() {
             <h3 className="mb-4 text-sm font-semibold">Services</h3>
             <DataTable
               columns={k8sServiceColumns}
-              data={k8sServices}
-              searchKey="name"
-              searchPlaceholder="Search services..."
+              data={filteredK8sServices}
+              hideSearch
               pageSize={15}
             />
           </div>


### PR DESCRIPTION
## Summary

Consolidates the Infrastructure page so each tab has **one** Workload-Explorer-style smart search bar (rounded, full-width, with clickable example chips), regroups the filter dropdowns onto the search toolbar, removes the redundant per-table `DataTable` search boxes, and adds smart search to the Kubernetes tab.

- **`FleetSearch` upgrade** (`components/fleet/fleet-search.tsx`): in-field example chips, `autoFocus`, Escape-to-blur, an optional `showCount`, rounded-xl/full-width styling + iOS no-zoom guard.
- **Fleet & Stacks tabs**: search bar + status/type/endpoint dropdowns + count + view toggle now share one responsive toolbar row; the table's built-in search is removed (`hideSearch`); the duplicate count badge is suppressed (the toolbar count is the single source).
- **Kubernetes tab**: new `lib/k8s-search-filter.ts` (`namespace:` / `status:` tokens + free-text on name) drives one search bar over pods/deployments/services; the three per-table searches are removed; a "no matching resources" empty state shows when a query matches nothing. A `status:` token only narrows resources that have a status (pods); status-less resources (deployments/services) pass through unaffected.
- Spec: `docs/superpowers/specs/2026-05-30-infrastructure-smart-search-design.md`; plan: `docs/superpowers/plans/2026-05-30-infrastructure-smart-search.md`.

Observer-first preserved — read-only UI, no container-mutating actions, no backend/API changes.

## Test Plan

- [x] `npm run test -w frontend` — full suite green (213 files, 2093 tests)
- [x] `npm run typecheck -w frontend` — clean
- [x] `npm run lint -w frontend` — clean (`--max-warnings=0`)
- [x] New/updated unit tests: `fleet-search.test.tsx` (chips, autoFocus, Escape-blur, showCount), `k8s-search-filter.test.ts` (parse + filter incl. status passthrough), `fleet-overview.test.tsx` (per-tab toolbar regroup, single search per tab, K8s search + empty state)
- [ ] Manual: verify each tab shows one search bar with example chips; table view has no second search; K8s search filters all three tables; empty-fleet still shows the toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)