### PR TITLE
fix(portainer): normalize container inspect response to Container shape (#1387)

### DIFF
--- a/packages/core/src/models/portainer.ts
+++ b/packages/core/src/models/portainer.ts
@@ -138,17 +138,24 @@ export type ContainerInspect = z.infer<typeof ContainerInspectSchema>;
  * string is synthesized from the inspect endpoint's structured `State.Health`
  * so health parsing (`"(healthy)"` / `"(unhealthy)"` / `"(health: starting)"`)
  * keeps working. Labels are returned as-is; callers apply path sanitization.
+ * `Mounts` is dropped because `Mounts[].Source` exposes raw host paths and no
+ * consumer reads it (see the inline note at the mapping below).
  */
 export function containerFromInspect(raw: unknown): Container {
   const i = ContainerInspectSchema.parse(raw);
 
   const stateStatus = i.State?.Status ?? 'unknown';
   const health = i.State?.Health?.Status;
-  const base = i.State?.Running
-    ? 'Up'
-    : stateStatus === 'exited'
-      ? `Exited (${i.State?.ExitCode ?? 0})`
-      : stateStatus.charAt(0).toUpperCase() + stateStatus.slice(1);
+  // A paused container reports Running=true AND Paused=true; Docker's own list
+  // endpoint surfaces this as "Up … (Paused)". Key off Paused first so the
+  // human-readable status reflects the pause instead of a bare "Up".
+  const base = i.State?.Paused
+    ? 'Up (Paused)'
+    : i.State?.Running
+      ? 'Up'
+      : stateStatus === 'exited'
+        ? `Exited (${i.State?.ExitCode ?? 0})`
+        : stateStatus.charAt(0).toUpperCase() + stateStatus.slice(1);
   const healthSuffix =
     health === 'healthy' ? ' (healthy)'
     : health === 'unhealthy' ? ' (unhealthy)'
@@ -186,7 +193,12 @@ export function containerFromInspect(raw: unknown): Container {
     NetworkSettings: i.NetworkSettings?.Networks
       ? { Networks: i.NetworkSettings.Networks }
       : undefined,
-    Mounts: i.Mounts ?? [],
+    // Mounts intentionally omitted: Mounts[].Source carries raw host
+    // filesystem paths (CLAUDE.md §5 — strip sensitive metadata before it
+    // reaches the frontend). The detail route returns this Container verbatim,
+    // normalizeContainer discards Mounts, and no consumer reads them, so we
+    // drop the array here rather than leak host paths. ContainerSchema's
+    // `.default([])` keeps the field contract-compliant.
     HostConfig: i.HostConfig,
   });
 }

--- a/packages/core/src/models/portainer.ts
+++ b/packages/core/src/models/portainer.ts
@@ -71,6 +71,126 @@ export const ContainerSchema = z.object({
   }).optional(),
 }).passthrough();
 
