### PR TITLE
feat(anomaly): labelled store — aggregate #1298 feedback into ground truth (part of #1364)

### DIFF
--- a/packages/ai-intelligence/src/__tests__/anomaly-labels.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-labels.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  aggregateLabel,
+  getAnomalyLabels,
+  measuredFpRate,
+  type FeedbackRow,
+} from '../services/anomaly-labels.js';
+
+describe('aggregateLabel — feedback votes → ground truth (#1364)', () => {
+  it('labels false (false positive) when FP votes win', () => {
+    expect(aggregateLabel(['false-positive', 'false-positive', 'true-positive']).label).toBe(false);
+  });
+
+  it('labels true (real anomaly) when TP votes win', () => {
+    expect(aggregateLabel(['true-positive', 'true-positive']).label).toBe(true);
+  });
+
+  it('is null (inconclusive) on a tie', () => {
+    expect(aggregateLabel(['false-positive', 'true-positive']).label).toBeNull();
+  });
+
+  it('is null when only "unsure" votes', () => {
+    expect(aggregateLabel(['unsure', 'unsure']).label).toBeNull();
+  });
+
+  it('counts the votes', () => {
+    expect(aggregateLabel(['false-positive', 'false-positive', 'true-positive', 'unsure']))
+      .toMatchObject({ label: false, fpVotes: 2, tpVotes: 1 });
+  });
+});
+
+describe('getAnomalyLabels — group feedback by anomaly', () => {
+  it('aggregates per anomaly via the injected fetcher', async () => {
+    const rows: FeedbackRow[] = [
+      { anomaly_id: 'a', disposition: 'false-positive', detector: 'ml-anomaly' },
+      { anomaly_id: 'a', disposition: 'false-positive', detector: 'ml-anomaly' },
+      { anomaly_id: 'b', disposition: 'true-positive', detector: 'ml-anomaly' },
+    ];
+    const labels = await getAnomalyLabels(async () => rows);
+    expect(labels.get('a')!.label).toBe(false);
+    expect(labels.get('b')!.label).toBe(true);
+    expect(labels.size).toBe(2);
+  });
+
+  it('passes the detector filter through to the fetcher', async () => {
+    let seen: string | undefined;
+    await getAnomalyLabels(async (opts) => { seen = opts.detector; return []; }, { detector: 'ml-anomaly' });
+    expect(seen).toBe('ml-anomaly');
+  });
+});
+
+describe('measuredFpRate', () => {
+  it('is the false-positive fraction of conclusively-labelled anomalies', () => {
+    const labels = new Map([
+      ['a', { label: false, fpVotes: 2, tpVotes: 0 }],
+      ['b', { label: true, fpVotes: 0, tpVotes: 1 }],
+      ['c', { label: false, fpVotes: 1, tpVotes: 0 }],
+      ['d', { label: null, fpVotes: 1, tpVotes: 1 }], // inconclusive → excluded
+    ]);
+    expect(measuredFpRate(labels)).toBeCloseTo(2 / 3, 6);
+  });
+
+  it('is 0 when there are no conclusive labels', () => {
+    expect(measuredFpRate(new Map())).toBe(0);
+  });
+});

