### PR TITLE
feat(anomaly): evaluation rig core — PR-AUC metrics + CI regression guard (part of #1364)

### DIFF
--- a/packages/ai-intelligence/src/__tests__/anomaly-eval.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-eval.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { precisionRecallF1, prAuc } from '../services/anomaly-eval.js';
+import {
+  precisionRecallF1,
+  prAuc,
+  scoreSeriesRobust,
+  scoreSeriesZScore,
+} from '../services/anomaly-eval.js';
 
 describe('precisionRecallF1', () => {
   it('computes precision/recall/F1 at a score threshold', () => {
@@ -44,5 +49,68 @@ describe('prAuc (average precision — area under the PR curve)', () => {
     const a = prAuc([0.9, 0.8, 0.7, 0.6], [true, false, true, false]);
     const b = prAuc([0.6, 0.7, 0.8, 0.9], [false, true, false, true]);
     expect(a).toBeCloseTo(b, 9);
+  });
+});
+
+describe('scoreSeriesRobust', () => {
+  it('emits null during warm-up, then scores a spike high and a within-band value low', () => {
+    const values = [50, 50, 50, 51, 49, 50, 50, 49, 51, 50, 80, 50.5];
+    const scores = scoreSeriesRobust(values, 10);
+    expect(scores.slice(0, 10).every((s) => s === null)).toBe(true);
+    expect(scores[10]!).toBeGreaterThan(scores[11]!); // 80 ≫ 50.5
+    expect(scores[11]!).toBeLessThan(3);
+  });
+
+  it('is one-sided: a drop scores 0', () => {
+    const values = [...Array(10).fill(50), 20];
+    expect(scoreSeriesRobust(values, 10)[10]).toBe(0);
+  });
+});
+
+describe('PR-AUC regression guard — robust one-sided beats two-sided z-score (#1364)', () => {
+  // Deterministic series: stable 50, periodic benign idle DIPS to 5 (label
+  // false), and a few real upward spikes to 70 (label true). The dips deviate
+  // MORE than the spikes, so two-sided |z| ranks the benign dips above the real
+  // spikes (false positives at the top → poor PR-AUC); one-sided robust scores
+  // dips at 0 and keeps the spikes on top.
+  function dropsScenario() {
+    const N = 600;
+    const values: number[] = [];
+    const labels: boolean[] = [];
+    const spikeAt = new Set([200, 201, 400, 401, 402]);
+    let seed = 0x1234_5678;
+    const rng = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    for (let i = 0; i < N; i++) {
+      if (spikeAt.has(i)) { values.push(70 + (rng() - 0.5)); labels.push(true); continue; }
+      const inDip = i > 60 && i % 90 < 4; // benign idle dips, label false
+      if (inDip) { values.push(5 + (rng() - 0.5)); labels.push(false); continue; }
+      values.push(50 + (rng() - 0.5) * 2);
+      labels.push(false);
+    }
+    return { values, labels };
+  }
+
+  function evaluable(scores: Array<number | null>, labels: boolean[]) {
+    const s: number[] = [];
+    const l: boolean[] = [];
+    for (let i = 0; i < scores.length; i++) {
+      if (scores[i] !== null) { s.push(scores[i]!); l.push(labels[i]); }
+    }
+    return { s, l };
+  }
+
+  it('robust one-sided PR-AUC exceeds two-sided z-score and clears a floor', () => {
+    const { values, labels } = dropsScenario();
+    const robust = evaluable(scoreSeriesRobust(values, 60), labels);
+    const zscore = evaluable(scoreSeriesZScore(values, 60), labels);
+
+    const robustAuc = prAuc(robust.s, robust.l);
+    const zscoreAuc = prAuc(zscore.s, zscore.l);
+
+    expect(robustAuc).toBeGreaterThan(zscoreAuc); // one-sided robustness win
+    expect(robustAuc).toBeGreaterThan(0.5); // CI regression floor
   });
 });

--- a/packages/ai-intelligence/src/__tests__/anomaly-eval.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-eval.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { precisionRecallF1, prAuc } from '../services/anomaly-eval.js';
+
+describe('precisionRecallF1', () => {
+  it('computes precision/recall/F1 at a score threshold', () => {
+    // predict anomalous when score >= 0.5
+    const r = precisionRecallF1([0.9, 0.6, 0.4, 0.1], [true, false, true, false], 0.5);
+    // >=0.5: 0.9(T)→tp, 0.6(F)→fp; <0.5: 0.4(T)→fn, 0.1(F)→tn
+    expect(r.precision).toBeCloseTo(0.5, 6);
+    expect(r.recall).toBeCloseTo(0.5, 6);
+    expect(r.f1).toBeCloseTo(0.5, 6);
+  });
+
+  it('is perfect when the threshold separates the classes', () => {
+    const r = precisionRecallF1([0.9, 0.8, 0.2, 0.1], [true, true, false, false], 0.5);
+    expect(r.precision).toBe(1);
+    expect(r.recall).toBe(1);
+    expect(r.f1).toBe(1);
+  });
+
+  it('precision is 1 (vacuous) when nothing is predicted positive', () => {
+    const r = precisionRecallF1([0.1, 0.2], [true, false], 0.9);
+    expect(r.precision).toBe(1);
+    expect(r.recall).toBe(0);
+    expect(r.f1).toBe(0);
+  });
+});
+
+describe('prAuc (average precision — area under the PR curve)', () => {
+  it('is 1.0 for perfect separation', () => {
+    expect(prAuc([0.9, 0.8, 0.3, 0.1], [true, true, false, false])).toBeCloseTo(1, 6);
+  });
+
+  it('matches the hand-computed average precision for interleaved scores', () => {
+    // desc: 0.9(T) p=1 r=0.5 → +0.5; 0.8(F); 0.7(T) p=2/3 r=1 → +0.333; 0.6(F)
+    expect(prAuc([0.9, 0.8, 0.7, 0.6], [true, false, true, false])).toBeCloseTo(0.8333, 3);
+  });
+
+  it('is 0 when there are no positives', () => {
+    expect(prAuc([0.5, 0.3], [false, false])).toBe(0);
+  });
+
+  it('is order-invariant in the inputs', () => {
+    const a = prAuc([0.9, 0.8, 0.7, 0.6], [true, false, true, false]);
+    const b = prAuc([0.6, 0.7, 0.8, 0.9], [false, true, false, true]);
+    expect(a).toBeCloseTo(b, 9);
+  });
+});

--- a/packages/ai-intelligence/src/services/anomaly-eval.ts
+++ b/packages/ai-intelligence/src/services/anomaly-eval.ts
@@ -8,6 +8,7 @@
  * threshold-independent summary that is the right headline for rare-event
  * detection (not ROC-AUC, which is optimistic under heavy imbalance).
  */
+import { meanAndStd, medianAndMad, modifiedZScore } from './anomaly-stats.js';
 
 export interface PrecisionRecallF1 {
   precision: number;
@@ -64,4 +65,59 @@ export function prAuc(scores: readonly number[], labels: readonly boolean[]): nu
     prevRecall = recall;
   }
   return ap;
+}
+
+/**
+ * Score each point of a series with the production ROBUST detector (#1362):
+ * one-sided modified z-score (median + MAD) over a trailing window that excludes
+ * the point under test. Drops score 0 (one-sided). The first `windowSize` points
+ * are warm-up (`null`). Used to replay labelled series through the eval rig.
+ */
+export function scoreSeriesRobust(
+  values: readonly number[],
+  windowSize: number,
+): Array<number | null> {
+  const scores: Array<number | null> = [];
+  for (let i = 0; i < values.length; i++) {
+    if (i < windowSize) {
+      scores.push(null);
+      continue;
+    }
+    const window = values.slice(i - windowSize, i);
+    const { median, mad } = medianAndMad(window);
+    if (mad === 0) {
+      const tol = Math.max(Math.abs(median) * 0.1, 0.01);
+      scores.push(Math.max(0, (values[i] - median) / tol));
+    } else {
+      scores.push(Math.max(0, modifiedZScore(values[i], median, mad)));
+    }
+  }
+  return scores;
+}
+
+/**
+ * Score each point with the legacy TWO-SIDED z-score (mean + std) — the
+ * pre-#1361/#1362 detector. Kept so the eval rig can quantify the improvement
+ * (and guard against regressing back toward it).
+ */
+export function scoreSeriesZScore(
+  values: readonly number[],
+  windowSize: number,
+): Array<number | null> {
+  const scores: Array<number | null> = [];
+  for (let i = 0; i < values.length; i++) {
+    if (i < windowSize) {
+      scores.push(null);
+      continue;
+    }
+    const window = values.slice(i - windowSize, i);
+    const { mean, std } = meanAndStd(window);
+    if (std === 0) {
+      const tol = Math.max(Math.abs(mean) * 0.1, 0.01);
+      scores.push(Math.abs(values[i] - mean) / tol);
+    } else {
+      scores.push(Math.abs((values[i] - mean) / std));
+    }
+  }
+  return scores;
 }

--- a/packages/ai-intelligence/src/services/anomaly-eval.ts
+++ b/packages/ai-intelligence/src/services/anomaly-eval.ts
@@ -1,0 +1,67 @@
+/**
+ * Anomaly-detector evaluation metrics (#1364).
+ *
+ * The detector has never been measured quantitatively — the #1294 audit had to
+ * proxy the false-positive rate, and accuracy is meaningless at this class
+ * imbalance. These are the rigorous metrics the eval rig reports: point-wise
+ * precision/recall/F1 at a threshold, and PR-AUC (average precision) — the
+ * threshold-independent summary that is the right headline for rare-event
+ * detection (not ROC-AUC, which is optimistic under heavy imbalance).
+ */
+
+export interface PrecisionRecallF1 {
+  precision: number;
+  recall: number;
+  f1: number;
+}
+
+/**
+ * Precision/recall/F1 for a single score threshold: an item is predicted
+ * anomalous when `score >= threshold`. Precision is 1 (vacuously) when nothing
+ * is predicted positive; recall is 1 when there are no actual positives.
+ */
+export function precisionRecallF1(
+  scores: readonly number[],
+  labels: readonly boolean[],
+  threshold: number,
+): PrecisionRecallF1 {
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  for (let i = 0; i < scores.length; i++) {
+    const predicted = scores[i] >= threshold;
+    if (predicted && labels[i]) tp++;
+    else if (predicted && !labels[i]) fp++;
+    else if (!predicted && labels[i]) fn++;
+  }
+  const precision = tp + fp > 0 ? tp / (tp + fp) : 1;
+  const recall = tp + fn > 0 ? tp / (tp + fn) : 1;
+  const f1 = precision + recall > 0 ? (2 * precision * recall) / (precision + recall) : 0;
+  return { precision, recall, f1 };
+}
+
+/**
+ * PR-AUC as average precision: sort by score descending and sum
+ * `precision · Δrecall` at each step (step interpolation). Threshold-independent
+ * and robust to class imbalance. Returns 0 when there are no positives.
+ */
+export function prAuc(scores: readonly number[], labels: readonly boolean[]): number {
+  const totalPositives = labels.reduce((acc, l) => acc + (l ? 1 : 0), 0);
+  if (totalPositives === 0) return 0;
+
+  const order = scores.map((_, i) => i).sort((a, b) => scores[b] - scores[a]);
+
+  let tp = 0;
+  let fp = 0;
+  let prevRecall = 0;
+  let ap = 0;
+  for (const i of order) {
+    if (labels[i]) tp++;
+    else fp++;
+    const precision = tp / (tp + fp);
+    const recall = tp / totalPositives;
+    ap += precision * (recall - prevRecall);
+    prevRecall = recall;
+  }
+  return ap;
+}


### PR DESCRIPTION
**Part of #1364** — the evaluation-rig **core**. #1364 stays open for the data-driven parts (labelled store, feedback-into-thresholds, seasonality).

## Why
The detector has never been measured quantitatively — the #1294 audit had to *proxy* the false-positive rate, and accuracy is meaningless at this class imbalance. This lands the rigorous measurement layer + a CI regression guard.

## What's in this PR
| Component | Detail |
|---|---|
| **Metrics** | `precisionRecallF1(scores, labels, threshold)` and `prAuc(scores, labels)` — average precision (area under the PR curve), the threshold-independent headline for rare-event detection (not ROC-AUC, which flatters under imbalance). |
| **Scoring** | `scoreSeriesRobust` (production one-sided median+MAD, drops→0) and `scoreSeriesZScore` (legacy two-sided mean/std) — replay a labelled series through a detector. |
| **CI regression guard** | A vitest test replays a deterministic labelled scenario through both and asserts **robust PR-AUC > z-score PR-AUC** *and* **robust PR-AUC > 0.5** — a future change that regresses detector quality fails CI. This is the rigorous PR-AUC version of the epic's benchmark claim. |

## Tests (TDD)
- `prAuc`: perfect-separation 1.0, hand-computed interleaved 0.833, no-positives 0, order-invariant; `precisionRecallF1` incl. vacuous cases.
- `scoreSeriesRobust`: warm-up nulls, spike-high/band-low, one-sided drop=0.
- The PR-AUC guard (robust beats two-sided on benign-drop false positives).
- Verified locally: 10 tests; `tsc --build` clean. Pure functions, no new deps.

## Still open under #1364 (the data-driven parts)
- **Ground-truth labels** — feed the #1298 "false positive" feedback into a labelled store.
- **Feedback → thresholds** — tune per-detector thresholds/confidence from accumulated labels; report a *measured* FP rate (replaces the proxy).
- **Seasonality upgrade** — `metrics_1hour` continuous aggregate (#1307) + day-of-week / STL.

Part of epic #1360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
