### PR TITLE
feat(anomaly): system-wide detection-time suppression floor (closes #1363)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -147,6 +147,13 @@ ANOMALY_FAST_BURN_MULTIPLIER=2
 # 'info' (a quieter log tier that does not page) instead of warning/critical.
 # Default 0.7 is above the 3-of-5 (0.6) confirmation floor; 0 surfaces everything.
 ANOMALY_CONFIDENCE_MIN_SURFACE=0.7
+# System-wide detection-time suppression floor (#1363). A confirmed anomaly with
+# confidence below this is DROPPED entirely (never inserted), keeping the shared
+# insights table / correlator / notifications clean for everyone — complements
+# the per-user Sensitivity preset (a read-time filter). Default 0 drops nothing
+# (info-tier routing already quiets low confidence); raise it in noisy envs.
+# Severe fast-burn anomalies (confidence 1.0) are never dropped.
+ANOMALY_SUPPRESS_BELOW_CONFIDENCE=0
 BOLLINGER_BANDS_ENABLED=true
 # Per-user Sensitivity preset (#1297) — Low / Default / High — is persisted
 # in the `user_settings` table (migration 036) and exposed via

--- a/docs/ai-anomaly-detection.md
+++ b/docs/ai-anomaly-detection.md
@@ -46,6 +46,7 @@ Instead of a single flat 24h baseline, the detector compares each observation ag
 | `ANOMALY_PERSISTENCE_M` / `ANOMALY_PERSISTENCE_N` | `3` / `5` | Confirm only when ≥ M of the last N cycles are anomalous — suppresses isolated benign blips. |
 | `ANOMALY_FAST_BURN_MULTIPLIER` | `2` | A severe single sample (severity ≥ this × threshold) bypasses persistence and surfaces immediately (short high-burn-rate window). |
 | `ANOMALY_CONFIDENCE_MIN_SURFACE` | `0.7` | Severity × confidence routing (#1363). A confirmed anomaly with confidence (max of persistence ratio and burn magnitude) below this is routed to `info` (a quieter log tier) instead of warning/critical. `0` surfaces everything. |
+| `ANOMALY_SUPPRESS_BELOW_CONFIDENCE` | `0` | System-wide detection-time suppression floor (#1363). Below this confidence an anomaly is **dropped entirely** (never inserted), keeping the shared table/correlator/notifications clean for everyone — complements the per-user Sensitivity preset (a read-time filter). `0` drops nothing; fast-burn anomalies are never dropped. |
 | `ANOMALY_COOLDOWN_MINUTES` | `30` | Per-container/metric cooldown to prevent alert spam |
 | `BOLLINGER_BANDS_ENABLED` | `true` | Enable the Bollinger method |
 

--- a/packages/ai-intelligence/src/__tests__/anomaly-gate.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-gate.test.ts
@@ -75,6 +75,41 @@ describe('confirmAnomaly — M-of-N persistence + multi-window (#1363)', () => {
   });
 });
 
+describe('global detection-time suppression floor (#1363)', () => {
+  beforeEach(() => {
+    setPersistenceStoreForTest(new InMemoryPersistenceStore());
+    setConfigForTest(baseCfg);
+  });
+  afterEach(() => {
+    setPersistenceStoreForTest(null);
+    resetConfig();
+  });
+
+  it('suppresses a confirmed anomaly whose confidence is below the floor', async () => {
+    setConfigForTest({ ...baseCfg, ANOMALY_SUPPRESS_BELOW_CONFIDENCE: 0.65 });
+    // 3-of-5 at low magnitude → confidence 0.6 < 0.65 → dropped entirely.
+    for (let i = 0; i < 2; i++) await confirmAnomaly({ key: 'k', isAnomalous: true, severity: 1.0 });
+    const r = await confirmAnomaly({ key: 'k', isAnomalous: true, severity: 1.0 });
+    expect(r.emit).toBe(false);
+    expect(r.reason).toBe('suppressed');
+  });
+
+  it('never suppresses a severe (fast-burn) anomaly regardless of the floor', async () => {
+    setConfigForTest({ ...baseCfg, ANOMALY_SUPPRESS_BELOW_CONFIDENCE: 0.9 });
+    const r = await confirmAnomaly({ key: 'k', isAnomalous: true, severity: 2.5 }); // confidence 1.0
+    expect(r.emit).toBe(true);
+    expect(r.reason).toBe('fast-burn');
+  });
+
+  it('a floor of 0 suppresses nothing (default)', async () => {
+    setConfigForTest({ ...baseCfg, ANOMALY_SUPPRESS_BELOW_CONFIDENCE: 0 });
+    for (let i = 0; i < 2; i++) await confirmAnomaly({ key: 'k', isAnomalous: true, severity: 1.0 });
+    const r = await confirmAnomaly({ key: 'k', isAnomalous: true, severity: 1.0 });
+    expect(r.emit).toBe(true);
+    expect(r.reason).toBe('persistence');
+  });
+});
+
 describe('routeSeverity — severity × confidence routing (#1363)', () => {
   const minSurface = 0.7;
 

--- a/packages/ai-intelligence/src/services/anomaly-gate.ts
+++ b/packages/ai-intelligence/src/services/anomaly-gate.ts
@@ -43,14 +43,13 @@ export async function confirmAnomaly(opts: {
 }): Promise<ConfirmResult> {
   const config = getConfig();
   const fastBurn = config.ANOMALY_FAST_BURN_MULTIPLIER;
+  const suppressFloor = config.ANOMALY_SUPPRESS_BELOW_CONFIDENCE;
   const magnitudeFactor = Math.min(1, Math.max(0, opts.severity) / fastBurn);
 
   if (config.ANOMALY_PERSISTENCE_ENABLED === false) {
-    return {
-      emit: opts.isAnomalous,
-      reason: 'disabled',
-      confidence: opts.isAnomalous ? magnitudeFactor : 0,
-    };
+    const confidence = opts.isAnomalous ? magnitudeFactor : 0;
+    const emit = opts.isAnomalous && confidence >= suppressFloor;
+    return { emit, reason: emit ? 'disabled' : 'suppressed', confidence };
   }
 
   const m = config.ANOMALY_PERSISTENCE_M;
@@ -62,6 +61,12 @@ export async function confirmAnomaly(opts: {
   const confidence = Math.max(Math.min(1, anomalousCount / n), magnitudeFactor);
 
   if (!opts.isAnomalous) return { emit: false, reason: 'suppressed', confidence: 0 };
+
+  // System-wide detection-time suppression floor (#1363): drop the lowest-
+  // confidence anomalies entirely so the shared insights table / correlator /
+  // notifications stay clean for everyone. Fast-burn has confidence 1.0, so a
+  // severe spike is never dropped here.
+  if (confidence < suppressFloor) return { emit: false, reason: 'suppressed', confidence };
 
   // Multi-window short path: a severe single sample pages immediately so brief
   // hard failures are not delayed by the persistence requirement.

--- a/packages/core/src/config/env.schema.ts
+++ b/packages/core/src/config/env.schema.ts
@@ -117,6 +117,15 @@ export const envSchema = z.object({
   // Default 0.7 sits above the 3-of-5 (0.6) confirmation floor, so a barely-
   // persisted low-magnitude anomaly is logged, not paged. 0 surfaces everything.
   ANOMALY_CONFIDENCE_MIN_SURFACE: z.coerce.number().min(0).max(1).default(0.7),
+  // System-wide detection-time suppression floor (#1363). A confirmed anomaly
+  // whose confidence is below this is DROPPED entirely (never inserted), so the
+  // shared insights table, incident correlator, and notifications stay clean for
+  // everyone — not just per-user view filtering. Complements the per-user
+  // Sensitivity preset (#1297), which remains a read-time filter. Default 0
+  // suppresses nothing (the info-tier routing already quiets low confidence);
+  // raise it in noisy environments. Severe fast-burn anomalies (confidence 1.0)
+  // are never dropped here.
+  ANOMALY_SUPPRESS_BELOW_CONFIDENCE: z.coerce.number().min(0).max(1).default(0),
   BOLLINGER_BANDS_ENABLED: z.coerce.boolean().default(true),
   // Hour-of-day baseline (issue #1295): compare the recent sample against the
   // baseline for the same hour-of-day across the last N days, rather than a

--- a/packages/core/src/config/index.test.ts
+++ b/packages/core/src/config/index.test.ts
@@ -260,6 +260,7 @@ describe('config validation', () => {
       expect(c.ANOMALY_PERSISTENCE_N).toBe(5);
       expect(c.ANOMALY_FAST_BURN_MULTIPLIER).toBe(2);
       expect(c.ANOMALY_CONFIDENCE_MIN_SURFACE).toBe(0.7);
+      expect(c.ANOMALY_SUPPRESS_BELOW_CONFIDENCE).toBe(0);
     });
 
     it('defaults ANOMALY_MOVING_AVERAGE_WINDOW to 60', async () => {


### PR DESCRIPTION
**Closes #1363** — the final alerting-discipline sub-feature, completing all five.

## System-wide detection-time suppression
The original review (C2) flagged that sensitivity was a *per-user, read-time* filter, so the shared `insights` table — and the incident correlator, notifications, and LLM context that read it — still saw the full false-positive volume.

This adds `ANOMALY_SUPPRESS_BELOW_CONFIDENCE`: a **global floor applied in the gate**. A confirmed anomaly whose confidence (max of persistence ratio + burn magnitude) is below it is **dropped entirely (never inserted)** — system-wide, at detection time. The per-user Sensitivity preset (#1297) remains a read-time filter on top.

- **Default 0** drops nothing (backward-compatible) — the M-of-N gate already suppresses unconfirmed anomalies before insert, and the info-tier routing (#1372) already quiets low-confidence ones, so this is an opt-in knob for noisy environments.
- **Fast-burn anomalies (confidence 1.0) are never dropped** — severe spikes always surface.

## Tests (TDD)
- below-floor confirmed anomaly → suppressed (`emit: false`); fast-burn never suppressed; floor 0 = no-op; config-default guard.
- Verified locally: core config 65, gate 13; `tsc --build` clean.

## #1363 is now complete (all 5 sub-features)
| Sub-feature | Landed |
|---|---|
| M-of-N persistence | #1371 |
| Multi-window fast-burn | #1371 |
| Cross-detector dedup | #1372 |
| Severity × confidence routing | #1372 |
| **System-wide suppression** | **this PR** |

Part of epic #1360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