+/**
+ * Docker container *inspect* response (`/containers/{id}/json`).
+ *
+ * This is a different shape from {@link ContainerSchema}, which models the
+ * *list* endpoint (`/containers/json`): here `State` is an object, `Created`
+ * is an ISO-8601 string, the name is a single `Name`, and the image tag +
+ * labels live under `Config`. Lenient on purpose — Docker returns dozens of
+ * fields we don't consume, so unknown keys pass through and everything we
+ * map is optional.
+ */
+export const ContainerInspectSchema = z.object({
+  Id: z.string(),
+  Name: z.string().optional(),
+  Created: z.string().optional(),
+  State: z.object({
+    Status: z.string().optional(),
+    Running: z.boolean().optional(),
+    Paused: z.boolean().optional(),
+    Restarting: z.boolean().optional(),
+    Dead: z.boolean().optional(),
+    ExitCode: z.number().optional(),
+    Health: z.object({ Status: z.string().optional() }).passthrough().optional(),
+  }).passthrough().optional(),
+  Image: z.string().optional(),
+  Config: z.object({
+    Image: z.string().optional(),
+    Labels: z.record(z.string(), z.string()).nullish(),
+  }).passthrough().optional(),
+  HostConfig: z.object({
+    NetworkMode: z.string().optional(),
+    Privileged: z.boolean().optional(),
+    CapAdd: z.array(z.string()).nullish(),
+    PidMode: z.string().optional(),
+  }).passthrough().optional(),
+  NetworkSettings: z.object({
+    Networks: z.record(z.string(), z.object({
+      NetworkID: z.string().optional(),
+      IPAddress: z.string().optional(),
+      Gateway: z.string().optional(),
+    }).passthrough()).nullish(),
+    Ports: z.record(
+      z.string(),
+      z.array(z.object({
+        HostIp: z.string().optional(),
+        HostPort: z.string().optional(),
+      }).passthrough()).nullable(),
+    ).nullish(),
+  }).passthrough().optional(),
+  Mounts: z.array(z.object({
+    Type: z.string().optional(),
+    Name: z.string().optional(),
+    Source: z.string().optional(),
+    Destination: z.string().optional(),
+    Mode: z.string().optional(),
+    RW: z.boolean().optional(),
+  }).passthrough()).nullish(),
+}).passthrough();
+
+export type ContainerInspect = z.infer<typeof ContainerInspectSchema>;
+
+/**
+ * Normalize a Docker *inspect* response into the list-shaped {@link Container}
+ * contract that the rest of the codebase consumes (`normalizeContainer`,
+ * PCAP capture-status polling). The list endpoint's human-readable `Status`
+ * string is synthesized from the inspect endpoint's structured `State.Health`
+ * so health parsing (`"(healthy)"` / `"(unhealthy)"` / `"(health: starting)"`)
+ * keeps working. Labels are returned as-is; callers apply path sanitization.
+ */
+export function containerFromInspect(raw: unknown): Container {
+  const i = ContainerInspectSchema.parse(raw);
+
+  const stateStatus = i.State?.Status ?? 'unknown';
+  const health = i.State?.Health?.Status;
+  const base = i.State?.Running
+    ? 'Up'
+    : stateStatus === 'exited'
+      ? `Exited (${i.State?.ExitCode ?? 0})`
+      : stateStatus.charAt(0).toUpperCase() + stateStatus.slice(1);
+  const healthSuffix =
+    health === 'healthy' ? ' (healthy)'
+    : health === 'unhealthy' ? ' (unhealthy)'
+    : health === 'starting' ? ' (health: starting)'
+    : '';
+  const status = `${base}${healthSuffix}`;
+
+  const createdMs = i.Created ? Date.parse(i.Created) : NaN;
+  const created = Number.isFinite(createdMs) ? Math.floor(createdMs / 1000) : 0;
+
+  const ports = Object.entries(i.NetworkSettings?.Ports ?? {}).flatMap(([key, bindings]) => {
+    const [portStr, type] = key.split('/');
+    const privatePort = Number(portStr);
+    if (!Number.isFinite(privatePort)) return [];
+    const hostPort = bindings?.[0]?.HostPort ? Number(bindings[0].HostPort) : undefined;
+    return [{
+      PrivatePort: privatePort,
+      PublicPort: hostPort !== undefined && Number.isFinite(hostPort) ? hostPort : undefined,
+      Type: type ?? 'tcp',
+    }];
+  });
+
+  // Re-parse through ContainerSchema so the returned object is guaranteed to
+  // conform to the Container contract (applies defaults, strips extras).
+  return ContainerSchema.parse({
+    Id: i.Id,
+    Names: i.Name ? [i.Name] : [],
+    Image: i.Config?.Image ?? i.Image ?? '',
+    ImageID: i.Image,
+    Created: created,
+    State: stateStatus,
+    Status: status,
+    Ports: ports,
+    Labels: i.Config?.Labels ?? {},
+    NetworkSettings: i.NetworkSettings?.Networks
+      ? { Networks: i.NetworkSettings.Networks }
+      : undefined,
+    Mounts: i.Mounts ?? [],
+    HostConfig: i.HostConfig,
+  });
+}
+
 export const StackSchema = z.object({
   Id: z.number(),
   Name: z.string(),

--- a/packages/core/src/portainer/portainer-client.test.ts
+++ b/packages/core/src/portainer/portainer-client.test.ts
@@ -31,7 +31,9 @@ import {
   isEdgeTunnelNotActive,
   EDGE_TUNNEL_NOT_ACTIVE_TOKEN,
   getDockerInfo,
+  getContainer,
 } from './portainer-client.js';
+import { normalizeContainer } from './portainer-normalizers.js';
 import pLimit from 'p-limit';
 
 const mockFetch = vi.mocked(undiciFetch);
@@ -475,5 +477,115 @@ describe('getDockerInfo — narrow slice + defensive narrowing', () => {
       OSType: undefined,
       Architecture: undefined,
     });
+  });
+});
+
+// =====================================================================
+//  getContainer — Docker inspect-response normalization (#1387)
+//
+//  getContainer hits the INSPECT endpoint (/containers/{id}/json), whose
+//  shape differs from the LIST endpoint (/containers/json) that
+//  ContainerSchema models:
+//    - State is an OBJECT ({ Status, Running, Health, ... }), not a string
+//    - Created is an ISO-8601 STRING, not a unix number
+//    - the name is a single `Name` field, not `Names: string[]`
+//    - image tag + labels live under `Config`, not at the top level
+//  Parsing the inspect body with the list schema threw a ZodError and broke
+//  PCAP capture-status polling. getContainer must normalize inspect → the
+//  Container (list) contract both callers (pcap-service, container-detail
+//  route via normalizeContainer) depend on.
+// =====================================================================
+
+describe('getContainer — Docker inspect normalization (#1387)', () => {
+  beforeEach(() => {
+    _resetClientState();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    _resetClientState();
+  });
+
+  const inspectBody = {
+    Id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    Created: '2026-05-31T16:30:00.000Z',
+    Name: '/pcap-sidecar-xyz',
+    State: {
+      Status: 'running',
+      Running: true,
+      Paused: false,
+      Restarting: false,
+      Dead: false,
+      ExitCode: 0,
+      Health: { Status: 'healthy', FailingStreak: 0 },
+    },
+    Image: 'sha256:deadbeefcafe',
+    Config: {
+      Image: 'nicolaka/netshoot:latest',
+      Labels: {
+        'com.docker.compose.project': 'pcap',
+        'custom.path': '/var/lib/docker/volumes/secret',
+      },
+    },
+    HostConfig: { NetworkMode: 'container:target', Privileged: false },
+    NetworkSettings: {
+      Networks: { bridge: { NetworkID: 'net1', IPAddress: '172.17.0.5', Gateway: '172.17.0.1' } },
+    },
+    Mounts: [],
+  };
+
+  it('parses the inspect response without throwing (repro of the ZodError)', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', inspectBody));
+    await expect(getContainer(4, inspectBody.Id)).resolves.toBeDefined();
+  });
+
+  it('exposes State as a plain status string (the shape pcap-service polls)', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', inspectBody));
+    const c = await getContainer(4, inspectBody.Id);
+    expect(c.State).toBe('running');
+  });
+
+  it('maps the single inspect Name into Names[] so name resolution works', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', inspectBody));
+    const c = await getContainer(4, inspectBody.Id);
+    expect(c.Names).toEqual(['/pcap-sidecar-xyz']);
+  });
+
+  it('converts the ISO Created timestamp to unix seconds (number)', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', inspectBody));
+    const c = await getContainer(4, inspectBody.Id);
+    expect(c.Created).toBe(Math.floor(Date.parse('2026-05-31T16:30:00.000Z') / 1000));
+  });
+
+  it('uses the human-readable Config.Image tag, not the image digest', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', inspectBody));
+    const c = await getContainer(4, inspectBody.Id);
+    expect(c.Image).toBe('nicolaka/netshoot:latest');
+  });
+
+  it('pulls labels from Config.Labels and sanitizes path-disclosing values', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', inspectBody));
+    const c = await getContainer(4, inspectBody.Id);
+    expect(c.Labels?.['com.docker.compose.project']).toBe('pcap');
+    expect(c.Labels?.['custom.path']).toBe('[REDACTED]');
+  });
+
+  it('survives normalizeContainer end-to-end (state + health + name)', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', inspectBody));
+    const c = await getContainer(4, inspectBody.Id);
+    const normalized = normalizeContainer(c, 4, 'prod');
+    expect(normalized.state).toBe('running');
+    expect(normalized.healthStatus).toBe('healthy');
+    expect(normalized.name).toBe('pcap-sidecar-xyz');
+  });
+
+  it('maps a stopped container State.Status through to normalizeContainer', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', {
+      ...inspectBody,
+      State: { Status: 'exited', Running: false, Dead: false, ExitCode: 137 },
+    }));
+    const c = await getContainer(4, inspectBody.Id);
+    expect(c.State).toBe('exited');
+    expect(normalizeContainer(c, 4, 'prod').state).toBe('stopped');
   });
 });

