### PR TITLE
fix(scheduler): log which container failed metrics collection and why (#1389)

### DIFF
--- a/packages/server/src/__tests__/scheduler.test.ts
+++ b/packages/server/src/__tests__/scheduler.test.ts
@@ -1,6 +1,23 @@
 import { beforeAll, afterAll, describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { setConfigForTest, resetConfig } from '@dashboard/core/config/index.js';
 
+// Kept: logger mock — lets us assert the scheduler's per-container failure
+// warning (#1389). createChildLogger returns a logger whose `warn` is a
+// stable, shared spy, so the scheduler's module-level `log.warn` is
+// observable in tests.
+const { warnSpy } = vi.hoisted(() => ({ warnSpy: vi.fn() }));
+vi.mock('@dashboard/core/utils/logger.js', () => {
+  const makeLogger = () => {
+    const l: Record<string, unknown> = {
+      trace: vi.fn(), debug: vi.fn(), info: vi.fn(),
+      warn: warnSpy, error: vi.fn(), fatal: vi.fn(),
+    };
+    l.child = () => l;
+    return l;
+  };
+  return { createChildLogger: () => makeLogger(), logger: makeLogger() };
+});
+
 // ---------------------------------------------------------------------------
 // Kept mocks — internal services the scheduler depends on
 // ---------------------------------------------------------------------------
@@ -346,6 +363,39 @@ describe('scheduler/setup – runMetricsCollection', () => {
     // Should still insert metrics for the 2 successful containers
     expect(insertMetricsMock).toHaveBeenCalledTimes(1);
     expect(insertMetricsMock.mock.calls[0][0]).toHaveLength(10); // 2 containers x 5 metrics
+  });
+
+  it('logs the failing container id, name, and reason — not just a count (#1389)', async () => {
+    warnSpy.mockClear();
+    getEndpointsMock.mockResolvedValueOnce([{ Id: 1, Name: 'ep1', Status: 1, Type: 1, URL: 'tcp://localhost' }] as any);
+    getContainersMock.mockResolvedValueOnce([
+      { Id: 'ok-1', Names: ['/app-a'], State: 'running' },
+      { Id: 'fail-1', Names: ['/app-b'], State: 'running' },
+    ] as any);
+    collectMetricsMock
+      .mockResolvedValueOnce({ cpu: 10, memory: 20, memoryBytes: 100, networkRxBytes: 0, networkTxBytes: 0 })
+      .mockRejectedValueOnce(new Error('container gone'));
+
+    await runMetricsCollection();
+
+    const failureWarn = warnSpy.mock.calls.find(
+      (call) => call[1] === 'Failed to collect metrics for some containers',
+    );
+    expect(failureWarn, 'expected a per-container failure warning to be logged').toBeDefined();
+
+    const payload = failureWarn![0] as {
+      endpointId: number;
+      failedContainers: number;
+      totalContainers: number;
+      failures: Array<{ containerId: string; containerName: string; reason: string }>;
+    };
+    expect(payload.endpointId).toBe(1);
+    expect(payload.failedContainers).toBe(1);
+    expect(payload.totalContainers).toBe(2);
+    // The whole point of #1389: the operator must see WHICH container failed and WHY.
+    expect(payload.failures).toEqual([
+      { containerId: 'fail-1', containerName: 'app-b', reason: 'container gone' },
+    ]);
   });
 
   it('handles entire endpoint failure gracefully', async () => {

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -51,25 +51,53 @@ async function collectEndpointMetrics(
   const running = containers.filter((c) => c.State === 'running');
 
   const containerLimit = pLimit(containerConcurrency);
+  // Catch per-container so a single failure carries its container identity
+  // through to the warn log below (#1389) — a bare Promise rejection would
+  // lose which container failed, leaving only an unactionable count.
   const results = await Promise.allSettled(
     running.map((container) =>
       containerLimit(async () => {
-        const stats = await collectMetrics(endpointId, container.Id);
         const containerName =
           container.Names?.[0]?.replace(/^\//, '') || container.Id.slice(0, 12);
-        return { stats, container, containerName };
+        try {
+          const stats = await collectMetrics(endpointId, container.Id);
+          return { ok: true as const, stats, container, containerName };
+        } catch (err) {
+          return {
+            ok: false as const,
+            container,
+            containerName,
+            reason: err instanceof Error ? err.message : String(err),
+          };
+        }
       }),
     ),
   );
 
   const metrics: MetricInsert[] = [];
-  let containerMetricsFailures = 0;
+  const failures: { containerId: string; containerName: string; reason: string }[] = [];
   for (const result of results) {
     if (result.status === 'rejected') {
-      containerMetricsFailures++;
+      // The mapped fn catches its own errors, so a rejection here is
+      // unexpected (e.g. the concurrency limiter itself threw) — record it
+      // without container identity rather than dropping it silently.
+      failures.push({
+        containerId: 'unknown',
+        containerName: 'unknown',
+        reason: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
       continue;
     }
-    const { stats, container, containerName } = result.value;
+    const value = result.value;
+    if (!value.ok) {
+      failures.push({
+        containerId: value.container.Id,
+        containerName: value.containerName,
+        reason: value.reason,
+      });
+      continue;
+    }
+    const { stats, container, containerName } = value;
     // Feed in-memory rate tracker (works without TimescaleDB)
     recordNetworkSample(endpointId, container.Id, stats.networkRxBytes, stats.networkTxBytes);
     metrics.push(
@@ -110,9 +138,9 @@ async function collectEndpointMetrics(
       },
     );
   }
-  if (containerMetricsFailures > 0) {
+  if (failures.length > 0) {
     log.warn(
-      { failedContainers: containerMetricsFailures, totalContainers: running.length, endpointId },
+      { endpointId, failedContainers: failures.length, totalContainers: running.length, failures },
       'Failed to collect metrics for some containers',
     );
   }


### PR DESCRIPTION
## Summary

The metrics scheduler logged a recurring `Failed to collect metrics for some containers` warning carrying only a bare `failedContainers` count — with no indication of *which* container failed or *why*. That made the persistent `failedContainers:1` per cycle impossible to diagnose from logs.

`collectEndpointMetrics` ran each container's stat collection inside a `Promise.allSettled` and, on rejection, just incremented a counter — the rejected promise had already lost the container's identity.

## Fix

`packages/server/src/scheduler.ts` — catch each container's failure *inside* the concurrency-limited task so the container id + name survive, and emit them (with the error reason) as a structured `failures` array on the warn log:

```js
// before
{ failedContainers: 1, totalContainers: 22, endpointId: 4 }
// after
{ endpointId: 4, failedContainers: 1, totalContainers: 22,
  failures: [{ containerId: '…', containerName: 'beyla-4', reason: 'container gone' }] }
```

A defensive `rejected` branch still records any unexpected top-level rejection (e.g. the limiter itself throwing) rather than dropping it silently. Successful collection and the existing count are unchanged.

This makes the persistent single-container failure diagnosable — often a `Restarting`/`Dead` container, or the `ZodError` from #1387 (which #1398 fixes).

## Tests

New test in `scheduler.test.ts` (written test-first — failed first with `failures: undefined`): asserts the warn payload's `failures` array contains the failing container's `containerId`, `containerName` (leading slash stripped), and `reason`, while the successful container still produces metrics. Adds a shared hoisted logger spy so the scheduler's module-level `log.warn` is observable.

## Verification

- New test: RED → GREEN
- scheduler test files: 31/31 pass
- Full `@dashboard/server` suite: 42/42 pass
- CI typecheck (`tsc --build`): clean

## Notes

- No `docs/architecture.md` / `docker/.env.example` / `CLAUDE.md` changes — observability-only change, no architectural, env-var, or command surface change.
- Second half of epic #1397 (alongside #1398 for #1387).

Refs #1397
Closes #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
