### PR TITLE
feat(pcap): search-first cross-endpoint packet-capture filters

### DIFF
--- a/docs/superpowers/plans/2026-05-30-packet-capture-filter-overhaul.md
+++ b/docs/superpowers/plans/2026-05-30-packet-capture-filter-overhaul.md
@@ -4,13 +4,20 @@
 
 **Goal:** Replace the Packet Capture page's forced Endpoint → Stack → Container cascade with a search-first, cross-endpoint container picker (type a name, or `stack:`/`endpoint:`), add capture-history search, and add BPF filter presets.
 
-**Architecture:** Reuse the existing `filterContainers()` parser and `cmdk` to build a small `CaptureTargetPicker` that filters the full cross-endpoint running-container list client-side, grouped by endpoint, with edge-async endpoints disabled. Extract `BpfFilterInput` for the presets. Add an optional `search` param to the captures list API (parameterized SQL). The 667-line page becomes an orchestrator composing these focused, independently tested components.
+**Architecture:** Reuse the existing `filterContainers()` parser and `cmdk` to build a small `CaptureTargetPicker` that filters the full cross-endpoint running-container list client-side, grouped by endpoint, with edge-async endpoints disabled. Extract `BpfFilterInput` for the presets and a `CaptureBrowseFallback` for the optional dropdown path. Add an optional `search` param to the captures list API (parameterized SQL). The 667-line page becomes an orchestrator composing these focused, independently tested components.
 
-**Tech Stack:** React 19 + TypeScript, `cmdk`, TanStack Query, Tailwind, Vitest + Testing Library (frontend, jsdom); Fastify 5 + Zod + PostgreSQL, Vitest + real PG (backend).
+**Tech Stack:** React 19 + TypeScript, `cmdk`, TanStack Query, Tailwind, Vitest + Testing Library (frontend, jsdom); Fastify 5 + Zod + PostgreSQL, Vitest (backend — pcap suites mock the store/service, no live DB).
 
 **Spec:** `docs/superpowers/specs/2026-05-30-packet-capture-filter-overhaul-design.md`
 
 **Working directory:** worktree `.claude/worktrees/feature+packet-capture-filter-overhaul` on branch `worktree-feature+packet-capture-filter-overhaul`. Run all commands from the worktree root.
+
+### Ground-truth facts (verified against the code — do not "fix" these)
+- `CaptureListQuerySchema` is **already exported** from `packages/security/src/models/pcap.ts` (line ~88) and **already imported** by `packages/security/src/routes/pcap.ts` (line 7). There is **no inline duplicate** to remove.
+- `packages/security/src/services/pcap-store.ts` `getCaptures` uses **`?` placeholders** (a `db()` wrapper translates them), e.g. `conditions.push('status = ?')`. The DB is PostgreSQL (so `ILIKE` is available), but **never** use `$1`/`$n` here.
+- `pcap-service.test.ts` **mocks `pcap-store`**; `pcap-route.test.ts` **mocks `pcap-service`**. Follow that: test plumbing with mocks, not a live DB.
+- `useCaptures` (`frontend/src/features/security/hooks/use-pcap.ts`, lines 46–74) calls `api.get<CapturesResponse>('/api/pcap/captures', { params })` with a `params` **object** (not a query string in the path), and contains a dead first `useQuery` plus a returned second one. Add `search` to the params object(s).
+- The page test (`packet-capture.test.tsx`) mocks `useContainers` with container objects that are **missing** `image`, `status`, `endpointName`, `ports`, `networks` — `filterContainers` reads those, so the mock data must be enriched (Task 7).
 
 ---
 
@@ -22,39 +29,32 @@
 
 Run:
 ```bash
-cd packages/security && npx vitest run src/__tests__/pcap-route.test.ts src/__tests__/pcap-model.test.ts
+cd packages/security && npx vitest run src/__tests__/pcap-route.test.ts src/__tests__/pcap-model.test.ts src/__tests__/pcap-service.test.ts
 cd ../../frontend && npx vitest run src/features/security/pages/packet-capture.test.tsx
 ```
-Expected: PASS (existing suites green). If anything fails before changes, stop and report — do not proceed.
+Expected: PASS. If anything fails before changes, stop and report — do not proceed.
 
 ---
 
 ## Task 1: Add `search` to the captures-list query schema (backend)
 
-The route currently defines `CaptureListQuerySchema` inline (`packages/security/src/routes/pcap.ts`) and a second unexported copy lives in `packages/security/src/models/pcap.ts`. Consolidate: export one schema from the model (with the new `search` field) and import it into the route. This is DRY and makes the schema unit-testable.
-
 **Files:**
-- Modify: `packages/security/src/models/pcap.ts` (export schema + add `search`)
-- Modify: `packages/security/src/routes/pcap.ts` (import it, delete inline copy)
+- Modify: `packages/security/src/models/pcap.ts` (add `search` to the existing exported `CaptureListQuerySchema`)
 - Test: `packages/security/src/__tests__/pcap-model.test.ts`
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `packages/security/src/__tests__/pcap-model.test.ts`:
+Add to `packages/security/src/__tests__/pcap-model.test.ts` (the file already imports from `../models/pcap.js`; reuse that import style):
 ```ts
 import { CaptureListQuerySchema } from '../models/pcap.js';
 
 describe('CaptureListQuerySchema search', () => {
   it('accepts an optional search string', () => {
-    const parsed = CaptureListQuerySchema.parse({ search: 'web' });
-    expect(parsed.search).toBe('web');
+    expect(CaptureListQuerySchema.parse({ search: 'web' }).search).toBe('web');
   });
-
   it('defaults search to undefined when absent', () => {
-    const parsed = CaptureListQuerySchema.parse({});
-    expect(parsed.search).toBeUndefined();
+    expect(CaptureListQuerySchema.parse({}).search).toBeUndefined();
   });
-
   it('rejects an over-long search string', () => {
     expect(() => CaptureListQuerySchema.parse({ search: 'x'.repeat(201) })).toThrow();
   });
@@ -64,11 +64,11 @@ describe('CaptureListQuerySchema search', () => {
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cd packages/security && npx vitest run src/__tests__/pcap-model.test.ts -t "search"`
-Expected: FAIL — `CaptureListQuerySchema` is not exported (import error) / `search` not present.
+Expected: FAIL — `search` is stripped/undefined (and over-long does not throw).
 
-- [ ] **Step 3: Export the schema and add `search` in `models/pcap.ts`**
+- [ ] **Step 3: Add the field**
 
-Replace the existing `const CaptureListQuerySchema = z.object({ ... });` block with:
+In `packages/security/src/models/pcap.ts`, inside the existing `export const CaptureListQuerySchema = z.object({ ... })`, add the `search` line after `containerId`:
 ```ts
 export const CaptureListQuerySchema = z.object({
   status: CaptureStatusSchema.optional(),
@@ -77,28 +77,17 @@ export const CaptureListQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(200).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });
-
-export type CaptureListQuery = z.infer<typeof CaptureListQuerySchema>;
 ```
 
-- [ ] **Step 4: Use the model schema in `routes/pcap.ts`**
-
-In `packages/security/src/routes/pcap.ts`:
-1. Extend the existing import from `'../models/pcap.js'` to include the schema:
-```ts
-import { StartCaptureRequestSchema, CaptureListQuerySchema } from '../models/pcap.js';
-```
-2. Delete the inline `const CaptureListQuerySchema = z.object({ ... });` block near the top of the file. Leave the `GET /api/pcap/captures` handler unchanged — it already does `CaptureListQuerySchema.safeParse(query)` and passes `parsed.data` to `listCaptures`, so `search` flows through automatically.
-
-- [ ] **Step 5: Run tests to verify they pass**
+- [ ] **Step 4: Run test to verify it passes**
 
 Run: `cd packages/security && npx vitest run src/__tests__/pcap-model.test.ts`
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add packages/security/src/models/pcap.ts packages/security/src/routes/pcap.ts packages/security/src/__tests__/pcap-model.test.ts
+git add packages/security/src/models/pcap.ts packages/security/src/__tests__/pcap-model.test.ts
 git commit -m "feat(pcap): add optional search to capture list query schema"
 ```
 
@@ -109,141 +98,103 @@ git commit -m "feat(pcap): add optional search to capture list query schema"
 **Files:**
 - Modify: `packages/security/src/services/pcap-store.ts` (`GetCapturesOptions` + `getCaptures`)
 - Modify: `packages/security/src/services/pcap-service.ts` (`listCaptures` options type)
-- Test: `packages/security/src/__tests__/pcap-store.test.ts` (create if absent; uses real PG via the test-db helper)
+- Test: `packages/security/src/__tests__/pcap-service.test.ts` (mocks the store — assert passthrough)
 
 - [ ] **Step 1: Write the failing test**
 
-In `packages/security/src/__tests__/pcap-store.test.ts` (follow the existing real-PG setup pattern used by other store tests in this package — import the test-db helper, insert rows directly into `pcap_captures`). Add:
+Add to the `describe('listCaptures', ...)` block in `packages/security/src/__tests__/pcap-service.test.ts`:
 ```ts
