### PR TITLE
fix(ci): use a non-blocklisted E2E DASHBOARD_PASSWORD to unblock nightly E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         run: npm run test -w backend -- --coverage
         env:
           DASHBOARD_USERNAME: admin
-          DASHBOARD_PASSWORD: changeme12345
+          DASHBOARD_PASSWORD: e2e-Sm0ke!Pw-7x2qD
           JWT_SECRET: test-secret-ci-e2e-do-not-use-in-prod-0123456789ab
           POSTGRES_TEST_URL: postgresql://app_user:changeme-postgres-app@localhost:5433/portainer_dashboard_test
           REDIS_URL: redis://localhost:6379
@@ -291,9 +291,12 @@ jobs:
     needs: [build]
     # Test credentials only — never used outside the disposable CI runner.
     # JWT_SECRET is 48 chars to satisfy the production 32+ char guard in env.schema.ts.
+    # The backend runs with NODE_ENV=production here, so DASHBOARD_PASSWORD must NOT
+    # be on the WEAK_DASHBOARD_PASSWORDS blocklist in packages/core/src/config/index.ts
+    # (the old `changeme12345` was, which crash-looped the backend → unhealthy → E2E fail).
     env:
       DASHBOARD_USERNAME: admin
-      DASHBOARD_PASSWORD: changeme12345
+      DASHBOARD_PASSWORD: e2e-Sm0ke!Pw-7x2qD
       JWT_SECRET: test-secret-ci-e2e-do-not-use-in-prod-0123456789ab
       POSTGRES_APP_PASSWORD: changeme-postgres-app
       TIMESCALE_PASSWORD: changeme-timescale
@@ -364,7 +367,8 @@ jobs:
         env:
           E2E_BASE_URL: http://localhost:8080
           E2E_USERNAME: admin
-          E2E_PASSWORD: changeme12345
+          # Must match DASHBOARD_PASSWORD above — this is the credential Playwright logs in with.
+          E2E_PASSWORD: e2e-Sm0ke!Pw-7x2qD
 
       - name: Dump service logs on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,16 +291,19 @@ jobs:
     needs: [build]
     # Test credentials only — never used outside the disposable CI runner.
     # JWT_SECRET is 48 chars to satisfy the production 32+ char guard in env.schema.ts.
-    # The backend runs with NODE_ENV=production here, so DASHBOARD_PASSWORD must NOT
-    # be on the WEAK_DASHBOARD_PASSWORDS blocklist in packages/core/src/config/index.ts
-    # (the old `changeme12345` was, which crash-looped the backend → unhealthy → E2E fail).
+    # The backend runs with NODE_ENV=production here, so DASHBOARD_PASSWORD *and* the
+    # service passwords (REDIS_PASSWORD, TIMESCALE_PASSWORD) must NOT be on the weak
+    # blocklists in packages/core/src/config/index.ts — validateDashboardCredentials /
+    # validateServicePasswords throw on startup otherwise, crash-looping the backend →
+    # unhealthy → E2E fails (the old `changeme*` values were all blocklisted).
+    # Service passwords are kept URL-safe (no @ : / #) since they go into connection URLs.
     env:
       DASHBOARD_USERNAME: admin
       DASHBOARD_PASSWORD: e2e-Sm0ke!Pw-7x2qD
       JWT_SECRET: test-secret-ci-e2e-do-not-use-in-prod-0123456789ab
       POSTGRES_APP_PASSWORD: changeme-postgres-app
-      TIMESCALE_PASSWORD: changeme-timescale
-      REDIS_PASSWORD: changeme-redis
+      TIMESCALE_PASSWORD: e2e-timescale-pw-7x2qD
+      REDIS_PASSWORD: e2e-redis-pw-7x2qD
       DASHBOARD_DOMAIN: localhost
       PORTAINER_API_URL: http://127.0.0.1:9999
       PORTAINER_API_KEY: e2e-dummy-key


### PR DESCRIPTION
## Summary

The **scheduled nightly CI** (`CI` workflow on `dev`) has been failing for weeks — only the **E2E Smoke Tests** job, which runs *only* on the nightly schedule / manual dispatch / PRs labeled `e2e` (it is skipped on normal push & PR events, which is why every recent PR merged green and nobody noticed).

**Root cause:** the backend container crash-loops on boot:

```
Invalid environment configuration:
  DASHBOARD_PASSWORD: weak dashboard password is not allowed
    at validateDashboardCredentials (packages/core/src/config/index.ts)
```

The E2E job set `DASHBOARD_PASSWORD: changeme12345`, which is on the backend's `WEAK_DASHBOARD_PASSWORDS` blocklist, and the container runs with `NODE_ENV=production` (so the validation is active). The unhealthy backend then blocks `frontend` (`depends_on: { backend: healthy }`), so `docker compose up --wait` exits 1 **before Playwright ever runs** (the run uploads no `playwright-report`). The databases were all healthy — confirmed via the captured `e2e-compose-logs` artifact.

This was a latent contradiction: the CI test password was itself on the blocklist the app enforces. Not caused by any recent feature merge (it fails across many unrelated SHAs).

## Fix

Replace the test password in all **three** places with `e2e-Sm0ke!Pw-7x2qD`:
- `e2e` job → `DASHBOARD_PASSWORD` (the one that crashed the backend)
- `test-backend` job → `DASHBOARD_PASSWORD` (consistency; that job runs `NODE_ENV=test` so it wasn't failing)
- `Run E2E tests` step → `E2E_PASSWORD` (**must** equal `DASHBOARD_PASSWORD` — it's the credential Playwright logs in with)

The new value satisfies every rule in `validateDashboardCredentials`, verified against the real `shannonEntropy()` helper:

| Check | Result |
|---|---|
| length ≥ 12 (`env.schema.ts`) | 18 ✓ |
| not in `WEAK_DASHBOARD_PASSWORDS` | ✓ |
| Shannon entropy ≥ 2.5 bits/char | 3.68 ✓ |

Also added a comment on the `e2e` job env explaining the `NODE_ENV=production` blocklist constraint so this doesn't regress.

## Verification

- New password passes the real validation; old `changeme12345` provably fails (blocklisted).
- YAML validated; pre-push hook (typecheck + full frontend suite) green.
- **This PR carries the `e2e` label so the E2E Smoke Tests job runs against the fix** — the real proof is that job going green here.

No app-code change; CI-config only.