### PR TITLE
fix(rate-limit): allow-list read-only observer GET endpoints to stop startup 429 burst (#1386)

### DIFF
--- a/backend/src/routes/security-regression-auth.test.ts
+++ b/backend/src/routes/security-regression-auth.test.ts
@@ -690,6 +690,86 @@ describe('Rate Limiting Verification', () => {
   });
 });
 
+// =====================================================================
+//  OBSERVER READ ALLOWLIST — startup 429 burst regression (#1386)
+// =====================================================================
+// The global rate limiter must NOT count read-only GET requests on these
+// prefixes against the API_RATE_LIMIT bucket, so that normal observer
+// activity on startup never triggers 429s.
+// Mutating verbs (POST/PUT/DELETE) on the same prefixes are still limited
+// because shouldBypassGlobalRateLimit() is GET-only.
+describe('Observer Read Allowlist — startup 429 prevention (#1386)', () => {
+  const OBSERVER_GET_PREFIXES: Array<{ route: string; url: string }> = [
+    { route: '/api/incidents/groups',       url: '/api/incidents/groups' },
+    { route: '/api/llm/feedback/stats',     url: '/api/llm/feedback/stats' },
+    { route: '/api/ebpf/coverage/summary',  url: '/api/ebpf/coverage/summary' },
+    { route: '/api/kubernetes/summary',     url: '/api/kubernetes/summary' },
+    { route: '/api/harbor/status',          url: '/api/harbor/status' },
+    { route: '/api/auth/oidc/status',       url: '/api/auth/oidc/status' },
+  ];
+
+  const BURST = 5; // more than the artificially low API_RATE_LIMIT below
+
+  it('GET requests on observer prefixes bypass the global rate limit (all return 200, never 429)', async () => {
+    setConfigForTest({ API_RATE_LIMIT: 3 });
+
+    try {
+      for (const { route, url } of OBSERVER_GET_PREFIXES) {
+        const app = Fastify({ logger: false });
+        await app.register(rateLimitPlugin);
+        app.get(route, async () => ({ ok: true }));
+        await app.ready();
+
+        try {
+          for (let i = 0; i < BURST; i++) {
+            const res = await app.inject({ method: 'GET', url });
+            expect(
+              res.statusCode,
+              `GET ${url} (attempt ${i + 1}) should not be rate-limited`,
+            ).toBe(200);
+          }
+        } finally {
+          await app.close();
+        }
+      }
+    } finally {
+      setConfigForTest({ API_RATE_LIMIT: 1200 });
+    }
+  });
+
+  it('POST on an observer-prefix path is still rate-limited (mutating verbs not exempt)', async () => {
+    setConfigForTest({ API_RATE_LIMIT: 3 });
+
+    try {
+      const app = Fastify({ logger: false });
+      await app.register(rateLimitPlugin);
+      // POST /api/harbor/sync — a mutating action on an observer-list prefix
+      app.post('/api/harbor/sync', async () => ({ ok: true }));
+      await app.ready();
+
+      try {
+        let rateLimitedResponse = null;
+        for (let i = 0; i <= BURST; i++) {
+          const res = await app.inject({ method: 'POST', url: '/api/harbor/sync' });
+          if (res.statusCode === 429) {
+            rateLimitedResponse = res;
+            break;
+          }
+        }
+        expect(
+          rateLimitedResponse,
+          'POST /api/harbor/sync must be rate-limited when the global limit is exceeded',
+        ).not.toBeNull();
+        expect(rateLimitedResponse!.statusCode).toBe(429);
+      } finally {
+        await app.close();
+      }
+    } finally {
+      setConfigForTest({ API_RATE_LIMIT: 1200 });
+    }
+  });
+});
+
 // ─── Trust Proxy & Client IP Identification (#1099) ───────────────────
 // Validates that Fastify is constructed with `trustProxy` enabled so that
 // `request.ip` reflects the real client IP from `X-Forwarded-For`, not the

--- a/packages/core/src/plugins/rate-limit.ts
+++ b/packages/core/src/plugins/rate-limit.ts
@@ -3,11 +3,21 @@ import fp from 'fastify-plugin';
 import rateLimit from '@fastify/rate-limit';
 import { getConfig } from '../config/index.js';
 
