### PR TITLE
feat(anomaly): feedback → threshold tuner (Part of #1364)

### DIFF
--- a/packages/ai-intelligence/src/__tests__/anomaly-threshold-tuner.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-threshold-tuner.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { recommendThreshold } from '../services/anomaly-threshold-tuner.js';
+
+const base = {
+  current: 3.5,
+  sampleCount: 50,
+  targetFpRate: 0.05,
+  tolerance: 0.02,
+  step: 0.1,
+  minSamples: 20,
+  min: 1.5,
+  max: 8,
+};
+
+describe('recommendThreshold — feedback → threshold loop (#1364)', () => {
+  it('holds when there is not enough labelled feedback', () => {
+    const r = recommendThreshold({ ...base, measuredFpRate: 0.4, sampleCount: 5 });
+    expect(r).toMatchObject({ threshold: 3.5, changed: false, reason: 'insufficient-data' });
+  });
+
+  it('raises the threshold when the measured FP rate is too high', () => {
+    const r = recommendThreshold({ ...base, measuredFpRate: 0.2 });
+    expect(r.reason).toBe('too-many-fp');
+    expect(r.threshold).toBeCloseTo(3.85, 6); // 3.5 × 1.1
+    expect(r.changed).toBe(true);
+  });
+
+  it('lowers the threshold when the measured FP rate is well below target (too strict)', () => {
+    const r = recommendThreshold({ ...base, measuredFpRate: 0.0 });
+    expect(r.reason).toBe('too-strict');
+    expect(r.threshold).toBeCloseTo(3.15, 6); // 3.5 × 0.9
+  });
+
+  it('holds inside the deadband around the target', () => {
+    const r = recommendThreshold({ ...base, measuredFpRate: 0.05 });
+    expect(r).toMatchObject({ threshold: 3.5, changed: false, reason: 'within-target' });
+  });
+
+  it('clamps to the max and reports no change at the ceiling', () => {
+    const r = recommendThreshold({ ...base, current: 8, measuredFpRate: 0.5 });
+    expect(r.threshold).toBe(8);
+    expect(r.changed).toBe(false);
+  });
+
+  it('clamps to the min at the floor', () => {
+    const r = recommendThreshold({ ...base, current: 1.5, measuredFpRate: 0 });
+    expect(r.threshold).toBe(1.5);
+    expect(r.changed).toBe(false);
+  });
+});

--- a/packages/ai-intelligence/src/services/anomaly-threshold-tuner.ts
+++ b/packages/ai-intelligence/src/services/anomaly-threshold-tuner.ts
@@ -1,0 +1,71 @@
+/**
+ * Feedback → threshold loop (#1364). Closes the loop opened by the labelled
+ * store: given the measured per-detector false-positive rate (from operator
+ * #1298 feedback), recommend a threshold adjustment toward a target FP rate.
+ *
+ * Pure and conservative: it nudges the threshold by one multiplicative step at a
+ * time, only outside a deadband around the target, only with enough labelled
+ * samples, and always within bounds. Callers decide whether to apply the
+ * recommendation (e.g. write it to settings) or just surface it.
+ */
+
+export type TuneReason =
+  | 'too-many-fp'
+  | 'too-strict'
+  | 'within-target'
+  | 'insufficient-data';
+
+export interface ThresholdRecommendation {
+  threshold: number;
+  changed: boolean;
+  reason: TuneReason;
+}
+
+export interface TuneOptions {
+  /** Current detector threshold (e.g. ANOMALY_ZSCORE_THRESHOLD). */
+  current: number;
+  /** Measured FP rate in [0,1] from the labelled store. */
+  measuredFpRate: number;
+  /** How many conclusively-labelled anomalies the rate is based on. */
+  sampleCount: number;
+  /** Desired FP rate (default 0.05). */
+  targetFpRate?: number;
+  /** Deadband around the target within which we hold (default 0.02). */
+  tolerance?: number;
+  /** Multiplicative step per adjustment (default 0.1 = ±10%). */
+  step?: number;
+  /** Minimum labelled samples before tuning (default 20). */
+  minSamples?: number;
+  /** Threshold bounds (defaults 1.5 / 8). */
+  min?: number;
+  max?: number;
+}
+
+export function recommendThreshold(opts: TuneOptions): ThresholdRecommendation {
+  const targetFpRate = opts.targetFpRate ?? 0.05;
+  const tolerance = opts.tolerance ?? 0.02;
+  const step = opts.step ?? 0.1;
+  const minSamples = opts.minSamples ?? 20;
+  const min = opts.min ?? 1.5;
+  const max = opts.max ?? 8;
+  const { current } = opts;
+
+  if (opts.sampleCount < minSamples) {
+    return { threshold: current, changed: false, reason: 'insufficient-data' };
+  }
+
+  if (opts.measuredFpRate > targetFpRate + tolerance) {
+    // Too many false positives → raise the threshold (stricter).
+    const next = Math.min(max, current * (1 + step));
+    return { threshold: next, changed: next !== current, reason: 'too-many-fp' };
+  }
+
+  if (opts.measuredFpRate < targetFpRate - tolerance) {
+    // Very few false positives → likely too strict; lower the threshold to
+    // recover sensitivity.
+    const next = Math.max(min, current * (1 - step));
+    return { threshold: next, changed: next !== current, reason: 'too-strict' };
+  }
+
+  return { threshold: current, changed: false, reason: 'within-target' };
+}


### PR DESCRIPTION
## What

Closes the feedback loop opened by the labelled store (#1376). `recommendThreshold` takes a measured per-detector false-positive rate — produced by `measuredFpRate` from operator #1298 feedback — and recommends a conservative threshold adjustment toward a target FP rate.

```ts
recommendThreshold({ current, measuredFpRate, sampleCount, /* targetFpRate, tolerance, step, minSamples, min, max */ })
//   → { threshold, changed, reason }
```

## Behaviour

- **`insufficient-data`** — fewer than `minSamples` (default 20) labelled anomalies → hold. Avoids chasing noise.
- **`too-many-fp`** — measured FP rate above `target + tolerance` → raise the threshold one multiplicative step (`current × (1 + step)`, default +10%), clamped to `max` (8).
- **`too-strict`** — measured FP rate below `target − tolerance` → lower the threshold (`current × (1 − step)`), clamped to `min` (1.5).
- **`within-target`** — inside the deadband → hold.
- `changed` is `false` when a clamp pins the value, so callers can no-op at the bounds.

Pure and side-effect-free — callers decide whether to apply the recommendation (write to settings) or just surface it. One step at a time keeps the loop stable rather than oscillating.

## Tests (TDD)

6 cases: insufficient-data hold, raise on too-many-FP, lower on too-strict, in-band hold, clamp-at-ceiling, clamp-at-floor. `ai` package suite green; `build:tsc` clean.

## Scope

Part of #1364 (does **not** close it). Remaining P3: production `anomaly_feedback` fetcher (DB wiring), periodic application of the recommendation, seasonality upgrade (#1307).

🤖 Generated with [Claude Code](https://claude.com/claude-code)