### PR TITLE
docs(anomaly): benchmark seasonality dimension + as-shipped outcome (epic #1360)

### DIFF
--- a/docs/superpowers/specs/2026-05-30-anomaly-detection-ml-review.md
+++ b/docs/superpowers/specs/2026-05-30-anomaly-detection-ml-review.md
@@ -193,3 +193,24 @@ External (via Ref docs + Gemini research):
 - Hampel filter / MAD robustness for spiky signals: https://pubmed.ncbi.nlm.nih.gov/24715406/
 
 > **Provenance note:** External research was performed via the local Gemini CLI (two passes: ML methods; evaluation + alerting) and Ref documentation lookups, per the requested workflow. Code findings were verified directly against the files at the `file:line` anchors above.
+
+---
+
+## 9. Outcome (as shipped — 2026-05-31)
+
+The redesign shipped as epic **#1360** with four children plus a seasonality follow-up, all merged to `dev`:
+
+| Phase | Issue | Delivered |
+|---|---|---|
+| P0 — determinism | #1361 | Seeded Isolation Forest RNG (FNV-1a → Mulberry32), baseline-leakage fix (exclude point-under-test), one-sided detection (`ANOMALY_DETECTION_DIRECTION`), Redis-backed cooldown + persistence stores. |
+| P1 — robust statistics | #1362 | Median + MAD modified z-score (default `robust-mad`), one-sided, timestamp-joined IF features; hour-of-day seasonality preserved. |
+| P2 — alerting discipline | #1363 | M-of-N (3-of-5) + multi-window fast-burn, cross-detector dedup, severity × confidence routing, system-wide suppression floor. |
+| P3 — eval + feedback | #1364 | PR-AUC eval rig + CI regression guard; #1298 labels → measured FP rate → gated auto-tune (`ANOMALY_AUTOTUNE_ENABLED`, default off, audited). |
+| Seasonality | #1307 | day-of-week × hour-of-day baseline; mean/std path moved onto the `metrics_1hour` continuous aggregate (exact pop-stats via the law of total variance), robust path adds a day-of-week filter on its raw query. |
+
+**Measured (synthetic labelled benchmark, `scripts/anomaly-mad-ab-benchmark.mjs`, seed `0x9E3779B9`):**
+
+- Full pipeline (`robust-mad + 3-of-5`) vs the original `current-zscore`, pooled across 5 failure-mode scenarios: **false positives 77 → 14 (−82%)**, **F1 24.2% → 53.8%** (≈2.2×) — matching the projection that justified the epic.
+- Seasonality A/B (weekly-pattern series, baseline varied in isolation): a day-of-week × hour baseline cuts false alarms **183 → 41 (−78%)** vs a flat trailing window while preserving 100% spike recall. Production stacks persistence (P2) on top of this.
+
+The benchmark remains synthetic: the dev TimescaleDB `metrics` hypertable is empty, so the **production before/after audit** (`scripts/audit-anomaly-detectors.ts`) against real history is the **one open item** on epic #1360 — it needs a prod data export or a live deploy. The CI eval-rig guards (`packages/ai-intelligence/src/services/anomaly-eval.ts`) assert both the robust-vs-z-score and the seasonal-vs-flat improvements on every PR.

--- a/scripts/anomaly-mad-ab-benchmark.mjs
+++ b/scripts/anomaly-mad-ab-benchmark.mjs
@@ -115,6 +115,38 @@ function detectRobustMad(values) {
   return out;
 }
 
+/**
+ * Seasonal robust median+MAD (#1307): instead of a flat trailing window, compare
+ * each point against the RAW prior samples in its (day-of-week × hour-of-day)
+ * bucket — faithful to the production robust path, which narrows its raw query by
+ * day-of-week rather than pooling hourly averages. The point under test is
+ * excluded (added to its bucket only after scoring). Points whose bucket has
+ * < minHistory prior samples are warm-up (null). One-sided, like the flat robust
+ * detector. (One sample per weekly phase would give an unstable MAD — the very
+ * "buckets too small" problem #1307 fixes with a wider lookback + raw samples.)
+ */
+function detectSeasonalBucketMad(values, dow, hod, minHistory = 8) {
+  const out = new Array(values.length).fill(null);
+  const buckets = new Map(); // (dow*24+hod) → prior raw samples
+  for (let i = 0; i < values.length; i++) {
+    const key = dow[i] * 24 + hod[i];
+    const hist = buckets.get(key);
+    if (hist && hist.length >= minHistory) {
+      const med = median(hist);
+      const mad = median(hist.map((x) => Math.abs(x - med)));
+      if (mad === 0) {
+        const tol = Math.max(Math.abs(med) * 0.1, 0.01);
+        out[i] = values[i] - med > tol;
+      } else {
+        out[i] = (0.6745 * (values[i] - med)) / mad > MAD_THRESHOLD;
+      }
+    }
+    if (hist) hist.push(values[i]);
+    else buckets.set(key, [values[i]]);
+  }
+  return out;
+}
+
 // ── scenarios: { name, why, values[], labels[] } (label=true → real anomaly) ─
 function buildScenarios() {
   const rng = mulberry32(0x9e3779b9);
@@ -260,3 +292,52 @@ for (const [name] of detectors) {
   console.log(row(name, m));
 }
 console.log('');
+
+// ── Seasonality A/B (#1307): flat window vs same-phase weekly baseline ────────
+// A strongly weekly-seasonal series (weekday high, weekend low). The flat
+// trailing window mistakes the regular weekday↔weekend steps for anomalies; the
+// same-phase (day-of-week × hour) baseline sees them as normal. Only the injected
+// weekday spikes are real. Both detectors scored on the indices where BOTH
+// produced a decision, for a fair comparison.
+function buildWeeklySeasonalScenario() {
+  const rng = mulberry32(0x51ed_5eed);
+  const PER_HOUR = 4;            // 15-minute samples → multiple raw points per (dow,hour) bucket
+  const PER_DAY = 24 * PER_HOUR; // 96
+  const PER_WEEK = 7 * PER_DAY;  // 672
+  const WEEKS = 8;
+  const N = WEEKS * PER_WEEK;
+  const values = [], labels = [], dow = [], hod = [];
+  // Real weekday spikes in later weeks (after the bucket warm-up).
+  const spikeAt = new Set([
+    6 * PER_WEEK + PER_DAY * 1 + 40, 6 * PER_WEEK + PER_DAY * 1 + 41, // Mon
+    6 * PER_WEEK + PER_DAY * 3 + 52,                                  // Wed
+    7 * PER_WEEK + PER_DAY * 2 + 36, 7 * PER_WEEK + PER_DAY * 2 + 37, // Tue
+  ]);
+  for (let i = 0; i < N; i++) {
+    const d = Math.floor(i / PER_DAY) % 7;       // 0=Sun … 6=Sat
+    const h = Math.floor((i % PER_DAY) / PER_HOUR);
+    dow.push(d); hod.push(h);
+    const weekend = d === 0 || d === 6;
+    const base = weekend ? 15 : 50;              // strong weekly pattern
+    if (spikeAt.has(i)) { values.push(base + 40 + gauss(rng, 0, 1)); labels.push(true); continue; }
+    values.push(base + gauss(rng, 0, 1.2)); labels.push(false);
+  }
+  return { values, labels, dow, hod };
+}
+
+{
+  const { values, labels, dow, hod } = buildWeeklySeasonalScenario();
+  // Vary ONLY the baseline (flat trailing window vs day-of-week × hour bucket) so
+  // the difference is purely the #1307 seasonality contribution. No persistence
+  // here — M-of-N would suppress the isolated spikes for BOTH and obscure it.
+  const flat = detectRobustMad(values);
+  const seasonal = detectSeasonalBucketMad(values, dow, hod);
+  // Score on indices where BOTH detectors produced a decision (fair denominator).
+  const mask = (a, b) => a.map((v, i) => (a[i] === null || b[i] === null ? null : v));
+  const anomalies = labels.filter(Boolean).length;
+  console.log(`▶ weekly_seasonal  (${values.length} pts @ 15-min, ${anomalies} true-anomaly pts) — #1307 day-of-week`);
+  console.log('    weekday/weekend steps look anomalous to a flat window; a day-of-week × hour baseline sees them as normal');
+  console.log(row('robust-mad (flat window)', score(mask(flat, seasonal), labels)));
+  console.log(row('robust-mad (seasonal dow×hr)', score(mask(seasonal, flat), labels)));
+  console.log('');
+}


### PR DESCRIPTION
## What

Closes out the measurement story for the anomaly redesign epic (#1360), now that all of P0–P3 (#1361–#1364) + seasonality (#1307) are on `dev`.

- **Benchmark seasonality A/B** — extends `scripts/anomaly-mad-ab-benchmark.mjs` with a weekly-pattern scenario and a faithful **day-of-week × hour-of-day bucket** detector (raw samples per `(dow,hour)` bucket — mirroring the #1307 robust path, not one-per-week which would have an unstable MAD). Varying *only* the baseline:

  ```
  ▶ weekly_seasonal (5376 pts @ 15-min, 5 true-anomaly pts) — #1307 day-of-week
    robust-mad (flat window)      FP= 183  FN= 0  R=100.0%
    robust-mad (seasonal dow×hr)  FP=  41  FN= 0  R=100.0%
  ```
  **−78% false positives, 100% spike recall preserved.** Production stacks persistence (P2) on top.

- **Spec "Outcome (as shipped)" section** — records what each phase delivered and the measured benchmark results, including the headline full-pipeline number that reproduces exactly:

  ```
  current-zscore     FP= 77  F1= 24.2%
  robust-mad+3of5    FP= 14  F1= 53.8%     # −82% FP, F1 ≈2.2×
  ```

## Why

The epic's acceptance asks for a measured before/after on a labelled set and a retrospective vs the ~82% projection. The benchmark + eval-rig (CI) provide the labelled-set measurement; this makes the synthetic harness reflect the *full* shipped pipeline (incl. seasonality) and records the outcome in the canonical spec.

The **one remaining epic item** is the **production** audit (`scripts/audit-anomaly-detectors.ts`) against real history — still blocked: the dev TimescaleDB `metrics` hypertable is empty. The seasonal-vs-flat and robust-vs-z-score improvements are both guarded in CI (`anomaly-eval.ts`).

Docs/tooling only — no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)