+// Read-only observer paths that bypass the global rate limit for GET requests.
+// Mutating verbs (POST/PUT/DELETE) on these paths remain rate-limited because
+// shouldBypassGlobalRateLimit() is GET-only. The six prefixes below were missing
+// from the original list and caused a 429 burst on startup (#1386).
 const OBSERVER_READ_PATH_PREFIXES = [
+  '/api/auth/oidc',
   '/api/containers',
   '/api/dashboard',
+  '/api/ebpf/coverage',
   '/api/endpoints',
+  '/api/harbor',
   '/api/images',
+  '/api/incidents',
+  '/api/kubernetes',
+  '/api/llm/feedback',
   '/api/llm/stats',
   '/api/llm/traces',
   '/api/logs',

--- a/packages/core/src/services/oidc-state-store-bound.test.ts
+++ b/packages/core/src/services/oidc-state-store-bound.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Regression for the DoS opened by #1386: exempting `GET /api/auth/oidc/status`
+// from the global rate limit removed the only throttle on the unauthenticated,
+// side-effecting status endpoint. When OIDC is enabled, that GET calls
+// generateAuthorizationUrl(), which inserts an entry into the in-memory
+// `stateStore` Map. Without a size cap an attacker could hammer the status GET
+// to inflate the Map within the 5-minute TTL window = memory-pressure DoS.
+//
+// The fix bounds the Map at OIDC_STATE_STORE_MAX. This test proves the Map can
+// never grow past the cap regardless of insertion rate, while a freshly-inserted
+// state remains retrievable (eviction targets the OLDEST entry, not the newest).
+
+// vi.mock factories are hoisted; bind a per-call unique state generator so each
+// generateAuthorizationUrl() insertion lands under a distinct key.
+const { stateCounter } = vi.hoisted(() => ({ stateCounter: { n: 0 } }));
+
+vi.mock('openid-client', () => ({
+  discovery: vi.fn().mockResolvedValue({ __fake: 'config' }),
+  allowInsecureRequests: vi.fn(),
+  ClientSecretBasic: vi.fn((secret: string) => ({ __auth: secret })),
+  randomPKCECodeVerifier: vi.fn(() => 'verifier'),
+  calculatePKCECodeChallenge: vi.fn(async () => 'challenge'),
+  randomState: vi.fn(() => `state-${stateCounter.n++}`),
+  randomNonce: vi.fn(() => 'nonce'),
+  buildAuthorizationUrl: vi.fn(() => new URL('https://idp.example.com/authz')),
+  authorizationCodeGrant: vi.fn(),
+  fetchUserInfo: vi.fn(),
+}));
+
+// Drive the settings DB read in-process so OIDC reads as enabled without a real DB.
+const settingsRows: { key: string; value: string }[] = [
+  { key: 'oidc.enabled', value: 'true' },
+  { key: 'oidc.issuer_url', value: 'http://idp.example.com' },
+  { key: 'oidc.client_id', value: 'client' },
+  { key: 'oidc.client_secret', value: 'secret' },
+  { key: 'oidc.scopes', value: 'openid profile email' },
+];
+vi.mock('../db/app-db-router.js', () => ({
+  getDbForDomain: () => ({
+    query: vi.fn(async () => settingsRows.slice()),
+  }),
+}));
+
+import {
+  generateAuthorizationUrl,
+  invalidateOIDCCache,
+  OIDC_STATE_STORE_MAX,
+  __getStateStoreStatsForTest,
+} from './oidc.js';
+
+describe('OIDC state store is bounded (DoS via exempted status GET — #1386)', () => {
+  beforeEach(() => {
+    invalidateOIDCCache();
+    stateCounter.n = 0;
+    __getStateStoreStatsForTest().clear();
+  });
+
+  afterEach(() => {
+    invalidateOIDCCache();
+    __getStateStoreStatsForTest().clear();
+  });
+
+  it('exposes a generous hard cap far above legitimate concurrent logins', () => {
+    expect(OIDC_STATE_STORE_MAX).toBeGreaterThanOrEqual(10_000);
+  });
+
+  it('never grows past OIDC_STATE_STORE_MAX no matter how many states are inserted', async () => {
+    const overflow = OIDC_STATE_STORE_MAX + 250;
+
+    for (let i = 0; i < overflow; i++) {
+      await generateAuthorizationUrl('https://app.example.com/auth/callback', 'openid');
+      // Invariant must hold on EVERY insertion, not just at the end.
+      expect(__getStateStoreStatsForTest().size()).toBeLessThanOrEqual(OIDC_STATE_STORE_MAX);
+    }
+
+    expect(__getStateStoreStatsForTest().size()).toBe(OIDC_STATE_STORE_MAX);
+  });
+
+  it('evicts the OLDEST state on overflow, keeping freshly-inserted login state retrievable', async () => {
+    // Fill exactly to the cap; record the first (oldest) state inserted.
+    const firstResult = await generateAuthorizationUrl('https://app.example.com/auth/callback', 'openid');
+    for (let i = 1; i < OIDC_STATE_STORE_MAX; i++) {
+      await generateAuthorizationUrl('https://app.example.com/auth/callback', 'openid');
+    }
+    expect(__getStateStoreStatsForTest().size()).toBe(OIDC_STATE_STORE_MAX);
+    expect(__getStateStoreStatsForTest().has(firstResult.state)).toBe(true);
+
+    // One more insertion overflows the cap: the oldest must be evicted and the
+    // newest must survive (a legitimate in-flight login still completes).
+    const newest = await generateAuthorizationUrl('https://app.example.com/auth/callback', 'openid');
+
+    expect(__getStateStoreStatsForTest().size()).toBe(OIDC_STATE_STORE_MAX);
+    expect(__getStateStoreStatsForTest().has(firstResult.state)).toBe(false); // oldest evicted
+    expect(__getStateStoreStatsForTest().has(newest.state)).toBe(true); // newest retained
+  });
+});

--- a/packages/core/src/services/oidc.ts
+++ b/packages/core/src/services/oidc.ts
@@ -62,6 +62,18 @@ let cachedConfigExpiry = 0;
 const STATE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const CONFIG_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
+// Hard upper bound on the in-memory state store. `GET /api/auth/oidc/status` is
+// unauthenticated and — once OIDC is enabled — side-effecting: it calls
+// generateAuthorizationUrl(), which inserts a state entry here. #1386 exempted
+// that GET from the global rate limit (to stop a startup 429 burst), removing
+// its only throttle. Without this cap an attacker could hammer the status GET to
+// inflate the Map within the 5-minute TTL window = a memory-pressure DoS. The
+// cap is intentionally far above any realistic count of concurrent in-flight
+// logins, so legitimate flows are never evicted under normal load; on overflow
+// we evict the OLDEST entry (insertion order) — closest to TTL expiry — which
+// preserves freshly-created, in-flight login state.
+export const OIDC_STATE_STORE_MAX = 10_000;
+
 /**
  * Clean expired state entries. Called on each request.
  */
@@ -72,6 +84,44 @@ function cleanExpiredStates(): void {
       stateStore.delete(key);
     }
   }
