### PR TITLE
perf(anomaly): metrics_1hour aggregate + day-of-week seasonality (Closes #1307)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -179,6 +179,18 @@ BOLLINGER_BANDS_ENABLED=true
 # ANOMALY_HOUROFDAY_LOOKBACK_DAYS=14
 # ANOMALY_HOUROFDAY_MIN_SAMPLES=3
 
+# Day-of-week × hour-of-day seasonality (#1307) — refines the hour-of-day
+# baseline so e.g. Monday 09:00 is compared against previous Mondays 09:00, not
+# every day's 09:00. Catches weekly patterns (weekday vs weekend). The detector
+# tries day-of-week → hour-of-day → flat, so sparse weekday buckets and cold
+# starts degrade gracefully. The mean/std path reads the metrics_1hour
+# continuous aggregate (cheap); the robust path narrows its raw query. A wider
+# lookback (default 28d ≈ 4 same-weekday occurrences) keeps the weekly bucket
+# stable. Set ANOMALY_DAYOFWEEK_ENABLED=false to keep hour-of-day-only.
+# ANOMALY_DAYOFWEEK_ENABLED=true
+# ANOMALY_DAYOFWEEK_LOOKBACK_DAYS=28
+# ANOMALY_DAYOFWEEK_MIN_SAMPLES=3
+
 # Predictive Alerting — proactive resource exhaustion warnings
 PREDICTIVE_ALERTING_ENABLED=true
 PREDICTIVE_ALERT_THRESHOLD_HOURS=24

--- a/docs/ai-anomaly-detection.md
+++ b/docs/ai-anomaly-detection.md
@@ -24,14 +24,25 @@ Anomalies are detected per-container, per-metric from historical time-series. Th
 
 > Note (#1295): very stable services now use a **1.0×** multiplier (previously 1.2×). After upgrading, expect a one-time uptick in alerts on historically quiet, low-variance services — this is intentional and surfaces previously-suppressed anomalies.
 
-### Hour-of-day seasonal baseline (#1295)
+### Seasonal baseline: hour-of-day (#1295) + day-of-week (#1307)
 
-Instead of a single flat 24h baseline, the detector compares each observation against the baseline for the **same UTC hour** over a lookback window. This eliminates false positives during predictable diurnal ramps (morning traffic, nightly batch). When an hour bucket hasn't warmed up, it falls back to the flat baseline.
+Instead of a single flat 24h baseline, the detector compares each observation against the baseline for its **seasonal bucket**, falling back from the finest bucket that has data:
+
+1. **day-of-week × hour-of-day** (#1307) — e.g. Monday 09:00 vs previous Mondays 09:00, catching weekly patterns (weekday vs weekend traffic);
+2. **hour-of-day** (#1295) — same UTC hour over a lookback window, catching diurnal ramps;
+3. **flat trailing window** — the historical behavior.
+
+Each level falls through to the next when its bucket is below the warm-up threshold, so cold starts and sparse weekday buckets degrade gracefully.
+
+**Data source by detector (#1307):** the mean/std path (`getMovingAverageByHourOfDay`) reads TimescaleDB's `metrics_1hour` continuous aggregate and reconstructs the exact population mean + `STDDEV_POP` from the per-hour `avg`/`stddev`/`count` via the law of total variance (`poolHourlyBuckets`) — a few dozen rows instead of a full hypertable scan. The **robust median+MAD** path stays on the raw `metrics` hypertable (median+MAD needs raw samples; pooling daily hourly *averages* would understate the spread and over-flag), but a day-of-week filter narrows its query, so it scans *less*. The improvement is guarded in CI by a PR-AUC regression test (`anomaly-eval.ts`): a same-phase seasonal baseline must beat a flat trailing window on a weekly-seasonal series.
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
 | `ANOMALY_HOUROFDAY_LOOKBACK_DAYS` | `14` | Days of history per hour-of-day bucket |
 | `ANOMALY_HOUROFDAY_MIN_SAMPLES` | `3` | Min samples in a bucket before it's used (else flat fallback) |
+| `ANOMALY_DAYOFWEEK_ENABLED` | `true` | Enable the day-of-week × hour-of-day layer; `false` keeps hour-of-day-only |
+| `ANOMALY_DAYOFWEEK_LOOKBACK_DAYS` | `28` | Days of history for the weekly bucket (≈ 4 same-weekday occurrences) |
+| `ANOMALY_DAYOFWEEK_MIN_SAMPLES` | `3` | Min samples in a weekday bucket before it's used (else hour-of-day fallback) |
 
 ### Core configuration
 

--- a/packages/ai-intelligence/src/__tests__/adaptive-anomaly-detector.test.ts
+++ b/packages/ai-intelligence/src/__tests__/adaptive-anomaly-detector.test.ts
@@ -165,6 +165,10 @@ describe('adaptive-anomaly-detector', () => {
       // median 50, MAD 4 → modified-z threshold (2.5) is crossed at value > ~64.8.
       const spread = () => [44, 46, 48, 50, 50, 52, 54, 56, 42, 58];
 
+      // These tests focus on the hour-of-day → flat fallback; disable the
+      // day-of-week layer so the call shapes stay 4-arg (covered separately).
+      beforeEach(() => setConfigForTest({ ANOMALY_DAYOFWEEK_ENABLED: false }));
+
       it('flags a spike beyond the modified-z threshold', async () => {
         const getWindow = vi.fn().mockResolvedValue(spread());
         const r = await detectAnomalyRobust('c1', 'web', 'cpu', 80, getWindow);
@@ -231,6 +235,49 @@ describe('adaptive-anomaly-detector', () => {
         const r = await detectAnomalyRobust('c1', 'web', 'cpu', 80, flat);
         expect(flat).toHaveBeenCalledWith('c1', 'cpu', 30);
         expect(r!.method).toBe('robust-mad');
+      });
+
+      // #1307 — day-of-week × hour-of-day seasonality, with dow → hour → flat fallback.
+      describe('day-of-week seasonality (#1307)', () => {
+        const NOW = new Date('2026-05-25T09:30:00Z');
+        const DOW = NOW.getUTCDay();
+        const HOUR = NOW.getUTCHours(); // 9
+
+        beforeEach(() => setConfigForTest({
+          ANOMALY_DAYOFWEEK_ENABLED: true,
+          ANOMALY_DAYOFWEEK_LOOKBACK_DAYS: 28,
+          ANOMALY_DAYOFWEEK_MIN_SAMPLES: 3,
+        }));
+
+        it('prefers the day-of-week × hour window when it has enough samples', async () => {
+          const flat = vi.fn().mockResolvedValue(spread());
+          const seasonal = vi.fn().mockResolvedValue(spread());
+          const r = await detectAnomalyRobust('c1', 'web', 'cpu', 80, flat, seasonal, NOW);
+          // First call narrows to the weekday over the wider dow lookback.
+          expect(seasonal).toHaveBeenCalledWith('c1', 'cpu', HOUR, 28, DOW);
+          expect(flat).not.toHaveBeenCalled();
+          expect(r!.is_anomalous).toBe(true);
+        });
+
+        it('falls back to the hour-of-day window when the weekday bucket is too sparse', async () => {
+          const flat = vi.fn().mockResolvedValue(spread());
+          const seasonal = vi.fn()
+            .mockResolvedValueOnce([50, 50])   // dow×hour → sparse (< 3)
+            .mockResolvedValueOnce(spread());  // hour-of-day → enough
+          const r = await detectAnomalyRobust('c1', 'web', 'cpu', 80, flat, seasonal, NOW);
+          expect(seasonal).toHaveBeenNthCalledWith(1, 'c1', 'cpu', HOUR, 28, DOW);
+          expect(seasonal).toHaveBeenNthCalledWith(2, 'c1', 'cpu', HOUR, 14); // hour-only, no dow
+          expect(flat).not.toHaveBeenCalled();
+          expect(r!.is_anomalous).toBe(true);
+        });
+
+        it('falls back to the flat window when both seasonal buckets are sparse', async () => {
+          const flat = vi.fn().mockResolvedValue(spread());
+          const seasonal = vi.fn().mockResolvedValue([50, 50]); // both sparse
+          const r = await detectAnomalyRobust('c1', 'web', 'cpu', 80, flat, seasonal, NOW);
+          expect(flat).toHaveBeenCalledWith('c1', 'cpu', 30);
+          expect(r!.is_anomalous).toBe(true);
+        });
       });
     });
 

--- a/packages/ai-intelligence/src/__tests__/anomaly-eval.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-eval.test.ts
@@ -4,6 +4,7 @@ import {
   prAuc,
   scoreSeriesRobust,
   scoreSeriesZScore,
+  scoreSeriesSeasonalRobust,
 } from '../services/anomaly-eval.js';
 
 describe('precisionRecallF1', () => {
@@ -112,5 +113,63 @@ describe('PR-AUC regression guard — robust one-sided beats two-sided z-score (
 
     expect(robustAuc).toBeGreaterThan(zscoreAuc); // one-sided robustness win
     expect(robustAuc).toBeGreaterThan(0.5); // CI regression floor
+  });
+});
+
+describe('PR-AUC regression guard — seasonal (day-of-week) beats flat-trailing (#1307)', () => {
+  const HOURS_PER_WEEK = 24 * 7; // seasonal period (hourly samples)
+
+  // Strong weekly seasonality: weekday baseline 50, weekend baseline 15. A flat
+  // trailing window mistakes the regular weekday↔weekend steps for anomalies; a
+  // same-phase (same hour-of-week) baseline sees them as normal. Real spikes
+  // (+40 on weekday hours) are the only true anomalies.
+  function weeklySeasonalScenario() {
+    const WEEKS = 6;
+    const N = WEEKS * HOURS_PER_WEEK;
+    const values: number[] = [];
+    const labels: boolean[] = [];
+    const spikeAt = new Set([
+      4 * HOURS_PER_WEEK + 50, 4 * HOURS_PER_WEEK + 51,
+      5 * HOURS_PER_WEEK + 80, 5 * HOURS_PER_WEEK + 81, 5 * HOURS_PER_WEEK + 130,
+    ]);
+    let seed = 0x2bad_c0de;
+    const rng = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    for (let i = 0; i < N; i++) {
+      const dayOfWeek = Math.floor(i / 24) % 7; // 0..6, 0/6 = weekend
+      const weekend = dayOfWeek === 0 || dayOfWeek === 6;
+      const baseline = weekend ? 15 : 50;
+      if (spikeAt.has(i)) { values.push(baseline + 40 + (rng() - 0.5)); labels.push(true); continue; }
+      values.push(baseline + (rng() - 0.5) * 2);
+      labels.push(false);
+    }
+    return { values, labels };
+  }
+
+  // Align two score arrays to the indices where BOTH produced a score.
+  function alignedEvaluable(a: Array<number | null>, b: Array<number | null>, labels: boolean[]) {
+    const sa: number[] = [];
+    const sb: number[] = [];
+    const l: boolean[] = [];
+    for (let i = 0; i < labels.length; i++) {
+      if (a[i] !== null && b[i] !== null) { sa.push(a[i]!); sb.push(b[i]!); l.push(labels[i]); }
+    }
+    return { sa, sb, l };
+  }
+
+  it('seasonal same-phase PR-AUC exceeds the flat trailing window and clears a floor', () => {
+    const { values, labels } = weeklySeasonalScenario();
+    // Flat trailing window of one day vs same-hour-of-week baseline.
+    const flat = scoreSeriesRobust(values, 24);
+    const seasonal = scoreSeriesSeasonalRobust(values, HOURS_PER_WEEK, 3);
+
+    const { sa: seasonalS, sb: flatS, l } = alignedEvaluable(seasonal, flat, labels);
+    const seasonalAuc = prAuc(seasonalS, l);
+    const flatAuc = prAuc(flatS, l);
+
+    expect(seasonalAuc).toBeGreaterThan(flatAuc); // weekly seasonality win
+    expect(seasonalAuc).toBeGreaterThan(0.5); // CI regression floor
   });
 });

--- a/packages/ai-intelligence/src/services/adaptive-anomaly-detector.ts
+++ b/packages/ai-intelligence/src/services/adaptive-anomaly-detector.ts
@@ -32,6 +32,7 @@ export type GetMetricWindowByHourOfDayFn = (
   metricType: string,
   hourOfDay: number,
   lookbackDays: number,
+  dayOfWeek?: number,
 ) => Promise<number[]>;
 
 interface BollingerBands {
@@ -104,6 +105,10 @@ export async function detectAnomalyAdaptive(
     minHourSamples,
     getMovingAverage,
     getMovingAverageByHourOfDay,
+    dayOfWeek: now.getUTCDay(),
+    dayOfWeekEnabled: config.ANOMALY_DAYOFWEEK_ENABLED,
+    dayOfWeekLookbackDays: config.ANOMALY_DAYOFWEEK_LOOKBACK_DAYS,
+    dayOfWeekMinSamples: config.ANOMALY_DAYOFWEEK_MIN_SAMPLES,
   });
 
   if (!stats || stats.sample_count < minSamples) {
@@ -219,19 +224,38 @@ export async function detectAnomalyRobust(
   const minHourSamples = config.ANOMALY_HOUROFDAY_MIN_SAMPLES;
 
   let window: number[] = [];
-  let usedHourOfDay = false;
+  // Seasonal preference: day-of-week × hour (#1307) → hour-of-day (#1295) →
+  // flat. Each level keeps RAW samples (median+MAD needs them) and excludes the
+  // point under test; we fall through when a bucket is below its warm-up floor.
+  let baselineKind: 'flat' | 'hourOfDay' | 'dayOfWeek' = 'flat';
   if (getMetricWindowByHourOfDay) {
-    const hourly = await getMetricWindowByHourOfDay(
-      containerId,
-      metricType,
-      now.getUTCHours(),
-      lookbackDays,
-    );
-    if (hourly.length >= minHourSamples) {
-      window = hourly;
-      usedHourOfDay = true;
+    if (config.ANOMALY_DAYOFWEEK_ENABLED) {
+      const dow = await getMetricWindowByHourOfDay(
+        containerId,
+        metricType,
+        now.getUTCHours(),
+        config.ANOMALY_DAYOFWEEK_LOOKBACK_DAYS,
+        now.getUTCDay(),
+      );
+      if (dow.length >= config.ANOMALY_DAYOFWEEK_MIN_SAMPLES) {
+        window = dow;
+        baselineKind = 'dayOfWeek';
+      }
+    }
+    if (baselineKind === 'flat') {
+      const hourly = await getMetricWindowByHourOfDay(
+        containerId,
+        metricType,
+        now.getUTCHours(),
+        lookbackDays,
+      );
+      if (hourly.length >= minHourSamples) {
+        window = hourly;
+        baselineKind = 'hourOfDay';
+      }
     }
   }
+  const usedHourOfDay = baselineKind !== 'flat';
   if (!usedHourOfDay) {
     window = await getMetricWindow(containerId, metricType, windowSize);
   }

--- a/packages/ai-intelligence/src/services/anomaly-detector.ts
+++ b/packages/ai-intelligence/src/services/anomaly-detector.ts
@@ -17,20 +17,22 @@ export type GetMovingAverageByHourOfDayFn = (
   metricType: string,
   hourOfDay: number,
   lookbackDays: number,
+  dayOfWeek?: number,
 ) => Promise<MovingAverageResult | null>;
 
+/** Which seasonal bucket the baseline was drawn from (finest that had data). */
+export type BaselineKind = 'flat' | 'hourOfDay' | 'dayOfWeek';
+
 /**
- * Resolve the baseline distribution for the current hour-of-day, falling back
- * to the flat rolling-window baseline when:
- *   • no hour-of-day fetcher was injected, or
- *   • the hour-of-day bucket has fewer than `minHourSamples` samples
- *     (warm-up window — issue #1295).
+ * Resolve the baseline distribution for the current seasonal bucket, trying the
+ * finest bucket first and falling back when it is unavailable or too sparse:
  *
- * The fallback is the historical (flat 24h) behavior, so existing callers
- * preserve their semantics until the hour bucket warms up.
+ *   1. day-of-week × hour-of-day (#1307) — when enabled and warm,
+ *   2. hour-of-day (#1295) — when warm,
+ *   3. flat rolling window — the historical behavior.
  *
- * Exported so that the trace detector and tests can reuse the same warm-up
- * policy.
+ * Each fallback preserves older callers' semantics until the finer bucket warms
+ * up. Exported so the trace detector and tests reuse the same policy.
  */
 export async function resolveBaseline(opts: {
   containerId: string;
@@ -42,8 +44,27 @@ export async function resolveBaseline(opts: {
   minHourSamples: number;
   getMovingAverage: GetMovingAverageFn;
   getMovingAverageByHourOfDay?: GetMovingAverageByHourOfDayFn;
-}): Promise<{ stats: MovingAverageResult | null; usedHourOfDay: boolean }> {
+  /** Day-of-week layer (#1307). When dayOfWeekEnabled, tried before hour-of-day. */
+  dayOfWeek?: number;
+  dayOfWeekEnabled?: boolean;
+  dayOfWeekLookbackDays?: number;
+  dayOfWeekMinSamples?: number;
+}): Promise<{ stats: MovingAverageResult | null; usedHourOfDay: boolean; baselineKind: BaselineKind }> {
   if (opts.getMovingAverageByHourOfDay) {
+    // 1. day-of-week × hour-of-day
+    if (opts.dayOfWeekEnabled && Number.isInteger(opts.dayOfWeek)) {
+      const dow = await opts.getMovingAverageByHourOfDay(
+        opts.containerId,
+        opts.metricType,
+        opts.hourOfDay,
+        opts.dayOfWeekLookbackDays ?? opts.lookbackDays,
+        opts.dayOfWeek,
+      );
+      if (dow && dow.sample_count >= (opts.dayOfWeekMinSamples ?? opts.minHourSamples)) {
+        return { stats: dow, usedHourOfDay: true, baselineKind: 'dayOfWeek' };
+      }
+    }
+    // 2. hour-of-day
     const hourly = await opts.getMovingAverageByHourOfDay(
       opts.containerId,
       opts.metricType,
@@ -51,15 +72,16 @@ export async function resolveBaseline(opts: {
       opts.lookbackDays,
     );
     if (hourly && hourly.sample_count >= opts.minHourSamples) {
-      return { stats: hourly, usedHourOfDay: true };
+      return { stats: hourly, usedHourOfDay: true, baselineKind: 'hourOfDay' };
     }
   }
+  // 3. flat
   const flat = await opts.getMovingAverage(
     opts.containerId,
     opts.metricType,
     opts.windowSize,
   );
-  return { stats: flat, usedHourOfDay: false };
+  return { stats: flat, usedHourOfDay: false, baselineKind: 'flat' };
 }
 
 /**
@@ -100,6 +122,10 @@ export async function detectAnomaly(
     minHourSamples,
     getMovingAverage,
     getMovingAverageByHourOfDay,
+    dayOfWeek: now.getUTCDay(),
+    dayOfWeekEnabled: config.ANOMALY_DAYOFWEEK_ENABLED,
+    dayOfWeekLookbackDays: config.ANOMALY_DAYOFWEEK_LOOKBACK_DAYS,
+    dayOfWeekMinSamples: config.ANOMALY_DAYOFWEEK_MIN_SAMPLES,
   });
 
   if (!stats || stats.sample_count < minSamples) {

--- a/packages/ai-intelligence/src/services/anomaly-eval.ts
+++ b/packages/ai-intelligence/src/services/anomaly-eval.ts
@@ -96,6 +96,43 @@ export function scoreSeriesRobust(
 }
 
 /**
+ * Score each point with the ROBUST detector against a SEASONAL same-phase
+ * baseline (#1307): instead of the flat trailing window, compare the point to
+ * the values at the same phase in prior cycles — `values[i-period]`,
+ * `values[i-2·period]`, … For hourly samples, `period = 24` is the hour-of-day
+ * baseline and `period = 24·7` is the day-of-week × hour-of-day baseline. This
+ * is the eval-rig analogue of the detector's seasonal window, so the rig can
+ * prove (and CI can guard) that seasonality lifts PR-AUC on periodic series
+ * where a flat window mistakes the cycle itself for anomalies.
+ *
+ * Points with fewer than `minHistory` prior same-phase samples are warm-up
+ * (`null`). One-sided (drops score 0), mirroring `scoreSeriesRobust`.
+ */
+export function scoreSeriesSeasonalRobust(
+  values: readonly number[],
+  period: number,
+  minHistory = 3,
+): Array<number | null> {
+  const scores: Array<number | null> = [];
+  for (let i = 0; i < values.length; i++) {
+    const history: number[] = [];
+    for (let j = i - period; j >= 0; j -= period) history.push(values[j]);
+    if (history.length < minHistory) {
+      scores.push(null);
+      continue;
+    }
+    const { median, mad } = medianAndMad(history);
+    if (mad === 0) {
+      const tol = Math.max(Math.abs(median) * 0.1, 0.01);
+      scores.push(Math.max(0, (values[i] - median) / tol));
+    } else {
+      scores.push(Math.max(0, modifiedZScore(values[i], median, mad)));
+    }
+  }
+  return scores;
+}
+
+/**
  * Score each point with the legacy TWO-SIDED z-score (mean + std) — the
  * pre-#1361/#1362 detector. Kept so the eval rig can quantify the improvement
  * (and guard against regressing back toward it).

--- a/packages/contracts/src/interfaces/metrics-interface.ts
+++ b/packages/contracts/src/interfaces/metrics-interface.ts
@@ -48,6 +48,8 @@ export interface MetricsInterface {
     metricType: string,
     hourOfDay: number,
     lookbackDays: number,
+    /** Optional UTC day-of-week (0=Sun..6=Sat) for week-aware seasonality (#1307). */
+    dayOfWeek?: number,
   ): Promise<MovingAverageResult | null>;
 
   /**
@@ -71,6 +73,8 @@ export interface MetricsInterface {
     metricType: string,
     hourOfDay: number,
     lookbackDays: number,
+    /** Optional UTC day-of-week (0=Sun..6=Sat); narrows the raw window (#1307). */
+    dayOfWeek?: number,
   ): Promise<number[]>;
 
   /** Retrieve top-N capacity forecasts sorted by urgency. */

--- a/packages/core/src/config/env.schema.ts
+++ b/packages/core/src/config/env.schema.ts
@@ -149,6 +149,18 @@ export const envSchema = z.object({
   // the legacy flat-baseline behavior. Prevents erratic alerts during the
   // warm-up window.
   ANOMALY_HOUROFDAY_MIN_SAMPLES: z.coerce.number().int().min(1).max(100).default(3),
+  // Day-of-week × hour-of-day seasonality (#1307, carried over from #1364).
+  // Refines the hour-of-day baseline so e.g. Monday 09:00 is compared against
+  // previous Mondays 09:00, not every day's 09:00 — catching weekly patterns
+  // (weekday vs weekend traffic). The detector tries day-of-week × hour first,
+  // falls back to hour-of-day, then to the flat window, so cold-start and sparse
+  // weekday buckets degrade gracefully. A wider lookback (default 28d ≈ 4 same-
+  // weekday occurrences) is needed for the weekly bucket to be stable. The
+  // mean/std path reads this from the metrics_1hour aggregate; the robust path
+  // narrows its raw query (median+MAD needs raw samples).
+  ANOMALY_DAYOFWEEK_ENABLED: z.coerce.boolean().default(true),
+  ANOMALY_DAYOFWEEK_LOOKBACK_DAYS: z.coerce.number().int().min(7).max(120).default(28),
+  ANOMALY_DAYOFWEEK_MIN_SAMPLES: z.coerce.number().int().min(1).max(1000).default(3),
 
   // Predictive Alerting
   PREDICTIVE_ALERTING_ENABLED: z.coerce.boolean().default(true),

--- a/packages/core/src/config/index.test.ts
+++ b/packages/core/src/config/index.test.ts
@@ -263,6 +263,14 @@ describe('config validation', () => {
       expect(c.ANOMALY_SUPPRESS_BELOW_CONFIDENCE).toBe(0);
     });
 
+    it('defaults day-of-week seasonality to ON, 28d lookback, 3-sample warm-up (#1307)', async () => {
+      const { getConfig } = await import('./index.js');
+      const c = getConfig();
+      expect(c.ANOMALY_DAYOFWEEK_ENABLED).toBe(true);
+      expect(c.ANOMALY_DAYOFWEEK_LOOKBACK_DAYS).toBe(28);
+      expect(c.ANOMALY_DAYOFWEEK_MIN_SAMPLES).toBe(3);
+    });
+
     it('defaults the feedback auto-tune to OFF, 6h cadence, 5% target (#1364)', async () => {
       const { getConfig } = await import('./index.js');
       const c = getConfig();

--- a/packages/observability/src/__tests__/metrics-store-moving-average.test.ts
+++ b/packages/observability/src/__tests__/metrics-store-moving-average.test.ts
@@ -41,25 +41,63 @@ describe('getMovingAverage — baseline leakage (#1361 fix 2)', () => {
   });
 });
 
-describe('getMovingAverageByHourOfDay — baseline leakage (#1361 fix 2)', () => {
+describe('getMovingAverageByHourOfDay — reads metrics_1hour aggregate (#1307)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockQuery.mockResolvedValue({ rows: [{ mean: 50, std_dev: 5, sample_count: 40 }] });
+    // metrics_1hour rows: per-day hourly buckets (avg + sample stddev + count).
+    mockQuery.mockResolvedValue({
+      rows: [
+        { avg_value: 50, stddev_value: 5, sample_count: 60 },
+        { avg_value: 54, stddev_value: 3, sample_count: 60 },
+      ],
+    });
   });
 
-  it('excludes the point under test (the latest sample) from the hour bucket', async () => {
+  it('queries the metrics_1hour continuous aggregate, not the raw hypertable', async () => {
     await getMovingAverageByHourOfDay('c1', 'cpu', 9, 14);
     const sql: string = mockQuery.mock.calls[0][0];
-    // The current observation is the most recent sample; exclude it so the
-    // hour-of-day baseline cannot include / be poisoned by the value under test.
-    expect(sql).toMatch(/timestamp\s*<\s*\(\s*SELECT\s+MAX\(timestamp\)/i);
+    expect(sql).toMatch(/from\s+metrics_1hour/i);
+    expect(sql).toMatch(/date_part\('hour'.*bucket/i);
   });
 
-  it('still aggregates the requested hour bucket over the lookback window', async () => {
+  it('excludes the current (incomplete) hour bucket — the point under test', async () => {
     await getMovingAverageByHourOfDay('c1', 'cpu', 9, 14);
     const sql: string = mockQuery.mock.calls[0][0];
-    expect(sql).toMatch(/date_part\('hour'/i);
+    // Only completed past hours form the baseline; the in-progress hour is dropped.
+    expect(sql).toMatch(/bucket\s*<\s*date_trunc\('hour'/i);
+  });
+
+  it('pools the hourly buckets into population mean + std over the raw samples', async () => {
+    const result = await getMovingAverageByHourOfDay('c1', 'cpu', 9, 14);
+    // Two equal-count buckets (avg 50±5, avg 54±3, n=60 each): pooled mean 52,
+    // pooled population variance = (5²·59 + 3²·59)/120 + (2²·60 + 2²·60)/120.
+    expect(result!.mean).toBeCloseTo(52, 9);
+    expect(result!.sample_count).toBe(120);
+    const within = (25 * 59 + 9 * 59) / 120;
+    const between = (60 * 4 + 60 * 4) / 120;
+    expect(result!.std_dev).toBeCloseTo(Math.sqrt(within + between), 9);
+  });
+
+  it('passes container/metric/lookback/hour params (hour-of-day only)', async () => {
+    await getMovingAverageByHourOfDay('c1', 'cpu', 9, 14);
     expect(mockQuery).toHaveBeenCalledWith(expect.any(String), ['c1', 'cpu', 14, 9]);
+  });
+
+  it('filters by day-of-week and passes it as a param when supplied', async () => {
+    await getMovingAverageByHourOfDay('c1', 'cpu', 9, 28, 1 /* Monday */);
+    const sql: string = mockQuery.mock.calls[0][0];
+    expect(sql).toMatch(/date_part\('dow'.*bucket/i);
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), ['c1', 'cpu', 28, 9, 1]);
+  });
+
+  it('returns null when the aggregate has no matching buckets', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    expect(await getMovingAverageByHourOfDay('c1', 'cpu', 9, 14)).toBeNull();
+  });
+
+  it('returns null without querying for an out-of-range hour', async () => {
+    expect(await getMovingAverageByHourOfDay('c1', 'cpu', 24, 14)).toBeNull();
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 });
 
@@ -103,5 +141,21 @@ describe('getMetricWindowByHourOfDay — robust hour-of-day window (#1362)', () 
   it('returns [] for an out-of-range hour without querying', async () => {
     expect(await getMetricWindowByHourOfDay('c1', 'cpu', 24, 14)).toEqual([]);
     expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('filters raw samples by day-of-week and passes it as a param when supplied (#1307)', async () => {
+    await getMetricWindowByHourOfDay('c1', 'cpu', 9, 28, 1 /* Monday */);
+    const sql: string = mockQuery.mock.calls[0][0];
+    // Still RAW samples (median+MAD needs them) — just narrowed to the weekday.
+    expect(sql).toMatch(/from\s+metrics\b/i);
+    expect(sql).toMatch(/date_part\('dow'/i);
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), ['c1', 'cpu', 28, 9, 1]);
+  });
+
+  it('does not add a day-of-week filter when none is given', async () => {
+    await getMetricWindowByHourOfDay('c1', 'cpu', 9, 14);
+    const sql: string = mockQuery.mock.calls[0][0];
+    expect(sql).not.toMatch(/date_part\('dow'/i);
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), ['c1', 'cpu', 14, 9]);
   });
 });

--- a/packages/observability/src/__tests__/seasonal-baseline.test.ts
+++ b/packages/observability/src/__tests__/seasonal-baseline.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { poolHourlyBuckets, type HourlyBucket } from '../services/seasonal-baseline.js';
+
+/** Reference: population mean + STDDEV_POP over a flat list of raw samples. */
+function popStats(values: number[]) {
+  const n = values.length;
+  const mean = values.reduce((a, b) => a + b, 0) / n;
+  const variance = values.reduce((a, b) => a + (b - mean) ** 2, 0) / n;
+  return { mean, std_dev: Math.sqrt(variance), sample_count: n };
+}
+
+/** Build a metrics_1hour-style bucket (avg + SAMPLE stddev + count) from raw samples. */
+function bucketOf(values: number[]): HourlyBucket {
+  const n = values.length;
+  const avg = values.reduce((a, b) => a + b, 0) / n;
+  const sampleVar = n > 1 ? values.reduce((a, b) => a + (b - avg) ** 2, 0) / (n - 1) : 0;
+  return { avg_value: avg, stddev_value: n > 1 ? Math.sqrt(sampleVar) : null, sample_count: n };
+}
+
+describe('poolHourlyBuckets — reconstruct AVG/STDDEV_POP from metrics_1hour buckets (#1307)', () => {
+  it('exactly matches the population mean + std over the pooled raw samples', () => {
+    // Three "days" of the same hour bucket, different within-bucket spread.
+    const day1 = [10, 12, 14, 16];
+    const day2 = [20, 22, 18];
+    const day3 = [11, 13, 15, 17, 19];
+    const buckets = [bucketOf(day1), bucketOf(day2), bucketOf(day3)];
+
+    const pooled = poolHourlyBuckets(buckets)!;
+    const reference = popStats([...day1, ...day2, ...day3]);
+
+    expect(pooled.sample_count).toBe(reference.sample_count);
+    expect(pooled.mean).toBeCloseTo(reference.mean, 9);
+    expect(pooled.std_dev).toBeCloseTo(reference.std_dev, 9);
+  });
+
+  it('weights the grand mean by each bucket sample_count, not equally', () => {
+    // One big bucket near 100, one tiny bucket near 0 — equal-weight mean (~50)
+    // would be wrong; count-weighted mean must sit near 100.
+    const big = Array.from({ length: 100 }, () => 100);
+    const tiny = [0];
+    const pooled = poolHourlyBuckets([bucketOf(big), bucketOf(tiny)])!;
+    expect(pooled.mean).toBeCloseTo((100 * 100 + 0) / 101, 9);
+    expect(pooled.sample_count).toBe(101);
+  });
+
+  it('handles single-sample buckets (null stddev) without NaN', () => {
+    const pooled = poolHourlyBuckets([
+      { avg_value: 5, stddev_value: null, sample_count: 1 },
+      { avg_value: 9, stddev_value: null, sample_count: 1 },
+    ])!;
+    // Two points {5, 9}: mean 7, pop std 2.
+    expect(pooled.mean).toBeCloseTo(7, 9);
+    expect(pooled.std_dev).toBeCloseTo(2, 9);
+    expect(pooled.sample_count).toBe(2);
+  });
+
+  it('returns null for no buckets or all-empty buckets', () => {
+    expect(poolHourlyBuckets([])).toBeNull();
+    expect(poolHourlyBuckets([{ avg_value: 0, stddev_value: null, sample_count: 0 }])).toBeNull();
+  });
+});

--- a/packages/observability/src/services/metrics-store.ts
+++ b/packages/observability/src/services/metrics-store.ts
@@ -1,6 +1,7 @@
 import { getMetricsDb } from '@dashboard/core/db/timescale.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import type { Metric } from '@dashboard/core/models/metrics.js';
+import { poolHourlyBuckets, type HourlyBucket } from './seasonal-baseline.js';
 
 const log = createChildLogger('metrics-store');
 
@@ -144,21 +145,33 @@ export async function getMetricWindow(
 }
 
 /**
- * Hour-of-day baseline statistics for a container metric (issue #1295).
+ * Hour-of-day (optionally day-of-week) baseline statistics for a container
+ * metric (issue #1295; #1307 aggregate migration).
  *
- * Aggregates samples whose timestamp falls in the supplied UTC hour-of-day
- * (0..23) across the last `lookbackDays` days. Returns null when no samples
- * are available; callers should then fall back to the flat-window baseline.
+ * Reads TimescaleDB's `metrics_1hour` continuous aggregate — one pre-computed
+ * row per (container, metric, hour) — instead of scanning the raw `metrics`
+ * hypertable, then pools the matching per-day hourly buckets back into the
+ * population mean + stddev of the underlying raw samples via the law of total
+ * variance (`poolHourlyBuckets`). This is statistically equivalent to the old
+ * `AVG(value)` / `STDDEV_POP(value)` raw query but touches a few dozen rows
+ * rather than millions.
  *
- * The aggregation uses Postgres `date_part('hour', timestamp AT TIME ZONE
- * 'UTC')` so the bucket boundary is fixed and not influenced by the server
- * local timezone.
+ * When `dayOfWeek` (0=Sun..6=Sat, UTC) is supplied, buckets are additionally
+ * filtered to that weekday — week-aware seasonality (weekday vs weekend), the
+ * #1364 carry-over. The caller decides the lookback (a wider window is needed
+ * for day-of-week so each weekday has enough occurrences).
+ *
+ * The current, in-progress hour bucket is excluded (`bucket < date_trunc('hour',
+ * NOW())`) so the baseline cannot include / be poisoned by the value under test
+ * — the aggregate-era equivalent of the raw path's OFFSET 1. Returns null when
+ * no completed buckets match; callers then fall back to a coarser baseline.
  */
 export async function getMovingAverageByHourOfDay(
   containerId: string,
   metricType: string,
   hourOfDay: number,
   lookbackDays: number,
+  dayOfWeek?: number,
 ): Promise<MovingAverageResult | null> {
   if (!Number.isInteger(hourOfDay) || hourOfDay < 0 || hourOfDay > 23) {
     return null;
@@ -166,52 +179,58 @@ export async function getMovingAverageByHourOfDay(
   if (!Number.isFinite(lookbackDays) || lookbackDays <= 0) {
     return null;
   }
+  const filterByDow = Number.isInteger(dayOfWeek) && dayOfWeek! >= 0 && dayOfWeek! <= 6;
   const db = await getMetricsDb();
 
+  const params: unknown[] = [containerId, metricType, lookbackDays, hourOfDay];
+  if (filterByDow) params.push(dayOfWeek);
+
   const { rows } = await db.query(
-    `SELECT
-       AVG(value) as mean,
-       STDDEV_POP(value) as std_dev,
-       COUNT(*)::int as sample_count
-     FROM metrics
+    `SELECT avg_value, stddev_value, sample_count
+     FROM metrics_1hour
      WHERE container_id = $1
        AND metric_type = $2
-       AND timestamp >= NOW() - ($3::int * INTERVAL '1 day')
-       AND date_part('hour', timestamp AT TIME ZONE 'UTC') = $4
-       -- #1361 fix 2: exclude the point under test (the latest sample) so the
-       -- hour-of-day baseline cannot include / be poisoned by the value being
-       -- evaluated, mirroring the OFFSET 1 on the flat-window baseline.
-       AND timestamp < (
-         SELECT MAX(timestamp) FROM metrics
-         WHERE container_id = $1 AND metric_type = $2
-       )`,
-    [containerId, metricType, lookbackDays, hourOfDay],
+       AND bucket >= NOW() - ($3::int * INTERVAL '1 day')
+       AND date_part('hour', bucket AT TIME ZONE 'UTC') = $4
+       ${filterByDow ? `AND date_part('dow', bucket AT TIME ZONE 'UTC') = $5` : ''}
+       -- Exclude the current, in-progress hour (the point under test lives there)
+       -- so the seasonal baseline is built only from completed past hours.
+       AND bucket < date_trunc('hour', NOW())`,
+    params,
   );
 
-  const result = rows[0];
-  if (!result || result.sample_count === 0 || result.mean === null) {
-    return null;
-  }
+  const buckets: HourlyBucket[] = (rows as Array<{ avg_value: number; stddev_value: number | null; sample_count: number }>)
+    .map((r) => ({
+      avg_value: Number(r.avg_value),
+      stddev_value: r.stddev_value == null ? null : Number(r.stddev_value),
+      sample_count: Number(r.sample_count),
+    }));
 
-  return {
-    mean: Number(result.mean),
-    std_dev: Number(result.std_dev ?? 0),
-    sample_count: result.sample_count,
-  };
+  const pooled = poolHourlyBuckets(buckets);
+  if (!pooled) return null;
+  return { mean: pooled.mean, std_dev: pooled.std_dev, sample_count: pooled.sample_count };
 }
 
 /**
- * Raw hour-of-day window: metric values whose timestamp falls in the supplied
- * UTC hour-of-day over the last N days, newest-first, EXCLUDING the most recent
- * sample (the point under test). Robust detection (#1362) uses this to keep the
- * #1295 seasonality handling while computing median + MAD instead of mean/std.
- * Returns [] for an out-of-range hour, bad lookback, or empty bucket.
+ * Raw hour-of-day (optionally day-of-week) window: metric values whose timestamp
+ * falls in the supplied UTC hour-of-day over the last N days, newest-first,
+ * EXCLUDING the most recent sample (the point under test). Robust detection
+ * (#1362) uses this to keep #1295 seasonality while computing median + MAD.
+ *
+ * Unlike the mean/std path, this stays on the RAW `metrics` hypertable: median +
+ * MAD need the actual samples, and the `metrics_1hour` aggregate only stores
+ * mean/stddev — pooling daily hourly *averages* would understate the spread and
+ * over-flag. When `dayOfWeek` (0=Sun..6=Sat, UTC) is supplied the query is
+ * narrowed to that weekday (week-aware seasonality, #1307/#1364), which also
+ * scans *fewer* rows. Returns [] for an out-of-range hour, bad lookback, or
+ * empty bucket.
  */
 export async function getMetricWindowByHourOfDay(
   containerId: string,
   metricType: string,
   hourOfDay: number,
   lookbackDays: number,
+  dayOfWeek?: number,
 ): Promise<number[]> {
   if (!Number.isInteger(hourOfDay) || hourOfDay < 0 || hourOfDay > 23) {
     return [];
@@ -219,19 +238,24 @@ export async function getMetricWindowByHourOfDay(
   if (!Number.isFinite(lookbackDays) || lookbackDays <= 0) {
     return [];
   }
+  const filterByDow = Number.isInteger(dayOfWeek) && dayOfWeek! >= 0 && dayOfWeek! <= 6;
   const db = await getMetricsDb();
+  const params: unknown[] = [containerId, metricType, lookbackDays, hourOfDay];
+  if (filterByDow) params.push(dayOfWeek);
+
   const { rows } = await db.query(
     `SELECT value FROM metrics
      WHERE container_id = $1
        AND metric_type = $2
        AND timestamp >= NOW() - ($3::int * INTERVAL '1 day')
        AND date_part('hour', timestamp AT TIME ZONE 'UTC') = $4
+       ${filterByDow ? `AND date_part('dow', timestamp AT TIME ZONE 'UTC') = $5` : ''}
        AND timestamp < (
          SELECT MAX(timestamp) FROM metrics
          WHERE container_id = $1 AND metric_type = $2
        )
      ORDER BY timestamp DESC`,
-    [containerId, metricType, lookbackDays, hourOfDay],
+    params,
   );
   return (rows as Array<{ value: number }>).map((r) => Number(r.value));
 }

--- a/packages/observability/src/services/seasonal-baseline.ts
+++ b/packages/observability/src/services/seasonal-baseline.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure seasonal-baseline math (#1307). Lets the hour-of-day / day-of-week
+ * baseline read TimescaleDB's `metrics_1hour` continuous aggregate instead of
+ * scanning the raw `metrics` hypertable: a handful of pre-computed hourly buckets
+ * replace ~millions of raw rows per lookup.
+ *
+ * `poolHourlyBuckets` reconstructs the EXACT population mean + `STDDEV_POP` over
+ * all underlying raw samples from the per-bucket `avg_value` / `stddev_value`
+ * (sample stddev, as Postgres `STDDEV` emits) / `sample_count`, via the law of
+ * total variance — so swapping the data source is statistically equivalent to the
+ * old raw query, just far cheaper.
+ *
+ * Kept dependency-free and DB-agnostic so it is unit-tested against known raw
+ * data with no database.
+ */
+
+export interface HourlyBucket {
+  avg_value: number;
+  /** Per-bucket SAMPLE stddev (Postgres `STDDEV`/`STDDEV_SAMP`); null for single-sample buckets. */
+  stddev_value: number | null;
+  sample_count: number;
+}
+
+export interface PooledStats {
+  mean: number;
+  /** Population stddev of the underlying raw samples (matches `STDDEV_POP`). */
+  std_dev: number;
+  sample_count: number;
+}
+
+/**
+ * Pool per-hour buckets back into the population mean + stddev of the raw
+ * samples they summarise. Returns null when the buckets contain no samples.
+ */
+export function poolHourlyBuckets(buckets: readonly HourlyBucket[]): PooledStats | null {
+  let n = 0;
+  for (const b of buckets) n += b.sample_count;
+  if (n === 0) return null;
+
+  // Count-weighted grand mean.
+  let weightedSum = 0;
+  for (const b of buckets) weightedSum += b.avg_value * b.sample_count;
+  const mean = weightedSum / n;
+
+  // Total sum of squares = within-bucket SS + between-bucket SS.
+  //   within_i  = (c_i - 1) · s_i²   (s_i = sample stddev; 0 for single-sample buckets)
+  //   between_i = c_i · (mean_i - grandMean)²
+  let ss = 0;
+  for (const b of buckets) {
+    if (b.sample_count > 1 && b.stddev_value != null) {
+      ss += b.stddev_value * b.stddev_value * (b.sample_count - 1);
+    }
+    ss += b.sample_count * (b.avg_value - mean) ** 2;
+  }
+
+  return { mean, std_dev: Math.sqrt(ss / n), sample_count: n };
+}


### PR DESCRIPTION
## What

Two-part upgrade to the anomaly seasonal baseline (#1307, carrying over #1364's deferred seasonality criterion), proven by the eval rig.

### 1. metrics_1hour aggregate — the mean/std path

`getMovingAverageByHourOfDay` now reads TimescaleDB's `metrics_1hour` continuous aggregate (a few dozen pre-computed rows) instead of scanning the raw `metrics` hypertable (~millions of rows per lookup). A **pure** `poolHourlyBuckets` reconstructs the **exact** population mean + `STDDEV_POP` from each bucket's `avg_value`/`stddev_value`/`sample_count` via the **law of total variance** — so the swap is statistically equivalent, not an approximation:

```
within_i  = (count_i − 1)·stddev_i²      (sample stddev → SS)
between_i = count_i·(mean_i − grandMean)²
pop_var   = Σ(within_i + between_i) / Σ count_i
```

The in-progress hour is excluded via `bucket < date_trunc('hour', NOW())` — the aggregate-era equivalent of the raw path's leakage guard. This resolves all three of #1307's open questions: the columns already exist (`001_metrics_hypertable.sql`); staleness is irrelevant since the baseline uses *completed past* hours; null-fallback semantics preserved.

### 2. day-of-week × hour-of-day seasonality — both paths

The detector now prefers a **day-of-week × hour** bucket (Monday 09:00 vs prior Mondays 09:00), catching weekly patterns (weekday vs weekend), and falls back **day-of-week → hour-of-day → flat** as buckets warm up:

- **mean/std path** reads it from the aggregate (`poolHourlyBuckets` + a `date_part('dow', bucket)` filter).
- **robust median+MAD path** (the default detector) adds a `date_part('dow', timestamp)` filter to its **raw** query. Median+MAD needs raw samples — pooling daily hourly *averages* would understate the spread and *over*-flag — and the filter scans *less* data, not more.

### 3. Eval-rig proof (CI guard)

New `scoreSeriesSeasonalRobust` (scores each point against same-phase prior cycles) + a PR-AUC regression guard: a same-phase seasonal baseline must beat a flat trailing window on a weekly-seasonal series (where the flat window mistakes the weekly cycle itself for anomalies). Mirrors the existing robust-vs-z-score guard.

## Config (with default guard tests)

| Var | Default | Meaning |
|---|---|---|
| `ANOMALY_DAYOFWEEK_ENABLED` | `true` | Enable the day-of-week layer; `false` = hour-of-day-only |
| `ANOMALY_DAYOFWEEK_LOOKBACK_DAYS` | `28` | ≈ 4 same-weekday occurrences for a stable bucket |
| `ANOMALY_DAYOFWEEK_MIN_SAMPLES` | `3` | Warm-up floor before the weekday bucket is used |

Optional `dayOfWeek` threaded through `MetricsInterface` (contract) + wiring; backward-compatible.

## Tests (TDD)

`poolHourlyBuckets` 4 (exact vs reference pop-stats), metrics-store 16 (aggregate SQL + dow + pooling), detector dow→hour→flat fallback 3, eval seasonal guard 1, config defaults 3. Build, typecheck, lint clean. Local `incidents-*` DB tests fail only on `ECONNREFUSED 5433` (no local test DB; CI has it).

## Scope

Closes #1307. Unblocks epic #1360's remaining item (only the before/after audit remains, which needs real prod `metrics` data). The robust path deliberately stays on raw samples (units); the trace p95 path is unchanged (hour-of-day, dow off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)