--- a/packages/ai-intelligence/src/services/anomaly-labels.ts
+++ b/packages/ai-intelligence/src/services/anomaly-labels.ts
@@ -1,0 +1,80 @@
+/**
+ * Labelled store (#1364): turns operator #1298 feedback into ground-truth
+ * labels the eval rig and threshold tuning consume.
+ *
+ * The `anomaly_feedback` table (migration 037) records one disposition per
+ * (anomaly, user) — `false-positive` / `true-positive` / `unsure` — so multiple
+ * operators can disagree. This module aggregates those votes into a single
+ * ground-truth label per anomaly and a measured per-detector false-positive
+ * rate, retiring the `is_acknowledged` proxy the #1294 audit had to use.
+ *
+ * The aggregation is pure (DB-independent, unit-testable); the feedback rows are
+ * supplied by an injected fetcher so production wires the SQL query while tests
+ * pass plain arrays.
+ */
+
+export type Disposition = 'false-positive' | 'true-positive' | 'unsure';
+
+export interface GroundTruth {
+  /** true = real anomaly, false = false positive, null = inconclusive (tie / unsure-only). */
+  label: boolean | null;
+  fpVotes: number;
+  tpVotes: number;
+}
+
+export interface FeedbackRow {
+  anomaly_id: string;
+  disposition: Disposition;
+  detector: string | null;
+}
+
+export type FetchFeedbackFn = (opts: { detector?: string }) => Promise<FeedbackRow[]>;
+
+/** Aggregate a set of operator dispositions for one anomaly into a label. */
+export function aggregateLabel(dispositions: readonly Disposition[]): GroundTruth {
+  let fpVotes = 0;
+  let tpVotes = 0;
+  for (const d of dispositions) {
+    if (d === 'false-positive') fpVotes++;
+    else if (d === 'true-positive') tpVotes++;
+  }
+  let label: boolean | null;
+  if (tpVotes > fpVotes) label = true;
+  else if (fpVotes > tpVotes) label = false;
+  else label = null; // tie or unsure-only → inconclusive
+  return { label, fpVotes, tpVotes };
+}
+
+/** Fetch feedback (optionally for one detector) and aggregate to per-anomaly ground truth. */
+export async function getAnomalyLabels(
+  fetch: FetchFeedbackFn,
+  opts: { detector?: string } = {},
+): Promise<Map<string, GroundTruth>> {
+  const rows = await fetch(opts);
+  const byAnomaly = new Map<string, Disposition[]>();
+  for (const r of rows) {
+    const arr = byAnomaly.get(r.anomaly_id);
+    if (arr) arr.push(r.disposition);
+    else byAnomaly.set(r.anomaly_id, [r.disposition]);
+  }
+  const labels = new Map<string, GroundTruth>();
+  for (const [id, disps] of byAnomaly) labels.set(id, aggregateLabel(disps));
+  return labels;
+}
+
+/**
+ * Measured false-positive rate: the fraction of conclusively-labelled anomalies
+ * that are false positives. Inconclusive (null) labels are excluded. This is the
+ * real per-detector FP rate that replaces the #1294 audit's `is_acknowledged`
+ * proxy once enough feedback has accumulated.
+ */
+export function measuredFpRate(labels: ReadonlyMap<string, GroundTruth>): number {
+  let fp = 0;
+  let conclusive = 0;
+  for (const gt of labels.values()) {
+    if (gt.label === null) continue;
+    conclusive++;
+    if (gt.label === false) fp++;
+  }
+  return conclusive > 0 ? fp / conclusive : 0;
+}


### PR DESCRIPTION
**Part of #1364** — the ground-truth labels for the eval rig (#1375 landed the metrics + CI guard). #1364 stays open for feedback-into-thresholds and the seasonality upgrade.

## What
Turns operator false-positive feedback (the #1298 `anomaly_feedback` table) into ground-truth labels the eval rig and threshold tuning consume:

- **`aggregateLabel`** — per-anomaly votes (`false-positive` / `true-positive` / `unsure`, across users) → one label: real / false-positive / inconclusive (tie or unsure-only).
- **`getAnomalyLabels`** — group feedback by anomaly via an injected fetcher (DI; prod wires the SQL, tests pass arrays).
- **`measuredFpRate`** — the real per-detector false-positive rate, retiring the `is_acknowledged` proxy the #1294 audit had to use.

## Tests (TDD)
9 tests: FP/TP majority, ties/unsure → inconclusive, vote counts, per-anomaly grouping, detector filter pass-through, measured FP rate (incl. empty). Pure functions, DB-independent, no new deps; `tsc --build` clean.

## Still open under #1364
- **Production fetcher** wiring the SQL query over `anomaly_feedback` into `getAnomalyLabels`.
- **Feedback → thresholds** — tune per-detector thresholds/confidence from `measuredFpRate`.
- **Seasonality upgrade** — `metrics_1hour` aggregate (#1307) + day-of-week / STL.

Part of epic #1360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)