-import { describe, it, expect, beforeEach } from 'vitest';
-import { query } from '@dashboard/core';
-import { getCaptures } from '../services/pcap-store.js';
-
-async function insertCapture(id: string, name: string, filter: string | null) {
-  await query(
-    `INSERT INTO pcap_captures (id, endpoint_id, container_id, container_name, status, filter, created_at)
-     VALUES ($1, 1, $2, $3, 'complete', $4, NOW())`,
-    [id, `cid-${id}`, name, filter],
-  );
-}
-
-describe('getCaptures search', () => {
-  beforeEach(async () => {
-    await query('DELETE FROM pcap_captures', []);
-    await insertCapture('s1', 'web-frontend', 'port 80');
-    await insertCapture('s2', 'db-postgres', 'port 5432');
-  });
-
-  it('filters by container_name (case-insensitive)', async () => {
-    const rows = await getCaptures({ search: 'WEB' });
-    expect(rows.map((r) => r.id)).toEqual(['s1']);
-  });
-
-  it('also matches the filter text', async () => {
-    const rows = await getCaptures({ search: '5432' });
-    expect(rows.map((r) => r.id)).toEqual(['s2']);
-  });
-
-  it('returns all when no search', async () => {
-    const rows = await getCaptures({});
-    expect(rows.length).toBe(2);
-  });
+it('passes search through to getCaptures', async () => {
+  vi.mocked(store.getCaptures).mockResolvedValue([]);
+  await listCaptures({ search: 'web' });
+  expect(store.getCaptures).toHaveBeenCalledWith({ search: 'web' });
 });
 ```
-> Note: read an existing `*-store`/route test in `packages/security/src/__tests__/` first to copy the exact DB bootstrap (some suites rely on a shared `beforeAll` migration). If a global setup already truncates tables, drop the local `DELETE`.
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd packages/security && npx vitest run src/__tests__/pcap-store.test.ts`
-Expected: FAIL — `search` is ignored, so `getCaptures({ search: 'WEB' })` returns both rows.
+Run: `cd packages/security && npx vitest run src/__tests__/pcap-service.test.ts -t "search"`
+Expected: FAIL — TypeScript error / `listCaptures` rejects `search` (its options type lacks it).
 
-- [ ] **Step 3: Implement the store change**
+- [ ] **Step 3: Add `search` to the service options type**
 
-In `packages/security/src/services/pcap-store.ts`:
-1. Add `search` to the options interface:
+In `packages/security/src/services/pcap-service.ts`, update `listCaptures`:
 ```ts
-export interface GetCapturesOptions {
-  status?: string;
+export async function listCaptures(options?: {
+  status?: CaptureStatus;
   containerId?: string;
   search?: string;
   limit?: number;
   offset?: number;
-}
-```
-2. Inside `getCaptures`, after the `containerId` condition block and before `const whereClause = ...`, add:
-```ts
-  if (options.search) {
-    conditions.push(
-      `(container_name ILIKE $${paramIndex} OR COALESCE(filter, '') ILIKE $${paramIndex})`,
-    );
-    params.push(`%${options.search}%`);
-    paramIndex++;
-  }
-```
-(One placeholder reused for both columns — parameterized, no concatenation of user input.)
-
-- [ ] **Step 4: Thread `search` through the service**
-
-In `packages/security/src/services/pcap-service.ts`, update the `listCaptures` options type to include `search`:
-```ts
-export async function listCaptures(options: {
-  status?: string;
-  containerId?: string;
-  search?: string;
-  limit?: number;
-  offset?: number;
-}) {
+}): Promise<Capture[]> {
   return getCaptures(options);
 }
 ```
 
-- [ ] **Step 5: Run tests to verify they pass**
+- [ ] **Step 4: Add `search` to the store options + SQL (parameterized, `?` placeholders)**
 
-Run: `cd packages/security && npx vitest run src/__tests__/pcap-store.test.ts`
+In `packages/security/src/services/pcap-store.ts`:
+1. Extend the options interface:
+```ts
+export interface GetCapturesOptions {
+  status?: CaptureStatus;
+  containerId?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+```
+2. In `getCaptures`, after the `containerId` condition block (before `const where = ...`), add:
+```ts
+  if (options.search) {
+    conditions.push("(container_name ILIKE ? OR COALESCE(filter, '') ILIKE ?)");
+    params.push(`%${options.search}%`, `%${options.search}%`);
+  }
+```
+(Use `?` placeholders to match the existing style — two `?`, so push the pattern twice. No string concatenation of user input.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd packages/security && npx vitest run src/__tests__/pcap-service.test.ts`
 Expected: PASS.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add packages/security/src/services/pcap-store.ts packages/security/src/services/pcap-service.ts packages/security/src/__tests__/pcap-store.test.ts
+git add packages/security/src/services/pcap-store.ts packages/security/src/services/pcap-service.ts packages/security/src/__tests__/pcap-service.test.ts
 git commit -m "feat(pcap): filter captures by parameterized search (name + filter text)"
 ```
 
 ---
 
-## Task 3: Route-level search test (backend integration)
+## Task 3: Route passes `search` through (backend route test)
+
+The route test mocks `pcap-service`. Verify the Zod schema accepts `?search=` and the parsed value reaches `listCaptures`.
 
 **Files:**
 - Test: `packages/security/src/__tests__/pcap-route.test.ts`
 
-- [ ] **Step 1: Read the existing route test setup**
+- [ ] **Step 1: Write the failing test**
 
-Read `packages/security/src/__tests__/pcap-route.test.ts` to reuse its app bootstrap, admin-auth decoration, and DB seeding helpers.
-
-- [ ] **Step 2: Write the failing test**
-
-Add an `it()` mirroring the existing setup (build the Fastify app, authenticate as admin, seed two captures with distinct `container_name`s):
+Add an `it()` mirroring the existing `'lists captures'` test (which uses the file's `buildApp()` helper and `vi.mocked(pcapService.listCaptures)`):
 ```ts
-it('GET /api/pcap/captures?search= filters by container name', async () => {
-  // seed two captures: container_name 'web-1' and 'db-1' (reuse this file's seed helper)
-  const res = await app.inject({
-    method: 'GET',
-    url: '/api/pcap/captures?search=web',
-    headers: { authorization: `Bearer ${adminToken}` }, // reuse this file's token helper
-  });
+it('passes search from the query string to listCaptures', async () => {
+  vi.mocked(pcapService.listCaptures).mockResolvedValue([]);
+  const app = await buildApp('admin');
+  const res = await app.inject({ method: 'GET', url: '/api/pcap/captures?search=web' });
   expect(res.statusCode).toBe(200);
-  const body = res.json();
-  expect(body.captures.map((c: { container_name: string }) => c.container_name)).toEqual(['web-1']);
+  expect(pcapService.listCaptures).toHaveBeenCalledWith(expect.objectContaining({ search: 'web' }));
+  await app.close();
 });
 ```
-> Match the variable names (`app`, `adminToken`, seed helper) to whatever the existing tests in this file use.
+> Match the exact app-build/inject idiom used by the existing tests in this file (e.g. whether they `await buildApp()` per test or share one). Keep `expect.objectContaining({ search: 'web' })`.
 
-- [ ] **Step 3: Run test to verify it fails, then passes**
+- [ ] **Step 2: Run the test**
 
 Run: `cd packages/security && npx vitest run src/__tests__/pcap-route.test.ts -t "search"`
-Expected: with Tasks 1–2 already merged this should PASS immediately (plumbing is done). If it FAILS, the failure pinpoints a plumbing gap to fix. The test's value is regression protection for the end-to-end path + admin gate.
+Expected: with Tasks 1–2 merged this should PASS (schema + plumbing already done). If it FAILS, the message pinpoints a gap. Value = regression cover for the end-to-end query path + admin gate.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
 git add packages/security/src/__tests__/pcap-route.test.ts
@@ -256,52 +207,45 @@ git commit -m "test(pcap): cover captures list search at the route level"
 
 **Files:**
 - Modify: `frontend/src/features/security/hooks/use-pcap.ts`
-- Test: `frontend/src/features/security/hooks/use-pcap.test.ts`
+- Test: `frontend/src/features/security/hooks/use-pcap.test.ts` (create if absent, following the repo's hook-test pattern: `renderHook` + a `QueryClientProvider` wrapper + `api` spied/mocked)
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `frontend/src/features/security/hooks/use-pcap.test.ts` (follow the file's existing render/mock-fetch pattern; it already mocks `api`). The intent: when `search` is provided, the request URL includes `search=`.
+Open `use-pcap.test.ts` and add (matching the file's existing `api` mock + `wrapper`):
 ```ts
-it('useCaptures includes search in the request path', async () => {
+it('useCaptures forwards search in the request params', async () => {
   const getSpy = vi.spyOn(api, 'get').mockResolvedValue({ captures: [] });
   renderHook(() => useCaptures({ search: 'web' }), { wrapper });
   await waitFor(() => expect(getSpy).toHaveBeenCalled());
-  expect(getSpy).toHaveBeenCalledWith('/api/pcap/captures?search=web');
+  expect(getSpy).toHaveBeenCalledWith(
+    '/api/pcap/captures',
+    { params: expect.objectContaining({ search: 'web' }) },
+  );
 });
 ```
-> Use the same `wrapper` (QueryClientProvider) and `api` import the existing tests use.
+> If the file does not exist, create it with the same provider wrapper used by other hook tests under `frontend/src/features/**/hooks/*.test.ts`. The key assertion is the `{ params: { search } }` shape — `useCaptures` calls `api.get(path, { params })`, NOT a query string.
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cd frontend && npx vitest run src/features/security/hooks/use-pcap.test.ts -t "search"`
-Expected: FAIL — `search` not added to params.
+Expected: FAIL — `search` absent from params.
 
 - [ ] **Step 3: Implement**
 
-In `frontend/src/features/security/hooks/use-pcap.ts`, update the options interface and `useCaptures`:
+In `frontend/src/features/security/hooks/use-pcap.ts`:
+1. Widen the `useCaptures` parameter type:
 ```ts
-interface UseCapturesOptions {
-  status?: string;
-  containerId?: string;
-  search?: string;
-}
-
-export function useCaptures(options?: UseCapturesOptions) {
-  const params = new URLSearchParams();
-  if (options?.status) params.set('status', options.status);
-  if (options?.containerId) params.set('containerId', options.containerId);
-  if (options?.search) params.set('search', options.search);
-
-  const qs = params.toString();
-  const path = qs ? `/api/pcap/captures?${qs}` : '/api/pcap/captures';
-
-  return useQuery<CapturesResponse>({
-    queryKey: ['pcap', 'captures', options?.status, options?.containerId, options?.search],
-    queryFn: () => api.get<CapturesResponse>(path),
-    refetchInterval: 5000,
-  });
-}
+export function useCaptures(filters?: { status?: string; containerId?: string; search?: string }) {
 ```
+2. Add `search: filters?.search` to **both** `params` objects (the dead first `useQuery` at ~line 50 and the returned one at ~line 66):
+```ts
+      const params: Record<string, string | undefined> = {
+        status: filters?.status,
+        containerId: filters?.containerId,
+        search: filters?.search,
+      };
+```
+The `queryKey` is already `['pcap', 'captures', filters]`, so `search` is included automatically. Leave `refetchInterval` logic unchanged.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -336,21 +280,18 @@ describe('BpfFilterInput', () => {
     render(<BpfFilterInput value="port 80" onChange={() => {}} />);
     expect(screen.getByLabelText('BPF filter')).toHaveValue('port 80');
   });
-
   it('sets the value to the preset when empty', () => {
     const onChange = vi.fn();
     render(<BpfFilterInput value="" onChange={onChange} />);
     fireEvent.click(screen.getByRole('button', { name: 'tcp' }));
     expect(onChange).toHaveBeenCalledWith('tcp');
   });
-
   it('appends the preset to an existing value', () => {
     const onChange = vi.fn();
     render(<BpfFilterInput value="port 80" onChange={onChange} />);
     fireEvent.click(screen.getByRole('button', { name: 'udp' }));
     expect(onChange).toHaveBeenCalledWith('port 80 udp');
   });
-
   it('edits via free text', () => {
     const onChange = vi.fn();
     render(<BpfFilterInput value="" onChange={onChange} />);
@@ -445,7 +386,7 @@ git commit -m "feat(pcap): BpfFilterInput with quick presets"
 Create `frontend/src/features/security/components/capture-target-picker.test.tsx`:
 ```tsx
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { CaptureTargetPicker, type CaptureTarget } from './capture-target-picker';
 import type { Container } from '@/features/containers/hooks/use-containers';
 import type { Stack } from '@/features/containers/hooks/use-stacks';
@@ -455,7 +396,6 @@ const containers = [
   { id: 'c2', name: 'nginx-stage', image: 'nginx', state: 'running', status: 'Up', endpointId: 2, endpointName: 'staging', ports: [], created: 0, labels: {}, networks: [] },
   { id: 'c3', name: 'postgres', image: 'postgres', state: 'running', status: 'Up', endpointId: 2, endpointName: 'staging', ports: [], created: 0, labels: {}, networks: [] },
 ] as unknown as Container[];
-
 const stacks = [{ id: 1, name: 'web', endpointId: 1 }] as unknown as Stack[];
 
 function setup(props: Partial<React.ComponentProps<typeof CaptureTargetPicker>> = {}) {
@@ -486,7 +426,7 @@ describe('CaptureTargetPicker', () => {
     expect(screen.queryByText('postgres')).not.toBeInTheDocument();
   });
 
-  it('selecting a container emits a CaptureTarget and shows a chip', () => {
+  it('selecting a container emits a CaptureTarget', () => {
     const { onChange } = setup();
     const input = screen.getByLabelText('Search capture target container');
     fireEvent.focus(input);
@@ -494,10 +434,7 @@ describe('CaptureTargetPicker', () => {
     fireEvent.click(screen.getByText('postgres'));
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining<Partial<CaptureTarget>>({
-        endpointId: 2,
-        containerId: 'c3',
-        containerName: 'postgres',
-        endpointName: 'staging',
+        endpointId: 2, containerId: 'c3', containerName: 'postgres', endpointName: 'staging',
       }),
     );
   });
@@ -565,12 +502,7 @@ export interface CaptureTargetPickerProps {
 }
 
 export function CaptureTargetPicker({
-  containers,
-  stacks,
-  edgeAsyncEndpointIds,
-  value,
-  onChange,
-  autoFocus,
+  containers, stacks, edgeAsyncEndpointIds, value, onChange, autoFocus,
 }: CaptureTargetPickerProps) {
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
@@ -581,7 +513,6 @@ export function CaptureTargetPicker({
     () => filterContainers(containers, query, knownStackNames),
     [containers, query, knownStackNames],
   );
-
   const grouped = useMemo(() => {
     const map = new Map<string, Container[]>();
     for (const c of matches) {
@@ -591,16 +522,13 @@ export function CaptureTargetPicker({
     }
     return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]));
   }, [matches]);
-
   const matchingStacks = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q || q.includes(':')) return [];
     return [...new Set(knownStackNames)].filter((n) => n.toLowerCase().includes(q)).slice(0, 4);
   }, [knownStackNames, query]);
 
-  useEffect(() => {
-    if (autoFocus) inputRef.current?.focus();
-  }, [autoFocus]);
+  useEffect(() => { if (autoFocus) inputRef.current?.focus(); }, [autoFocus]);
 
   if (value) {
     return (
@@ -703,12 +631,12 @@ export function CaptureTargetPicker({
   );
 }
 ```
-> cmdk sets `data-disabled` on disabled items (used by the edge-async test). `shouldFilter={false}` means cmdk shows exactly the items we render — our own `filterContainers` does the filtering.
+> cmdk sets `data-disabled` on disabled items (the edge-async test relies on it). `shouldFilter={false}` makes cmdk render exactly the items we pass — our `filterContainers` does the filtering.
 
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cd frontend && npx vitest run src/features/security/components/capture-target-picker.test.tsx`
-Expected: PASS. If cmdk's `onValueChange` doesn't fire under `fireEvent.change` in jsdom, switch the test to `@testing-library/user-event` `await userEvent.type(input, 'nginx')` (already a dependency in this repo's frontend tests).
+Expected: PASS. If cmdk's `onValueChange` doesn't fire under `fireEvent.change` in jsdom, switch the typing lines to `@testing-library/user-event`: `const user = userEvent.setup(); await user.type(input, 'nginx');`.
 
 - [ ] **Step 5: Commit**
 
@@ -723,28 +651,37 @@ git commit -m "feat(pcap): cross-endpoint CaptureTargetPicker (cmdk + filterCont
 
 **Files:**
 - Modify: `frontend/src/features/security/pages/packet-capture.tsx`
-- Test: `frontend/src/features/security/pages/packet-capture.test.tsx`
+- Modify: `frontend/src/features/security/pages/packet-capture.test.tsx`
 
 - [ ] **Step 1: Update the page test for the new flow**
 
 In `frontend/src/features/security/pages/packet-capture.test.tsx`:
-1. Update `mockContainers` to include containers on two endpoints (e.g. add one with `endpointId: 2, endpointName: 'edge-async-host'`). Keep `mockEndpoints` as-is (endpoint 2 has `edgeMode: 'async'`).
-2. Replace any assertions that rely on selecting an endpoint dropdown first. Add:
+
+1. **Enrich the `useContainers` mock** so `filterContainers` works (it reads `image`, `status`, `endpointName`, `ports`, `state`, `labels`, `name`). Replace the mocked container array with objects that include every field, spanning two endpoints, e.g.:
+```ts
+{ id: 'c1', name: 'api-1', image: 'api:1', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'alpha' } },
+{ id: 'c2', name: 'worker-1', image: 'worker:1', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'alpha' } },
+{ id: 'c4', name: 'beta-api-1', image: 'beta:1', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'beta' } },
+{ id: 'c3', name: 'standalone-1', image: 'std:1', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: {} },
+```
+
+2. **Remove the two cascade-based tests** — `'groups running container options by stack and no-stack bucket'` and `'filters container options by selected stack'`. Their coverage moves to `capture-browse-fallback.test.tsx` (Task 9). Keep `'shows the empty state when there are no captures'` and `'renders the capture history in a DataTable...'`.
+
+3. **Add new tests:**
 ```ts
 it('shows capture targets without selecting an endpoint first', () => {
-  renderPage(); // the file's existing render helper
+  render(<PacketCapture />);
   const input = screen.getByLabelText('Search capture target container');
   fireEvent.focus(input);
-  fireEvent.change(input, { target: { value: 'web-1' } });
-  expect(screen.getByText('web-1')).toBeInTheDocument();
+  fireEvent.change(input, { target: { value: 'api-1' } });
+  expect(screen.getByText('api-1')).toBeInTheDocument();
 });
 
 it('disables Start until a target is selected', () => {
-  renderPage();
+  render(<PacketCapture />);
   expect(screen.getByRole('button', { name: /start capture/i })).toBeDisabled();
 });
 ```
-3. Ensure the `useContainers` mock still returns `{ data: mockContainers }` (the page will now call it with `{ state: 'running' }` — the mock ignores args, so it still returns the list).
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -761,17 +698,17 @@ import { CaptureTargetPicker, type CaptureTarget } from '@/features/security/com
 import { BpfFilterInput } from '@/features/security/components/bpf-filter-input';
 ```
 
-2. Replace the four target-selection state vars (`selectedEndpoint`, `selectedStack`, `selectedContainer`, `selectedContainerName`) with:
+2. Replace the four target-selection state vars (`selectedEndpoint`, `selectedStack`, `selectedContainer`, `selectedContainerName`) with one:
 ```tsx
 const [target, setTarget] = useState<CaptureTarget | null>(null);
 ```
 
-3. Change the containers query to fetch running containers across all endpoints:
+3. Fetch running containers across all endpoints:
 ```tsx
 const { data: containers } = useContainers({ state: 'running' });
 ```
 
-4. Derive edge-async endpoints and remove the old per-endpoint capability usage:
+4. Replace the per-endpoint capability/grouping derivations with:
 ```tsx
 const edgeAsyncEndpointIds = useMemo(
   () => new Set((endpoints ?? []).filter((e) => e.edgeMode === 'async').map((e) => e.id)),
@@ -781,10 +718,13 @@ const endpointNameById = useMemo(
   () => new Map((endpoints ?? []).map((e) => [e.id, e.name])),
   [endpoints],
 );
-const runningContainers = useMemo(() => (containers ?? []).filter((c) => c.state === 'running'), [containers]);
+const runningContainers = useMemo(
+  () => (containers ?? []).filter((c) => c.state === 'running'),
+  [containers],
+);
 const targetIsEdgeAsync = target ? edgeAsyncEndpointIds.has(target.endpointId) : false;
 ```
-Delete the now-unused `useEndpointCapabilities` call, `stackNamesForEndpoint`, `stackOptions`, `filteredRunningContainers`, `groupedContainerOptions`, `handleContainerChange`, and the `isEdgeAsync` page-level variable. Keep `useStacks()` (passed to the picker).
+Delete the now-dead code: the `useEndpointCapabilities(selectedEndpoint)` call and `isEdgeAsync`, `stackNamesForEndpoint`, `stackOptions`, `filteredRunningContainers`, `groupedContainerOptions`, `handleContainerChange`, and the old `runningContainers` line. Keep `useStacks()`.
 
 5. Update `handleStartCapture`:
 ```tsx
@@ -801,7 +741,7 @@ const handleStartCapture = () => {
 };
 ```
 
-6. Replace the New Capture form body (the Endpoint / Stack / Container `ThemedSelect` blocks and the inline BPF `<input>`) with the picker, the BPF input, and contextual edge-async warning. The grid keeps Duration / Max Packets / Start as-is:
+6. In the New Capture form, **replace** the three `ThemedSelect` blocks (Endpoint / Stack / Container) and the inline BPF `<input>` with the target picker, the BPF component, and a contextual edge-async note. Keep Duration / Max Packets / Start in the grid; update the Start `disabled`:
 ```tsx
 <div className="mb-4">
   <label className="mb-1 block text-sm font-medium">Target container</label>
@@ -823,7 +763,6 @@ const handleStartCapture = () => {
   <BpfFilterInput value={bpfFilter} onChange={setBpfFilter} />
   {/* keep the existing Duration block */}
   {/* keep the existing Max Packets block */}
-  {/* Start button (updated disabled condition) */}
   <div className="flex items-end">
     <button
       onClick={handleStartCapture}
@@ -836,7 +775,7 @@ const handleStartCapture = () => {
   </div>
 </div>
 ```
-Remove the old top-level `{isEdgeAsync && (...)}` warning banner block (now handled contextually). Remove the now-unused imports (`ThemedSelect`, `buildStackGroupedContainerOptions`, `NO_STACK_LABEL`, `resolveContainerStackName`, `useEndpointCapabilities`) — let the typecheck in Task 11 catch any stragglers.
+7. Remove the old top-level `{isEdgeAsync && (...)}` warning banner block (now contextual). Remove now-unused imports (`ThemedSelect`, `buildStackGroupedContainerOptions`, `NO_STACK_LABEL`, `resolveContainerStackName`, `useEndpointCapabilities`); the Task 11 typecheck will flag any stragglers.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -856,37 +795,41 @@ git commit -m "feat(pcap): search-first cross-endpoint target picker on the capt
 
 **Files:**
 - Modify: `frontend/src/features/security/pages/packet-capture.tsx`
-- Test: `frontend/src/features/security/pages/packet-capture.test.tsx`
+- Modify: `frontend/src/features/security/pages/packet-capture.test.tsx`
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `packet-capture.test.tsx`:
+Add to `packet-capture.test.tsx` (import `useCaptures` is already mocked at top via `vi.mock('@/features/security/hooks/use-pcap', ...)`; `mockUseCaptures = vi.mocked(useCaptures)` already exists):
 ```ts
 it('passes the history search term to useCaptures', async () => {
-  renderPage();
-  const search = screen.getByLabelText('Search capture history');
-  fireEvent.change(search, { target: { value: 'web' } });
+  render(<PacketCapture />);
+  fireEvent.change(screen.getByLabelText('Search capture history'), { target: { value: 'web' } });
   await waitFor(() =>
-    expect(vi.mocked(useCaptures)).toHaveBeenCalledWith(expect.objectContaining({ search: 'web' })),
+    expect(mockUseCaptures).toHaveBeenCalledWith(expect.objectContaining({ search: 'web' })),
   );
 });
 
 it('shows the endpoint name in the history table', () => {
-  renderPage();
+  mockUseCaptures.mockReturnValue({
+    data: { captures: [makeCapture({ endpoint_id: 1, container_name: 'web-1' })] },
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useCaptures>);
+  render(<PacketCapture />);
   expect(screen.getByText('local')).toBeInTheDocument(); // endpoint_id 1 -> 'local'
 });
 ```
+> `waitFor` is imported from `@testing-library/react`; add it to the existing import if not present.
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cd frontend && npx vitest run src/features/security/pages/packet-capture.test.tsx -t "history search"`
-Expected: FAIL — no history search input / endpoint column.
+Expected: FAIL — no search input / endpoint column.
 
 - [ ] **Step 3: Implement**
 
 In `packet-capture.tsx`:
 
-1. Add debounced history-search state:
+1. Add debounced history-search state (ensure `useEffect` is imported):
 ```tsx
 const [historySearch, setHistorySearch] = useState('');
 const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -904,7 +847,7 @@ const { data: capturesData, refetch, isFetching } = useCaptures({
 });
 ```
 
-3. Add the search input next to the status tabs (in the "Capture History" header row, before the tabs):
+3. Add the search input in the "Capture History" header row, before the status-tabs block:
 ```tsx
 <input
   type="text"
@@ -916,7 +859,7 @@ const { data: capturesData, refetch, isFetching } = useCaptures({
 />
 ```
 
-4. Add an Endpoint column to the `columns` definition (insert after the `container_name` column). Include `endpointNameById` in the `useMemo` dependency array:
+4. Add an Endpoint column to the `columns` `useMemo` (insert right after the `container_name` column object) and add `endpointNameById` to that `useMemo`'s dependency array:
 ```tsx
 {
   accessorKey: 'endpoint_id',
@@ -945,7 +888,7 @@ git commit -m "feat(pcap): search capture history + show endpoint column"
 
 ## Task 9: Collapsible "Browse by endpoint" fallback
 
-Keeps the familiar Endpoint → Stack → Container dropdowns as an optional path, sourced from the same cross-endpoint `runningContainers` list and producing the same `CaptureTarget`.
+Keeps the familiar Endpoint → Stack → Container dropdowns as an optional path, sourced from the same cross-endpoint `runningContainers` list and producing the same `CaptureTarget`. This is also where the old stack-grouping assertions live now.
 
 **Files:**
 - Create: `frontend/src/features/security/components/capture-browse-fallback.tsx`
@@ -954,7 +897,7 @@ Keeps the familiar Endpoint → Stack → Container dropdowns as an optional pat
 
 - [ ] **Step 1: Write the failing test**
 
-Create `frontend/src/features/security/components/capture-browse-fallback.test.tsx`:
+First read `frontend/src/shared/components/ui/themed-select.tsx` to confirm the option/group shape and how a `ThemedSelect` renders options (Radix `combobox` role + `option` role, as the old page test used). Then create `frontend/src/features/security/components/capture-browse-fallback.test.tsx`:
 ```tsx
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -963,29 +906,44 @@ import type { Container } from '@/features/containers/hooks/use-containers';
 import type { Stack } from '@/features/containers/hooks/use-stacks';
 
 const containers = [
-  { id: 'c1', name: 'web-1', image: 'nginx', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, labels: {}, networks: [] },
+  { id: 'c1', name: 'api-1', image: 'a', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'alpha' } },
+  { id: 'c4', name: 'beta-api-1', image: 'b', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'beta' } },
+  { id: 'c3', name: 'standalone-1', image: 's', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: {} },
 ] as unknown as Container[];
-const endpoints = [{ id: 1, name: 'local' }] as { id: number; name: string }[];
+const stacks = [{ id: 1, name: 'alpha', endpointId: 1 }, { id: 2, name: 'beta', endpointId: 1 }] as unknown as Stack[];
+const endpoints = [{ id: 1, name: 'local' }];
 
-it('selecting endpoint then container emits a CaptureTarget', () => {
-  const onChange = vi.fn();
-  render(
-    <CaptureBrowseFallback
-      containers={containers}
-      stacks={[] as Stack[]}
-      endpoints={endpoints}
-      edgeAsyncEndpointIds={new Set()}
-      onChange={onChange}
-    />,
-  );
-  // Open the disclosure
+function open() {
   fireEvent.click(screen.getByText(/browse by endpoint/i));
-  // (Drive the ThemedSelects per their test-friendly API; assert onChange receives endpointId 1 + containerId 'c1'.)
-  // This asserts the wiring contract:
-  expect(typeof onChange).toBe('function');
+}
+
+describe('CaptureBrowseFallback', () => {
+  it('groups containers by stack once an endpoint is chosen', () => {
+    render(<CaptureBrowseFallback containers={containers} stacks={stacks} endpoints={endpoints} edgeAsyncEndpointIds={new Set()} onChange={() => {}} />);
+    open();
+    fireEvent.click(screen.getAllByRole('combobox')[0]); // endpoint
+    fireEvent.click(screen.getByRole('option', { name: 'local' }));
+    fireEvent.click(screen.getAllByRole('combobox')[2]); // container
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.getByText('No Stack')).toBeInTheDocument();
+  }, 20000);
+
+  it('emits a CaptureTarget when a container is chosen', () => {
+    const onChange = vi.fn();
+    render(<CaptureBrowseFallback containers={containers} stacks={stacks} endpoints={endpoints} edgeAsyncEndpointIds={new Set()} onChange={onChange} />);
+    open();
+    fireEvent.click(screen.getAllByRole('combobox')[0]);
+    fireEvent.click(screen.getByRole('option', { name: 'local' }));
+    fireEvent.click(screen.getAllByRole('combobox')[2]);
+    fireEvent.click(screen.getByRole('option', { name: 'api-1' }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ endpointId: 1, containerId: 'c1', containerName: 'api-1', endpointName: 'local' }),
+    );
+  }, 20000);
 });
 ```
-> The exact ThemedSelect interaction depends on its implementation; read `frontend/src/shared/components/ui/themed-select.tsx` and assert selection drives `onChange` with `{ endpointId: 1, containerId: 'c1', containerName: 'web-1', endpointName: 'local', stackName }`. Keep at least one assertion that a full endpoint→container selection calls `onChange` with the right target.
+> If `ThemedSelect`'s interaction differs from Radix `combobox`/`option` roles, adapt the queries to its actual API (the old page test used `getAllByRole('combobox')` + `getByRole('option', { name })`, so this should hold).
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -1016,11 +974,7 @@ export interface CaptureBrowseFallbackProps {
 }
 
 export function CaptureBrowseFallback({
-  containers,
-  stacks,
-  endpoints,
-  edgeAsyncEndpointIds,
-  onChange,
+  containers, stacks, endpoints, edgeAsyncEndpointIds, onChange,
 }: CaptureBrowseFallbackProps) {
   const [endpointId, setEndpointId] = useState<number | undefined>();
   const [stackName, setStackName] = useState<string | undefined>();
@@ -1041,12 +995,9 @@ export function CaptureBrowseFallback({
     return [...set].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base', numeric: true }));
   }, [endpointContainers, knownStackNames]);
   const filtered = useMemo(
-    () =>
-      stackName
-        ? endpointContainers.filter(
-            (c) => (resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL) === stackName,
-          )
-        : endpointContainers,
+    () => (stackName
+      ? endpointContainers.filter((c) => (resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL) === stackName)
+      : endpointContainers),
     [endpointContainers, stackName, knownStackNames],
   );
   const containerOptions = useMemo(
@@ -1074,15 +1025,9 @@ export function CaptureBrowseFallback({
       <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
         <ThemedSelect
           value={endpointId != null ? String(endpointId) : '__all__'}
-          onValueChange={(v) => {
-            setEndpointId(v === '__all__' ? undefined : Number(v));
-            setStackName(undefined);
-          }}
+          onValueChange={(v) => { setEndpointId(v === '__all__' ? undefined : Number(v)); setStackName(undefined); }}
           placeholder="Select endpoint..."
-          options={[
-            { value: '__all__', label: 'Select endpoint...' },
-            ...endpoints.map((e) => ({ value: String(e.id), label: e.name })),
-          ]}
+          options={[{ value: '__all__', label: 'Select endpoint...' }, ...endpoints.map((e) => ({ value: String(e.id), label: e.name }))]}
           className="w-full text-sm"
         />
         <ThemedSelect
@@ -1090,10 +1035,7 @@ export function CaptureBrowseFallback({
           onValueChange={(v) => setStackName(v === '__all__' ? undefined : v)}
           disabled={endpointId == null}
           placeholder="All stacks"
-          options={[
-            { value: '__all__', label: 'All stacks' },
-            ...stackOptions.map((s) => ({ value: s, label: s })),
-          ]}
+          options={[{ value: '__all__', label: 'All stacks' }, ...stackOptions.map((s) => ({ value: s, label: s }))]}
           className="w-full text-sm"
         />
         <ThemedSelect
@@ -1112,7 +1054,7 @@ export function CaptureBrowseFallback({
 
 - [ ] **Step 4: Mount it in the page under the picker**
 
-In `packet-capture.tsx`, import and render below the `CaptureTargetPicker` block:
+In `packet-capture.tsx`, import and render directly below the `CaptureTargetPicker` block (inside the same `<div className="mb-4">` or just after it):
 ```tsx
 import { CaptureBrowseFallback } from '@/features/security/components/capture-browse-fallback';
 // ...
@@ -1146,7 +1088,7 @@ git commit -m "feat(pcap): collapsible browse-by-endpoint fallback picker"
 
 - [ ] **Step 1: Document the change**
 
-Add a short note under the relevant section of `docs/architecture.md` (packet capture / security): the capture target picker now searches running containers across all endpoints (no endpoint pre-selection) via the shared `filterContainers` parser and `cmdk`; the captures list API accepts an optional `search` param (parameterized match on `container_name`/`filter`). No new env vars. If there is a packet-capture note in the repo root `CLAUDE.md`, add one sentence describing cross-endpoint search; otherwise skip.
+Add a short note under the packet-capture / security section of `docs/architecture.md`: the capture target picker now searches running containers across all endpoints (no endpoint pre-selection) via the shared `filterContainers` parser and `cmdk`, with a collapsible browse-by-endpoint fallback; the captures list API accepts an optional `search` param (parameterized match on `container_name`/`filter`). No new env vars.
 
 - [ ] **Step 2: Commit**
 
@@ -1168,24 +1110,23 @@ Run:
 npm run typecheck
 npm run lint
 ```
-Expected: no errors. Fix any unused-import / type errors surfaced by the page refactor (e.g. removed `ThemedSelect`/`useEndpointCapabilities` imports) before continuing.
+Expected: no errors. Fix unused-import / type errors from the page refactor (removed `ThemedSelect`/`useEndpointCapabilities`/grouping imports) before continuing.
 
-- [ ] **Step 2: Run the affected test suites**
+- [ ] **Step 2: Run the affected suites**
 
 Run:
 ```bash
-cd packages/security && npx vitest run src/__tests__/pcap-model.test.ts src/__tests__/pcap-store.test.ts src/__tests__/pcap-route.test.ts
+cd packages/security && npx vitest run src/__tests__/pcap-model.test.ts src/__tests__/pcap-service.test.ts src/__tests__/pcap-route.test.ts
 cd ../../frontend && npx vitest run src/features/security
 ```
 Expected: all PASS.
 
-- [ ] **Step 3: Final review commit (if anything was fixed)**
+- [ ] **Step 3: Final fixups commit (only if something changed)**
 
 ```bash
 git add -A
 git commit -m "chore(pcap): typecheck/lint fixups for filter overhaul"
 ```
-(Skip if nothing changed.)
 
 ---
 
@@ -1194,12 +1135,13 @@ git commit -m "chore(pcap): typecheck/lint fixups for filter overhaul"
 - **Type container name directly** → Task 6 (`filterContainers` free-text), Task 7 (page wiring).
 - **Search stacks + containers without selecting an endpoint** → Task 6 (cross-endpoint list + `stack:` quick-filters), Task 7 (`useContainers({ state: 'running' })`, no endpoint gate).
 - **Dropdowns as fallback** → Task 9.
-- **History search** → Tasks 1–4 (backend + hook), Task 8 (UI + endpoint column).
+- **History search** → Tasks 1–4 (schema/store/service/route/hook), Task 8 (UI + endpoint column).
 - **BPF presets** → Task 5 + Task 7 wiring.
 - **Chip with endpoint/stack context** → Task 6 (selected-state chip).
-- **Edge-async safety** → Task 6 (disabled items) + Task 7 (contextual warning + Start gating).
+- **Edge-async safety** → Task 6 (disabled items) + Task 7 (contextual warning + Start gating) + Task 9 (fallback guards).
 - **Parameterized SQL / Zod boundary** → Tasks 1–2.
 - **Tests for every change** → each task is TDD.
 - **Docs** → Task 10.
 
-Type consistency: `CaptureTarget` is defined once in Task 6 and imported by Tasks 7 & 9; `GetCapturesOptions.search`, `listCaptures({search})`, `CaptureListQuerySchema.search`, and `useCaptures({search})` all use the same `search` name.
+Type consistency: `CaptureTarget` is defined once in Task 6 and imported by Tasks 7 & 9; `GetCapturesOptions.search`, `listCaptures({search})`, `CaptureListQuerySchema.search`, and `useCaptures({search})` all use the same `search` name and shapes verified against the current code.
+```

--- a/docs/superpowers/plans/2026-05-30-packet-capture-filter-overhaul.md
+++ b/docs/superpowers/plans/2026-05-30-packet-capture-filter-overhaul.md
@@ -1,0 +1,1205 @@
+# Packet Capture Filter Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Packet Capture page's forced Endpoint → Stack → Container cascade with a search-first, cross-endpoint container picker (type a name, or `stack:`/`endpoint:`), add capture-history search, and add BPF filter presets.
+
+**Architecture:** Reuse the existing `filterContainers()` parser and `cmdk` to build a small `CaptureTargetPicker` that filters the full cross-endpoint running-container list client-side, grouped by endpoint, with edge-async endpoints disabled. Extract `BpfFilterInput` for the presets. Add an optional `search` param to the captures list API (parameterized SQL). The 667-line page becomes an orchestrator composing these focused, independently tested components.
+
+**Tech Stack:** React 19 + TypeScript, `cmdk`, TanStack Query, Tailwind, Vitest + Testing Library (frontend, jsdom); Fastify 5 + Zod + PostgreSQL, Vitest + real PG (backend).
+
+**Spec:** `docs/superpowers/specs/2026-05-30-packet-capture-filter-overhaul-design.md`
+
+**Working directory:** worktree `.claude/worktrees/feature+packet-capture-filter-overhaul` on branch `worktree-feature+packet-capture-filter-overhaul`. Run all commands from the worktree root.
+
+---
+
+## Task 0: Verify clean baseline
+
+**Files:** none
+
+- [ ] **Step 1: Run the existing security + packet-capture tests to confirm green start**
+
+Run:
+```bash
+cd packages/security && npx vitest run src/__tests__/pcap-route.test.ts src/__tests__/pcap-model.test.ts
+cd ../../frontend && npx vitest run src/features/security/pages/packet-capture.test.tsx
+```
+Expected: PASS (existing suites green). If anything fails before changes, stop and report — do not proceed.
+
+---
+
+## Task 1: Add `search` to the captures-list query schema (backend)
+
+The route currently defines `CaptureListQuerySchema` inline (`packages/security/src/routes/pcap.ts`) and a second unexported copy lives in `packages/security/src/models/pcap.ts`. Consolidate: export one schema from the model (with the new `search` field) and import it into the route. This is DRY and makes the schema unit-testable.
+
+**Files:**
+- Modify: `packages/security/src/models/pcap.ts` (export schema + add `search`)
+- Modify: `packages/security/src/routes/pcap.ts` (import it, delete inline copy)
+- Test: `packages/security/src/__tests__/pcap-model.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/security/src/__tests__/pcap-model.test.ts`:
+```ts
+import { CaptureListQuerySchema } from '../models/pcap.js';
+
+describe('CaptureListQuerySchema search', () => {
+  it('accepts an optional search string', () => {
+    const parsed = CaptureListQuerySchema.parse({ search: 'web' });
+    expect(parsed.search).toBe('web');
+  });
+
+  it('defaults search to undefined when absent', () => {
+    const parsed = CaptureListQuerySchema.parse({});
+    expect(parsed.search).toBeUndefined();
+  });
+
+  it('rejects an over-long search string', () => {
+    expect(() => CaptureListQuerySchema.parse({ search: 'x'.repeat(201) })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/security && npx vitest run src/__tests__/pcap-model.test.ts -t "search"`
+Expected: FAIL — `CaptureListQuerySchema` is not exported (import error) / `search` not present.
+
+- [ ] **Step 3: Export the schema and add `search` in `models/pcap.ts`**
+
+Replace the existing `const CaptureListQuerySchema = z.object({ ... });` block with:
+```ts
+export const CaptureListQuerySchema = z.object({
+  status: CaptureStatusSchema.optional(),
+  containerId: z.string().optional(),
+  search: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type CaptureListQuery = z.infer<typeof CaptureListQuerySchema>;
+```
+
+- [ ] **Step 4: Use the model schema in `routes/pcap.ts`**
+
+In `packages/security/src/routes/pcap.ts`:
+1. Extend the existing import from `'../models/pcap.js'` to include the schema:
+```ts
+import { StartCaptureRequestSchema, CaptureListQuerySchema } from '../models/pcap.js';
+```
+2. Delete the inline `const CaptureListQuerySchema = z.object({ ... });` block near the top of the file. Leave the `GET /api/pcap/captures` handler unchanged — it already does `CaptureListQuerySchema.safeParse(query)` and passes `parsed.data` to `listCaptures`, so `search` flows through automatically.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/security && npx vitest run src/__tests__/pcap-model.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/security/src/models/pcap.ts packages/security/src/routes/pcap.ts packages/security/src/__tests__/pcap-model.test.ts
+git commit -m "feat(pcap): add optional search to capture list query schema"
+```
+
+---
+
+## Task 2: Apply `search` as a parameterized SQL filter (backend store + service)
+
+**Files:**
+- Modify: `packages/security/src/services/pcap-store.ts` (`GetCapturesOptions` + `getCaptures`)
+- Modify: `packages/security/src/services/pcap-service.ts` (`listCaptures` options type)
+- Test: `packages/security/src/__tests__/pcap-store.test.ts` (create if absent; uses real PG via the test-db helper)
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/security/src/__tests__/pcap-store.test.ts` (follow the existing real-PG setup pattern used by other store tests in this package — import the test-db helper, insert rows directly into `pcap_captures`). Add:
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { query } from '@dashboard/core';
+import { getCaptures } from '../services/pcap-store.js';
+
+async function insertCapture(id: string, name: string, filter: string | null) {
+  await query(
+    `INSERT INTO pcap_captures (id, endpoint_id, container_id, container_name, status, filter, created_at)
+     VALUES ($1, 1, $2, $3, 'complete', $4, NOW())`,
+    [id, `cid-${id}`, name, filter],
+  );
+}
+
+describe('getCaptures search', () => {
+  beforeEach(async () => {
+    await query('DELETE FROM pcap_captures', []);
+    await insertCapture('s1', 'web-frontend', 'port 80');
+    await insertCapture('s2', 'db-postgres', 'port 5432');
+  });
+
+  it('filters by container_name (case-insensitive)', async () => {
+    const rows = await getCaptures({ search: 'WEB' });
+    expect(rows.map((r) => r.id)).toEqual(['s1']);
+  });
+
+  it('also matches the filter text', async () => {
+    const rows = await getCaptures({ search: '5432' });
+    expect(rows.map((r) => r.id)).toEqual(['s2']);
+  });
+
+  it('returns all when no search', async () => {
+    const rows = await getCaptures({});
+    expect(rows.length).toBe(2);
+  });
+});
+```
+> Note: read an existing `*-store`/route test in `packages/security/src/__tests__/` first to copy the exact DB bootstrap (some suites rely on a shared `beforeAll` migration). If a global setup already truncates tables, drop the local `DELETE`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/security && npx vitest run src/__tests__/pcap-store.test.ts`
+Expected: FAIL — `search` is ignored, so `getCaptures({ search: 'WEB' })` returns both rows.
+
+- [ ] **Step 3: Implement the store change**
+
+In `packages/security/src/services/pcap-store.ts`:
+1. Add `search` to the options interface:
+```ts
+export interface GetCapturesOptions {
+  status?: string;
+  containerId?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+```
+2. Inside `getCaptures`, after the `containerId` condition block and before `const whereClause = ...`, add:
+```ts
+  if (options.search) {
+    conditions.push(
+      `(container_name ILIKE $${paramIndex} OR COALESCE(filter, '') ILIKE $${paramIndex})`,
+    );
+    params.push(`%${options.search}%`);
+    paramIndex++;
+  }
+```
+(One placeholder reused for both columns — parameterized, no concatenation of user input.)
+
+- [ ] **Step 4: Thread `search` through the service**
+
+In `packages/security/src/services/pcap-service.ts`, update the `listCaptures` options type to include `search`:
+```ts
+export async function listCaptures(options: {
+  status?: string;
+  containerId?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}) {
+  return getCaptures(options);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/security && npx vitest run src/__tests__/pcap-store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/security/src/services/pcap-store.ts packages/security/src/services/pcap-service.ts packages/security/src/__tests__/pcap-store.test.ts
+git commit -m "feat(pcap): filter captures by parameterized search (name + filter text)"
+```
+
+---
+
+## Task 3: Route-level search test (backend integration)
+
+**Files:**
+- Test: `packages/security/src/__tests__/pcap-route.test.ts`
+
+- [ ] **Step 1: Read the existing route test setup**
+
+Read `packages/security/src/__tests__/pcap-route.test.ts` to reuse its app bootstrap, admin-auth decoration, and DB seeding helpers.
+
+- [ ] **Step 2: Write the failing test**
+
+Add an `it()` mirroring the existing setup (build the Fastify app, authenticate as admin, seed two captures with distinct `container_name`s):
+```ts
+it('GET /api/pcap/captures?search= filters by container name', async () => {
+  // seed two captures: container_name 'web-1' and 'db-1' (reuse this file's seed helper)
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/pcap/captures?search=web',
+    headers: { authorization: `Bearer ${adminToken}` }, // reuse this file's token helper
+  });
+  expect(res.statusCode).toBe(200);
+  const body = res.json();
+  expect(body.captures.map((c: { container_name: string }) => c.container_name)).toEqual(['web-1']);
+});
+```
+> Match the variable names (`app`, `adminToken`, seed helper) to whatever the existing tests in this file use.
+
+- [ ] **Step 3: Run test to verify it fails, then passes**
+
+Run: `cd packages/security && npx vitest run src/__tests__/pcap-route.test.ts -t "search"`
+Expected: with Tasks 1–2 already merged this should PASS immediately (plumbing is done). If it FAILS, the failure pinpoints a plumbing gap to fix. The test's value is regression protection for the end-to-end path + admin gate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/security/src/__tests__/pcap-route.test.ts
+git commit -m "test(pcap): cover captures list search at the route level"
+```
+
+---
+
+## Task 4: `useCaptures` accepts a `search` param (frontend hook)
+
+**Files:**
+- Modify: `frontend/src/features/security/hooks/use-pcap.ts`
+- Test: `frontend/src/features/security/hooks/use-pcap.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/features/security/hooks/use-pcap.test.ts` (follow the file's existing render/mock-fetch pattern; it already mocks `api`). The intent: when `search` is provided, the request URL includes `search=`.
+```ts
+it('useCaptures includes search in the request path', async () => {
+  const getSpy = vi.spyOn(api, 'get').mockResolvedValue({ captures: [] });
+  renderHook(() => useCaptures({ search: 'web' }), { wrapper });
+  await waitFor(() => expect(getSpy).toHaveBeenCalled());
+  expect(getSpy).toHaveBeenCalledWith('/api/pcap/captures?search=web');
+});
+```
+> Use the same `wrapper` (QueryClientProvider) and `api` import the existing tests use.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/security/hooks/use-pcap.test.ts -t "search"`
+Expected: FAIL — `search` not added to params.
+
+- [ ] **Step 3: Implement**
+
+In `frontend/src/features/security/hooks/use-pcap.ts`, update the options interface and `useCaptures`:
+```ts
+interface UseCapturesOptions {
+  status?: string;
+  containerId?: string;
+  search?: string;
+}
+
+export function useCaptures(options?: UseCapturesOptions) {
+  const params = new URLSearchParams();
+  if (options?.status) params.set('status', options.status);
+  if (options?.containerId) params.set('containerId', options.containerId);
+  if (options?.search) params.set('search', options.search);
+
+  const qs = params.toString();
+  const path = qs ? `/api/pcap/captures?${qs}` : '/api/pcap/captures';
+
+  return useQuery<CapturesResponse>({
+    queryKey: ['pcap', 'captures', options?.status, options?.containerId, options?.search],
+    queryFn: () => api.get<CapturesResponse>(path),
+    refetchInterval: 5000,
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/features/security/hooks/use-pcap.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/security/hooks/use-pcap.ts frontend/src/features/security/hooks/use-pcap.test.ts
+git commit -m "feat(pcap): useCaptures supports search param"
+```
+
+---
+
+## Task 5: `BpfFilterInput` component (free-text + presets)
+
+**Files:**
+- Create: `frontend/src/features/security/components/bpf-filter-input.tsx`
+- Test: `frontend/src/features/security/components/bpf-filter-input.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/features/security/components/bpf-filter-input.test.tsx`:
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BpfFilterInput } from './bpf-filter-input';
+
+describe('BpfFilterInput', () => {
+  it('renders the current value', () => {
+    render(<BpfFilterInput value="port 80" onChange={() => {}} />);
+    expect(screen.getByLabelText('BPF filter')).toHaveValue('port 80');
+  });
+
+  it('sets the value to the preset when empty', () => {
+    const onChange = vi.fn();
+    render(<BpfFilterInput value="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'tcp' }));
+    expect(onChange).toHaveBeenCalledWith('tcp');
+  });
+
+  it('appends the preset to an existing value', () => {
+    const onChange = vi.fn();
+    render(<BpfFilterInput value="port 80" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'udp' }));
+    expect(onChange).toHaveBeenCalledWith('port 80 udp');
+  });
+
+  it('edits via free text', () => {
+    const onChange = vi.fn();
+    render(<BpfFilterInput value="" onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('BPF filter'), { target: { value: 'icmp' } });
+    expect(onChange).toHaveBeenCalledWith('icmp');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/security/components/bpf-filter-input.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/features/security/components/bpf-filter-input.tsx`:
+```tsx
+import { Filter } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+
+const BPF_PRESETS = ['tcp', 'udp', 'icmp', 'port 80', 'port 443', 'port 53', 'not port 22'];
+
+export interface BpfFilterInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function BpfFilterInput({ value, onChange }: BpfFilterInputProps) {
+  const addPreset = (preset: string) => {
+    const trimmed = value.trim();
+    onChange(trimmed ? `${trimmed} ${preset}` : preset);
+  };
+
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-medium" htmlFor="bpf-filter">
+        <Filter className="mr-1 inline h-3.5 w-3.5" />
+        BPF Filter
+      </label>
+      <input
+        id="bpf-filter"
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="e.g. port 80 or tcp"
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        aria-label="BPF filter"
+      />
+      <div className="mt-1.5 flex flex-wrap gap-1.5">
+        {BPF_PRESETS.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => addPreset(preset)}
+            className={cn(
+              'rounded-md border border-border/60 bg-card/80 px-2 py-0.5 text-xs font-medium text-muted-foreground',
+              'transition-colors hover:border-primary/30 hover:bg-primary/10 hover:text-primary',
+            )}
+          >
+            {preset}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/features/security/components/bpf-filter-input.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/security/components/bpf-filter-input.tsx frontend/src/features/security/components/bpf-filter-input.test.tsx
+git commit -m "feat(pcap): BpfFilterInput with quick presets"
+```
+
+---
+
+## Task 6: `CaptureTargetPicker` component (cross-endpoint cmdk search)
+
+**Files:**
+- Create: `frontend/src/features/security/components/capture-target-picker.tsx`
+- Test: `frontend/src/features/security/components/capture-target-picker.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/features/security/components/capture-target-picker.test.tsx`:
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { CaptureTargetPicker, type CaptureTarget } from './capture-target-picker';
+import type { Container } from '@/features/containers/hooks/use-containers';
+import type { Stack } from '@/features/containers/hooks/use-stacks';
+
+const containers = [
+  { id: 'c1', name: 'nginx-prod', image: 'nginx', state: 'running', status: 'Up', endpointId: 1, endpointName: 'prod', ports: [], created: 0, labels: { 'com.docker.compose.project': 'web' }, networks: [] },
+  { id: 'c2', name: 'nginx-stage', image: 'nginx', state: 'running', status: 'Up', endpointId: 2, endpointName: 'staging', ports: [], created: 0, labels: {}, networks: [] },
+  { id: 'c3', name: 'postgres', image: 'postgres', state: 'running', status: 'Up', endpointId: 2, endpointName: 'staging', ports: [], created: 0, labels: {}, networks: [] },
+] as unknown as Container[];
+
+const stacks = [{ id: 1, name: 'web', endpointId: 1 }] as unknown as Stack[];
+
+function setup(props: Partial<React.ComponentProps<typeof CaptureTargetPicker>> = {}) {
+  const onChange = vi.fn();
+  render(
+    <CaptureTargetPicker
+      containers={containers}
+      stacks={stacks}
+      edgeAsyncEndpointIds={new Set()}
+      value={null}
+      onChange={onChange}
+      {...props}
+    />,
+  );
+  return { onChange };
+}
+
+describe('CaptureTargetPicker', () => {
+  it('finds matching containers across endpoints with no endpoint pre-selection', () => {
+    setup();
+    const input = screen.getByLabelText('Search capture target container');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'nginx' } });
+    expect(screen.getByText('prod')).toBeInTheDocument();
+    expect(screen.getByText('staging')).toBeInTheDocument();
+    expect(screen.getByText('nginx-prod')).toBeInTheDocument();
+    expect(screen.getByText('nginx-stage')).toBeInTheDocument();
+    expect(screen.queryByText('postgres')).not.toBeInTheDocument();
+  });
+
+  it('selecting a container emits a CaptureTarget and shows a chip', () => {
+    const { onChange } = setup();
+    const input = screen.getByLabelText('Search capture target container');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'postgres' } });
+    fireEvent.click(screen.getByText('postgres'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<CaptureTarget>>({
+        endpointId: 2,
+        containerId: 'c3',
+        containerName: 'postgres',
+        endpointName: 'staging',
+      }),
+    );
+  });
+
+  it('renders the selected target as a clearable chip', () => {
+    const onChange = vi.fn();
+    render(
+      <CaptureTargetPicker
+        containers={containers}
+        stacks={stacks}
+        edgeAsyncEndpointIds={new Set()}
+        value={{ endpointId: 1, containerId: 'c1', containerName: 'nginx-prod', endpointName: 'prod', stackName: 'web' }}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByText('nginx-prod')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Clear selected container'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('disables containers on edge-async endpoints', () => {
+    setup({ edgeAsyncEndpointIds: new Set([2]) });
+    const input = screen.getByLabelText('Search capture target container');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'nginx' } });
+    const stageItem = screen.getByText('nginx-stage').closest('[data-disabled]') as HTMLElement;
+    expect(stageItem).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/security/components/capture-target-picker.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/features/security/components/capture-target-picker.tsx`:
+```tsx
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Command } from 'cmdk';
+import { Search, X, Box, Server } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+import type { Container } from '@/features/containers/hooks/use-containers';
+import type { Stack } from '@/features/containers/hooks/use-stacks';
+import { filterContainers } from '@/features/containers/lib/workload-search-filter';
+import { resolveContainerStackName, NO_STACK_LABEL } from '@/features/containers/lib/container-stack-grouping';
+
+export interface CaptureTarget {
+  endpointId: number;
+  containerId: string;
+  containerName: string;
+  endpointName: string;
+  stackName: string;
+}
+
+export interface CaptureTargetPickerProps {
+  containers: Container[];
+  stacks: Stack[];
+  edgeAsyncEndpointIds: Set<number>;
+  value: CaptureTarget | null;
+  onChange: (target: CaptureTarget | null) => void;
+  autoFocus?: boolean;
+}
+
+export function CaptureTargetPicker({
+  containers,
+  stacks,
+  edgeAsyncEndpointIds,
+  value,
+  onChange,
+  autoFocus,
+}: CaptureTargetPickerProps) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const knownStackNames = useMemo(() => stacks.map((s) => s.name), [stacks]);
+  const matches = useMemo(
+    () => filterContainers(containers, query, knownStackNames),
+    [containers, query, knownStackNames],
+  );
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Container[]>();
+    for (const c of matches) {
+      const arr = map.get(c.endpointName) ?? [];
+      arr.push(c);
+      map.set(c.endpointName, arr);
+    }
+    return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [matches]);
+
+  const matchingStacks = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q || q.includes(':')) return [];
+    return [...new Set(knownStackNames)].filter((n) => n.toLowerCase().includes(q)).slice(0, 4);
+  }, [knownStackNames, query]);
+
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
+
+  if (value) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm">
+        <Box className="h-4 w-4 shrink-0 text-primary" />
+        <span className="font-medium">{value.containerName}</span>
+        <span className="truncate text-muted-foreground">· {value.endpointName} · {value.stackName}</span>
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          className="ml-auto rounded p-0.5 text-muted-foreground hover:text-foreground"
+          aria-label="Clear selected container"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <Command shouldFilter={false} className="relative">
+      <div className="flex items-center gap-2 rounded-md border bg-background px-3">
+        <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <Command.Input
+          ref={inputRef}
+          value={query}
+          onValueChange={setQuery}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 120)}
+          placeholder="Search containers — name, stack:web, endpoint:prod…"
+          className="w-full bg-transparent py-2 text-sm focus:outline-none"
+          aria-label="Search capture target container"
+        />
+      </div>
+      {open && query.trim() && (
+        <Command.List className="scrollbar-themed absolute z-20 mt-1 max-h-72 w-full overflow-y-auto rounded-md border bg-popover p-1 shadow-md">
+          <Command.Empty className="px-3 py-2 text-sm text-muted-foreground">
+            No running containers match.
+          </Command.Empty>
+
+          {matchingStacks.length > 0 && (
+            <Command.Group heading="Stacks" className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:text-muted-foreground">
+              {matchingStacks.map((name) => (
+                <Command.Item
+                  key={`stack-${name}`}
+                  value={`stack:${name}`}
+                  onSelect={() => setQuery(`stack:${name}`)}
+                  className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm aria-selected:bg-accent"
+                >
+                  <Server className="h-3.5 w-3.5" /> Stack: {name}
+                </Command.Item>
+              ))}
+            </Command.Group>
+          )}
+
+          {grouped.map(([endpointName, conts]) => (
+            <Command.Group
+              key={endpointName}
+              heading={endpointName}
+              className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:text-muted-foreground"
+            >
+              {conts.map((c) => {
+                const disabled = edgeAsyncEndpointIds.has(c.endpointId);
+                const stackName = resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL;
+                return (
+                  <Command.Item
+                    key={c.id}
+                    value={c.id}
+                    disabled={disabled}
+                    onSelect={() => {
+                      if (disabled) return;
+                      onChange({
+                        endpointId: c.endpointId,
+                        containerId: c.id,
+                        containerName: c.name,
+                        endpointName: c.endpointName,
+                        stackName,
+                      });
+                      setQuery('');
+                      setOpen(false);
+                    }}
+                    title={disabled ? 'Capture unavailable — Edge Async endpoint (no docker exec)' : undefined}
+                    className={cn(
+                      'flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm aria-selected:bg-accent',
+                      disabled && 'cursor-not-allowed opacity-50',
+                    )}
+                  >
+                    <Box className="h-3.5 w-3.5 shrink-0" />
+                    <span className="font-medium">{c.name}</span>
+                    <span className="truncate text-xs text-muted-foreground">{c.image}</span>
+                    <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{stackName}</span>
+                  </Command.Item>
+                );
+              })}
+            </Command.Group>
+          ))}
+        </Command.List>
+      )}
+    </Command>
+  );
+}
+```
+> cmdk sets `data-disabled` on disabled items (used by the edge-async test). `shouldFilter={false}` means cmdk shows exactly the items we render — our own `filterContainers` does the filtering.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/features/security/components/capture-target-picker.test.tsx`
+Expected: PASS. If cmdk's `onValueChange` doesn't fire under `fireEvent.change` in jsdom, switch the test to `@testing-library/user-event` `await userEvent.type(input, 'nginx')` (already a dependency in this repo's frontend tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/security/components/capture-target-picker.tsx frontend/src/features/security/components/capture-target-picker.test.tsx
+git commit -m "feat(pcap): cross-endpoint CaptureTargetPicker (cmdk + filterContainers)"
+```
+
+---
+
+## Task 7: Wire the picker + BPF input into the page; drop the forced cascade
+
+**Files:**
+- Modify: `frontend/src/features/security/pages/packet-capture.tsx`
+- Test: `frontend/src/features/security/pages/packet-capture.test.tsx`
+
+- [ ] **Step 1: Update the page test for the new flow**
+
+In `frontend/src/features/security/pages/packet-capture.test.tsx`:
+1. Update `mockContainers` to include containers on two endpoints (e.g. add one with `endpointId: 2, endpointName: 'edge-async-host'`). Keep `mockEndpoints` as-is (endpoint 2 has `edgeMode: 'async'`).
+2. Replace any assertions that rely on selecting an endpoint dropdown first. Add:
+```ts
+it('shows capture targets without selecting an endpoint first', () => {
+  renderPage(); // the file's existing render helper
+  const input = screen.getByLabelText('Search capture target container');
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value: 'web-1' } });
+  expect(screen.getByText('web-1')).toBeInTheDocument();
+});
+
+it('disables Start until a target is selected', () => {
+  renderPage();
+  expect(screen.getByRole('button', { name: /start capture/i })).toBeDisabled();
+});
+```
+3. Ensure the `useContainers` mock still returns `{ data: mockContainers }` (the page will now call it with `{ state: 'running' }` — the mock ignores args, so it still returns the list).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/security/pages/packet-capture.test.tsx -t "without selecting"`
+Expected: FAIL — picker not present yet.
+
+- [ ] **Step 3: Implement the page changes**
+
+In `frontend/src/features/security/pages/packet-capture.tsx`:
+
+1. Add imports:
+```tsx
+import { CaptureTargetPicker, type CaptureTarget } from '@/features/security/components/capture-target-picker';
+import { BpfFilterInput } from '@/features/security/components/bpf-filter-input';
+```
+
+2. Replace the four target-selection state vars (`selectedEndpoint`, `selectedStack`, `selectedContainer`, `selectedContainerName`) with:
+```tsx
+const [target, setTarget] = useState<CaptureTarget | null>(null);
+```
+
+3. Change the containers query to fetch running containers across all endpoints:
+```tsx
+const { data: containers } = useContainers({ state: 'running' });
+```
+
+4. Derive edge-async endpoints and remove the old per-endpoint capability usage:
+```tsx
+const edgeAsyncEndpointIds = useMemo(
+  () => new Set((endpoints ?? []).filter((e) => e.edgeMode === 'async').map((e) => e.id)),
+  [endpoints],
+);
+const endpointNameById = useMemo(
+  () => new Map((endpoints ?? []).map((e) => [e.id, e.name])),
+  [endpoints],
+);
+const runningContainers = useMemo(() => (containers ?? []).filter((c) => c.state === 'running'), [containers]);
+const targetIsEdgeAsync = target ? edgeAsyncEndpointIds.has(target.endpointId) : false;
+```
+Delete the now-unused `useEndpointCapabilities` call, `stackNamesForEndpoint`, `stackOptions`, `filteredRunningContainers`, `groupedContainerOptions`, `handleContainerChange`, and the `isEdgeAsync` page-level variable. Keep `useStacks()` (passed to the picker).
+
+5. Update `handleStartCapture`:
+```tsx
+const handleStartCapture = () => {
+  if (!target || targetIsEdgeAsync) return;
+  startCapture.mutate({
+    endpointId: target.endpointId,
+    containerId: target.containerId,
+    containerName: target.containerName,
+    filter: bpfFilter || undefined,
+    durationSeconds: duration ? parseInt(duration, 10) : undefined,
+    maxPackets: maxPackets ? parseInt(maxPackets, 10) : undefined,
+  });
+};
+```
+
+6. Replace the New Capture form body (the Endpoint / Stack / Container `ThemedSelect` blocks and the inline BPF `<input>`) with the picker, the BPF input, and contextual edge-async warning. The grid keeps Duration / Max Packets / Start as-is:
+```tsx
+<div className="mb-4">
+  <label className="mb-1 block text-sm font-medium">Target container</label>
+  <CaptureTargetPicker
+    containers={runningContainers}
+    stacks={stacks ?? []}
+    edgeAsyncEndpointIds={edgeAsyncEndpointIds}
+    value={target}
+    onChange={setTarget}
+  />
+  {targetIsEdgeAsync && (
+    <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+      This container's endpoint is Edge Async — packet capture requires docker exec and is unavailable.
+    </p>
+  )}
+</div>
+
+<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+  <BpfFilterInput value={bpfFilter} onChange={setBpfFilter} />
+  {/* keep the existing Duration block */}
+  {/* keep the existing Max Packets block */}
+  {/* Start button (updated disabled condition) */}
+  <div className="flex items-end">
+    <button
+      onClick={handleStartCapture}
+      disabled={!target || targetIsEdgeAsync || startCapture.isPending}
+      className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+    >
+      <Play className="h-4 w-4" />
+      {startCapture.isPending ? 'Starting...' : 'Start Capture'}
+    </button>
+  </div>
+</div>
+```
+Remove the old top-level `{isEdgeAsync && (...)}` warning banner block (now handled contextually). Remove the now-unused imports (`ThemedSelect`, `buildStackGroupedContainerOptions`, `NO_STACK_LABEL`, `resolveContainerStackName`, `useEndpointCapabilities`) — let the typecheck in Task 11 catch any stragglers.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/features/security/pages/packet-capture.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/security/pages/packet-capture.tsx frontend/src/features/security/pages/packet-capture.test.tsx
+git commit -m "feat(pcap): search-first cross-endpoint target picker on the capture page"
+```
+
+---
+
+## Task 8: Capture history search + Endpoint column
+
+**Files:**
+- Modify: `frontend/src/features/security/pages/packet-capture.tsx`
+- Test: `frontend/src/features/security/pages/packet-capture.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packet-capture.test.tsx`:
+```ts
+it('passes the history search term to useCaptures', async () => {
+  renderPage();
+  const search = screen.getByLabelText('Search capture history');
+  fireEvent.change(search, { target: { value: 'web' } });
+  await waitFor(() =>
+    expect(vi.mocked(useCaptures)).toHaveBeenCalledWith(expect.objectContaining({ search: 'web' })),
+  );
+});
+
+it('shows the endpoint name in the history table', () => {
+  renderPage();
+  expect(screen.getByText('local')).toBeInTheDocument(); // endpoint_id 1 -> 'local'
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/security/pages/packet-capture.test.tsx -t "history search"`
+Expected: FAIL — no history search input / endpoint column.
+
+- [ ] **Step 3: Implement**
+
+In `packet-capture.tsx`:
+
+1. Add debounced history-search state:
+```tsx
+const [historySearch, setHistorySearch] = useState('');
+const [debouncedSearch, setDebouncedSearch] = useState('');
+useEffect(() => {
+  const t = setTimeout(() => setDebouncedSearch(historySearch), 300);
+  return () => clearTimeout(t);
+}, [historySearch]);
+```
+
+2. Pass it to the hook:
+```tsx
+const { data: capturesData, refetch, isFetching } = useCaptures({
+  status: statusFilter,
+  search: debouncedSearch || undefined,
+});
+```
+
+3. Add the search input next to the status tabs (in the "Capture History" header row, before the tabs):
+```tsx
+<input
+  type="text"
+  value={historySearch}
+  onChange={(e) => setHistorySearch(e.target.value)}
+  placeholder="Search history…"
+  aria-label="Search capture history"
+  className="rounded-md border bg-background px-3 py-1.5 text-xs"
+/>
+```
+
+4. Add an Endpoint column to the `columns` definition (insert after the `container_name` column). Include `endpointNameById` in the `useMemo` dependency array:
+```tsx
+{
+  accessorKey: 'endpoint_id',
+  header: 'Endpoint',
+  cell: ({ row }) => (
+    <span className="text-muted-foreground">
+      {endpointNameById.get(row.original.endpoint_id) ?? `#${row.original.endpoint_id}`}
+    </span>
+  ),
+},
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/features/security/pages/packet-capture.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/security/pages/packet-capture.tsx frontend/src/features/security/pages/packet-capture.test.tsx
+git commit -m "feat(pcap): search capture history + show endpoint column"
+```
+
+---
+
+## Task 9: Collapsible "Browse by endpoint" fallback
+
+Keeps the familiar Endpoint → Stack → Container dropdowns as an optional path, sourced from the same cross-endpoint `runningContainers` list and producing the same `CaptureTarget`.
+
+**Files:**
+- Create: `frontend/src/features/security/components/capture-browse-fallback.tsx`
+- Modify: `frontend/src/features/security/pages/packet-capture.tsx`
+- Test: `frontend/src/features/security/components/capture-browse-fallback.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/features/security/components/capture-browse-fallback.test.tsx`:
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CaptureBrowseFallback } from './capture-browse-fallback';
+import type { Container } from '@/features/containers/hooks/use-containers';
+import type { Stack } from '@/features/containers/hooks/use-stacks';
+
+const containers = [
+  { id: 'c1', name: 'web-1', image: 'nginx', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, labels: {}, networks: [] },
+] as unknown as Container[];
+const endpoints = [{ id: 1, name: 'local' }] as { id: number; name: string }[];
+
+it('selecting endpoint then container emits a CaptureTarget', () => {
+  const onChange = vi.fn();
+  render(
+    <CaptureBrowseFallback
+      containers={containers}
+      stacks={[] as Stack[]}
+      endpoints={endpoints}
+      edgeAsyncEndpointIds={new Set()}
+      onChange={onChange}
+    />,
+  );
+  // Open the disclosure
+  fireEvent.click(screen.getByText(/browse by endpoint/i));
+  // (Drive the ThemedSelects per their test-friendly API; assert onChange receives endpointId 1 + containerId 'c1'.)
+  // This asserts the wiring contract:
+  expect(typeof onChange).toBe('function');
+});
+```
+> The exact ThemedSelect interaction depends on its implementation; read `frontend/src/shared/components/ui/themed-select.tsx` and assert selection drives `onChange` with `{ endpointId: 1, containerId: 'c1', containerName: 'web-1', endpointName: 'local', stackName }`. Keep at least one assertion that a full endpoint→container selection calls `onChange` with the right target.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/security/components/capture-browse-fallback.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the fallback component**
+
+Create `frontend/src/features/security/components/capture-browse-fallback.tsx`:
+```tsx
+import { useMemo, useState } from 'react';
+import { ThemedSelect } from '@/shared/components/ui/themed-select';
+import type { Container } from '@/features/containers/hooks/use-containers';
+import type { Stack } from '@/features/containers/hooks/use-stacks';
+import {
+  buildStackGroupedContainerOptions,
+  resolveContainerStackName,
+  NO_STACK_LABEL,
+} from '@/features/containers/lib/container-stack-grouping';
+import type { CaptureTarget } from './capture-target-picker';
+
+export interface CaptureBrowseFallbackProps {
+  containers: Container[];
+  stacks: Stack[];
+  endpoints: { id: number; name: string }[];
+  edgeAsyncEndpointIds: Set<number>;
+  onChange: (target: CaptureTarget) => void;
+}
+
+export function CaptureBrowseFallback({
+  containers,
+  stacks,
+  endpoints,
+  edgeAsyncEndpointIds,
+  onChange,
+}: CaptureBrowseFallbackProps) {
+  const [endpointId, setEndpointId] = useState<number | undefined>();
+  const [stackName, setStackName] = useState<string | undefined>();
+
+  const knownStackNames = useMemo(
+    () => stacks.filter((s) => s.endpointId === endpointId).map((s) => s.name),
+    [stacks, endpointId],
+  );
+  const endpointContainers = useMemo(
+    () => containers.filter((c) => c.endpointId === endpointId),
+    [containers, endpointId],
+  );
+  const stackOptions = useMemo(() => {
+    const set = new Set<string>(knownStackNames);
+    for (const c of endpointContainers) {
+      set.add(resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL);
+    }
+    return [...set].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base', numeric: true }));
+  }, [endpointContainers, knownStackNames]);
+  const filtered = useMemo(
+    () =>
+      stackName
+        ? endpointContainers.filter(
+            (c) => (resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL) === stackName,
+          )
+        : endpointContainers,
+    [endpointContainers, stackName, knownStackNames],
+  );
+  const containerOptions = useMemo(
+    () => buildStackGroupedContainerOptions(filtered, knownStackNames),
+    [filtered, knownStackNames],
+  );
+
+  const handleContainer = (id: string) => {
+    const c = filtered.find((x) => x.id === id);
+    if (!c || edgeAsyncEndpointIds.has(c.endpointId)) return;
+    onChange({
+      endpointId: c.endpointId,
+      containerId: c.id,
+      containerName: c.name,
+      endpointName: c.endpointName,
+      stackName: resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL,
+    });
+  };
+
+  return (
+    <details className="mt-3 rounded-md border bg-card/50 p-3 text-sm">
+      <summary className="cursor-pointer select-none font-medium text-muted-foreground">
+        Browse by endpoint
+      </summary>
+      <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <ThemedSelect
+          value={endpointId != null ? String(endpointId) : '__all__'}
+          onValueChange={(v) => {
+            setEndpointId(v === '__all__' ? undefined : Number(v));
+            setStackName(undefined);
+          }}
+          placeholder="Select endpoint..."
+          options={[
+            { value: '__all__', label: 'Select endpoint...' },
+            ...endpoints.map((e) => ({ value: String(e.id), label: e.name })),
+          ]}
+          className="w-full text-sm"
+        />
+        <ThemedSelect
+          value={stackName ?? '__all__'}
+          onValueChange={(v) => setStackName(v === '__all__' ? undefined : v)}
+          disabled={endpointId == null}
+          placeholder="All stacks"
+          options={[
+            { value: '__all__', label: 'All stacks' },
+            ...stackOptions.map((s) => ({ value: s, label: s })),
+          ]}
+          className="w-full text-sm"
+        />
+        <ThemedSelect
+          value="__all__"
+          onValueChange={(v) => v !== '__all__' && handleContainer(v)}
+          disabled={endpointId == null}
+          placeholder="Select container..."
+          options={[{ value: '__all__', label: 'Select container...' }, ...containerOptions]}
+          className="w-full text-sm"
+        />
+      </div>
+    </details>
+  );
+}
+```
+
+- [ ] **Step 4: Mount it in the page under the picker**
+
+In `packet-capture.tsx`, import and render below the `CaptureTargetPicker` block:
+```tsx
+import { CaptureBrowseFallback } from '@/features/security/components/capture-browse-fallback';
+// ...
+<CaptureBrowseFallback
+  containers={runningContainers}
+  stacks={stacks ?? []}
+  endpoints={endpoints ?? []}
+  edgeAsyncEndpointIds={edgeAsyncEndpointIds}
+  onChange={setTarget}
+/>
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/features/security/components/capture-browse-fallback.test.tsx src/features/security/pages/packet-capture.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/features/security/components/capture-browse-fallback.tsx frontend/src/features/security/components/capture-browse-fallback.test.tsx frontend/src/features/security/pages/packet-capture.tsx
+git commit -m "feat(pcap): collapsible browse-by-endpoint fallback picker"
+```
+
+---
+
+## Task 10: Docs update
+
+**Files:**
+- Modify: `docs/architecture.md`
+
+- [ ] **Step 1: Document the change**
+
+Add a short note under the relevant section of `docs/architecture.md` (packet capture / security): the capture target picker now searches running containers across all endpoints (no endpoint pre-selection) via the shared `filterContainers` parser and `cmdk`; the captures list API accepts an optional `search` param (parameterized match on `container_name`/`filter`). No new env vars. If there is a packet-capture note in the repo root `CLAUDE.md`, add one sentence describing cross-endpoint search; otherwise skip.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/architecture.md
+git commit -m "docs(pcap): note cross-endpoint capture search + history search param"
+```
+
+---
+
+## Task 11: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck + lint**
+
+Run:
+```bash
+npm run typecheck
+npm run lint
+```
+Expected: no errors. Fix any unused-import / type errors surfaced by the page refactor (e.g. removed `ThemedSelect`/`useEndpointCapabilities` imports) before continuing.
+
+- [ ] **Step 2: Run the affected test suites**
+
+Run:
+```bash
+cd packages/security && npx vitest run src/__tests__/pcap-model.test.ts src/__tests__/pcap-store.test.ts src/__tests__/pcap-route.test.ts
+cd ../../frontend && npx vitest run src/features/security
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Final review commit (if anything was fixed)**
+
+```bash
+git add -A
+git commit -m "chore(pcap): typecheck/lint fixups for filter overhaul"
+```
+(Skip if nothing changed.)
+
+---
+
+## Self-review notes (coverage map)
+
+- **Type container name directly** → Task 6 (`filterContainers` free-text), Task 7 (page wiring).
+- **Search stacks + containers without selecting an endpoint** → Task 6 (cross-endpoint list + `stack:` quick-filters), Task 7 (`useContainers({ state: 'running' })`, no endpoint gate).
+- **Dropdowns as fallback** → Task 9.
+- **History search** → Tasks 1–4 (backend + hook), Task 8 (UI + endpoint column).
+- **BPF presets** → Task 5 + Task 7 wiring.
+- **Chip with endpoint/stack context** → Task 6 (selected-state chip).
+- **Edge-async safety** → Task 6 (disabled items) + Task 7 (contextual warning + Start gating).
+- **Parameterized SQL / Zod boundary** → Tasks 1–2.
+- **Tests for every change** → each task is TDD.
+- **Docs** → Task 10.
+
+Type consistency: `CaptureTarget` is defined once in Task 6 and imported by Tasks 7 & 9; `GetCapturesOptions.search`, `listCaptures({search})`, `CaptureListQuerySchema.search`, and `useCaptures({search})` all use the same `search` name.

--- a/docs/superpowers/specs/2026-05-30-packet-capture-filter-overhaul-design.md
+++ b/docs/superpowers/specs/2026-05-30-packet-capture-filter-overhaul-design.md
@@ -1,0 +1,208 @@
+# Packet Capture filter overhaul — design
+
+**Date:** 2026-05-30
+**Branch:** `worktree-feature+packet-capture-filter-overhaul`
+**Status:** Approved (design); pending implementation plan
+
+## Problem
+
+The New Capture form on the Packet Capture page (`frontend/src/features/security/pages/packet-capture.tsx`) forces a rigid cascade:
+
+1. Select an **Endpoint** (required).
+2. Only then do the **Stack** and **Container** dropdowns unlock (they are `disabled` until an endpoint is chosen).
+
+Consequences:
+
+- You cannot simply **type a container name** to start a capture.
+- You cannot **find a stack or container across endpoints** without first knowing — and selecting — its endpoint. In a multi-endpoint fleet you must already know where a workload lives.
+
+This overhaul makes the target picker **search-first and cross-endpoint**, while keeping the dropdowns as an optional browse fallback. It also adds search to the capture history table and quick presets to the BPF filter input.
+
+## Goals
+
+- Type a container name (or stack/endpoint name) directly to find a capture target — no endpoint pre-selection.
+- Search **stacks and containers across all endpoints** at once; results show which endpoint/stack they belong to.
+- Keep the existing Endpoint → Stack → Container dropdowns available as a collapsible fallback.
+- Add free-text search to the capture **History** table (server-side, across all captures).
+- Add quick **BPF presets** alongside the free-text BPF input.
+- Improve internal structure: extract focused, independently testable components from the 667-line page.
+
+## Non-goals (YAGNI)
+
+- AI / natural-language search mode (the `WorkloadSmartSearch` AI path). Not needed for target selection.
+- URL-synced filter state / shareable deep links.
+- Saved filters.
+- Server-side **async** container search. Client-side cross-endpoint filtering is fine at typical Portainer fleet scale (tens–hundreds of containers). The picker interface is designed so this can be swapped later without changing call sites.
+- Changing capture semantics: a capture still targets exactly **one container** on one endpoint. "Searching stacks" narrows the container list; a stack is not itself a capture target.
+
+## Current state (verified)
+
+- `useContainers({ state: 'running' })` with **no** `endpointId` already returns running containers across **all** endpoints via `GET /api/containers?state=running`. Each `Container` carries `endpointId` and `endpointName` (`frontend/src/features/containers/hooks/use-containers.ts`).
+- `useStacks()` returns all stacks across all endpoints; `Stack` has `endpointId`, `name` (`.../hooks/use-stacks.ts`).
+- `useEndpoints()` returns each endpoint's `edgeMode: 'standard' | 'async' | null` and `capabilities` (`.../hooks/use-endpoints.ts`). Edge-async endpoints cannot run docker exec → cannot capture.
+- `filterContainers(containers, query, knownStackNames)` already parses free text plus `name:` / `image:` / `state:` / `status:` / `stack:` / `endpoint:` / `port:` / `label:` tokens (AND semantics) (`frontend/src/features/containers/lib/workload-search-filter.ts`). Reused as-is.
+- `cmdk` is already a dependency (used by `frontend/src/features/core/components/layout/command-palette.tsx`).
+- Stack grouping helpers exist: `buildStackGroupedContainerOptions`, `resolveContainerStackName`, `NO_STACK_LABEL` (`frontend/src/features/containers/lib/container-stack-grouping.ts`).
+- `POST /api/pcap/captures` requires `{ endpointId, containerId, containerName, filter?, durationSeconds?, maxPackets? }`. Once a container is selected we know its `endpointId`, so no extra lookup is needed.
+- `GET /api/pcap/captures` (admin-gated, `PCAP_ENABLED`-gated) accepts `status` / `containerId` / `limit` / `offset` only — **no text search** (`packages/security/src/routes/pcap.ts`, `CaptureListQuerySchema` in `packages/security/src/models/pcap.ts`).
+- The history table does not currently display which endpoint a capture ran on.
+
+## Architecture
+
+The page becomes an orchestrator that composes three focused components. New components live in `frontend/src/features/security/components/` (dir already exists).
+
+### 1. `CaptureTargetPicker` — search-first, cross-endpoint target selector
+
+File: `frontend/src/features/security/components/capture-target-picker.tsx`
+
+**Responsibility:** Given the full cross-endpoint running-container list, let the user find and select exactly one container as the capture target, then display it as a removable chip with endpoint/stack context.
+
+**Props (interface):**
+
+```ts
+export interface CaptureTarget {
+  endpointId: number;
+  containerId: string;
+  containerName: string;
+  endpointName: string;
+  stackName: string; // resolved stack or NO_STACK_LABEL, for the chip
+}
+
+export interface CaptureTargetPickerProps {
+  containers: Container[];      // all running containers, cross-endpoint
+  stacks: Stack[];             // all stacks, cross-endpoint
+  edgeAsyncEndpointIds: Set<number>; // endpoints that cannot capture
+  value: CaptureTarget | null;
+  onChange: (target: CaptureTarget | null) => void;
+  autoFocus?: boolean;
+}
+```
+
+**Behavior:**
+
+- Renders a `cmdk` combobox: a `Command.Input` plus an inline `Command.List` shown when the input is focused and non-empty.
+- `shouldFilter={false}` — filtering is done by the existing `filterContainers(containers, query, knownStackNames)`, so `name:` / `stack:` / `endpoint:` / `image:` / `port:` tokens and bare free text all work. `knownStackNames` derives from `stacks`.
+- Results are **grouped by endpoint** (`Command.Group` heading = `endpointName`). Each `Command.Item`:
+  - `value={container.id}`, `onSelect` → builds a `CaptureTarget` (resolving stack via `resolveContainerStackName`) and calls `onChange`.
+  - Renders container name, muted image, and a stack chip.
+  - If `edgeAsyncEndpointIds.has(container.endpointId)`: rendered **disabled** with a tooltip ("Capture unavailable — Edge Async endpoint (no docker exec)").
+- **Stack quick-filters:** at the top of the list, stack names matching the current query render as selectable rows ("Stack: web-stack") that set the query to `stack:<name>`. This is how a user "searches stacks" and drills into a stack's containers without choosing an endpoint.
+- **Selected state:** when `value` is set, render a removable token/chip — `containerName · endpointName · stackName` — with an X that calls `onChange(null)`. The search input is hidden while a target is selected (clicking X returns to search).
+- Empty state: if the query yields no matches, show "No running containers match." If there are zero running containers at all, show a hint to check endpoints.
+- Keyboard a11y comes from cmdk (arrow nav, Enter to select); the input has an `aria-label`.
+
+### 2. `BpfFilterInput` — free-text BPF + presets
+
+File: `frontend/src/features/security/components/bpf-filter-input.tsx`
+
+**Props:** `{ value: string; onChange: (v: string) => void }`
+
+**Behavior:**
+
+- The existing free-text input (placeholder "e.g. port 80 or tcp"), unchanged validation contract (server-side regex `BPF_FILTER_REGEX` stays authoritative).
+- A row of preset chips: `tcp`, `udp`, `icmp`, `port 80`, `port 443`, `port 53`, `not port 22`. Clicking a chip appends the token to the current value (space-separated), or sets it if empty. Presets are a starting point the user can edit freely.
+
+### 3. Capture History search + Endpoint column
+
+- A debounced search box rendered beside the existing status tabs (status tabs unchanged). The search term is passed to `useCaptures({ status, search })`.
+- `useCaptures` (`frontend/src/features/security/hooks/use-pcap.ts`) gains an optional `search` param, forwarded as `?search=` and folded into the query key.
+- The history `DataTable` gains an **Endpoint** column that maps `capture.endpoint_id` → endpoint name via `useEndpoints()` (falls back to `#<id>` when unknown). This matters now that captures span endpoints.
+
+### 4. `packet-capture.tsx` orchestration
+
+- Loads `useContainers({ state: 'running' })` (cross-endpoint, no `endpointId`), `useStacks()`, `useEndpoints()`.
+- Computes `edgeAsyncEndpointIds = new Set(endpoints.filter(e => e.edgeMode === 'async').map(e => e.id))`.
+- Holds `target: CaptureTarget | null` state (replaces the four separate `selectedEndpoint/Stack/Container/ContainerName` states for the primary path).
+- Edge-async warning is shown contextually for the **selected target's** endpoint (not a global per-dropdown warning).
+- Start Capture enabled when: `target != null` && target endpoint not edge-async && capture not pending. Calls `startCapture.mutate({ endpointId: target.endpointId, containerId: target.containerId, containerName: target.containerName, filter, durationSeconds, maxPackets })`.
+- **Browse fallback:** the existing Endpoint → Stack → Container dropdowns move into a collapsible "Browse by endpoint" `<details>`/disclosure (default collapsed). Selecting through it produces the same `CaptureTarget` and updates the chip. This reuses the existing grouping helpers and keeps discoverability for users who prefer drilling down.
+
+## Data flow
+
+```
+page mount
+  ├─ useContainers({ state: 'running' })  → all running containers (cross-endpoint)
+  ├─ useStacks()                          → all stacks (knownStackNames)
+  ├─ useEndpoints()                       → edgeAsyncEndpointIds, endpoint-name map
+  └─ useCaptures({ status, search })      → history rows
+
+CaptureTargetPicker(query)
+  → filterContainers(containers, query, knownStackNames)
+  → grouped by endpoint, edge-async disabled
+  → onSelect → target {endpointId, containerId, containerName, endpointName, stackName}
+
+Start Capture → startCapture.mutate({ ...target, filter, durationSeconds, maxPackets })
+```
+
+## Backend changes (minimal)
+
+- `packages/security/src/models/pcap.ts`: add `search: z.string().max(200).optional()` to `CaptureListQuerySchema`.
+- `packages/security/src/services/pcap-service.ts` (`listCaptures`): pass `search` through to the store.
+- pcap-store `getCaptures(options)`: when `search` is present, add a **parameterized** SQL predicate — `AND (container_name ILIKE $n OR COALESCE(filter,'') ILIKE $n)` with `%search%`. No string concatenation. Existing `status` / `containerId` / `limit` / `offset` behavior unchanged.
+- Route, admin gate (`requireRole('admin')`), and `PCAP_ENABLED` gate unchanged.
+
+## Edge cases
+
+- **Edge-async endpoints:** containers shown but disabled in the picker; Start disabled with a contextual warning if somehow selected via fallback.
+- **Stopped containers:** only `state: 'running'` are fetched (tcpdump needs a live container), matching today's behavior.
+- **No endpoints / zero running containers:** picker shows a helpful empty state.
+- **Container disappears between load and capture start:** the start mutation already errors server-side; surface the existing error toast.
+- **Duplicate container names across endpoints:** disambiguated by the endpoint group heading and the selection chip context.
+- **History search with pagination:** search is server-side, so it filters across all captures, not just the loaded 50.
+
+## Testing plan (mandatory — every change needs tests)
+
+**Frontend (Vitest + jsdom + Testing Library):**
+
+- `capture-target-picker.test.tsx`:
+  - typing `nginx` surfaces matching containers from multiple endpoints (grouped);
+  - `stack:web` narrows to that stack's containers across endpoints;
+  - an edge-async endpoint's container is rendered disabled;
+  - selecting a container emits the correct `CaptureTarget` and renders the chip with endpoint + stack;
+  - clearing the chip resets to search;
+  - no endpoint pre-selection is required to see results.
+- `bpf-filter-input.test.tsx`: clicking a preset appends the token; free-text editing preserved.
+- `packet-capture.test.tsx` (update): page works with no endpoint selected; Start disabled until a target is chosen; edge-async target disables Start with warning; history search box drives `useCaptures` `search`; Endpoint column renders.
+
+**Backend (Vitest + real PostgreSQL):**
+
+- `packages/security/src/__tests__/pcap-route.test.ts`: `GET /api/pcap/captures?search=foo` returns only captures whose `container_name`/`filter` match; still admin-gated.
+- `packages/security/src/__tests__/pcap-model.test.ts`: `CaptureListQuerySchema` accepts `search`, rejects over-long input.
+- pcap-store/service test: `getCaptures`/`listCaptures` apply the parameterized search filter.
+
+## File-by-file change list
+
+**New (frontend):**
+- `frontend/src/features/security/components/capture-target-picker.tsx`
+- `frontend/src/features/security/components/capture-target-picker.test.tsx`
+- `frontend/src/features/security/components/bpf-filter-input.tsx`
+- `frontend/src/features/security/components/bpf-filter-input.test.tsx`
+
+**Edit (frontend):**
+- `frontend/src/features/security/pages/packet-capture.tsx` (orchestrate; remove forced cascade; collapsible browse fallback; endpoint column; history search box)
+- `frontend/src/features/security/pages/packet-capture.test.tsx` (update)
+- `frontend/src/features/security/hooks/use-pcap.ts` (`useCaptures` gains `search`)
+
+**Reuse (frontend, no change):**
+- `frontend/src/features/containers/lib/workload-search-filter.ts` (`filterContainers`)
+- `frontend/src/features/containers/lib/container-stack-grouping.ts`
+- `cmdk`
+
+**Edit (backend):**
+- `packages/security/src/models/pcap.ts` (`search` in `CaptureListQuerySchema`)
+- `packages/security/src/services/pcap-service.ts` (`listCaptures` passthrough)
+- pcap-store (`getCaptures` parameterized search predicate)
+- `packages/security/src/__tests__/pcap-route.test.ts`, `pcap-model.test.ts`, store/service test (add cases)
+
+## Docs (project rule)
+
+- `docs/architecture.md`: note the cross-endpoint capture target picker + the `search` param on the captures list.
+- `.env.example`: no new variables.
+- `CLAUDE.md`: short note on the packet-capture cross-endpoint search if behavior warrants.
+
+## Security checklist touchpoints
+
+- New `search` query param validated with Zod at the boundary (`max(200)`).
+- SQL filter strictly parameterized (no concatenation).
+- pcap routes remain admin-gated and `PCAP_ENABLED`-gated; no change to the auth posture.
+- No new sensitive data exposed (container/endpoint names already returned by existing endpoints).

--- a/frontend/src/features/security/components/bpf-filter-input.test.tsx
+++ b/frontend/src/features/security/components/bpf-filter-input.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BpfFilterInput } from './bpf-filter-input';
+
+describe('BpfFilterInput', () => {
+  it('renders the current value', () => {
+    render(<BpfFilterInput value="port 80" onChange={() => {}} />);
+    expect(screen.getByLabelText('BPF filter')).toHaveValue('port 80');
+  });
+  it('sets the value to the preset when empty', () => {
+    const onChange = vi.fn();
+    render(<BpfFilterInput value="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'tcp' }));
+    expect(onChange).toHaveBeenCalledWith('tcp');
+  });
+  it('appends the preset to an existing value', () => {
+    const onChange = vi.fn();
+    render(<BpfFilterInput value="port 80" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'udp' }));
+    expect(onChange).toHaveBeenCalledWith('port 80 udp');
+  });
+  it('edits via free text', () => {
+    const onChange = vi.fn();
+    render(<BpfFilterInput value="" onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('BPF filter'), { target: { value: 'icmp' } });
+    expect(onChange).toHaveBeenCalledWith('icmp');
+  });
+});

--- a/frontend/src/features/security/components/bpf-filter-input.tsx
+++ b/frontend/src/features/security/components/bpf-filter-input.tsx
@@ -1,0 +1,49 @@
+import { Filter } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+
+const BPF_PRESETS = ['tcp', 'udp', 'icmp', 'port 80', 'port 443', 'port 53', 'not port 22'];
+
+export interface BpfFilterInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function BpfFilterInput({ value, onChange }: BpfFilterInputProps) {
+  const addPreset = (preset: string) => {
+    const trimmed = value.trim();
+    onChange(trimmed ? `${trimmed} ${preset}` : preset);
+  };
+
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-medium" htmlFor="bpf-filter">
+        <Filter className="mr-1 inline h-3.5 w-3.5" />
+        BPF Filter
+      </label>
+      <input
+        id="bpf-filter"
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="e.g. port 80 or tcp"
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        aria-label="BPF filter"
+      />
+      <div className="mt-1.5 flex flex-wrap gap-1.5">
+        {BPF_PRESETS.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => addPreset(preset)}
+            className={cn(
+              'rounded-md border border-border/60 bg-card/80 px-2 py-0.5 text-xs font-medium text-muted-foreground',
+              'transition-colors hover:border-primary/30 hover:bg-primary/10 hover:text-primary',
+            )}
+          >
+            {preset}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/security/components/capture-browse-fallback.test.tsx
+++ b/frontend/src/features/security/components/capture-browse-fallback.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CaptureBrowseFallback } from './capture-browse-fallback';
+import type { Container } from '@/features/containers/hooks/use-containers';
+import type { Stack } from '@/features/containers/hooks/use-stacks';
+
+const containers = [
+  { id: 'c1', name: 'api-1', image: 'a', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'alpha' } },
+  { id: 'c4', name: 'beta-api-1', image: 'b', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'beta' } },
+  { id: 'c3', name: 'standalone-1', image: 's', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: {} },
+] as unknown as Container[];
+const stacks = [{ id: 1, name: 'alpha', endpointId: 1 }, { id: 2, name: 'beta', endpointId: 1 }] as unknown as Stack[];
+const endpoints = [{ id: 1, name: 'local' }];
+
+function openDisclosure() {
+  fireEvent.click(screen.getByText(/browse by endpoint/i));
+}
+
+describe('CaptureBrowseFallback', () => {
+  it('groups containers by stack once an endpoint is chosen', () => {
+    render(<CaptureBrowseFallback containers={containers} stacks={stacks} endpoints={endpoints} edgeAsyncEndpointIds={new Set()} onChange={() => {}} />);
+    openDisclosure();
+    fireEvent.click(screen.getAllByRole('combobox')[0]); // endpoint select
+    fireEvent.click(screen.getByRole('option', { name: 'local' }));
+    fireEvent.click(screen.getAllByRole('combobox')[2]); // container select
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.getByText('No Stack')).toBeInTheDocument();
+  }, 20000);
+
+  it('emits a CaptureTarget when a container is chosen', () => {
+    const onChange = vi.fn();
+    render(<CaptureBrowseFallback containers={containers} stacks={stacks} endpoints={endpoints} edgeAsyncEndpointIds={new Set()} onChange={onChange} />);
+    openDisclosure();
+    fireEvent.click(screen.getAllByRole('combobox')[0]);
+    fireEvent.click(screen.getByRole('option', { name: 'local' }));
+    fireEvent.click(screen.getAllByRole('combobox')[2]);
+    fireEvent.click(screen.getByRole('option', { name: 'api-1' }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ endpointId: 1, containerId: 'c1', containerName: 'api-1', endpointName: 'local' }),
+    );
+  }, 20000);
+});

--- a/frontend/src/features/security/components/capture-browse-fallback.tsx
+++ b/frontend/src/features/security/components/capture-browse-fallback.tsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from 'react';
+import { ThemedSelect } from '@/shared/components/ui/themed-select';
+import type { Container } from '@/features/containers/hooks/use-containers';
+import type { Stack } from '@/features/containers/hooks/use-stacks';
+import {
+  buildStackGroupedContainerOptions,
+  resolveContainerStackName,
+  NO_STACK_LABEL,
+} from '@/features/containers/lib/container-stack-grouping';
+import type { CaptureTarget } from './capture-target-picker';
+
+export interface CaptureBrowseFallbackProps {
+  containers: Container[];
+  stacks: Stack[];
+  endpoints: { id: number; name: string }[];
+  edgeAsyncEndpointIds: Set<number>;
+  onChange: (target: CaptureTarget) => void;
+}
+
+export function CaptureBrowseFallback({
+  containers, stacks, endpoints, edgeAsyncEndpointIds, onChange,
+}: CaptureBrowseFallbackProps) {
+  const [endpointId, setEndpointId] = useState<number | undefined>();
+  const [stackName, setStackName] = useState<string | undefined>();
+
+  const knownStackNames = useMemo(
+    () => stacks.filter((s) => s.endpointId === endpointId).map((s) => s.name),
+    [stacks, endpointId],
+  );
+  const endpointContainers = useMemo(
+    () => containers.filter((c) => c.endpointId === endpointId),
+    [containers, endpointId],
+  );
+  const stackOptions = useMemo(() => {
+    const set = new Set<string>(knownStackNames);
+    for (const c of endpointContainers) {
+      set.add(resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL);
+    }
+    return [...set].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base', numeric: true }));
+  }, [endpointContainers, knownStackNames]);
+  const filtered = useMemo(
+    () => (stackName
+      ? endpointContainers.filter((c) => (resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL) === stackName)
+      : endpointContainers),
+    [endpointContainers, stackName, knownStackNames],
+  );
+  const containerOptions = useMemo(
+    () => buildStackGroupedContainerOptions(filtered, knownStackNames),
+    [filtered, knownStackNames],
+  );
+
+  const handleContainer = (id: string) => {
+    const c = filtered.find((x) => x.id === id);
+    if (!c || edgeAsyncEndpointIds.has(c.endpointId)) return;
+    onChange({
+      endpointId: c.endpointId,
+      containerId: c.id,
+      containerName: c.name,
+      endpointName: c.endpointName,
+      stackName: resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL,
+    });
+  };
+
+  return (
+    <details className="mt-3 rounded-md border bg-card/50 p-3 text-sm">
+      <summary className="cursor-pointer select-none font-medium text-muted-foreground">
+        Browse by endpoint
+      </summary>
+      <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <ThemedSelect
+          value={endpointId != null ? String(endpointId) : '__all__'}
+          onValueChange={(v) => { setEndpointId(v === '__all__' ? undefined : Number(v)); setStackName(undefined); }}
+          placeholder="Select endpoint..."
+          options={[{ value: '__all__', label: 'Select endpoint...' }, ...endpoints.map((e) => ({ value: String(e.id), label: e.name }))]}
+          className="w-full text-sm"
+        />
+        <ThemedSelect
+          value={stackName ?? '__all__'}
+          onValueChange={(v) => setStackName(v === '__all__' ? undefined : v)}
+          disabled={endpointId == null}
+          placeholder="All stacks"
+          options={[{ value: '__all__', label: 'All stacks' }, ...stackOptions.map((s) => ({ value: s, label: s }))]}
+          className="w-full text-sm"
+        />
+        <ThemedSelect
+          value="__all__"
+          onValueChange={(v) => v !== '__all__' && handleContainer(v)}
+          disabled={endpointId == null}
+          placeholder="Select container..."
+          options={[{ value: '__all__', label: 'Select container...' }, ...containerOptions]}
+          className="w-full text-sm"
+        />
+      </div>
+    </details>
+  );
+}

--- a/frontend/src/features/security/components/capture-target-picker.test.tsx
+++ b/frontend/src/features/security/components/capture-target-picker.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CaptureTargetPicker, type CaptureTarget } from './capture-target-picker';
+import type { Container } from '@/features/containers/hooks/use-containers';
+import type { Stack } from '@/features/containers/hooks/use-stacks';
+
+const containers = [
+  { id: 'c1', name: 'nginx-prod', image: 'nginx', state: 'running', status: 'Up', endpointId: 1, endpointName: 'prod', ports: [], created: 0, labels: { 'com.docker.compose.project': 'web' }, networks: [] },
+  { id: 'c2', name: 'nginx-stage', image: 'nginx', state: 'running', status: 'Up', endpointId: 2, endpointName: 'staging', ports: [], created: 0, labels: {}, networks: [] },
+  { id: 'c3', name: 'postgres', image: 'postgres', state: 'running', status: 'Up', endpointId: 2, endpointName: 'staging', ports: [], created: 0, labels: {}, networks: [] },
+] as unknown as Container[];
+const stacks = [{ id: 1, name: 'web', endpointId: 1 }] as unknown as Stack[];
+
+function setup(props: Partial<React.ComponentProps<typeof CaptureTargetPicker>> = {}) {
+  const onChange = vi.fn();
+  render(
+    <CaptureTargetPicker
+      containers={containers}
+      stacks={stacks}
+      edgeAsyncEndpointIds={new Set()}
+      value={null}
+      onChange={onChange}
+      {...props}
+    />,
+  );
+  return { onChange };
+}
+
+describe('CaptureTargetPicker', () => {
+  it('finds matching containers across endpoints with no endpoint pre-selection', () => {
+    setup();
+    const input = screen.getByLabelText('Search capture target container');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'nginx' } });
+    expect(screen.getByText('prod')).toBeInTheDocument();
+    expect(screen.getByText('staging')).toBeInTheDocument();
+    expect(screen.getByText('nginx-prod')).toBeInTheDocument();
+    expect(screen.getByText('nginx-stage')).toBeInTheDocument();
+    expect(screen.queryByText('postgres')).not.toBeInTheDocument();
+  });
+
+  it('selecting a container emits a CaptureTarget', () => {
+    const { onChange } = setup();
+    const input = screen.getByLabelText('Search capture target container');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'postgres' } });
+    // The fixture container is named "postgres" with image "postgres", so plain
+    // getByText('postgres') is ambiguous. Click the cmdk item (the row) instead —
+    // this is the spec-sanctioned "click the closest cmdk-item ancestor" approach.
+    fireEvent.click(screen.getByRole('option', { name: /postgres/ }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<CaptureTarget>>({
+        endpointId: 2, containerId: 'c3', containerName: 'postgres', endpointName: 'staging',
+      }),
+    );
+  });
+
+  it('renders the selected target as a clearable chip', () => {
+    const onChange = vi.fn();
+    render(
+      <CaptureTargetPicker
+        containers={containers}
+        stacks={stacks}
+        edgeAsyncEndpointIds={new Set()}
+        value={{ endpointId: 1, containerId: 'c1', containerName: 'nginx-prod', endpointName: 'prod', stackName: 'web' }}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByText('nginx-prod')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Clear selected container'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('disables containers on edge-async endpoints', () => {
+    setup({ edgeAsyncEndpointIds: new Set([2]) });
+    const input = screen.getByLabelText('Search capture target container');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'nginx' } });
+    const stageItem = screen.getByText('nginx-stage').closest('[data-disabled]') as HTMLElement;
+    expect(stageItem).toBeTruthy();
+  });
+});

--- a/frontend/src/features/security/components/capture-target-picker.test.tsx
+++ b/frontend/src/features/security/components/capture-target-picker.test.tsx
@@ -79,4 +79,28 @@ describe('CaptureTargetPicker', () => {
     const stageItem = screen.getByText('nginx-stage').closest('[data-disabled]') as HTMLElement;
     expect(stageItem).toBeTruthy();
   });
+
+  it('keeps endpoints with the same display name as distinct groups', () => {
+    const dupNameContainers = [
+      { id: 'd1', name: 'svc-a', image: 'x', state: 'running', status: 'Up', endpointId: 1, endpointName: 'edge', ports: [], created: 0, labels: {}, networks: [] },
+      { id: 'd2', name: 'svc-b', image: 'x', state: 'running', status: 'Up', endpointId: 2, endpointName: 'edge', ports: [], created: 0, labels: {}, networks: [] },
+    ] as unknown as Container[];
+    render(
+      <CaptureTargetPicker
+        containers={dupNameContainers}
+        stacks={[] as unknown as Stack[]}
+        edgeAsyncEndpointIds={new Set()}
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+    const input = screen.getByLabelText('Search capture target container');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'svc' } });
+    // Both containers from the two same-named endpoints are listed (not merged
+    // or dropped), and the heading appears once per endpoint group.
+    expect(screen.getByText('svc-a')).toBeInTheDocument();
+    expect(screen.getByText('svc-b')).toBeInTheDocument();
+    expect(screen.getAllByText('edge')).toHaveLength(2);
+  });
 });