+}
+
+/**
+ * Insert (or refresh) a state entry while enforcing the hard size cap.
+ *
+ * TTL cleanup runs first (cheap, removes naturally-expired entries). If the
+ * store is still at the cap, evict the oldest entries — Map preserves insertion
+ * order, so the first key in iteration is the oldest and nearest to TTL expiry.
+ * This guarantees the Map can never exceed OIDC_STATE_STORE_MAX regardless of
+ * request rate, while the just-created state (added last) always survives.
+ */
+function putState(state: string, entry: StateEntry): void {
+  cleanExpiredStates();
+
+  // Updating an existing key doesn't grow the Map, so only enforce the cap for
+  // genuinely new keys.
+  if (!stateStore.has(state)) {
+    while (stateStore.size >= OIDC_STATE_STORE_MAX) {
+      const oldest = stateStore.keys().next().value;
+      if (oldest === undefined) break;
+      stateStore.delete(oldest);
+    }
+  }
+
+  stateStore.set(state, entry);
+}
+
+/**
+ * Test-only introspection seam for the bounded in-memory state store. Not part
+ * of the public OIDC surface — exposes just enough to assert the size invariant
+ * and eviction policy without reaching into module internals.
+ */
+export function __getStateStoreStatsForTest() {
+  return {
+    size: () => stateStore.size,
+    has: (state: string) => stateStore.has(state),
+    clear: () => stateStore.clear(),
+  };
 }
 
 /**
@@ -220,8 +270,6 @@ export function invalidateOIDCCache(): void {
  * Generate an authorization URL with PKCE, state, and nonce.
  */
 export async function generateAuthorizationUrl(redirectUri: string, scopes: string): Promise<AuthUrlResult> {
-  cleanExpiredStates();
-
   const config = await getOrCreateConfiguration();
 
   const codeVerifier = client.randomPKCECodeVerifier();
@@ -229,8 +277,10 @@ export async function generateAuthorizationUrl(redirectUri: string, scopes: stri
   const state = client.randomState();
   const nonce = client.randomNonce();
 
-  // Store state → code_verifier + nonce mapping server-side
-  stateStore.set(state, {
+  // Store state → code_verifier + nonce mapping server-side. putState() runs TTL
+  // cleanup and enforces the OIDC_STATE_STORE_MAX hard cap so this unauthenticated,
+  // rate-limit-exempt insertion path can never grow the Map without bound (#1386).
+  putState(state, {
     codeVerifier,
     nonce,
     createdAt: Date.now(),


### PR DESCRIPTION
## Summary

Two related fixes for #1386. **This PR contains two commits — please review both.**

### 1. Rate-limit allow-list (`4b05cbd5`)
On backend startup the frontend fires many read-only API calls and got a burst of HTTP 429s, leaving pages empty. Root cause: the global rate limiter's allow-list (`OBSERVER_READ_PATH_PREFIXES` in `packages/core/src/plugins/rate-limit.ts`) was **missing six read-only GET endpoint prefixes** the frontend hits on initial load, so those calls counted against the global `API_RATE_LIMIT` and tripped it.

Added the six missing prefixes: `/api/auth/oidc`, `/api/ebpf/coverage`, `/api/harbor`, `/api/incidents`, `/api/kubernetes`, `/api/llm/feedback`.

`shouldBypassGlobalRateLimit()` is **GET-only** (`method !== 'GET'` → not bypassed), so every mutating verb on these prefixes (e.g. `POST /api/harbor/sync`) **remains rate-limited**. No auth/admin mutation is exempted; RBAC is unaffected.

### 2. Bound the OIDC in-memory state store (`e45aafb6`)
Fix #1 exempted `GET /api/auth/oidc/status` from the global rate limit. That endpoint is **unauthenticated and side-effecting** when OIDC is enabled — it calls `generateAuthorizationUrl()`, which inserts into an in-memory `stateStore` Map (5-min TTL, previously **unbounded**). Exempting it removed its only throttle, opening a **memory-pressure DoS**: an attacker could hammer the status GET to inflate the Map within the TTL window.

Bound the Map at `OIDC_STATE_STORE_MAX = 10_000` (far above any realistic count of concurrent in-flight logins). A new `putState()` helper runs the existing TTL cleanup, then on overflow evicts the **oldest** entry (Map insertion order = nearest to TTL expiry) so freshly-created, in-flight login state always survives. The #1386 startup-burst fix stays fully intact (status GET remains exempt) while unbounded growth becomes impossible regardless of request rate.

> The two changes belong together: exempting the status GET (fix #1) is only safe once the state store it feeds is bounded (fix #2).

## Tests

- Security-regression tests in `backend/src/routes/security-regression-auth.test.ts` (per CLAUDE.md §6): new GET prefixes bypass the global limit (fire > limit → all 200); a mutating `POST` on an observer prefix is **still** rate-limited (429).
- `packages/core/src/services/oidc-state-store-bound.test.ts`: drives the real `generateAuthorizationUrl()` past the cap, asserting the size invariant holds on every insert and the newest state survives while the oldest is evicted.

Both written test-first (red→green). Full CI green.

Closes #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)