### PR TITLE
fix(anomaly): guard near-zero stddev/MAD to stop astronomical z-scores (#1391)

### DIFF
--- a/packages/ai-intelligence/src/__tests__/adaptive-anomaly-detector.test.ts
+++ b/packages/ai-intelligence/src/__tests__/adaptive-anomaly-detector.test.ts
@@ -160,6 +160,41 @@ describe('adaptive-anomaly-detector', () => {
       expect(result!.z_score).toBe(0);
     });
 
+    // #1391 — a near-constant baseline yields a floating-point std_dev (~5.6e-17),
+    // which slips past the strict `std_dev === 0` guard. The raw (value-mean)/std_dev
+    // then explodes to an astronomical z-score (the reported ~1.78e14) and the tiny,
+    // operationally-meaningless deviation is flagged as an anomaly.
+    it('does not flag a tiny deviation when std dev is near-zero floating-point noise (#1391)', async () => {
+      mockGetMovingAverage.mockResolvedValue({ mean: 0.16, std_dev: 5.6e-17, sample_count: 15 });
+      // Mirrors the bug report: memory 0.17 vs mean 0.16.
+      const result = await detectAnomalyAdaptive('c1', 'web', 'memory', 0.17, 'adaptive', mockGetMovingAverage);
+      expect(result).not.toBeNull();
+      expect(result!.is_anomalous).toBe(false);
+      // The z-score must stay finite/small, not the astronomical ~1.78e14 from the report.
+      expect(Math.abs(result!.z_score)).toBeLessThan(10);
+    });
+
+    // Drives a *relative* floor (not just an absolute FP epsilon): a genuinely tiny
+    // but non-trivial variance on a low mean is still effectively constant, so a
+    // sub-tolerance deviation must not be flagged.
+    it('does not flag a sub-tolerance deviation when variance is negligible vs the mean (#1391)', async () => {
+      mockGetMovingAverage.mockResolvedValue({ mean: 0.16, std_dev: 1e-5, sample_count: 15 });
+      const result = await detectAnomalyAdaptive('c1', 'web', 'memory', 0.17, 'adaptive', mockGetMovingAverage);
+      expect(result).not.toBeNull();
+      expect(result!.is_anomalous).toBe(false);
+      expect(Math.abs(result!.z_score)).toBeLessThan(10);
+    });
+
+    // Guard against over-correction: a real jump on a near-constant baseline must
+    // still be flagged via the percentage-tolerance rule.
+    it('still flags a genuine spike on a near-constant baseline (#1391)', async () => {
+      mockGetMovingAverage.mockResolvedValue({ mean: 0.16, std_dev: 5.6e-17, sample_count: 15 });
+      const result = await detectAnomalyAdaptive('c1', 'web', 'memory', 0.5, 'adaptive', mockGetMovingAverage);
+      expect(result).not.toBeNull();
+      expect(result!.is_anomalous).toBe(true);
+      expect(Number.isFinite(result!.z_score)).toBe(true);
+    });
+
     // #1362 — robust median+MAD detection (one-sided, outlier-resistant).
     describe('detectAnomalyRobust', () => {
       // median 50, MAD 4 → modified-z threshold (2.5) is crossed at value > ~64.8.
@@ -209,6 +244,27 @@ describe('adaptive-anomaly-detector', () => {
         const tiny = await detectAnomalyRobust('c1', 'web', 'cpu', 50.2, getWindow);
         expect(spike!.is_anomalous).toBe(true);
         expect(tiny!.is_anomalous).toBe(false); // within 10% tolerance of median
+      });
+
+      // #1391 — same class of bug as the mean/std path, in the default detector.
+      // A baseline that jitters by ±1e-5 around 0.16 has a tiny but NON-zero MAD,
+      // so the strict `mad === 0` guard is skipped and the modified z-score
+      // (0.6745·Δ/MAD) explodes — flagging an operationally-meaningless deviation.
+      const nearConstant = () => Array.from({ length: 12 }, (_, i) => 0.16 + (i % 2 === 0 ? -1e-5 : 1e-5));
+
+      it('does not flag a sub-tolerance deviation when MAD is near-zero, not exactly 0 (#1391)', async () => {
+        const getWindow = vi.fn().mockResolvedValue(nearConstant());
+        const r = await detectAnomalyRobust('c1', 'web', 'memory', 0.165, getWindow);
+        expect(r).not.toBeNull();
+        expect(r!.is_anomalous).toBe(false);
+        expect(Math.abs(r!.z_score)).toBeLessThan(10);
+      });
+
+      it('still flags a genuine spike when MAD is near-zero (#1391)', async () => {
+        const getWindow = vi.fn().mockResolvedValue(nearConstant());
+        const r = await detectAnomalyRobust('c1', 'web', 'memory', 0.5, getWindow);
+        expect(r!.is_anomalous).toBe(true);
+        expect(Number.isFinite(r!.z_score)).toBe(true);
       });
 
       // #1362 review — keep #1295 seasonality: prefer the hour-of-day window.

--- a/packages/ai-intelligence/src/__tests__/anomaly-stats.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-stats.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
   classifyCv,
   cvThresholdMultiplier,
+  isEffectivelyConstant,
   meanAndStd,
   medianAndMad,
   modifiedZScore,
@@ -149,5 +150,33 @@ describe('modifiedZScore', () => {
   it('returns 0 when MAD is 0 (zero-spread is handled by the detector)', () => {
     expect(modifiedZScore(5, 5, 0)).toBe(0);
     expect(modifiedZScore(99, 5, 0)).toBe(0);
+  });
+});
+
+// #1391 — boundary pin for the near-constant guard. If you change the floors,
+// update both this block and the doc comment on `isEffectivelyConstant`.
+describe('isEffectivelyConstant', () => {
+  it('treats exact zero and the floating-point-noise std-dev from the bug report as constant', () => {
+    expect(isEffectivelyConstant(0.16, 0)).toBe(true);
+    expect(isEffectivelyConstant(0.16, 5.6e-17)).toBe(true); // the reported ~1.78e14 z-score case
+  });
+
+  it('catches a tiny variance that is negligible relative to the centre (0.1% floor)', () => {
+    expect(isEffectivelyConstant(0.16, 1e-5)).toBe(true); // cv 6.25e-5 ≪ 1e-3
+    expect(isEffectivelyConstant(100, 0.05)).toBe(true); // cv 5e-4 < 1e-3
+  });
+
+  it('leaves a legitimate low-variance series on the z-score path', () => {
+    expect(isEffectivelyConstant(100, 5)).toBe(false); // cv 0.05 — lowest CV the ladder handles
+    expect(isEffectivelyConstant(0.16, 0.02)).toBe(false); // cv 0.125
+  });
+
+  it('uses the absolute floor when the centre is ~zero (relative floor degenerate)', () => {
+    expect(isEffectivelyConstant(0, 1e-12)).toBe(true);
+    expect(isEffectivelyConstant(0, 0.5)).toBe(false);
+  });
+
+  it('treats a non-finite spread as constant (safe fallback to tolerance)', () => {
+    expect(isEffectivelyConstant(0.16, Number.NaN)).toBe(true);
   });
 });

--- a/packages/ai-intelligence/src/services/adaptive-anomaly-detector.ts
+++ b/packages/ai-intelligence/src/services/adaptive-anomaly-detector.ts
@@ -11,6 +11,7 @@ import {
   classifyCv,
   cvThresholdMultiplier,
   exceedsThreshold,
+  isEffectivelyConstant,
   medianAndMad,
   modifiedZScore,
 } from './anomaly-stats.js';
@@ -160,8 +161,12 @@ export async function detectAnomalyAdaptive(
     isAnomalous = exceedsThreshold(zScore, threshold, direction);
   }
 
-  // Handle zero std_dev
-  if (stats.std_dev === 0) {
+  // Handle zero / near-zero std_dev (#1391). A near-constant baseline yields a
+  // floating-point std_dev (e.g. ~5.6e-17) that slips past a strict `=== 0`
+  // check; the raw (value - mean)/std_dev above then explodes. Treat any
+  // effectively-constant baseline like a zero-spread one and use the
+  // percentage-tolerance rule instead.
+  if (isEffectivelyConstant(stats.mean, stats.std_dev)) {
     const absMean = Math.abs(stats.mean);
     // Use a percentage-based tolerance for stable workloads to avoid tiny-value false positives.
     const tolerance = absMean > 0
@@ -272,9 +277,11 @@ export async function detectAnomalyRobust(
 
   let zScore: number;
   let isAnomalous: boolean;
-  if (mad === 0) {
-    // Perfectly stable baseline → modified z is undefined. Use a relative
-    // tolerance (mirrors the std === 0 path in the other detectors).
+  if (isEffectivelyConstant(median, mad)) {
+    // Perfectly stable — or near-constant (#1391) — baseline → the modified z is
+    // undefined / numerically explosive. A tiny non-zero MAD (e.g. ±1e-5 jitter)
+    // slips past a strict `mad === 0` check and makes 0.6745·Δ/MAD blow up, so
+    // use a relative tolerance instead (mirrors the std === 0 path above).
     const tolerance = Math.max(Math.abs(median) * 0.1, 0.01);
     const delta = currentValue - median;
     isAnomalous = exceedsThreshold(delta, tolerance, direction);

--- a/packages/ai-intelligence/src/services/anomaly-stats.ts
+++ b/packages/ai-intelligence/src/services/anomaly-stats.ts
@@ -100,6 +100,32 @@ export function scaledThresholdForCv(
   return { threshold: baseThreshold * multiplier, regime, multiplier };
 }
 
+/**
+ * Is a baseline effectively constant? A spread (population std-dev or MAD) that
+ * is a negligible fraction of its centre — or negligibly small in absolute
+ * terms — means the series is flat to within floating-point noise. Dividing by
+ * such a spread yields astronomical, meaningless z-scores (#1391): a
+ * near-constant memory series at ~0.16 accumulates a std-dev of ~5.6e-17, so
+ * (0.17 − 0.16) / 5.6e-17 ≈ 1.8e14 — a false-positive anomaly with a garbage
+ * score. Detectors must treat this like a zero-spread baseline and fall back to
+ * the percentage-tolerance rule instead of dividing.
+ *
+ *   absolute floor: spread ≤ 1e-9           (pure FP noise / exact zero)
+ *   relative floor: spread ≤ |centre|·1e-3  (a genuinely tiny variance that is
+ *                                            still negligible vs the centre)
+ *
+ * The 0.1% relative floor sits far below the lowest CV the z-score path is meant
+ * to handle (the CV→multiplier ladder only starts distinguishing regimes at
+ * 10%), so legitimate low-variance series keep using the z-score path.
+ */
+export function isEffectivelyConstant(centre: number, spread: number): boolean {
+  const ABSOLUTE_FLOOR = 1e-9;
+  const RELATIVE_FLOOR = 1e-3;
+  if (!Number.isFinite(spread) || spread <= ABSOLUTE_FLOOR) return true;
+  if (!Number.isFinite(centre)) return false;
+  return spread <= Math.abs(centre) * RELATIVE_FLOOR;
+}
+
 /** Population mean and standard deviation. Empty/short series → zero std. */
 export function meanAndStd(values: number[]): { mean: number; std: number } {
   if (values.length === 0) return { mean: 0, std: 0 };


### PR DESCRIPTION
## Summary

The adaptive anomaly detector emitted astronomically high z-scores (the reported `1.78e14` / `1.91e14`) on near-constant low-value metrics — e.g. memory `0.17` vs mean `0.16` — producing false-positive "Anomaly detected" alerts with meaningless scores (#1391).

**Root cause:** a near-constant baseline doesn't produce an *exact* zero spread — it accumulates a floating-point std-dev of ~`5.6e-17`. The detectors guarded only the strict `std_dev === 0` / `mad === 0` cases, so a near-zero-but-nonzero spread slipped through to the raw `(value - centre) / spread` division, which blows up: `(0.17 - 0.16) / 5.6e-17 ≈ 1.8e14`.

## Fix

- New shared predicate **`isEffectivelyConstant(centre, spread)`** in `anomaly-stats.ts`:
  - absolute floor `spread ≤ 1e-9` (pure FP noise / exact zero)
  - relative floor `spread ≤ |centre|·1e-3` (a genuinely tiny variance still negligible vs the centre)
- Both detection paths now route an effectively-constant baseline to the **existing percentage-tolerance rule** instead of dividing:
  - `detectAnomalyAdaptive` (mean/std): `std_dev === 0` → `isEffectivelyConstant(mean, std_dev)`
  - `detectAnomalyRobust` (median+MAD, the default detector): `mad === 0` → `isEffectivelyConstant(median, mad)`

The `0.1%` relative floor sits far below the lowest CV the z-score path is meant to handle (the CV→multiplier ladder only starts distinguishing regimes at 10%), so **legitimate low-variance series are unaffected**. A genuine spike on a near-constant baseline is still flagged — via the percentage tolerance (10% of the centre, floored at 0.01).

## Tests (TDD, red → green)

`adaptive-anomaly-detector.test.ts`:
- near-zero `std_dev` (5.6e-17) → tiny deviation no longer flagged; z-score stays finite/small
- negligible-vs-mean `std_dev` (1e-5) → sub-tolerance deviation not flagged (drives the *relative* floor, not just an FP epsilon)
- near-zero **MAD** (±1e-5 jitter) → same, in the default `robust-mad` path
- both paths: a genuine spike on a near-constant baseline is **still** flagged

`anomaly-stats.test.ts`: boundary pins for `isEffectivelyConstant` (exact 0, the bug's 5.6e-17, the relative floor, the centre≈0 absolute-floor fallback, non-finite spread).

## Verification

- New + existing detector/stats/eval tests: **70/70 pass** (incl. the PR-AUC CI regression guard)
- `tsc --build` (CI typecheck): clean
- Pre-push hook (typecheck + full frontend suite, 2118 tests): green
- The 17 failing tests in the full `@dashboard/ai` run are all `ECONNREFUSED 127.0.0.1:5433` (DB-backed incidents tests; no local Postgres) — unrelated to this pure-function change.

## Notes

- **Operator impact:** historically near-constant services (e.g. memory pinned low) will stop emitting garbage-score false positives; real jumps still alert. No config or schema change.
- No `docs/architecture.md` / `docker/.env.example` / `CLAUDE.md` change — internal detector bugfix, no new env var, surface, or command (matches the no-doc-change precedent of the sibling #1387/#1389 fixes).

Closes #1391

🤖 Generated with [Claude Code](https://claude.com/claude-code)