--- a/frontend/src/features/security/components/capture-target-picker.tsx
+++ b/frontend/src/features/security/components/capture-target-picker.tsx
@@ -36,14 +36,19 @@ export function CaptureTargetPicker({
     () => filterContainers(containers, query, knownStackNames),
     [containers, query, knownStackNames],
   );
+  // Group by endpointId (stable + unique) rather than endpointName, so two
+  // endpoints that happen to share a display name don't merge into one group
+  // or collide on the React key. The name is kept for the group heading.
   const grouped = useMemo(() => {
-    const map = new Map<string, Container[]>();
+    const map = new Map<number, { name: string; containers: Container[] }>();
     for (const c of matches) {
-      const arr = map.get(c.endpointName) ?? [];
-      arr.push(c);
-      map.set(c.endpointName, arr);
+      const entry = map.get(c.endpointId) ?? { name: c.endpointName, containers: [] };
+      entry.containers.push(c);
+      map.set(c.endpointId, entry);
     }
-    return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+    return [...map.entries()]
+      .map(([endpointId, { name, containers: conts }]) => ({ endpointId, name, containers: conts }))
+      .sort((a, b) => a.name.localeCompare(b.name));
   }, [matches]);
   const matchingStacks = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -107,10 +112,10 @@ export function CaptureTargetPicker({
             </Command.Group>
           )}
 
-          {grouped.map(([endpointName, conts]) => (
+          {grouped.map(({ endpointId, name, containers: conts }) => (
             <Command.Group
-              key={endpointName}
-              heading={endpointName}
+              key={endpointId}
+              heading={name}
               className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:text-muted-foreground"
             >
               {conts.map((c) => {

--- a/frontend/src/features/security/components/capture-target-picker.tsx
+++ b/frontend/src/features/security/components/capture-target-picker.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Command } from 'cmdk';
+import { Search, X, Box, Server } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+import type { Container } from '@/features/containers/hooks/use-containers';
+import type { Stack } from '@/features/containers/hooks/use-stacks';
+import { filterContainers } from '@/features/containers/lib/workload-search-filter';
+import { resolveContainerStackName, NO_STACK_LABEL } from '@/features/containers/lib/container-stack-grouping';
+
+export interface CaptureTarget {
+  endpointId: number;
+  containerId: string;
+  containerName: string;
+  endpointName: string;
+  stackName: string;
+}
+
+export interface CaptureTargetPickerProps {
+  containers: Container[];
+  stacks: Stack[];
+  edgeAsyncEndpointIds: Set<number>;
+  value: CaptureTarget | null;
+  onChange: (target: CaptureTarget | null) => void;
+  autoFocus?: boolean;
+}
+
+export function CaptureTargetPicker({
+  containers, stacks, edgeAsyncEndpointIds, value, onChange, autoFocus,
+}: CaptureTargetPickerProps) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const knownStackNames = useMemo(() => stacks.map((s) => s.name), [stacks]);
+  const matches = useMemo(
+    () => filterContainers(containers, query, knownStackNames),
+    [containers, query, knownStackNames],
+  );
+  const grouped = useMemo(() => {
+    const map = new Map<string, Container[]>();
+    for (const c of matches) {
+      const arr = map.get(c.endpointName) ?? [];
+      arr.push(c);
+      map.set(c.endpointName, arr);
+    }
+    return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [matches]);
+  const matchingStacks = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q || q.includes(':')) return [];
+    return [...new Set(knownStackNames)].filter((n) => n.toLowerCase().includes(q)).slice(0, 4);
+  }, [knownStackNames, query]);
+
+  useEffect(() => { if (autoFocus) inputRef.current?.focus(); }, [autoFocus]);
+
+  if (value) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm">
+        <Box className="h-4 w-4 shrink-0 text-primary" />
+        <span className="font-medium">{value.containerName}</span>
+        <span className="truncate text-muted-foreground">· {value.endpointName} · {value.stackName}</span>
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          className="ml-auto rounded p-0.5 text-muted-foreground hover:text-foreground"
+          aria-label="Clear selected container"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <Command shouldFilter={false} className="relative">
+      <div className="flex items-center gap-2 rounded-md border bg-background px-3">
+        <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <Command.Input
+          ref={inputRef}
+          value={query}
+          onValueChange={setQuery}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 120)}
+          placeholder="Search containers — name, stack:web, endpoint:prod…"
+          className="w-full bg-transparent py-2 text-sm focus:outline-none"
+          aria-label="Search capture target container"
+        />
+      </div>
+      {open && query.trim() && (
+        <Command.List className="scrollbar-themed absolute z-20 mt-1 max-h-72 w-full overflow-y-auto rounded-md border bg-popover p-1 shadow-md">
+          <Command.Empty className="px-3 py-2 text-sm text-muted-foreground">
+            No running containers match.
+          </Command.Empty>
+
+          {matchingStacks.length > 0 && (
+            <Command.Group heading="Stacks" className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:text-muted-foreground">
+              {matchingStacks.map((name) => (
+                <Command.Item
+                  key={`stack-${name}`}
+                  value={`stack:${name}`}
+                  onSelect={() => setQuery(`stack:${name}`)}
+                  className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm aria-selected:bg-accent"
+                >
+                  <Server className="h-3.5 w-3.5" /> Stack: {name}
+                </Command.Item>
+              ))}
+            </Command.Group>
+          )}
+
+          {grouped.map(([endpointName, conts]) => (
+            <Command.Group
+              key={endpointName}
+              heading={endpointName}
+              className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:text-muted-foreground"
+            >
+              {conts.map((c) => {
+                const disabled = edgeAsyncEndpointIds.has(c.endpointId);
+                const stackName = resolveContainerStackName(c, knownStackNames) ?? NO_STACK_LABEL;
+                return (
+                  <Command.Item
+                    key={c.id}
+                    value={c.id}
+                    disabled={disabled}
+                    onSelect={() => {
+                      if (disabled) return;
+                      onChange({
+                        endpointId: c.endpointId,
+                        containerId: c.id,
+                        containerName: c.name,
+                        endpointName: c.endpointName,
+                        stackName,
+                      });
+                      setQuery('');
+                      setOpen(false);
+                    }}
+                    title={disabled ? 'Capture unavailable — Edge Async endpoint (no docker exec)' : undefined}
+                    className={cn(
+                      'flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm aria-selected:bg-accent',
+                      disabled && 'cursor-not-allowed opacity-50',
+                    )}
+                  >
+                    <Box className="h-3.5 w-3.5 shrink-0" />
+                    <span className="font-medium">{c.name}</span>
+                    <span className="truncate text-xs text-muted-foreground">{c.image}</span>
+                    <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{stackName}</span>
+                  </Command.Item>
+                );
+              })}
+            </Command.Group>
+          ))}
+        </Command.List>
+      )}
+    </Command>
+  );
+}

--- a/frontend/src/features/security/components/capture-target-picker.tsx
+++ b/frontend/src/features/security/components/capture-target-picker.tsx
@@ -31,6 +31,10 @@ export function CaptureTargetPicker({
   const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // Stack names span every endpoint on purpose — this picker searches across
+  // all endpoints, so a `stack:` token should match by name fleet-wide. (A name
+  // shared by stacks on different endpoints is treated as one label here; the
+  // browse-by-endpoint fallback scopes stacks per endpoint instead.)
   const knownStackNames = useMemo(() => stacks.map((s) => s.name), [stacks]);
   const matches = useMemo(
     () => filterContainers(containers, query, knownStackNames),

--- a/frontend/src/features/security/hooks/use-pcap.test.ts
+++ b/frontend/src/features/security/hooks/use-pcap.test.ts
@@ -71,6 +71,13 @@ describe('use-pcap', () => {
         params: { status: 'complete', containerId: undefined },
       });
     });
+
+    it('useCaptures forwards search in the request params', async () => {
+      const getSpy = vi.spyOn(api, 'get').mockResolvedValue({ captures: [] });
+      renderHook(() => useCaptures({ search: 'web' }), { wrapper: createWrapper() });
+      await waitFor(() => expect(getSpy).toHaveBeenCalled());
+      expect(getSpy).toHaveBeenCalledWith('/api/pcap/captures', { params: expect.objectContaining({ search: 'web' }) });
+    });
   });
 
   describe('useCapture', () => {

--- a/frontend/src/features/security/hooks/use-pcap.ts
+++ b/frontend/src/features/security/hooks/use-pcap.ts
@@ -44,23 +44,6 @@ interface CapturesResponse {
 }
 
 export function useCaptures(filters?: { status?: string; containerId?: string; search?: string }) {
-  const query = useQuery<CapturesResponse>({
-    queryKey: ['pcap', 'captures', filters],
-    queryFn: () => {
-      const params: Record<string, string | undefined> = {
-        status: filters?.status,
-        containerId: filters?.containerId,
-        search: filters?.search,
-      };
-      return api.get<CapturesResponse>('/api/pcap/captures', { params });
-    },
-  });
-
-  // Auto-refetch when there are active captures
-  const hasActive = query.data?.captures.some(
-    (c) => c.status === 'capturing' || c.status === 'pending' || c.status === 'processing',
-  );
-
   return useQuery<CapturesResponse>({
     queryKey: ['pcap', 'captures', filters],
     queryFn: () => {
@@ -71,24 +54,26 @@ export function useCaptures(filters?: { status?: string; containerId?: string; s
       };
       return api.get<CapturesResponse>('/api/pcap/captures', { params });
     },
-    refetchInterval: hasActive ? 2000 : false,
+    // Poll while any capture is still in flight; stop once they all settle.
+    refetchInterval: (query) =>
+      query.state.data?.captures.some(
+        (c) => c.status === 'capturing' || c.status === 'pending' || c.status === 'processing',
+      )
+        ? 2000
+        : false,
   });
 }
 
 export function useCapture(id: string | undefined) {
-  const result = useQuery<Capture>({
-    queryKey: ['pcap', 'capture', id],
-    queryFn: () => api.get<Capture>(`/api/pcap/captures/${id}`),
-    enabled: !!id,
-  });
-
-  const isActive = result.data?.status === 'capturing' || result.data?.status === 'processing';
-
   return useQuery<Capture>({
     queryKey: ['pcap', 'capture', id],
     queryFn: () => api.get<Capture>(`/api/pcap/captures/${id}`),
     enabled: !!id,
-    refetchInterval: isActive ? 2000 : false,
+    // Poll while this capture is still running.
+    refetchInterval: (query) =>
+      query.state.data?.status === 'capturing' || query.state.data?.status === 'processing'
+        ? 2000
+        : false,
   });
 }
 

--- a/frontend/src/features/security/hooks/use-pcap.ts
+++ b/frontend/src/features/security/hooks/use-pcap.ts
@@ -43,13 +43,14 @@ interface CapturesResponse {
   captures: Capture[];
 }
 
-export function useCaptures(filters?: { status?: string; containerId?: string }) {
+export function useCaptures(filters?: { status?: string; containerId?: string; search?: string }) {
   const query = useQuery<CapturesResponse>({
     queryKey: ['pcap', 'captures', filters],
     queryFn: () => {
       const params: Record<string, string | undefined> = {
         status: filters?.status,
         containerId: filters?.containerId,
+        search: filters?.search,
       };
       return api.get<CapturesResponse>('/api/pcap/captures', { params });
     },
@@ -66,6 +67,7 @@ export function useCaptures(filters?: { status?: string; containerId?: string })
       const params: Record<string, string | undefined> = {
         status: filters?.status,
         containerId: filters?.containerId,
+        search: filters?.search,
       };
       return api.get<CapturesResponse>('/api/pcap/captures', { params });
     },

--- a/frontend/src/features/security/pages/packet-capture.test.tsx
+++ b/frontend/src/features/security/pages/packet-capture.test.tsx
@@ -16,30 +16,10 @@ vi.mock('@/features/containers/hooks/use-endpoints', () => ({
 vi.mock('@/features/containers/hooks/use-containers', () => ({
   useContainers: vi.fn().mockReturnValue({
     data: [
-      {
-        id: 'c1',
-        name: 'api-1',
-        state: 'running',
-        labels: { 'com.docker.compose.project': 'alpha' },
-      },
-      {
-        id: 'c2',
-        name: 'worker-1',
-        state: 'running',
-        labels: { 'com.docker.compose.project': 'alpha' },
-      },
-      {
-        id: 'c4',
-        name: 'beta-api-1',
-        state: 'running',
-        labels: { 'com.docker.compose.project': 'beta' },
-      },
-      {
-        id: 'c3',
-        name: 'standalone-1',
-        state: 'running',
-        labels: {},
-      },
+      { id: 'c1', name: 'api-1', image: 'api:1', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'alpha' } },
+      { id: 'c2', name: 'worker-1', image: 'worker:1', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'alpha' } },
+      { id: 'c4', name: 'beta-api-1', image: 'beta:1', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: { 'com.docker.compose.project': 'beta' } },
+      { id: 'c3', name: 'standalone-1', image: 'std:1', state: 'running', status: 'Up', endpointId: 1, endpointName: 'local', ports: [], created: 0, networks: [], labels: {} },
     ],
   }),
 }));
@@ -113,45 +93,18 @@ function makeCapture(overrides: Partial<Capture> = {}): Capture {
 }
 
 describe('PacketCapture', () => {
-  // Radix Select portal interactions are slow on cold JSDOM start; give them headroom.
-  it('groups running container options by stack and no-stack bucket', () => {
+  it('shows capture targets without selecting an endpoint first', () => {
     render(<PacketCapture />);
+    const input = screen.getByLabelText('Search capture target container');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'api-1' } });
+    expect(screen.getByText('api-1')).toBeInTheDocument();
+  });
 
-    const endpointSelect = screen.getAllByRole('combobox')[0];
-    fireEvent.click(endpointSelect);
-    fireEvent.click(screen.getByRole('option', { name: 'local' }));
-
-    const containerSelect = screen.getAllByRole('combobox')[2];
-    fireEvent.click(containerSelect);
-
-    expect(screen.getByText('alpha')).toBeInTheDocument();
-    expect(screen.getByText('beta')).toBeInTheDocument();
-    expect(screen.getByText('No Stack')).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'api-1' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'worker-1' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'beta-api-1' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'standalone-1' })).toBeInTheDocument();
-  }, 20000);
-
-  it('filters container options by selected stack', () => {
+  it('disables Start until a target is selected', () => {
     render(<PacketCapture />);
-
-    const endpointSelect = screen.getAllByRole('combobox')[0];
-    fireEvent.click(endpointSelect);
-    fireEvent.click(screen.getByRole('option', { name: 'local' }));
-
-    const stackSelect = screen.getAllByRole('combobox')[1];
-    fireEvent.click(stackSelect);
-    fireEvent.click(screen.getByRole('option', { name: 'alpha' }));
-
-    const containerSelect = screen.getAllByRole('combobox')[2];
-    fireEvent.click(containerSelect);
-
-    expect(screen.getByRole('option', { name: 'api-1' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'worker-1' })).toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: 'beta-api-1' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: 'standalone-1' })).not.toBeInTheDocument();
-  }, 20000);
+    expect(screen.getByRole('button', { name: /start capture/i })).toBeDisabled();
+  });
 
   it('shows the empty state when there are no captures', () => {
     mockUseCaptures.mockReturnValue({ data: { captures: [] }, refetch: vi.fn() } as unknown as ReturnType<typeof useCaptures>);

--- a/frontend/src/features/security/pages/packet-capture.test.tsx
+++ b/frontend/src/features/security/pages/packet-capture.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { useCaptures, type Capture } from '@/features/security/hooks/use-pcap';
 
 vi.mock('@/features/containers/hooks/use-endpoints', () => ({
@@ -146,5 +146,22 @@ describe('PacketCapture', () => {
     // Download + delete actions available for a completed capture with a file
     expect(within(table).getByTitle('Download PCAP')).toBeInTheDocument();
     expect(within(table).getByTitle('Delete capture')).toBeInTheDocument();
+  });
+
+  it('passes the history search term to useCaptures', async () => {
+    render(<PacketCapture />);
+    fireEvent.change(screen.getByLabelText('Search capture history'), { target: { value: 'web' } });
+    await waitFor(() =>
+      expect(mockUseCaptures).toHaveBeenCalledWith(expect.objectContaining({ search: 'web' })),
+    );
+  });
+
+  it('shows the endpoint name in the history table', () => {
+    mockUseCaptures.mockReturnValue({
+      data: { captures: [makeCapture({ endpoint_id: 1, container_name: 'web-1' })] },
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useCaptures>);
+    render(<PacketCapture />);
+    expect(screen.getByText('local')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/security/pages/packet-capture.tsx
+++ b/frontend/src/features/security/pages/packet-capture.tsx
@@ -7,7 +7,6 @@ import {
   Download,
   Trash2,
   Clock,
-  Filter,
   Brain,
   ChevronDown,
   ChevronRight,
@@ -20,7 +19,7 @@ import {
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { DataTable } from '@/shared/components/tables/data-table';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
-import { useEndpoints, useEndpointCapabilities } from '@/features/containers/hooks/use-endpoints';
+import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
 import { useContainers } from '@/features/containers/hooks/use-containers';
 import { useStacks } from '@/features/containers/hooks/use-stacks';
 import {
@@ -34,10 +33,10 @@ import {
   type PcapAnalysisResult,
   type PcapFinding,
 } from '@/features/security/hooks/use-pcap';
+import { CaptureTargetPicker, type CaptureTarget } from '@/features/security/components/capture-target-picker';
+import { BpfFilterInput } from '@/features/security/components/bpf-filter-input';
 import { api } from '@/shared/lib/api';
 import { cn } from '@/shared/lib/utils';
-import { ThemedSelect } from '@/shared/components/ui/themed-select';
-import { buildStackGroupedContainerOptions, NO_STACK_LABEL, resolveContainerStackName } from '@/features/containers/lib/container-stack-grouping';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 function formatBytes(bytes: number): string {
@@ -65,17 +64,14 @@ const STATUS_TABS = [
 ] as const;
 
 export default function PacketCapture() {
-  const [selectedEndpoint, setSelectedEndpoint] = useState<number | undefined>();
-  const [selectedStack, setSelectedStack] = useState<string | undefined>();
-  const [selectedContainer, setSelectedContainer] = useState('');
-  const [selectedContainerName, setSelectedContainerName] = useState('');
+  const [target, setTarget] = useState<CaptureTarget | null>(null);
   const [bpfFilter, setBpfFilter] = useState('');
   const [duration, setDuration] = useState('60');
   const [maxPackets, setMaxPackets] = useState('');
   const [statusFilter, setStatusFilter] = useState<string | undefined>();
 
   const { data: endpoints } = useEndpoints();
-  const { data: containers } = useContainers(selectedEndpoint !== undefined ? { endpointId: selectedEndpoint } : undefined);
+  const { data: containers } = useContainers({ state: 'running' });
   const { data: stacks } = useStacks();
   const { data: capturesData, refetch, isFetching } = useCaptures({ status: statusFilter });
   const [expandedAnalysis, setExpandedAnalysis] = useState<Set<string>>(new Set());
@@ -84,55 +80,31 @@ export default function PacketCapture() {
   const deleteCapture = useDeleteCapture();
   const analyzeMutation = useAnalyzeCapture();
 
-  const { isEdgeAsync } = useEndpointCapabilities(selectedEndpoint);
   const captures = capturesData?.captures ?? [];
   const activeCaptures = captures.filter(
     (c) => c.status === 'capturing' || c.status === 'pending' || c.status === 'processing',
   );
-  const runningContainers = containers?.filter((c) => c.state === 'running') ?? [];
-  const stackNamesForEndpoint = useMemo(() => {
-    if (!selectedEndpoint || !stacks) return [];
-    return stacks
-      .filter((stack) => stack.endpointId === selectedEndpoint)
-      .map((stack) => stack.name);
-  }, [selectedEndpoint, stacks]);
-  const stackOptions = useMemo(() => {
-    const stackSet = new Set<string>(stackNamesForEndpoint);
-    for (const container of runningContainers) {
-      const resolvedStack = resolveContainerStackName(container, stackNamesForEndpoint) ?? NO_STACK_LABEL;
-      stackSet.add(resolvedStack);
-    }
-    return [...stackSet].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base', numeric: true }));
-  }, [runningContainers, stackNamesForEndpoint]);
-  const filteredRunningContainers = useMemo(() => {
-    if (!selectedStack) return runningContainers;
-    return runningContainers.filter((container) => {
-      const resolvedStack = resolveContainerStackName(container, stackNamesForEndpoint) ?? NO_STACK_LABEL;
-      return resolvedStack === selectedStack;
-    });
-  }, [runningContainers, selectedStack, stackNamesForEndpoint]);
-  const groupedContainerOptions = useMemo(
-    () => buildStackGroupedContainerOptions(filteredRunningContainers, stackNamesForEndpoint),
-    [filteredRunningContainers, stackNamesForEndpoint],
+  const edgeAsyncEndpointIds = useMemo(
+    () => new Set((endpoints ?? []).filter((e) => e.edgeMode === 'async').map((e) => e.id)),
+    [endpoints],
   );
+  const runningContainers = useMemo(
+    () => (containers ?? []).filter((c) => c.state === 'running'),
+    [containers],
+  );
+  const targetIsEdgeAsync = target ? edgeAsyncEndpointIds.has(target.endpointId) : false;
 
   const handleStartCapture = () => {
-    if (!selectedEndpoint || !selectedContainer) return;
+    if (!target || targetIsEdgeAsync) return;
 
     startCapture.mutate({
-      endpointId: selectedEndpoint,
-      containerId: selectedContainer,
-      containerName: selectedContainerName,
+      endpointId: target.endpointId,
+      containerId: target.containerId,
+      containerName: target.containerName,
       filter: bpfFilter || undefined,
       durationSeconds: duration ? parseInt(duration, 10) : undefined,
       maxPackets: maxPackets ? parseInt(maxPackets, 10) : undefined,
     });
-  };
-
-  const handleContainerChange = (value: string) => {
-    setSelectedContainer(value);
-    const container = filteredRunningContainers.find((c) => c.id === value);
-    setSelectedContainerName(container?.name ?? '');
   };
 
   const stopMutate = stopCapture.mutate;
@@ -300,97 +272,31 @@ export default function PacketCapture() {
         <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
       </div>
 
-      {/* Edge Async warning */}
-      {isEdgeAsync && (
-        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 flex items-center gap-3">
-          <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0" />
-          <div>
-            <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
-              Edge Async Agent — Packet capture unavailable
-            </p>
-            <p className="text-xs text-muted-foreground">
-              This endpoint uses asynchronous communication without a persistent tunnel. Docker exec operations (required for tcpdump) are not supported.
-            </p>
-          </div>
-        </div>
-      )}
-
       {/* New Capture Form */}
       <SpotlightCard>
       <div className="rounded-lg border bg-card p-6 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold">New Capture</h2>
+
+        {/* Target container */}
+        <div className="mb-4">
+          <label className="mb-1 block text-sm font-medium">Target container</label>
+          <CaptureTargetPicker
+            containers={runningContainers}
+            stacks={stacks ?? []}
+            edgeAsyncEndpointIds={edgeAsyncEndpointIds}
+            value={target}
+            onChange={setTarget}
+          />
+          {targetIsEdgeAsync && (
+            <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+              This container&apos;s endpoint is Edge Async — packet capture requires docker exec and is unavailable.
+            </p>
+          )}
+        </div>
+
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {/* Endpoint */}
-          <div>
-            <label className="mb-1 block text-sm font-medium">Endpoint</label>
-            <ThemedSelect
-              value={selectedEndpoint != null ? String(selectedEndpoint) : '__all__'}
-              onValueChange={(val) => {
-                const resolved = val === '__all__' ? undefined : Number(val);
-                setSelectedEndpoint(resolved);
-                setSelectedStack(undefined);
-                setSelectedContainer('');
-                setSelectedContainerName('');
-              }}
-              placeholder="Select endpoint..."
-              options={[
-                { value: '__all__', label: 'Select endpoint...' },
-                ...(endpoints?.map((ep) => ({ value: String(ep.id), label: ep.name })) ?? []),
-              ]}
-              className="w-full text-sm"
-            />
-          </div>
-
-          {/* Stack */}
-          <div>
-            <label className="mb-1 block text-sm font-medium">Stack</label>
-            <ThemedSelect
-              value={selectedStack ?? '__all__'}
-              onValueChange={(val) => {
-                setSelectedStack(val === '__all__' ? undefined : val);
-                setSelectedContainer('');
-                setSelectedContainerName('');
-              }}
-              disabled={!selectedEndpoint}
-              placeholder="All stacks"
-              options={[
-                { value: '__all__', label: 'All stacks' },
-                ...stackOptions.map((stackName) => ({ value: stackName, label: stackName })),
-              ]}
-              className="w-full text-sm"
-            />
-          </div>
-
-          {/* Container */}
-          <div>
-            <label className="mb-1 block text-sm font-medium">Container</label>
-            <ThemedSelect
-              value={selectedContainer || '__all__'}
-              onValueChange={(val) => handleContainerChange(val === '__all__' ? '' : val)}
-              disabled={!selectedEndpoint}
-              placeholder="Select container..."
-              options={[
-                { value: '__all__', label: 'Select container...' },
-                ...groupedContainerOptions,
-              ]}
-              className="w-full text-sm"
-            />
-          </div>
-
           {/* BPF Filter */}
-          <div>
-            <label className="mb-1 block text-sm font-medium">
-              <Filter className="mr-1 inline h-3.5 w-3.5" />
-              BPF Filter
-            </label>
-            <input
-              type="text"
-              value={bpfFilter}
-              onChange={(e) => setBpfFilter(e.target.value)}
-              placeholder="e.g. port 80 or tcp"
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            />
-          </div>
+          <BpfFilterInput value={bpfFilter} onChange={setBpfFilter} />
 
           {/* Duration */}
           <div>
@@ -426,7 +332,7 @@ export default function PacketCapture() {
           <div className="flex items-end">
             <button
               onClick={handleStartCapture}
-              disabled={!selectedEndpoint || !selectedContainer || startCapture.isPending || isEdgeAsync}
+              disabled={!target || targetIsEdgeAsync || startCapture.isPending}
               className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
             >
               <Play className="h-4 w-4" />

--- a/frontend/src/features/security/pages/packet-capture.tsx
+++ b/frontend/src/features/security/pages/packet-capture.tsx
@@ -34,6 +34,7 @@ import {
   type PcapFinding,
 } from '@/features/security/hooks/use-pcap';
 import { CaptureTargetPicker, type CaptureTarget } from '@/features/security/components/capture-target-picker';
+import { CaptureBrowseFallback } from '@/features/security/components/capture-browse-fallback';
 import { BpfFilterInput } from '@/features/security/components/bpf-filter-input';
 import { api } from '@/shared/lib/api';
 import { cn } from '@/shared/lib/utils';
@@ -314,6 +315,13 @@ export default function PacketCapture() {
               This container&apos;s endpoint is Edge Async — packet capture requires docker exec and is unavailable.
             </p>
           )}
+          <CaptureBrowseFallback
+            containers={runningContainers}
+            stacks={stacks ?? []}
+            endpoints={endpoints ?? []}
+            edgeAsyncEndpointIds={edgeAsyncEndpointIds}
+            onChange={setTarget}
+          />
         </div>
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/frontend/src/features/security/pages/packet-capture.tsx
+++ b/frontend/src/features/security/pages/packet-capture.tsx
@@ -102,10 +102,9 @@ export default function PacketCapture() {
     () => new Map((endpoints ?? []).map((e) => [e.id, e.name])),
     [endpoints],
   );
-  const runningContainers = useMemo(
-    () => (containers ?? []).filter((c) => c.state === 'running'),
-    [containers],
-  );
+  // useContainers({ state: 'running' }) already filters server-side, so this is
+  // just a stable [] fallback for the picker/fallback props.
+  const runningContainers = containers ?? [];
   const targetIsEdgeAsync = target ? edgeAsyncEndpointIds.has(target.endpointId) : false;
 
   const handleStartCapture = () => {

--- a/frontend/src/features/security/pages/packet-capture.tsx
+++ b/frontend/src/features/security/pages/packet-capture.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type ColumnDef } from '@tanstack/react-table';
 import {
   Radio,
@@ -69,11 +69,20 @@ export default function PacketCapture() {
   const [duration, setDuration] = useState('60');
   const [maxPackets, setMaxPackets] = useState('');
   const [statusFilter, setStatusFilter] = useState<string | undefined>();
+  const [historySearch, setHistorySearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(historySearch), 300);
+    return () => clearTimeout(t);
+  }, [historySearch]);
 
   const { data: endpoints } = useEndpoints();
   const { data: containers } = useContainers({ state: 'running' });
   const { data: stacks } = useStacks();
-  const { data: capturesData, refetch, isFetching } = useCaptures({ status: statusFilter });
+  const { data: capturesData, refetch, isFetching } = useCaptures({
+    status: statusFilter,
+    search: debouncedSearch || undefined,
+  });
   const [expandedAnalysis, setExpandedAnalysis] = useState<Set<string>>(new Set());
   const startCapture = useStartCapture();
   const stopCapture = useStopCapture();
@@ -86,6 +95,10 @@ export default function PacketCapture() {
   );
   const edgeAsyncEndpointIds = useMemo(
     () => new Set((endpoints ?? []).filter((e) => e.edgeMode === 'async').map((e) => e.id)),
+    [endpoints],
+  );
+  const endpointNameById = useMemo(
+    () => new Map((endpoints ?? []).map((e) => [e.id, e.name])),
     [endpoints],
   );
   const runningContainers = useMemo(
@@ -152,6 +165,15 @@ export default function PacketCapture() {
           </div>
         );
       },
+    },
+    {
+      accessorKey: 'endpoint_id',
+      header: 'Endpoint',
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">
+          {endpointNameById.get(row.original.endpoint_id) ?? `#${row.original.endpoint_id}`}
+        </span>
+      ),
     },
     {
       accessorKey: 'status',
@@ -245,7 +267,7 @@ export default function PacketCapture() {
         );
       },
     },
-  ], [expandedAnalysis, toggleExpand, handleStop, handleDelete, handleDownload, handleAnalyze, analyzePending, analyzeVariables]);
+  ], [endpointNameById, expandedAnalysis, toggleExpand, handleStop, handleDelete, handleDownload, handleAnalyze, analyzePending, analyzeVariables]);
 
   const expandedCaptures = useMemo(
     () =>
@@ -364,21 +386,31 @@ export default function PacketCapture() {
       <div className="space-y-3">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold">Capture History</h2>
-          <div className="flex gap-1 rounded-md border p-0.5">
-            {STATUS_TABS.map((tab) => (
-              <button
-                key={tab.label}
-                onClick={() => setStatusFilter(tab.value)}
-                className={cn(
-                  'rounded px-3 py-1 text-xs font-medium transition-colors',
-                  statusFilter === tab.value
-                    ? 'bg-primary text-primary-foreground'
-                    : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                {tab.label}
-              </button>
-            ))}
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={historySearch}
+              onChange={(e) => setHistorySearch(e.target.value)}
+              placeholder="Search history…"
+              aria-label="Search capture history"
+              className="rounded-md border bg-background px-3 py-1.5 text-xs"
+            />
+            <div className="flex gap-1 rounded-md border p-0.5">
+              {STATUS_TABS.map((tab) => (
+                <button
+                  key={tab.label}
+                  onClick={() => setStatusFilter(tab.value)}
+                  className={cn(
+                    'rounded px-3 py-1 text-xs font-medium transition-colors',
+                    statusFilter === tab.value
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 

--- a/packages/security/src/__tests__/pcap-model.test.ts
+++ b/packages/security/src/__tests__/pcap-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { StartCaptureRequestSchema } from '../models/pcap.js';
+import { StartCaptureRequestSchema, CaptureListQuerySchema } from '../models/pcap.js';
 
 describe('StartCaptureRequestSchema filter validation', () => {
   const basePayload = {
@@ -33,5 +33,17 @@ describe('StartCaptureRequestSchema filter validation', () => {
     });
 
     expect(result.success).toBe(false);
+  });
+});
+
+describe('CaptureListQuerySchema search', () => {
+  it('accepts an optional search string', () => {
+    expect(CaptureListQuerySchema.parse({ search: 'web' }).search).toBe('web');
+  });
+  it('defaults search to undefined when absent', () => {
+    expect(CaptureListQuerySchema.parse({}).search).toBeUndefined();
+  });
+  it('rejects an over-long search string', () => {
+    expect(() => CaptureListQuerySchema.parse({ search: 'x'.repeat(201) })).toThrow();
   });
 });

--- a/packages/security/src/__tests__/pcap-route.test.ts
+++ b/packages/security/src/__tests__/pcap-route.test.ts
@@ -236,6 +236,13 @@ describe('PCAP Routes', () => {
       );
     });
 
+    it('passes search from the query string to listCaptures', async () => {
+      mockListCaptures.mockResolvedValue([]);
+      const res = await app.inject({ method: 'GET', url: '/api/pcap/captures?search=web' });
+      expect(res.statusCode).toBe(200);
+      expect(mockListCaptures).toHaveBeenCalledWith(expect.objectContaining({ search: 'web' }));
+    });
+
     testAdminOnly(() => app, (r) => { currentRole = r; }, 'GET', '/api/pcap/captures');
   });
 

--- a/packages/security/src/__tests__/pcap-service.test.ts
+++ b/packages/security/src/__tests__/pcap-service.test.ts
@@ -38,6 +38,7 @@ const {
   getCaptureById,
   deleteCaptureById,
   cleanupOrphanedSidecars,
+  listCaptures,
 } = await import('../services/pcap-service.js');
 import * as portainer from '@dashboard/core/portainer/portainer-client.js';
 
@@ -496,6 +497,14 @@ describe('pcap-service', () => {
       const cleaned = await cleanupOrphanedSidecars([1]);
 
       expect(cleaned).toBe(0);
+    });
+  });
+
+  describe('listCaptures', () => {
+    it('passes search through to getCaptures', async () => {
+      mockGetCaptures.mockResolvedValue([]);
+      await listCaptures({ search: 'web' });
+      expect(mockGetCaptures).toHaveBeenCalledWith({ search: 'web' });
     });
   });
 });

--- a/packages/security/src/__tests__/pcap-store.test.ts
+++ b/packages/security/src/__tests__/pcap-store.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { escapeLikePattern } from '../services/pcap-store.js';
+
+describe('escapeLikePattern', () => {
+  it('leaves a plain term unchanged', () => {
+    expect(escapeLikePattern('web')).toBe('web');
+  });
+
+  it('escapes percent so it matches literally', () => {
+    expect(escapeLikePattern('100%')).toBe('100\\%');
+  });
+
+  it('escapes underscore so it matches literally', () => {
+    expect(escapeLikePattern('a_b')).toBe('a\\_b');
+  });
+
+  it('escapes backslash itself', () => {
+    expect(escapeLikePattern('a\\b')).toBe('a\\\\b');
+  });
+
+  it('escapes a combination of metacharacters', () => {
+    expect(escapeLikePattern('%_\\')).toBe('\\%\\_\\\\');
+  });
+});

--- a/packages/security/src/models/pcap.ts
+++ b/packages/security/src/models/pcap.ts
@@ -88,6 +88,7 @@ export type StartCaptureRequest = z.infer<typeof StartCaptureRequestSchema>;
 export const CaptureListQuerySchema = z.object({
   status: CaptureStatusSchema.optional(),
   containerId: z.string().optional(),
+  search: z.string().max(200).optional(),
   limit: z.coerce.number().int().min(1).max(200).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });

--- a/packages/security/src/services/pcap-service.ts
+++ b/packages/security/src/services/pcap-service.ts
@@ -393,6 +393,7 @@ export async function getCaptureById(id: string): Promise<Capture | undefined> {
 export async function listCaptures(options?: {
   status?: CaptureStatus;
   containerId?: string;
+  search?: string;
   limit?: number;
   offset?: number;
 }): Promise<Capture[]> {

--- a/packages/security/src/services/pcap-store.ts
+++ b/packages/security/src/services/pcap-store.ts
@@ -76,6 +76,7 @@ export async function getCapture(id: string): Promise<Capture | undefined> {
 export interface GetCapturesOptions {
   status?: CaptureStatus;
   containerId?: string;
+  search?: string;
   limit?: number;
   offset?: number;
 }
@@ -92,6 +93,11 @@ export async function getCaptures(options: GetCapturesOptions = {}): Promise<Cap
   if (options.containerId) {
     conditions.push('container_id = ?');
     params.push(options.containerId);
+  }
+
+  if (options.search) {
+    conditions.push("(container_name ILIKE ? OR COALESCE(filter, '') ILIKE ?)");
+    params.push(`%${options.search}%`, `%${options.search}%`);
   }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';

--- a/packages/security/src/services/pcap-store.ts
+++ b/packages/security/src/services/pcap-store.ts
@@ -81,6 +81,16 @@ export interface GetCapturesOptions {
   offset?: number;
 }
 
+/**
+ * Escape LIKE/ILIKE wildcard metacharacters so a user's search term is matched
+ * literally. PostgreSQL's default LIKE escape character is backslash, so a
+ * backslash-prefixed `%`, `_`, or `\` is treated as the literal character.
+ * Without this, typing `%` would match every row and `_` any single character.
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&');
+}
+
 export async function getCaptures(options: GetCapturesOptions = {}): Promise<Capture[]> {
   const conditions: string[] = [];
   const params: unknown[] = [];
@@ -96,8 +106,9 @@ export async function getCaptures(options: GetCapturesOptions = {}): Promise<Cap
   }
 
   if (options.search) {
+    const pattern = `%${escapeLikePattern(options.search)}%`;
     conditions.push("(container_name ILIKE ? OR COALESCE(filter, '') ILIKE ?)");
-    params.push(`%${options.search}%`, `%${options.search}%`);
+    params.push(pattern, pattern);
   }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';


### PR DESCRIPTION
## Summary

Overhauls the Packet Capture filter system. The New Capture form no longer forces an **Endpoint → Stack → Container** cascade — you can now type a container name (or `stack:`/`endpoint:`) and pick a target across **all** endpoints with no pre-selection.

- **Search-first target picker** (`CaptureTargetPicker`, cmdk): loads running containers across every endpoint (`useContainers({ state: 'running' })`), filters client-side via the shared `filterContainers` parser (`name:` / `stack:` / `endpoint:` / `image:` …), groups results by endpoint (keyed by stable `endpointId`), and shows the choice as a removable chip with endpoint + stack context. Edge-async endpoints are shown disabled (no docker exec). Selecting a target needs no endpoint pre-selection.
- **Browse-by-endpoint fallback** (`CaptureBrowseFallback`): the classic Endpoint → Stack → Container dropdowns kept as a collapsed `<details>` for discoverability; produces the same `CaptureTarget`.
- **BPF presets** (`BpfFilterInput`): quick chips (`tcp`, `udp`, `port 80`, `not port 22`, …) alongside the free-text BPF box.
- **Capture history search + Endpoint column**: debounced server-side search on `GET /api/pcap/captures` (`?search=`, parameterized `container_name`/`filter` ILIKE with wildcard escaping) and a new Endpoint column.

Reuses existing infra rather than reinventing it: `filterContainers`, `buildStackGroupedContainerOptions`, `resolveContainerStackName`, and `cmdk`.

## Security

- New `search` param validated with Zod (`max(200)`); SQL strictly parameterized (`?` placeholders), LIKE wildcards (`%`/`_`/`\`) escaped so they match literally.
- PCAP routes remain admin-gated + `PCAP_ENABLED`-gated (unchanged). No new sensitive data exposed.

## Test Plan

- [x] Backend: `cd packages/security && npx vitest run src/__tests__/pcap-*.test.ts` — 74 pass (schema accepts/rejects `search`, store passes parameterized filter, `escapeLikePattern` unit tests, route forwards `search`, admin gate intact).
- [x] Frontend: `cd frontend && npx vitest run src/features/security` — 82 pass (picker cross-endpoint search, edge-async disabled, chip select/clear, same-name endpoints stay distinct, BPF presets, history search drives `useCaptures`, endpoint column, browse fallback grouping).
- [x] `npm run typecheck` — 0 errors in changed files.
- [ ] Manual: open Packet Capture, type a container name with no endpoint selected, start a capture; search history; try the browse fallback.

Spec: `docs/superpowers/specs/2026-05-30-packet-capture-filter-overhaul-design.md`
Plan: `docs/superpowers/plans/2026-05-30-packet-capture-filter-overhaul.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)