### PR TITLE
fix(anomaly): cast IS-NULL detector param in the feedback fetcher

### DIFF
--- a/packages/ai-intelligence/src/__tests__/anomaly-feedback-source.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-feedback-source.test.ts
@@ -39,6 +39,15 @@ describe('createFeedbackFetcher — reads anomaly_feedback rows (#1364)', () => 
     const [, params] = query.mock.calls[0];
     expect(params).toContain(null); // null detector → no filter
   });
+
+  it('type-casts the IS-NULL detector param so Postgres can infer its type', async () => {
+    // A bare `$n IS NULL` on a param used nowhere else throws "could not determine
+    // data type of parameter" on Postgres when the value is NULL. The cast fixes it.
+    const { db, query } = fakeDb([]);
+    await createFeedbackFetcher(db as any)({});
+    const [sql] = query.mock.calls[0];
+    expect(sql).toMatch(/\?::text\s+IS\s+NULL/i);
+  });
 });
 
 describe('measureFpRateFromDb — DB rows → measured FP rate + sample count', () => {

--- a/packages/ai-intelligence/src/services/anomaly-feedback-source.ts
+++ b/packages/ai-intelligence/src/services/anomaly-feedback-source.ts
@@ -37,14 +37,17 @@ export function createFeedbackFetcher(
 ): FetchFeedbackFn {
   const lookbackDays = opts.lookbackDays ?? 30;
   return async ({ detector } = {}) => {
-    // `(? IS NULL OR detector = ?)` — the same value is bound twice so the
-    // detector filter is a no-op when none is supplied. `make_interval` keeps
-    // the lookback window parameterised (no string-built intervals).
+    // `(?::text IS NULL OR detector = ?)` — the same value is bound twice so the
+    // detector filter is a no-op when none is supplied. The `::text` cast is
+    // required: a bare `$n IS NULL` on a param used nowhere else gives Postgres
+    // no way to infer the type and throws "could not determine data type of
+    // parameter" when the value is NULL. `make_interval` keeps the lookback
+    // window parameterised (no string-built intervals).
     return db.query<FeedbackRow>(
       `SELECT anomaly_id, disposition, detector
          FROM anomaly_feedback
         WHERE created_at > NOW() - make_interval(days => ?)
-          AND (? IS NULL OR detector = ?)`,
+          AND (?::text IS NULL OR detector = ?)`,
       [lookbackDays, detector ?? null, detector ?? null],
     );
   };


### PR DESCRIPTION
## What

A retrospective review of #1378 (gated auto-tune) surfaced a **latent Postgres bug** in `createFeedbackFetcher` (`anomaly-feedback-source.ts`):

```sql
AND (? IS NULL OR detector = ?)   -- params: [days, detector??null, detector??null]
```

The first placeholder there (`$2`) is used **only** inside `IS NULL`. When it's bound to `NULL`, Postgres has no way to infer the parameter's type and throws:

```
error: could not determine data type of parameter $2
```

Fix: cast it — `(?::text IS NULL OR detector = ?)`.

## Severity: latent, not live

- The **sole** production caller (the auto-tune job → `measureFpRateFromDb`) always passes `detector='ml-anomaly'`, so `$2` is a non-null text value and the query works today. Verified there is no no-detector caller.
- But the no-detector (fleet-wide) path is an **exported, tested API shape**, and the unit suite only exercises it against a fake `db` (SQL-string assertions) — so the type-inference error was never executed. This is the class of issue mock-based TDD + CI can't catch, which is why it slipped through.

## Tests

Added a regression test asserting the `::text` cast is present. Build, typecheck, lint clean.

Found during retrospective review of #1378/#1379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)