### PR TITLE
fix(security-audit): guard undefined containers before .map() (#1388)

### DIFF
--- a/packages/security/src/__tests__/security-audit.test.ts
+++ b/packages/security/src/__tests__/security-audit.test.ts
@@ -102,6 +102,65 @@ describe('security-audit service', () => {
     expect(isIgnoredContainer('api', ['nginx*'])).toBe(false);
   });
 
+  describe('wildcard matcher prefix*suffix overlap (#1388)', () => {
+    // The pure-string matcher must stay semantically equivalent to the old
+    // `^prefix.*suffix$` regex. For a `prefix*suffix` shape matched against a
+    // SHORT value, the fixed prefix and fixed suffix must NOT consume
+    // overlapping characters — otherwise an over-matching ignore pattern
+    // silently suppresses a flagged container (security false-negative).
+
+    it('rejects a single char when prefix and suffix would overlap (a*a vs a)', () => {
+      // old `^a.*a$` against 'a' → false (needs >= 2 chars)
+      expect(isIgnoredContainer('a', ['a*a'])).toBe(false);
+      // sanity: a value long enough for both anchors still matches
+      expect(isIgnoredContainer('aba', ['a*a'])).toBe(true);
+      expect(isIgnoredContainer('aa', ['a*a'])).toBe(true);
+    });
+
+    it('rejects an overlapping realistic prefix*suffix (app*pp vs app)', () => {
+      // old `^app.*pp$` against 'app' → false (suffix `pp` overlaps prefix `app`)
+      expect(isIgnoredContainer('app', ['app*pp'])).toBe(false);
+      // non-overlapping value where both anchors fit → matches
+      expect(isIgnoredContainer('app-pp', ['app*pp'])).toBe(true);
+      expect(isIgnoredContainer('appxpp', ['app*pp'])).toBe(true);
+    });
+
+    it('rejects overlap for a hyphenated prefix*suffix (app*-prod vs approd)', () => {
+      // old `^app.*-prod$` against 'approd' → false; against 'app-prod' → true
+      expect(isIgnoredContainer('approd', ['app*-prod'])).toBe(false);
+      expect(isIgnoredContainer('app-prod', ['app*-prod'])).toBe(true);
+      expect(isIgnoredContainer('app-svc-prod', ['app*-prod'])).toBe(true);
+    });
+
+    it('preserves single-anchor wildcard shapes', () => {
+      // prefix-anchored: foo*
+      expect(isIgnoredContainer('nginx-proxy', ['nginx*'])).toBe(true);
+      expect(isIgnoredContainer('mynginx', ['nginx*'])).toBe(false);
+      // suffix-anchored: *foo
+      expect(isIgnoredContainer('my-sidecar', ['*sidecar'])).toBe(true);
+      expect(isIgnoredContainer('sidecar-proxy', ['*sidecar'])).toBe(false);
+      // contains: *foo*
+      expect(isIgnoredContainer('prometheus-node', ['*metheus*'])).toBe(true);
+      expect(isIgnoredContainer('grafana', ['*metheus*'])).toBe(false);
+      // exact, no wildcard
+      expect(isIgnoredContainer('traefik', ['traefik'])).toBe(true);
+      expect(isIgnoredContainer('traefik-2', ['traefik'])).toBe(false);
+    });
+
+    it('preserves default ignore-pattern behavior', () => {
+      const defaults = ['portainer', 'traefik', 'nginx*', 'caddy*', 'prometheus*', 'grafana*'];
+      expect(isIgnoredContainer('portainer', defaults)).toBe(true);
+      expect(isIgnoredContainer('traefik', defaults)).toBe(true);
+      expect(isIgnoredContainer('nginx-proxy', defaults)).toBe(true);
+      expect(isIgnoredContainer('caddy-1', defaults)).toBe(true);
+      expect(isIgnoredContainer('prometheus-node', defaults)).toBe(true);
+      expect(isIgnoredContainer('grafana', defaults)).toBe(true);
+      // an actual app must NOT be ignored by the defaults
+      expect(isIgnoredContainer('my-api', defaults)).toBe(false);
+      expect(isIgnoredContainer('mynginx', defaults)).toBe(false);
+    });
+  });
+
   it('returns audit entries with ignored visibility preserved', async () => {
     mockGetSetting.mockResolvedValue({ value: JSON.stringify(['portainer']) });
 

--- a/packages/security/src/__tests__/security-audit.test.ts
+++ b/packages/security/src/__tests__/security-audit.test.ts
@@ -270,6 +270,19 @@ describe('security-audit service', () => {
     expect(entries).toEqual([]);
   });
 
+  it('does not throw when containers resolve undefined (#1388)', async () => {
+    // Regression: cachedFetch resolving containers as undefined previously made
+    // computeSecurityAudit call undefined.map() and throw a TypeError.
+    // The fix is to guard the containers assignment with `?? []`, mirroring
+    // the existing `?? []` guard on the endpoints assignment (#1270).
+    mockCachedFetch.mockImplementation((key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+      if (key.startsWith('containers:')) return Promise.resolve(undefined);
+      return fetcher();
+    });
+
+    await expect(getSecurityAudit()).resolves.toBeDefined();  // no throw; returns an array
+  });
+
   it('computes audit summary counts', () => {
     const summary = buildSecurityAuditSummary([
       {

--- a/packages/security/src/__tests__/security-audit.test.ts
+++ b/packages/security/src/__tests__/security-audit.test.ts
@@ -132,6 +132,21 @@ describe('security-audit service', () => {
       expect(isIgnoredContainer('app-svc-prod', ['app*-prod'])).toBe(true);
     });
 
+    it('handles multiple wildcards via the middle segment branch (a*b*c)', () => {
+      // Multi-`*` patterns exercise the interior indexOf branch of matchesPattern
+      // (a fixed segment that is neither the anchored prefix nor suffix). Each
+      // case mirrors the old `^a.*b.*c$` regex semantics.
+      expect(isIgnoredContainer('axbxc', ['a*b*c'])).toBe(true);   // a … b … c, in order
+      expect(isIgnoredContainer('abc', ['a*b*c'])).toBe(true);     // empty `.*` between segments
+      expect(isIgnoredContainer('ac', ['a*b*c'])).toBe(false);     // middle `b` absent
+      expect(isIgnoredContainer('acb', ['a*b*c'])).toBe(false);    // segments out of order
+      expect(isIgnoredContainer('xabc', ['a*b*c'])).toBe(false);   // must start at the prefix
+      expect(isIgnoredContainer('abcd', ['a*b*c'])).toBe(false);   // must end at the suffix
+      // Realistic shape: env-tagged service with two wildcards.
+      expect(isIgnoredContainer('svc-api-prod-1', ['svc*api*prod*'])).toBe(true);
+      expect(isIgnoredContainer('svc-web-prod-1', ['svc*api*prod*'])).toBe(false);
+    });
+
     it('preserves single-anchor wildcard shapes', () => {
       // prefix-anchored: foo*
       expect(isIgnoredContainer('nginx-proxy', ['nginx*'])).toBe(true);

--- a/packages/security/src/services/security-audit.ts
+++ b/packages/security/src/services/security-audit.ts
@@ -48,21 +48,50 @@ function normalizePattern(pattern: string): string {
   return pattern.trim().toLowerCase();
 }
 
-function escapeRegExp(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function wildcardToRegExp(pattern: string): RegExp {
-  const escaped = escapeRegExp(pattern).replace(/\\\*/g, '.*');
-  return new RegExp(`^${escaped}$`, 'i');
-}
-
+/**
+ * Pure-string wildcard match — supports only `*` as a multi-character glob.
+ * Splits the pattern on `*` and verifies each literal segment appears in the
+ * correct order inside `value` without constructing a dynamic RegExp
+ * (avoids CWE-1333 ReDoS).
+ *
+ * Examples:
+ *   matchesPattern('nginx-ingress', 'nginx*')  → true
+ *   matchesPattern('api',           'nginx*')  → false
+ *   matchesPattern('prometheus-1',  '*metheus*') → true
+ */
 function matchesPattern(value: string, pattern: string): boolean {
   if (!pattern) return false;
-  if (!pattern.includes('*')) {
-    return value.toLowerCase() === pattern.toLowerCase();
+
+  const v = value.toLowerCase();
+  const p = pattern.toLowerCase();
+
+  // Fast path: no wildcard → exact match.
+  if (!p.includes('*')) return v === p;
+
+  const segments = p.split('*');
+  const startsFixed = !p.startsWith('*');
+  const endsFixed   = !p.endsWith('*');
+
+  let cursor = 0;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (seg === '') continue;   // consecutive or leading/trailing `*`
+
+    if (i === 0 && startsFixed) {
+      // First segment must match at position 0
+      if (!v.startsWith(seg)) return false;
+      cursor = seg.length;
+    } else if (i === segments.length - 1 && endsFixed) {
+      // Last segment must match at the very end
+      if (!v.endsWith(seg)) return false;
+      cursor = v.length;  // consumed
+    } else {
+      const idx = v.indexOf(seg, cursor);
+      if (idx === -1) return false;
+      cursor = idx + seg.length;
+    }
   }
-  return wildcardToRegExp(pattern).test(value);
+  return true;
 }
 
 export function resolveAuditSeverity(findings: SecurityFinding[]): SecurityAuditEntry['severity'] {
@@ -134,11 +163,11 @@ async function computeSecurityAudit(endpointId?: number): Promise<SecurityAuditE
   for (const endpoint of scopedEndpoints.filter((ep) => isDockerEndpoint(ep.Type))) {
     let containers: Awaited<ReturnType<typeof getContainers>>;
     try {
-      containers = await cachedFetch(
+      containers = (await cachedFetch(
         getCacheKey('containers', endpoint.Id),
         TTL.CONTAINERS,
         () => getContainers(endpoint.Id, true),
-      );
+      )) ?? [];
     } catch (err) {
       if (err instanceof CircuitBreakerOpenError) {
         log.debug({ endpointId: endpoint.Id }, 'Skipping security audit for endpoint with open circuit breaker');

--- a/packages/security/src/services/security-audit.ts
+++ b/packages/security/src/services/security-audit.ts
@@ -82,8 +82,13 @@ function matchesPattern(value: string, pattern: string): boolean {
       if (!v.startsWith(seg)) return false;
       cursor = seg.length;
     } else if (i === segments.length - 1 && endsFixed) {
-      // Last segment must match at the very end
-      if (!v.endsWith(seg)) return false;
+      // Last segment must match at the very end AND must start at or after the
+      // cursor advanced by the fixed prefix — otherwise the prefix and suffix
+      // could consume overlapping characters, over-matching where the old
+      // `^prefix.*suffix$` regex would not (e.g. `a*a` vs `a`). Anchor the
+      // suffix by index so it cannot reach back into already-consumed input.
+      const start = v.length - seg.length;
+      if (start < cursor || !v.startsWith(seg, start)) return false;
       cursor = v.length;  // consumed
     } else {
       const idx = v.indexOf(seg, cursor);


### PR DESCRIPTION
## Summary

`computeSecurityAudit` in `packages/security/src/services/security-audit.ts` assigned `containers` from `cachedFetch(...)` without a guard, then called `containers.map(...)`. When the underlying fetch resolves `undefined` (e.g. Portainer returns HTTP 204 / empty body and `cachedFetch` passes it through), `undefined.map()` threw `TypeError: Cannot read properties of undefined (reading 'map')` — the crash reported in #1388. Fixed with a `?? []` guard, mirroring the existing `endpoints` guard from #1270.

## Changes

- **Guard (#1388):** `containers = (await cachedFetch(...)) ?? []`.
- **ReDoS hardening (incidental, required by the pre-commit Semgrep hook):** the same file's `wildcardToRegExp` built a dynamic `new RegExp(...)` (CWE-1333), which the repo's Semgrep pre-commit gate flags and blocks. Since `--no-verify` is disallowed, the wildcard matcher was reimplemented as a pure-string segment walk (`matchesPattern`) — no dynamic RegExp. It preserves the matching semantics for the leading/trailing-`*` glob patterns used for infrastructure-service classification (all existing wildcard tests pass).

## Tests

- New regression test in `packages/security/src/__tests__/security-audit.test.ts`: when `cachedFetch` resolves `undefined` for `containers:*`, `getSecurityAudit()` resolves without throwing (red→green: it threw the exact TypeError before the guard).
- Full `security-audit` suite green (14/14); CI typecheck clean. Existing infrastructure-pattern wildcard tests still pass.

## Note
The Semgrep-driven `wildcardToRegExp`→`matchesPattern` change is disclosed here in case you'd prefer it split out; it's bundled because the hook blocks committing the file otherwise.

Closes #1388

🤖 Generated with [Claude Code](https://claude.com/claude-code)
