### PR TITLE
feat(anomaly): gated auto-apply of the feedback → threshold loop (Part of #1364)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -154,6 +154,17 @@ ANOMALY_CONFIDENCE_MIN_SURFACE=0.7
 # (info-tier routing already quiets low confidence); raise it in noisy envs.
 # Severe fast-burn anomalies (confidence 1.0) are never dropped.
 ANOMALY_SUPPRESS_BELOW_CONFIDENCE=0
+# Feedback → threshold auto-tune (#1364). A scheduled job measures the real
+# per-detector false-positive rate from operator feedback (#1298) and nudges
+# ANOMALY_ZSCORE_THRESHOLD toward ANOMALY_AUTOTUNE_TARGET_FP_RATE, one bounded
+# step at a time. OFF by default — auto-mutating a detection threshold is opt-in
+# (observer-first). With the flag off the job still LOGS what it would change, so
+# you can preview the loop before enabling it. Every applied change is audited.
+ANOMALY_AUTOTUNE_ENABLED=false
+ANOMALY_AUTOTUNE_INTERVAL_MINUTES=360
+ANOMALY_AUTOTUNE_TARGET_FP_RATE=0.05
+ANOMALY_AUTOTUNE_MIN_SAMPLES=20
+ANOMALY_AUTOTUNE_LOOKBACK_DAYS=30
 BOLLINGER_BANDS_ENABLED=true
 # Per-user Sensitivity preset (#1297) — Low / Default / High — is persisted
 # in the `user_settings` table (migration 036) and exposed via

--- a/docs/ai-anomaly-detection.md
+++ b/docs/ai-anomaly-detection.md
@@ -48,6 +48,11 @@ Instead of a single flat 24h baseline, the detector compares each observation ag
 | `ANOMALY_CONFIDENCE_MIN_SURFACE` | `0.7` | Severity × confidence routing (#1363). A confirmed anomaly with confidence (max of persistence ratio and burn magnitude) below this is routed to `info` (a quieter log tier) instead of warning/critical. `0` surfaces everything. |
 | `ANOMALY_SUPPRESS_BELOW_CONFIDENCE` | `0` | System-wide detection-time suppression floor (#1363). Below this confidence an anomaly is **dropped entirely** (never inserted), keeping the shared table/correlator/notifications clean for everyone — complements the per-user Sensitivity preset (a read-time filter). `0` drops nothing; fast-burn anomalies are never dropped. |
 | `ANOMALY_COOLDOWN_MINUTES` | `30` | Per-container/metric cooldown to prevent alert spam |
+| `ANOMALY_AUTOTUNE_ENABLED` | `false` | Feedback → threshold auto-tune (#1364). A scheduled job measures the real per-detector false-positive rate from operator feedback (#1298) and nudges `ANOMALY_ZSCORE_THRESHOLD` toward target, one bounded step at a time. **Off by default** (opt-in); with the flag off it still *logs* what it would change. Applied changes are audited. |
+| `ANOMALY_AUTOTUNE_INTERVAL_MINUTES` | `360` | Auto-tune cadence (default 6h). First run is deferred a full interval after startup. |
+| `ANOMALY_AUTOTUNE_TARGET_FP_RATE` | `0.05` | Target false-positive rate. Above target + 0.02 → raise the threshold; below target − 0.02 → lower it; inside the band → hold. |
+| `ANOMALY_AUTOTUNE_MIN_SAMPLES` | `20` | Minimum conclusively-labelled anomalies before tuning acts (avoids chasing noise). |
+| `ANOMALY_AUTOTUNE_LOOKBACK_DAYS` | `30` | Feedback window the measured rate is computed over. |
 | `BOLLINGER_BANDS_ENABLED` | `true` | Enable the Bollinger method |
 
 ## Isolation Forest (ML)
@@ -133,6 +138,16 @@ Any authenticated user can flag an anomaly as a false positive; the row is alway
 
 - `POST /api/monitoring/anomaly-feedback` — body `{ anomalyId, disposition?, detector? }`. The `detector` field is restricted to an allowlist (`threshold`, `ml-anomaly`, `prediction`, `health-check`, `log-pattern`, `security-scan`, `correlated-zscore`, `isolation-forest`) so client input can't pollute the per-detector breakdown.
 - `GET /api/monitoring/anomaly-feedback/rates` — per-detector false-positive rates. Admins receive **fleet-wide** aggregates (counts per detector only, never individual user dispositions); `?scope=mine` returns caller-scoped data. Non-admins are always caller-scoped, even if they pass `?scope=fleet`.
+
+### Closing the loop: feedback → threshold auto-tune (#1364)
+
+Feedback isn't only a read-time view filter — it can drive the threshold. The aggregation is layered so each stage is pure and independently tested:
+
+1. **Labels** (`anomaly-labels.ts`) — dispositions per anomaly are aggregated into a ground-truth label (FP votes vs TP votes; ties/unsure → inconclusive), and `measuredFpRate` is the false-positive fraction of *conclusively* labelled anomalies. This retires the old `is_acknowledged` proxy.
+2. **Recommendation** (`anomaly-threshold-tuner.ts`) — `recommendThreshold` maps the measured rate to a conservative, one-step threshold change: above target → raise (stricter), well below → lower (recover sensitivity), inside the deadband or below `minSamples` → hold. Always bounded to `[min, max]`.
+3. **Gated apply** (`anomaly-autotune.ts` + `anomaly-autotune-job.ts`) — a scheduled job (`ANOMALY_AUTOTUNE_INTERVAL_MINUTES`) measures the rate for the `ml-anomaly` detector, computes the recommendation, and — **only when `ANOMALY_AUTOTUNE_ENABLED` is on** — writes the new value to the `ai_tuning.anomaly_zscore_threshold` setting (read fresh each detection cycle) and records an `anomaly_threshold_autotuned` audit entry. With the flag off it logs what it *would* do, so operators can preview the loop before opting in (observer-first).
+
+The recommendation/eval logic is validated by a CI regression guard (`anomaly-eval.ts`): robust median+MAD must beat the legacy z-score on PR-AUC for a labelled scenario.
 
 ## Per-User Sensitivity Presets (#1297)
 

--- a/packages/ai-intelligence/src/__tests__/anomaly-autotune-job.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-autotune-job.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runAnomalyAutoTuneJob,
+  ANOMALY_THRESHOLD_SETTING_KEY,
+  type AutoTuneJobPrimitives,
+} from '../services/anomaly-autotune-job.js';
+import type { FeedbackRow } from '../services/anomaly-labels.js';
+
+const FP_HEAVY: FeedbackRow[] = Array.from({ length: 30 }, (_, i) => ({
+  anomaly_id: `a${i}`,
+  disposition: 'false-positive' as const,
+  detector: 'ml-anomaly',
+}));
+
+function primitives(over: Partial<AutoTuneJobPrimitives> = {}): AutoTuneJobPrimitives {
+  return {
+    enabled: true,
+    envThreshold: 3.5,
+    targetFpRate: 0.05,
+    minSamples: 20,
+    lookbackDays: 30,
+    db: { query: vi.fn(async () => FP_HEAVY as unknown[]) },
+    getSetting: vi.fn(async () => ({ value: '3.5' })),
+    setSetting: vi.fn(async () => {}),
+    writeAuditLog: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+describe('runAnomalyAutoTuneJob — production wiring of the auto-tune loop (#1364)', () => {
+  it('persists a raised threshold under the ai_tuning key and audits it', async () => {
+    const p = primitives();
+    const r = await runAnomalyAutoTuneJob(p);
+
+    expect(r.applied).toBe(true);
+    expect(ANOMALY_THRESHOLD_SETTING_KEY).toBe('ai_tuning.anomaly_zscore_threshold');
+
+    const [key, value, category] = vi.mocked(p.setSetting).mock.calls[0];
+    expect(key).toBe('ai_tuning.anomaly_zscore_threshold');
+    expect(Number(value)).toBeCloseTo(3.85, 6); // stringified numeric threshold
+    expect(category).toBe('ai_tuning');
+
+    const [audit] = vi.mocked(p.writeAuditLog).mock.calls[0];
+    expect(audit.action).toBe('anomaly_threshold_autotuned');
+    expect(audit.details).toMatchObject({ previous: 3.5, rate: 1 });
+  });
+
+  it('reads the current threshold from the settings row when present', async () => {
+    const p = primitives({ getSetting: vi.fn(async () => ({ value: '4.2' })) });
+    const r = await runAnomalyAutoTuneJob(p);
+    expect(r.previous).toBe(4.2); // setting wins over env default
+  });
+
+  it('falls back to the env threshold when the setting is missing', async () => {
+    const p = primitives({ getSetting: vi.fn(async () => null), envThreshold: 3.5 });
+    const r = await runAnomalyAutoTuneJob(p);
+    expect(r.previous).toBe(3.5);
+  });
+
+  it('falls back to the env threshold when the setting value is unparseable', async () => {
+    const p = primitives({ getSetting: vi.fn(async () => ({ value: 'not-a-number' })), envThreshold: 3.5 });
+    const r = await runAnomalyAutoTuneJob(p);
+    expect(r.previous).toBe(3.5);
+  });
+
+  it('does not write or audit when the flag is off', async () => {
+    const p = primitives({ enabled: false });
+    const r = await runAnomalyAutoTuneJob(p);
+    expect(r.applied).toBe(false);
+    expect(r.skipped).toBe('disabled');
+    expect(p.setSetting).not.toHaveBeenCalled();
+    expect(p.writeAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('targets the ml-anomaly detector by default', async () => {
+    const p = primitives();
+    const r = await runAnomalyAutoTuneJob(p);
+    expect(r.detector).toBe('ml-anomaly');
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/anomaly-autotune.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-autotune.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runAutoTune, type AutoTuneDeps } from '../services/anomaly-autotune.js';
+
+function deps(over: Partial<AutoTuneDeps> = {}): AutoTuneDeps {
+  return {
+    enabled: true,
+    getMeasuredFpRate: vi.fn(async () => ({ rate: 0.2, sampleCount: 50 })),
+    getCurrentThreshold: vi.fn(async () => 3.5),
+    applyThreshold: vi.fn(async () => {}),
+    audit: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+describe('runAutoTune — gated auto-apply of the threshold recommendation (#1364)', () => {
+  it('applies and audits when enabled and the FP rate is too high', async () => {
+    const d = deps();
+    const r = await runAutoTune(d, { detector: 'ml-anomaly' });
+
+    expect(r.applied).toBe(true);
+    expect(r.previous).toBe(3.5);
+    expect(r.recommended).toBeCloseTo(3.85, 6); // raised one step
+    expect(r.reason).toBe('too-many-fp');
+    expect(vi.mocked(d.applyThreshold).mock.calls[0][0]).toBeCloseTo(3.85, 6);
+    expect(d.audit).toHaveBeenCalledTimes(1);
+    const audited = vi.mocked(d.audit).mock.calls[0][0];
+    expect(audited).toMatchObject({ previous: 3.5, rate: 0.2, sampleCount: 50, detector: 'ml-anomaly', reason: 'too-many-fp' });
+    expect(audited.next).toBeCloseTo(3.85, 6);
+  });
+
+  it('computes the recommendation but does NOT apply when the flag is off', async () => {
+    const d = deps({ enabled: false });
+    const r = await runAutoTune(d, { detector: 'ml-anomaly' });
+
+    expect(r.applied).toBe(false);
+    expect(r.skipped).toBe('disabled');
+    expect(r.recommended).toBeCloseTo(3.85, 6); // still surfaces what it WOULD do
+    expect(d.applyThreshold).not.toHaveBeenCalled();
+    expect(d.audit).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the recommendation is within target (no change)', async () => {
+    const d = deps({ getMeasuredFpRate: vi.fn(async () => ({ rate: 0.05, sampleCount: 50 })) });
+    const r = await runAutoTune(d);
+
+    expect(r.applied).toBe(false);
+    expect(r.skipped).toBe('no-change');
+    expect(r.reason).toBe('within-target');
+    expect(d.applyThreshold).not.toHaveBeenCalled();
+    expect(d.audit).not.toHaveBeenCalled();
+  });
+
+  it('holds (no apply) when there is not enough labelled feedback', async () => {
+    const d = deps({ getMeasuredFpRate: vi.fn(async () => ({ rate: 0.9, sampleCount: 3 })) });
+    const r = await runAutoTune(d);
+
+    expect(r.applied).toBe(false);
+    expect(r.skipped).toBe('no-change');
+    expect(r.reason).toBe('insufficient-data');
+    expect(d.applyThreshold).not.toHaveBeenCalled();
+  });
+
+  it('does not apply when a clamp pins the threshold at the ceiling', async () => {
+    const d = deps({
+      getCurrentThreshold: vi.fn(async () => 8),
+      getMeasuredFpRate: vi.fn(async () => ({ rate: 0.5, sampleCount: 50 })),
+    });
+    const r = await runAutoTune(d, { max: 8 });
+
+    expect(r.applied).toBe(false);
+    expect(r.skipped).toBe('no-change');
+    expect(d.applyThreshold).not.toHaveBeenCalled();
+  });
+
+  it('lowers the threshold when the detector is too strict (FP rate near zero)', async () => {
+    const d = deps({ getMeasuredFpRate: vi.fn(async () => ({ rate: 0, sampleCount: 80 })) });
+    const r = await runAutoTune(d);
+
+    expect(r.applied).toBe(true);
+    expect(r.reason).toBe('too-strict');
+    expect(r.recommended).toBeCloseTo(3.15, 6); // 3.5 × 0.9
+    expect(d.applyThreshold).toHaveBeenCalledWith(3.15);
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/anomaly-feedback-source.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-feedback-source.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createFeedbackFetcher,
+  measureFpRateFromDb,
+} from '../services/anomaly-feedback-source.js';
+import type { FeedbackRow } from '../services/anomaly-labels.js';
+
+/** Minimal AppDb-shaped stub — only `query` is exercised. */
+function fakeDb(rows: FeedbackRow[]) {
+  const query = vi.fn(async () => rows as unknown[]);
+  return { db: { query, queryOne: vi.fn(), execute: vi.fn() }, query };
+}
+
+describe('createFeedbackFetcher — reads anomaly_feedback rows (#1364)', () => {
+  it('selects the feedback columns from the anomaly_feedback table', async () => {
+    const { db, query } = fakeDb([]);
+    await createFeedbackFetcher(db as any)({ detector: 'ml-anomaly' });
+
+    const [sql] = query.mock.calls[0];
+    expect(sql).toMatch(/from\s+anomaly_feedback/i);
+    expect(sql).toMatch(/anomaly_id/i);
+    expect(sql).toMatch(/disposition/i);
+  });
+
+  it('bounds the query to a lookback window and passes the detector filter', async () => {
+    const { db, query } = fakeDb([]);
+    await createFeedbackFetcher(db as any, { lookbackDays: 14 })({ detector: 'ml-anomaly' });
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/created_at\s*>/i); // time-bounded
+    expect(params).toContain(14); // lookback days parameterised
+    expect(params).toContain('ml-anomaly'); // detector filter parameterised
+  });
+
+  it('does not filter by detector when none is given', async () => {
+    const { db, query } = fakeDb([]);
+    await createFeedbackFetcher(db as any)({});
+
+    const [, params] = query.mock.calls[0];
+    expect(params).toContain(null); // null detector → no filter
+  });
+});
+
+describe('measureFpRateFromDb — DB rows → measured FP rate + sample count', () => {
+  it('aggregates dispositions into a rate and a conclusive sample count', async () => {
+    const rows: FeedbackRow[] = [
+      // anomaly a: 2 FP votes → false
+      { anomaly_id: 'a', disposition: 'false-positive', detector: 'ml-anomaly' },
+      { anomaly_id: 'a', disposition: 'false-positive', detector: 'ml-anomaly' },
+      // anomaly b: TP → true
+      { anomaly_id: 'b', disposition: 'true-positive', detector: 'ml-anomaly' },
+      // anomaly c: FP → false
+      { anomaly_id: 'c', disposition: 'false-positive', detector: 'ml-anomaly' },
+      // anomaly d: tie → inconclusive, excluded from both rate and count
+      { anomaly_id: 'd', disposition: 'false-positive', detector: 'ml-anomaly' },
+      { anomaly_id: 'd', disposition: 'true-positive', detector: 'ml-anomaly' },
+    ];
+    const { db } = fakeDb(rows);
+
+    const { rate, sampleCount } = await measureFpRateFromDb(db as any, 'ml-anomaly');
+    expect(sampleCount).toBe(3); // a, b, c conclusive; d excluded
+    expect(rate).toBeCloseTo(2 / 3, 6); // a, c false out of 3
+  });
+
+  it('is rate 0 / count 0 when there is no conclusive feedback', async () => {
+    const { db } = fakeDb([]);
+    const { rate, sampleCount } = await measureFpRateFromDb(db as any, 'ml-anomaly');
+    expect(rate).toBe(0);
+    expect(sampleCount).toBe(0);
+  });
+});

--- a/packages/ai-intelligence/src/index.ts
+++ b/packages/ai-intelligence/src/index.ts
@@ -49,6 +49,11 @@ export { isLlmAvailable, chatStream, buildInfrastructureContext } from './servic
 // Services — insights
 export { cleanupOldInsights } from './services/insights-store.js';
 
+// Services — anomaly auto-tune (feedback → threshold loop, #1364)
+export { runAnomalyAutoTuneJob, ANOMALY_THRESHOLD_SETTING_KEY } from './services/anomaly-autotune-job.js';
+export type { AutoTuneJobPrimitives } from './services/anomaly-autotune-job.js';
+export type { AutoTuneResult } from './services/anomaly-autotune.js';
+
 // Services — dedup-engine telemetry (#1200)
 export { runDedupTelemetryCycle, collectDedupMetrics, cleanupOldDedupMetrics } from './services/dedup-telemetry.js';
 export type { DedupMetricRow, DedupTelemetryCycleResult } from './services/dedup-telemetry.js';

--- a/packages/ai-intelligence/src/services/anomaly-autotune-job.ts
+++ b/packages/ai-intelligence/src/services/anomaly-autotune-job.ts
@@ -1,0 +1,69 @@
+/**
+ * Production wiring for the gated auto-tune loop (#1364). Binds the pure
+ * orchestrator (`runAutoTune`) and DB feedback source (`measureFpRateFromDb`) to
+ * the global settings store and audit log so a scheduled job can close the loop.
+ *
+ * The collaborators are injected as primitives (db, getSetting, setSetting,
+ * writeAuditLog) so the wiring — setting-key parse/format and audit shape — is
+ * unit-testable end-to-end without mocking `@dashboard/core` modules. The
+ * scheduler binds the real core functions.
+ */
+
+import { runAutoTune, type AutoTuneResult } from './anomaly-autotune.js';
+import { measureFpRateFromDb, type FeedbackDb } from './anomaly-feedback-source.js';
+
+/** Settings key the metric ('ml-anomaly') z-score/robust detector reads each cycle. */
+export const ANOMALY_THRESHOLD_SETTING_KEY = 'ai_tuning.anomaly_zscore_threshold';
+
+/** The detector whose feedback drives this knob (writes detection_method 'ml-anomaly'). */
+const DEFAULT_DETECTOR = 'ml-anomaly';
+
+export interface AutoTuneJobPrimitives {
+  enabled: boolean;
+  /** Env-config threshold, used when the settings row is absent/unparseable. */
+  envThreshold: number;
+  /** Override the tuned detector (defaults to 'ml-anomaly'). */
+  detector?: string;
+  targetFpRate: number;
+  minSamples: number;
+  lookbackDays: number;
+  db: FeedbackDb;
+  getSetting: (key: string) => Promise<{ value: string } | null>;
+  setSetting: (key: string, value: string, category: string) => Promise<void>;
+  writeAuditLog: (entry: {
+    username?: string;
+    action: string;
+    target_type?: string;
+    target_id?: string;
+    details?: Record<string, unknown>;
+  }) => Promise<void>;
+}
+
+export async function runAnomalyAutoTuneJob(p: AutoTuneJobPrimitives): Promise<AutoTuneResult> {
+  const detector = p.detector ?? DEFAULT_DETECTOR;
+
+  return runAutoTune(
+    {
+      enabled: p.enabled,
+      getMeasuredFpRate: (d) => measureFpRateFromDb(p.db, d, { lookbackDays: p.lookbackDays }),
+      getCurrentThreshold: async () => {
+        const row = await p.getSetting(ANOMALY_THRESHOLD_SETTING_KEY);
+        const parsed = row ? Number(row.value) : Number.NaN;
+        // Empty string coerces to 0 via Number(); guard it so a blank setting
+        // falls back to the env default rather than collapsing the threshold.
+        return Number.isFinite(parsed) && row?.value.trim() !== '' ? parsed : p.envThreshold;
+      },
+      applyThreshold: (next) =>
+        p.setSetting(ANOMALY_THRESHOLD_SETTING_KEY, String(next), 'ai_tuning'),
+      audit: (e) =>
+        p.writeAuditLog({
+          username: 'system',
+          action: 'anomaly_threshold_autotuned',
+          target_type: 'anomaly_detector',
+          target_id: ANOMALY_THRESHOLD_SETTING_KEY,
+          details: { ...e },
+        }),
+    },
+    { detector, targetFpRate: p.targetFpRate, minSamples: p.minSamples },
+  );
+}

--- a/packages/ai-intelligence/src/services/anomaly-autotune.ts
+++ b/packages/ai-intelligence/src/services/anomaly-autotune.ts
@@ -1,0 +1,113 @@
+/**
+ * Gated auto-tune orchestrator (#1364). Closes the feedback loop end-to-end:
+ * measure the per-detector false-positive rate from operator #1298 feedback,
+ * ask `recommendThreshold` for a conservative one-step adjustment, and — only
+ * when the `ANOMALY_AUTOTUNE_ENABLED` flag is on — apply it to the global
+ * `ai_tuning.anomaly_zscore_threshold` setting and write an audit record.
+ *
+ * Observer-first: the recommendation is always computed (so the job can log /
+ * surface "would change 3.5 → 3.85" even with the flag off), but a threshold is
+ * only mutated when explicitly enabled, one bounded step at a time, and every
+ * applied change is audited.
+ *
+ * All side effects (measure, read, apply, audit) are injected so the orchestrator
+ * is pure-by-construction and unit-testable without a database; production wiring
+ * binds the real settings store, feedback query, and audit logger.
+ */
+
+import { recommendThreshold, type TuneReason } from './anomaly-threshold-tuner.js';
+
+export interface AutoTuneDeps {
+  /** Master flag — when false, recommend but never apply. */
+  enabled: boolean;
+  /** Measured FP rate + how many conclusively-labelled anomalies it is based on. */
+  getMeasuredFpRate: (detector: string) => Promise<{ rate: number; sampleCount: number }>;
+  /** Current effective threshold (settings store value, env fallback). */
+  getCurrentThreshold: () => Promise<number>;
+  /** Persist a new threshold (e.g. setSetting('ai_tuning.anomaly_zscore_threshold', ...)). */
+  applyThreshold: (next: number) => Promise<void>;
+  /** Record the applied change for the audit trail. */
+  audit: (event: {
+    previous: number;
+    next: number;
+    rate: number;
+    sampleCount: number;
+    reason: TuneReason;
+    detector: string;
+  }) => Promise<void>;
+}
+
+export interface AutoTuneOptions {
+  /** Which detector's feedback drives tuning (default 'ml-anomaly'). */
+  detector?: string;
+  targetFpRate?: number;
+  tolerance?: number;
+  step?: number;
+  minSamples?: number;
+  min?: number;
+  max?: number;
+}
+
+export interface AutoTuneResult {
+  applied: boolean;
+  previous: number;
+  recommended: number;
+  rate: number;
+  sampleCount: number;
+  reason: TuneReason;
+  detector: string;
+  /** Why no change was applied, when applied === false. */
+  skipped?: 'disabled' | 'no-change';
+}
+
+export async function runAutoTune(
+  deps: AutoTuneDeps,
+  opts: AutoTuneOptions = {},
+): Promise<AutoTuneResult> {
+  const detector = opts.detector ?? 'ml-anomaly';
+  const { rate, sampleCount } = await deps.getMeasuredFpRate(detector);
+  const current = await deps.getCurrentThreshold();
+
+  const rec = recommendThreshold({
+    current,
+    measuredFpRate: rate,
+    sampleCount,
+    targetFpRate: opts.targetFpRate,
+    tolerance: opts.tolerance,
+    step: opts.step,
+    minSamples: opts.minSamples,
+    min: opts.min,
+    max: opts.max,
+  });
+
+  const base = {
+    previous: current,
+    recommended: rec.threshold,
+    rate,
+    sampleCount,
+    reason: rec.reason,
+    detector,
+  };
+
+  // No actionable change (within target, insufficient data, or clamped at a bound).
+  if (!rec.changed) {
+    return { ...base, applied: false, skipped: 'no-change' };
+  }
+
+  // Actionable change, but auto-apply is off — surface it without mutating.
+  if (!deps.enabled) {
+    return { ...base, applied: false, skipped: 'disabled' };
+  }
+
+  await deps.applyThreshold(rec.threshold);
+  await deps.audit({
+    previous: current,
+    next: rec.threshold,
+    rate,
+    sampleCount,
+    reason: rec.reason,
+    detector,
+  });
+
+  return { ...base, applied: true };
+}

--- a/packages/ai-intelligence/src/services/anomaly-feedback-source.ts
+++ b/packages/ai-intelligence/src/services/anomaly-feedback-source.ts
@@ -1,0 +1,70 @@
+/**
+ * Production feedback source (#1364). Binds the pure labelled-store logic
+ * (`anomaly-labels.ts`) to the real `anomaly_feedback` table (migration 037,
+ * #1298) so the auto-tune job can measure a true per-detector false-positive
+ * rate from operator dispositions.
+ *
+ * The SQL is a thin read; the aggregation (votes → ground truth → FP rate) stays
+ * in the pure, unit-tested labelled store. A fake `AppDb` exercises this module
+ * without a database.
+ */
+
+import {
+  getAnomalyLabels,
+  measuredFpRate,
+  type FeedbackRow,
+  type FetchFeedbackFn,
+} from './anomaly-labels.js';
+
+/** The slice of `AppDb` this module needs (avoids importing the concrete type). */
+export interface FeedbackDb {
+  query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
+}
+
+export interface FeedbackSourceOptions {
+  /** Only consider feedback from the last N days (default 30). */
+  lookbackDays?: number;
+}
+
+/**
+ * Build a `FetchFeedbackFn` over the `anomaly_feedback` table. Bounded to a
+ * lookback window so the measured rate tracks recent detector behaviour rather
+ * than ancient feedback; optionally filtered to one detector.
+ */
+export function createFeedbackFetcher(
+  db: FeedbackDb,
+  opts: FeedbackSourceOptions = {},
+): FetchFeedbackFn {
+  const lookbackDays = opts.lookbackDays ?? 30;
+  return async ({ detector } = {}) => {
+    // `(? IS NULL OR detector = ?)` — the same value is bound twice so the
+    // detector filter is a no-op when none is supplied. `make_interval` keeps
+    // the lookback window parameterised (no string-built intervals).
+    return db.query<FeedbackRow>(
+      `SELECT anomaly_id, disposition, detector
+         FROM anomaly_feedback
+        WHERE created_at > NOW() - make_interval(days => ?)
+          AND (? IS NULL OR detector = ?)`,
+      [lookbackDays, detector ?? null, detector ?? null],
+    );
+  };
+}
+
+/**
+ * Measure the per-detector false-positive rate and the number of conclusively
+ * labelled anomalies it is based on — the exact `{rate, sampleCount}` shape the
+ * auto-tune orchestrator consumes.
+ */
+export async function measureFpRateFromDb(
+  db: FeedbackDb,
+  detector: string,
+  opts: FeedbackSourceOptions = {},
+): Promise<{ rate: number; sampleCount: number }> {
+  const fetch = createFeedbackFetcher(db, opts);
+  const labels = await getAnomalyLabels(fetch, { detector });
+  let sampleCount = 0;
+  for (const gt of labels.values()) {
+    if (gt.label !== null) sampleCount++;
+  }
+  return { rate: measuredFpRate(labels), sampleCount };
+}

--- a/packages/core/src/config/env.schema.ts
+++ b/packages/core/src/config/env.schema.ts
@@ -126,6 +126,17 @@ export const envSchema = z.object({
   // raise it in noisy environments. Severe fast-burn anomalies (confidence 1.0)
   // are never dropped here.
   ANOMALY_SUPPRESS_BELOW_CONFIDENCE: z.coerce.number().min(0).max(1).default(0),
+  // Feedback → threshold auto-tune (#1364). A scheduled job measures the real
+  // per-detector false-positive rate from operator feedback (#1298) and nudges
+  // ANOMALY_ZSCORE_THRESHOLD toward the target rate, one bounded step at a time.
+  // OFF by default — auto-mutating a detection threshold is opt-in (observer-
+  // first); with the flag off the job still logs what it WOULD change. Every
+  // applied change is written to the audit log.
+  ANOMALY_AUTOTUNE_ENABLED: z.coerce.boolean().default(false),
+  ANOMALY_AUTOTUNE_INTERVAL_MINUTES: z.coerce.number().int().min(5).default(360),
+  ANOMALY_AUTOTUNE_TARGET_FP_RATE: z.coerce.number().min(0).max(1).default(0.05),
+  ANOMALY_AUTOTUNE_MIN_SAMPLES: z.coerce.number().int().min(1).default(20),
+  ANOMALY_AUTOTUNE_LOOKBACK_DAYS: z.coerce.number().int().min(1).default(30),
   BOLLINGER_BANDS_ENABLED: z.coerce.boolean().default(true),
   // Hour-of-day baseline (issue #1295): compare the recent sample against the
   // baseline for the same hour-of-day across the last N days, rather than a

--- a/packages/core/src/config/index.test.ts
+++ b/packages/core/src/config/index.test.ts
@@ -263,6 +263,16 @@ describe('config validation', () => {
       expect(c.ANOMALY_SUPPRESS_BELOW_CONFIDENCE).toBe(0);
     });
 
+    it('defaults the feedback auto-tune to OFF, 6h cadence, 5% target (#1364)', async () => {
+      const { getConfig } = await import('./index.js');
+      const c = getConfig();
+      expect(c.ANOMALY_AUTOTUNE_ENABLED).toBe(false); // opt-in (observer-first)
+      expect(c.ANOMALY_AUTOTUNE_INTERVAL_MINUTES).toBe(360);
+      expect(c.ANOMALY_AUTOTUNE_TARGET_FP_RATE).toBe(0.05);
+      expect(c.ANOMALY_AUTOTUNE_MIN_SAMPLES).toBe(20);
+      expect(c.ANOMALY_AUTOTUNE_LOOKBACK_DAYS).toBe(30);
+    });
+
     it('defaults ANOMALY_MOVING_AVERAGE_WINDOW to 60', async () => {
       // Raised 20 → 60 in #1294 (epic #1291): the previous ~20-min window
       // over-reacted to traffic ramps and short-lived bursts.

--- a/packages/server/src/__tests__/scheduler-session-cleanup.test.ts
+++ b/packages/server/src/__tests__/scheduler-session-cleanup.test.ts
@@ -65,6 +65,7 @@ vi.mock('@dashboard/ai', () => ({
   startCooldownSweep: vi.fn(),
   stopCooldownSweep: vi.fn(),
   cleanupOldInsights: vi.fn().mockResolvedValue(0),
+  runAnomalyAutoTuneJob: vi.fn().mockResolvedValue({ applied: false, skipped: 'no-change', reason: 'within-target', previous: 3.5, recommended: 3.5, rate: 0, sampleCount: 0, detector: 'ml-anomaly' }),
 }));
 // initCooldownStore would otherwise attempt a real Redis connect at startup.
 vi.mock('@dashboard/core/services/cooldown-store.js', () => ({

--- a/packages/server/src/__tests__/scheduler.test.ts
+++ b/packages/server/src/__tests__/scheduler.test.ts
@@ -79,6 +79,7 @@ vi.mock('@dashboard/ai', () => ({
   stopCooldownSweep: vi.fn(),
   cleanupOldInsights: (...args: unknown[]) => cleanupOldInsightsMock(...args),
   pruneCanaryRegistry: (...args: unknown[]) => pruneCanaryRegistryMock(...args),
+  runAnomalyAutoTuneJob: vi.fn().mockResolvedValue({ applied: false, skipped: 'no-change', reason: 'within-target', previous: 3.5, recommended: 3.5, rate: 0, sampleCount: 0, detector: 'ml-anomaly' }),
 }));
 // initCooldownStore would otherwise attempt a real Redis connect at startup.
 vi.mock('@dashboard/core/services/cooldown-store.js', () => ({

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -5,9 +5,10 @@ import { getEndpoints, getContainers, isEndpointDegraded, getImages } from '@das
 import { isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { cachedFetch, cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/index.js';
 import { normalizeEndpoint, type NormalizedEndpoint } from '@dashboard/core/portainer/index.js';
-import { getSetting, getEffectiveHarborConfig, getEffectiveMonitoringSchedulerConfig, cleanExpiredSessions, cleanExpiredStreamTickets } from '@dashboard/core/services/index.js';
+import { getSetting, setSetting, writeAuditLog, getEffectiveHarborConfig, getEffectiveMonitoringSchedulerConfig, cleanExpiredSessions, cleanExpiredStreamTickets } from '@dashboard/core/services/index.js';
+import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { runWithTraceContext } from '@dashboard/core/tracing/index.js';
-import { startCooldownSweep, stopCooldownSweep, cleanupOldInsights, pruneCanaryRegistry, runDedupTelemetryCycle, cleanupOldDedupMetrics } from '@dashboard/ai';
+import { startCooldownSweep, stopCooldownSweep, cleanupOldInsights, pruneCanaryRegistry, runDedupTelemetryCycle, cleanupOldDedupMetrics, runAnomalyAutoTuneJob } from '@dashboard/ai';
 import { initCooldownStore } from '@dashboard/core/services/cooldown-store.js';
 import { initPersistenceStore } from '@dashboard/core/services/persistence-store.js';
 import { collectMetrics, insertMetrics, cleanOldMetrics, cleanOldSpans, type MetricInsert, recordNetworkSample, insertKpiSnapshot, cleanOldKpiSnapshots, pruneStaleEntries } from '@dashboard/observability';
@@ -432,6 +433,49 @@ export async function runCleanup(): Promise<void> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Anomaly threshold auto-tune (#1364) — feedback → threshold loop
+// ---------------------------------------------------------------------------
+
+/** Measure the real FP rate from operator feedback and nudge the z-score/robust
+ *  threshold toward target. Always computes the recommendation; only APPLIES
+ *  (and audits) it when ANOMALY_AUTOTUNE_ENABLED is on. With the flag off it logs
+ *  what it would do so operators can preview the loop before opting in. */
+async function runAutoTuneCycle(): Promise<void> {
+  const cfg = getConfig();
+  try {
+    const result = await runAnomalyAutoTuneJob({
+      enabled: cfg.ANOMALY_AUTOTUNE_ENABLED,
+      envThreshold: cfg.ANOMALY_ZSCORE_THRESHOLD,
+      targetFpRate: cfg.ANOMALY_AUTOTUNE_TARGET_FP_RATE,
+      minSamples: cfg.ANOMALY_AUTOTUNE_MIN_SAMPLES,
+      lookbackDays: cfg.ANOMALY_AUTOTUNE_LOOKBACK_DAYS,
+      db: getDbForDomain('feedback'),
+      getSetting,
+      setSetting,
+      writeAuditLog,
+    });
+
+    if (result.applied) {
+      log.info(
+        { previous: result.previous, next: result.recommended, rate: result.rate, samples: result.sampleCount, reason: result.reason },
+        'Anomaly threshold auto-tuned',
+      );
+    } else if (result.skipped === 'disabled') {
+      // A change was recommended but the flag is off — surface it so operators
+      // can see the loop working before enabling auto-apply.
+      log.info(
+        { previous: result.previous, recommended: result.recommended, rate: result.rate, samples: result.sampleCount, reason: result.reason },
+        'Anomaly auto-tune suggests a threshold change (set ANOMALY_AUTOTUNE_ENABLED=true to apply)',
+      );
+    } else {
+      log.debug({ reason: result.reason, rate: result.rate, samples: result.sampleCount }, 'Anomaly auto-tune: no change');
+    }
+  } catch (err) {
+    log.error({ err }, 'Anomaly auto-tune cycle failed');
+  }
+}
+
 async function waitForPortainer(): Promise<boolean> {
   const maxRetries = 10;
   const retryDelayMs = 2000;
@@ -539,6 +583,32 @@ export async function startScheduler(runMonitoringCycle: () => Promise<void>): P
         'Starting dynamic monitoring scheduler (1-min poll)',
       );
     }).catch(() => {});
+  }
+
+  // Anomaly threshold auto-tune (#1364) — polls every minute, runs at
+  // ANOMALY_AUTOTUNE_INTERVAL_MINUTES cadence. `lastAutoTuneRunAt` starts at
+  // "now" so the first run is deferred a full interval (no tuning storm on
+  // restart loops). The job is internally gated by ANOMALY_AUTOTUNE_ENABLED.
+  {
+    let lastAutoTuneRunAt = Date.now();
+    const autoTuneInterval = setInterval(
+      () => runWithTraceContext({ source: 'scheduler' }, async () => {
+        try {
+          const intervalMs = getConfig().ANOMALY_AUTOTUNE_INTERVAL_MINUTES * 60 * 1000;
+          if (Date.now() - lastAutoTuneRunAt < intervalMs) return;
+          lastAutoTuneRunAt = Date.now();
+          await runAutoTuneCycle();
+        } catch (err) {
+          log.error({ err }, 'Anomaly auto-tune tick failed');
+        }
+      }),
+      60_000, // poll every minute; actual cadence controlled by interval-minutes
+    );
+    intervals.push(autoTuneInterval);
+    log.info(
+      { enabled: config.ANOMALY_AUTOTUNE_ENABLED, intervalMinutes: config.ANOMALY_AUTOTUNE_INTERVAL_MINUTES },
+      'Starting anomaly auto-tune scheduler (1-min poll)',
+    );
   }
 
   // Webhook retry processing


### PR DESCRIPTION
## What

Closes the feedback loop **end-to-end**. A scheduled job measures the real per-detector false-positive rate from operator feedback (#1298), asks the tuner (#1377) for a conservative one-step threshold adjustment, and — **only when `ANOMALY_AUTOTUNE_ENABLED` is on** — applies it to the global `ai_tuning.anomaly_zscore_threshold` setting (read fresh each detection cycle) and writes an audit record.

Operator decision captured in the redesign: **auto-apply, gated** — default **off**, bounded, one step at a time, audited. With the flag off the job still *logs* what it would change, so the loop can be previewed before opting in (observer-first).

## Layering (each stage pure + independently tested)

| File | Role | Tests |
|---|---|---|
| `anomaly-feedback-source.ts` | Thin SQL over `anomaly_feedback` (migration 037) bound to the merged labelled store → `measureFpRateFromDb` → `{rate, sampleCount}` | 5 (fake `AppDb`) |
| `anomaly-autotune.ts` | `runAutoTune` orchestrator — compute always, apply only when enabled, one bounded step, audit on apply. Fully DI | 6 |
| `anomaly-autotune-job.ts` | Production wiring — settings-key parse/format + audit shape, injectable primitives | 6 (no core mocking) |
| `scheduler.ts` | 1-min poll, `ANOMALY_AUTOTUNE_INTERVAL_MINUTES` cadence, **first run deferred a full interval** (no tuning storm on restart) | scheduler mocks updated |

## Behaviour

- **Flag off** (default): recommendation computed; nothing mutated; logs `suggests a threshold change (set ANOMALY_AUTOTUNE_ENABLED=true to apply)`.
- **Flag on**: writes new threshold via `setSetting('ai_tuning.anomaly_zscore_threshold', …, 'ai_tuning')`, audits as `anomaly_threshold_autotuned` (action/target/previous/next/rate/reason).
- One multiplicative step toward target (`±10%`), clamped to `[1.5, 8]`; holds inside the ±0.02 deadband and below `minSamples`. No restart needed — the detector reads the setting fresh each cycle.
- Current threshold read from the settings row, falling back to env `ANOMALY_ZSCORE_THRESHOLD` when absent/unparseable/blank.
- Targets the `ml-anomaly` detector (the one whose threshold *is* `ANOMALY_ZSCORE_THRESHOLD`).

## Config (all with config-default guard tests)

| Var | Default |
|---|---|
| `ANOMALY_AUTOTUNE_ENABLED` | `false` |
| `ANOMALY_AUTOTUNE_INTERVAL_MINUTES` | `360` |
| `ANOMALY_AUTOTUNE_TARGET_FP_RATE` | `0.05` |
| `ANOMALY_AUTOTUNE_MIN_SAMPLES` | `20` |
| `ANOMALY_AUTOTUNE_LOOKBACK_DAYS` | `30` |

## Tests / verification

17 new unit tests (orchestrator 6, feedback source 5, production job 6) + config-default guard. `build:tsc`, `typecheck`, `lint` all clean. Local DB-backed `incidents-*` tests fail only on `ECONNREFUSED 5433` (no local test DB; CI has it).

## Scope

Part of #1364 (does **not** close it). Remaining P3: seasonality upgrade (`metrics_1hour` continuous aggregate #1307 + day-of-week/STL); re-run the #1291 before/after audit against a real data source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)