--- a/packages/core/src/portainer/portainer-client.test.ts
+++ b/packages/core/src/portainer/portainer-client.test.ts
@@ -588,4 +588,86 @@ describe('getContainer — Docker inspect normalization (#1387)', () => {
     expect(c.State).toBe('exited');
     expect(normalizeContainer(c, 4, 'prod').state).toBe('stopped');
   });
+
+  // Docker inspect for a paused container reports Running=true, Paused=true,
+  // Status="paused". The synthesized human-readable Status keyed off Running
+  // alone, so it read "Up" with no paused indicator — masking the pause in any
+  // UI that shows the status text. State must still resolve to 'paused'.
+  it('synthesizes a paused-aware Status string while keeping State=paused', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', {
+      ...inspectBody,
+      State: {
+        Status: 'paused',
+        Running: true,
+        Paused: true,
+        Restarting: false,
+        Dead: false,
+        ExitCode: 0,
+      },
+    }));
+    const c = await getContainer(4, inspectBody.Id);
+    // State (used for normalizeContainer's state mapping) stays correct.
+    expect(c.State).toBe('paused');
+    expect(normalizeContainer(c, 4, 'prod').state).toBe('paused');
+    // The human-readable status must reflect the pause, not read a bare "Up".
+    expect(c.Status).toContain('Paused');
+    expect(c.Status).not.toBe('Up');
+  });
+
+  // NetworkSettings.Ports (inspect shape) maps to the list-shaped Ports[].
+  // Keys are "<port>/<proto>"; the value is either an array of host bindings
+  // or `null` for an exposed-but-unpublished port. Both must round-trip:
+  // bound → PublicPort set; null → PublicPort undefined (still listed).
+  it('maps NetworkSettings.Ports (bound + null bindings) into Ports[]', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', {
+      ...inspectBody,
+      NetworkSettings: {
+        ...inspectBody.NetworkSettings,
+        Ports: {
+          '80/tcp': [{ HostIp: '0.0.0.0', HostPort: '8080' }],
+          '53/udp': null,
+        },
+      },
+    }));
+    const c = await getContainer(4, inspectBody.Id);
+    const tcp = c.Ports?.find((p) => p.PrivatePort === 80);
+    const udp = c.Ports?.find((p) => p.PrivatePort === 53);
+
+    expect(tcp).toBeDefined();
+    expect(tcp?.PublicPort).toBe(8080);
+    expect(tcp?.Type).toBe('tcp');
+
+    expect(udp).toBeDefined();
+    expect(udp?.PublicPort).toBeUndefined();
+    expect(udp?.Type).toBe('udp');
+
+    // normalizeContainer consumes the mapped Ports[] — verify it survives.
+    const ports = normalizeContainer(c, 4, 'prod').ports;
+    expect(ports).toContainEqual({ private: 80, public: 8080, type: 'tcp' });
+    expect(ports).toContainEqual({ private: 53, public: undefined, type: 'udp' });
+  });
+
+  // Security (CLAUDE.md §5): Mounts[].Source carries raw host filesystem
+  // paths. The detail route returns the raw Container, so those paths must
+  // never pass through. normalizeContainer drops Mounts entirely and no
+  // consumer reads them, so containerFromInspect omits them.
+  it('does not expose raw Mounts[].Source host paths on the mapped Container', async () => {
+    mockFetch.mockResolvedValueOnce(buildJsonResponse(200, 'OK', {
+      ...inspectBody,
+      Mounts: [
+        {
+          Type: 'bind',
+          Source: '/home/simon/secret-host-path',
+          Destination: '/data',
+          Mode: 'rw',
+          RW: true,
+        },
+      ],
+    }));
+    const c = await getContainer(4, inspectBody.Id);
+    const sources = (c.Mounts ?? []).map((m) => m.Source).filter(Boolean);
+    // Either no Mounts at all, or every Source redacted — never the raw path.
+    expect(sources).not.toContain('/home/simon/secret-host-path');
+    expect(JSON.stringify(c)).not.toContain('/home/simon/secret-host-path');
+  });
 });

