### PR TITLE
feat(anomaly): cross-detector dedup + severity×confidence routing (part of #1363)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -142,6 +142,11 @@ ANOMALY_PERSISTENCE_ENABLED=true
 ANOMALY_PERSISTENCE_M=3
 ANOMALY_PERSISTENCE_N=5
 ANOMALY_FAST_BURN_MULTIPLIER=2
+# Severity × confidence routing (#1363). A confirmed anomaly whose confidence
+# (max of persistence ratio and burn magnitude) is below this surfaces as
+# 'info' (a quieter log tier that does not page) instead of warning/critical.
+# Default 0.7 is above the 3-of-5 (0.6) confirmation floor; 0 surfaces everything.
+ANOMALY_CONFIDENCE_MIN_SURFACE=0.7
 BOLLINGER_BANDS_ENABLED=true
 # Per-user Sensitivity preset (#1297) — Low / Default / High — is persisted
 # in the `user_settings` table (migration 036) and exposed via

--- a/docs/ai-anomaly-detection.md
+++ b/docs/ai-anomaly-detection.md
@@ -45,6 +45,7 @@ Instead of a single flat 24h baseline, the detector compares each observation ag
 | `ANOMALY_PERSISTENCE_ENABLED` | `true` | M-of-N persistence + multi-window gate (#1363). An anomaly must persist before it surfaces; `false` = legacy (surface every raw anomaly). |
 | `ANOMALY_PERSISTENCE_M` / `ANOMALY_PERSISTENCE_N` | `3` / `5` | Confirm only when ≥ M of the last N cycles are anomalous — suppresses isolated benign blips. |
 | `ANOMALY_FAST_BURN_MULTIPLIER` | `2` | A severe single sample (severity ≥ this × threshold) bypasses persistence and surfaces immediately (short high-burn-rate window). |
+| `ANOMALY_CONFIDENCE_MIN_SURFACE` | `0.7` | Severity × confidence routing (#1363). A confirmed anomaly with confidence (max of persistence ratio and burn magnitude) below this is routed to `info` (a quieter log tier) instead of warning/critical. `0` surfaces everything. |
 | `ANOMALY_COOLDOWN_MINUTES` | `30` | Per-container/metric cooldown to prevent alert spam |
 | `BOLLINGER_BANDS_ENABLED` | `true` | Enable the Bollinger method |
 

--- a/packages/ai-intelligence/src/__tests__/anomaly-gate.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-gate.test.ts
@@ -4,7 +4,7 @@ import {
   InMemoryPersistenceStore,
   setPersistenceStoreForTest,
 } from '@dashboard/core/services/persistence-store.js';
-import { confirmAnomaly } from '../services/anomaly-gate.js';
+import { confirmAnomaly, routeSeverity } from '../services/anomaly-gate.js';
 
 const baseCfg = {
   ANOMALY_PERSISTENCE_ENABLED: true,
@@ -56,5 +56,42 @@ describe('confirmAnomaly — M-of-N persistence + multi-window (#1363)', () => {
     const r = await confirmAnomaly({ key: 'c1:cpu', isAnomalous: true, severity: 1.0 });
     expect(r.emit).toBe(true);
     expect(r.reason).toBe('disabled');
+  });
+
+  it('reports confidence as max(persistence ratio, burn magnitude)', async () => {
+    // Fast-burn severe (severity 2.5, multiplier 2) → magnitude factor 1.0.
+    const fb = await confirmAnomaly({ key: 'a', isAnomalous: true, severity: 2.5 });
+    expect(fb.confidence).toBeCloseTo(1, 5);
+
+    // First moderate cycle on 'b': persistence 1/5 = 0.2, magnitude 1.2/2 = 0.6
+    // → confidence 0.6 (magnitude dominates early).
+    const r1 = await confirmAnomaly({ key: 'b', isAnomalous: true, severity: 1.2 });
+    expect(r1.confidence).toBeCloseTo(0.6, 5);
+
+    // Low-magnitude but fully persisted on 'c': 5/5 = 1.0 dominates.
+    for (let i = 0; i < 4; i++) await confirmAnomaly({ key: 'c', isAnomalous: true, severity: 1.0 });
+    const r5 = await confirmAnomaly({ key: 'c', isAnomalous: true, severity: 1.0 }); // 5/5
+    expect(r5.confidence).toBeCloseTo(1, 5);
+  });
+});
+
+describe('routeSeverity — severity × confidence routing (#1363)', () => {
+  const minSurface = 0.7;
+
+  it('routes low-confidence anomalies to the info (log) tier', () => {
+    // 3-of-5 with low magnitude → confidence 0.6 < 0.7 → quieter tier.
+    expect(routeSeverity(0.6, 3.5, minSurface)).toBe('info');
+  });
+
+  it('routes confident, moderate anomalies to warning', () => {
+    expect(routeSeverity(0.8, 3.5, minSurface)).toBe('warning'); // |z| <= 4
+  });
+
+  it('routes confident, large-magnitude anomalies to critical', () => {
+    expect(routeSeverity(1.0, 5, minSurface)).toBe('critical'); // |z| > 4
+  });
+
+  it('surfaces everything when minSurface is 0', () => {
+    expect(routeSeverity(0, 3.5, 0)).toBe('warning');
   });
 });

--- a/packages/ai-intelligence/src/__tests__/insight-dedup.test.ts
+++ b/packages/ai-intelligence/src/__tests__/insight-dedup.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { hasMetricInsight } from '../services/insight-dedup.js';
+
+describe('hasMetricInsight — cross-detector dedup signature (#1363)', () => {
+  const insight = (container_id: string | null, metric_type: string) =>
+    ({ container_id, metric_type }) as never;
+
+  it('dedups by (container, metric) — NOT by title substring', () => {
+    // A memory anomaly on a container literally named "cpu-pod". The old
+    // title-substring check (`title.includes('cpu')`) would wrongly treat a CPU
+    // threshold breach as a duplicate because the container name contains "cpu".
+    const insights = [insight('cpu-pod', 'memory')];
+
+    expect(hasMetricInsight(insights, 'cpu-pod', 'cpu')).toBe(false); // different metric → emit
+    expect(hasMetricInsight(insights, 'cpu-pod', 'memory')).toBe(true); // same → dedupe
+    expect(hasMetricInsight(insights, 'other', 'memory')).toBe(false); // different container → emit
+  });
+
+  it('returns false for an empty set', () => {
+    expect(hasMetricInsight([], 'c1', 'cpu')).toBe(false);
+  });
+});

--- a/packages/ai-intelligence/src/services/anomaly-gate.ts
+++ b/packages/ai-intelligence/src/services/anomaly-gate.ts
@@ -18,6 +18,13 @@ export interface ConfirmResult {
   /** Whether this anomaly should be surfaced (inserted) this cycle. */
   emit: boolean;
   reason: ConfirmReason;
+  /**
+   * Confidence in [0,1] that this is a real, actionable anomaly — the max of the
+   * persistence ratio (how many of the last N cycles fired) and the burn
+   * magnitude (severity ÷ fast-burn multiplier). Callers route low-confidence
+   * anomalies to a quieter tier (#1363).
+   */
+  confidence: number;
 }
 
 /**
@@ -35,26 +42,48 @@ export async function confirmAnomaly(opts: {
   severity: number;
 }): Promise<ConfirmResult> {
   const config = getConfig();
+  const fastBurn = config.ANOMALY_FAST_BURN_MULTIPLIER;
+  const magnitudeFactor = Math.min(1, Math.max(0, opts.severity) / fastBurn);
+
   if (config.ANOMALY_PERSISTENCE_ENABLED === false) {
-    return { emit: opts.isAnomalous, reason: 'disabled' };
+    return {
+      emit: opts.isAnomalous,
+      reason: 'disabled',
+      confidence: opts.isAnomalous ? magnitudeFactor : 0,
+    };
   }
 
   const m = config.ANOMALY_PERSISTENCE_M;
   const n = config.ANOMALY_PERSISTENCE_N;
-  const fastBurn = config.ANOMALY_FAST_BURN_MULTIPLIER;
 
   // Always record the decision so the window rolls correctly cycle-to-cycle,
   // even on non-anomalous cycles.
   const anomalousCount = await getPersistenceStore().record(opts.key, opts.isAnomalous, n);
+  const confidence = Math.max(Math.min(1, anomalousCount / n), magnitudeFactor);
 
-  if (!opts.isAnomalous) return { emit: false, reason: 'suppressed' };
+  if (!opts.isAnomalous) return { emit: false, reason: 'suppressed', confidence: 0 };
 
   // Multi-window short path: a severe single sample pages immediately so brief
   // hard failures are not delayed by the persistence requirement.
-  if (opts.severity >= fastBurn) return { emit: true, reason: 'fast-burn' };
+  if (opts.severity >= fastBurn) return { emit: true, reason: 'fast-burn', confidence };
 
   // Long path: require ≥ M of the last N cycles to be anomalous.
   return anomalousCount >= m
-    ? { emit: true, reason: 'persistence' }
-    : { emit: false, reason: 'suppressed' };
+    ? { emit: true, reason: 'persistence', confidence }
+    : { emit: false, reason: 'suppressed', confidence };
+}
+
+/**
+ * Map a confirmed anomaly's confidence + magnitude to a severity tier (#1363).
+ * Below `minSurface` confidence it routes to 'info' — a quieter log tier that
+ * does not page — instead of warning/critical. At or above, severity is by
+ * magnitude (|z| > 4 → critical, else warning). minSurface = 0 surfaces all.
+ */
+export function routeSeverity(
+  confidence: number,
+  magnitudeZ: number,
+  minSurface: number,
+): 'critical' | 'warning' | 'info' {
+  if (confidence < minSurface) return 'info';
+  return Math.abs(magnitudeZ) > 4 ? 'critical' : 'warning';
 }

--- a/packages/ai-intelligence/src/services/insight-dedup.ts
+++ b/packages/ai-intelligence/src/services/insight-dedup.ts
@@ -1,0 +1,19 @@
+import type { InsightInsert } from './insights-store.js';
+
+/**
+ * Cross-detector dedup signature (#1363). An anomaly is a duplicate when one
+ * already exists this cycle for the same (container, metric) — the real
+ * signature. Replaces a fragile `title.toLowerCase().includes(metricType)`
+ * check, which falsely deduped whenever the container NAME contained a metric
+ * substring (e.g. a container named "cpu-pod" would suppress a real CPU
+ * threshold breach because a memory insight's title mentioned "cpu-pod").
+ */
+export function hasMetricInsight(
+  insights: ReadonlyArray<Pick<InsightInsert, 'container_id' | 'metric_type'>>,
+  containerId: string,
+  metricType: string,
+): boolean {
+  return insights.some(
+    (a) => a.container_id === containerId && a.metric_type === metricType,
+  );
+}

--- a/packages/ai-intelligence/src/services/monitoring-service.ts
+++ b/packages/ai-intelligence/src/services/monitoring-service.ts
@@ -5,7 +5,7 @@ import { getEffectiveMonitoringConfig } from '@dashboard/core/services/settings-
 import type { MonitoringConfig } from '@dashboard/core/services/settings-store.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { getCooldownStore } from '@dashboard/core/services/cooldown-store.js';
-import { confirmAnomaly } from './anomaly-gate.js';
+import { confirmAnomaly, routeSeverity } from './anomaly-gate.js';
 import { hasMetricInsight } from './insight-dedup.js';
 import { getEndpoints, getContainers, isEndpointDegraded, isCircuitOpen } from '@dashboard/core/portainer/portainer-client.js';
 import { CircuitBreakerOpenError } from '@dashboard/core/portainer/circuit-breaker.js';
@@ -354,6 +354,13 @@ export function createMonitoringService(deps: MonitoringDeps) {
           : Math.abs(anomaly.z_score);
         const gate = await confirmAnomaly({ key, isAnomalous: anomaly.is_anomalous, severity });
         if (!gate.emit) continue;
+        // Severity × confidence routing (#1363): low-confidence anomalies land
+        // in the quieter 'info' tier instead of warning/critical.
+        const anomalySeverity = routeSeverity(
+          gate.confidence,
+          anomaly.z_score,
+          getConfig().ANOMALY_CONFIDENCE_MIN_SURFACE,
+        );
 
         // Cooldown check: skip if this container+metric was recently flagged
         const cooldownKey = key;
@@ -373,13 +380,13 @@ export function createMonitoringService(deps: MonitoringDeps) {
           endpoint_name: item.endpointName,
           container_id: item.containerId,
           container_name: item.containerName,
-          severity: Math.abs(anomaly.z_score) > 4 ? 'critical' : 'warning',
+          severity: anomalySeverity,
           category: 'anomaly',
           title: `Anomalous ${item.metricType} usage on "${item.containerName}"`,
           description:
             `Current ${item.metricType}: ${anomaly.current_value.toFixed(1)}% ` +
             `(mean: ${anomaly.mean.toFixed(1)}%, z-score: ${anomaly.z_score.toFixed(2)}, ` +
-            `method: ${anomaly.method ?? 'zscore'}). ` +
+            `method: ${anomaly.method ?? 'zscore'}, confidence: ${gate.confidence.toFixed(2)}). ` +
             `This is ${Math.abs(anomaly.z_score).toFixed(1)} standard deviations from the moving average.`,
           suggested_action: item.metricType === 'memory'
             ? 'Investigate memory usage patterns and check container configuration'

--- a/packages/ai-intelligence/src/services/monitoring-service.ts
+++ b/packages/ai-intelligence/src/services/monitoring-service.ts
@@ -6,6 +6,7 @@ import type { MonitoringConfig } from '@dashboard/core/services/settings-store.j
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { getCooldownStore } from '@dashboard/core/services/cooldown-store.js';
 import { confirmAnomaly } from './anomaly-gate.js';
+import { hasMetricInsight } from './insight-dedup.js';
 import { getEndpoints, getContainers, isEndpointDegraded, isCircuitOpen } from '@dashboard/core/portainer/portainer-client.js';
 import { CircuitBreakerOpenError } from '@dashboard/core/portainer/circuit-breaker.js';
 import { cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
@@ -401,10 +402,9 @@ export function createMonitoringService(deps: MonitoringDeps) {
             );
             if (!metric || metric.value <= monCfg.anomalyThresholdPct) continue;
 
-            // Skip if already flagged by statistical detection
-            if (anomalyInsights.some(
-              (a) => a.container_id === container.raw.Id && a.title.toLowerCase().includes(metricType),
-            )) continue;
+            // Skip if statistical detection already flagged this (container,
+            // metric) — real signature dedup, not a title substring (#1363).
+            if (hasMetricInsight(anomalyInsights, container.raw.Id, metricType)) continue;
 
             // Cooldown check
             const cooldownKey = `${container.raw.Id}:${metricType}:threshold`;

--- a/packages/core/src/config/env.schema.ts
+++ b/packages/core/src/config/env.schema.ts
@@ -111,6 +111,12 @@ export const envSchema = z.object({
   ANOMALY_PERSISTENCE_M: z.coerce.number().int().min(1).default(3),
   ANOMALY_PERSISTENCE_N: z.coerce.number().int().min(1).default(5),
   ANOMALY_FAST_BURN_MULTIPLIER: z.coerce.number().min(1).default(2),
+  // Severity × confidence routing (#1363). A confirmed anomaly whose confidence
+  // (max of persistence ratio and burn magnitude) is below this surfaces as
+  // 'info' — a quieter log tier that does not page — instead of warning/critical.
+  // Default 0.7 sits above the 3-of-5 (0.6) confirmation floor, so a barely-
+  // persisted low-magnitude anomaly is logged, not paged. 0 surfaces everything.
+  ANOMALY_CONFIDENCE_MIN_SURFACE: z.coerce.number().min(0).max(1).default(0.7),
   BOLLINGER_BANDS_ENABLED: z.coerce.boolean().default(true),
   // Hour-of-day baseline (issue #1295): compare the recent sample against the
   // baseline for the same hour-of-day across the last N days, rather than a

--- a/packages/core/src/config/index.test.ts
+++ b/packages/core/src/config/index.test.ts
@@ -259,6 +259,7 @@ describe('config validation', () => {
       expect(c.ANOMALY_PERSISTENCE_M).toBe(3);
       expect(c.ANOMALY_PERSISTENCE_N).toBe(5);
       expect(c.ANOMALY_FAST_BURN_MULTIPLIER).toBe(2);
+      expect(c.ANOMALY_CONFIDENCE_MIN_SURFACE).toBe(0.7);
     });
 
     it('defaults ANOMALY_MOVING_AVERAGE_WINDOW to 60', async () => {


### PR DESCRIPTION
**Part of #1363** — two of the three remaining alerting-discipline follow-ups (after the M-of-N + multi-window core in #1371). #1363 stays open for the last one (system-wide suppression).

## 1. Cross-detector dedup by `(container, metric)` signature
The threshold detector deduped against the statistical detector with `title.toLowerCase().includes(metricType)` — which false-deduped whenever the **container name** contained a metric substring (a container named `cpu-pod` would suppress a real CPU threshold breach because a memory insight's title mentions `cpu-pod`). Replaced with a real signature via `hasMetricInsight(insights, containerId, metricType)`.

## 2. Severity × confidence routing
`confirmAnomaly` now returns a **confidence** ∈ [0,1] = `max(persistence ratio, burn magnitude)`. `routeSeverity` maps it to a tier: below `ANOMALY_CONFIDENCE_MIN_SURFACE` (default **0.7**, just above the 3-of-5 = 0.6 confirmation floor) a confirmed anomaly is routed to **`info`** — a quieter log tier that doesn't page — instead of warning/critical. Confidence is recorded in the insight description.

- *No schema change* — confidence is derived (persistence ratio + burn) and routed onto the existing `severity` enum's `info` tier (the "log tier"). Avoids the deferred typed-column work (#1308).

## Tests (TDD)
- `hasMetricInsight` dedups by (container, metric), not title (the `cpu-pod` case now correctly emits the CPU breach).
- gate `confidence = max(ratio, magnitude)`; `routeSeverity` (info / warning / critical / surface-all); config-default guard.
- Existing high-z detections keep their severity (confidence 1.0 ≥ 0.7) — no regression.
- Verified locally: core 71, ai-intelligence 47; `tsc --build` clean.

## Still open under #1363
- **System-wide suppression** — move the per-user sensitivity filter to a global detection-time floor (design decision: per-user vs global). Tracked there.

Part of epic #1360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