--- a/packages/core/src/portainer/portainer-client.ts
+++ b/packages/core/src/portainer/portainer-client.ts
@@ -6,13 +6,13 @@ import { createChildLogger } from '../utils/logger.js';
 import { withSpan } from '../tracing/trace-context.js';
 import { CircuitBreaker } from './circuit-breaker.js';
 import {
-  EndpointSchema, ContainerSchema, StackSchema,
+  EndpointSchema, StackSchema,
   ContainerStatsSchema, NetworkSchema, ImageSchema,
   EndpointArraySchema, ContainerArraySchema, StackArraySchema,
   NetworkArraySchema, ImageArraySchema,
   EdgeJobSchema, EdgeJobArraySchema, EdgeJobTaskArraySchema,
   K8sPodListSchema, K8sDeploymentListSchema, K8sServiceListSchema, K8sNamespaceListSchema,
-  isKubernetesEndpoint, isDockerEndpoint,
+  isKubernetesEndpoint, isDockerEndpoint, containerFromInspect,
   type Endpoint, type Container, type Stack,
   type ContainerStats, type Network, type DockerImage, type EdgeJob, type EdgeJobTask,
   type K8sPod, type K8sDeployment, type K8sService, type K8sNamespace,
@@ -527,10 +527,13 @@ export async function getContainers(endpointId: number, all = true): Promise<Con
 }
 
 export async function getContainer(endpointId: number, containerId: string): Promise<Container> {
+  // NB: this hits the Docker *inspect* endpoint, whose response shape differs
+  // from the list endpoint that ContainerSchema models — containerFromInspect
+  // bridges the two (see #1387).
   const raw = await portainerFetch<unknown>(
     `/api/endpoints/${endpointId}/docker/containers/${containerId}/json`,
   );
-  const container = ContainerSchema.parse(raw);
+  const container = containerFromInspect(raw);
   return {
     ...container,
     Labels: sanitizeContainerLabels(container.Labels ?? {}),


### PR DESCRIPTION
## Summary

`getContainer()` requests the Docker **inspect** endpoint (`/api/endpoints/{id}/docker/containers/{cid}/json`) but parsed the response with `ContainerSchema`, which models the **list** endpoint (`/containers/json`). The two shapes differ, so validation threw a `ZodError` on every call:

| Field | list schema expects | inspect actually returns |
|---|---|---|
| `Created` | number (unix) | ISO-8601 string |
| `State` | string | object (`{ Status, Running, Health, … }`) |
| `Status` | string | absent |
| `Names` | string[] | absent (single `Name`) |

This broke PCAP capture-status polling (`pcap-service.ts` logged the ZodError every ~2s) and was a likely source of the metrics scheduler's persistent `failedContainers:1` (#1389).

## Fix

- Add `ContainerInspectSchema` + `containerFromInspect()` in `packages/core/src/models/portainer.ts` — a lenient inspect-shaped schema plus a normalizer that maps the inspect response into the list-shaped `Container` contract both callers (`pcap-service` status polling, the container-detail route via `normalizeContainer`) depend on.
- The list-style `Status` string is synthesized from the inspect endpoint's structured `State.Health` (`(healthy)` / `(unhealthy)` / `(health: starting)`) so health parsing in `normalizeContainer` keeps working.
- Rewire `getContainer()` to use it; label sanitization is unchanged.

## Tests

8 new tests in `portainer-client.test.ts` (written test-first — they reproduced the exact `ZodError` before the fix):
- parses the inspect body without throwing (repro)
- `State` surfaces as a plain status string
- single `Name` → `Names[]`
- ISO `Created` → unix seconds
- `Config.Image` tag (not the digest)
- labels pulled from `Config.Labels` and path-sanitized
- end-to-end through `normalizeContainer` (running+healthy, and exited→stopped)

## Verification

- New tests: 8/8 pass
- `@dashboard/core` suite: 740/740 pass
- `@dashboard/security` suite (pcap-service caller): 284/284 pass
- Full repo suite (pre-push hook): 2127/2127 pass
- CI typecheck (`tsc --build`): clean

## Notes

- No `docs/architecture.md` / `docker/.env.example` / `CLAUDE.md` changes — this is an internal schema-handling bugfix with no architectural, env-var, or command surface change.
- Pre-existing (not introduced here): the per-package `tsc --noEmit` over `*.test.ts` reports a global-`Response` vs undici-`Response` type mismatch; it exists on `dev` and is excluded by CI's `tsc --build`. Can be cleaned up separately.

Refs #1397
Closes #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
