### PR TITLE
refactor(security): remove decorative GIF from Vulnerability Management page

### DIFF
--- a/frontend/src/features/security/pages/harbor-vulnerabilities.test.tsx
+++ b/frontend/src/features/security/pages/harbor-vulnerabilities.test.tsx
@@ -133,6 +133,14 @@ describe('HarborVulnerabilitiesPage', () => {
     expect(screen.getByText('Sync Now')).toBeInTheDocument();
   });
 
+  it('does not render a decorative gif image on the summary cards', () => {
+    const { container } = render(<HarborVulnerabilitiesPage />);
+    // No <img> elements should be rendered on the page at all.
+    expect(container.querySelector('img')).toBeNull();
+    // And nothing should point at the previously hard-coded animated gif.
+    expect(container.querySelector('img[src*=".gif"]')).toBeNull();
+  });
+
   it('shows search input', () => {
     render(<HarborVulnerabilitiesPage />);
     expect(screen.getByPlaceholderText(/Search by CVE/)).toBeInTheDocument();

--- a/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
+++ b/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
@@ -256,7 +256,6 @@ export default function HarborVulnerabilitiesPage() {
             icon={ShieldAlert}
             className="text-red-600 dark:text-red-400"
             highlight={summary.critical > 0}
-            gif="https://media1.tenor.com/m/hwTQtfoXjB8AAAAC/wewew-minions.gif"
           />
           <SummaryCard
             label="In-Use Critical"
@@ -381,14 +380,12 @@ function SummaryCard({
   icon: Icon,
   className,
   highlight,
-  gif,
 }: {
   label: string;
   value: number;
   icon: React.ComponentType<{ className?: string }>;
   className?: string;
   highlight?: boolean;
-  gif?: string;
 }) {
   return (
     <SpotlightCard className="h-full">
@@ -398,18 +395,11 @@ function SummaryCard({
           highlight && 'border-red-500/30 bg-red-500/5',
         )}
       >
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex-1">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-muted-foreground">{label}</p>
-              <Icon className={cn('h-5 w-5', className)} />
-            </div>
-            <p className={cn('mt-2 text-3xl font-bold tracking-tight', className)}>{value.toLocaleString()}</p>
-          </div>
-          {gif && (
-            <img src={gif} alt="" aria-hidden="true" className="h-12 w-12 rounded object-cover shrink-0" />
-          )}
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
+          <Icon className={cn('h-5 w-5', className)} />
         </div>
+        <p className={cn('mt-2 text-3xl font-bold tracking-tight', className)}>{value.toLocaleString()}</p>
       </div>
     </SpotlightCard>
   );


### PR DESCRIPTION
## Summary

Removes the decorative animated GIF shown on the **Vulnerability Management** (Harbor) page.

The GIF was a hard-coded **remote Tenor URL** (an animated minions GIF) passed via the `gif` prop to the page's local `SummaryCard` helper, rendered only on the "Critical" summary card — not a polished fit for a security dashboard.

## Changes

- `frontend/src/features/security/pages/harbor-vulnerabilities.tsx`
  - Removed the `gif="https://media1.tenor.com/.../wewew-minions.gif"` prop on the Critical card.
  - Removed the `<img src={gif} … />` element and the now-unused `gif?: string` prop from the `SummaryCard` destructure/type.
  - Collapsed the wrapper layout that existed only to seat the value next to the GIF, restoring `SummaryCard` to the same label/icon-row + value layout the other cards use.
- **No asset file deleted** — the GIF was an inline remote URL, not a local asset (repo-wide grep for the filename/ID and `find … -name '*.gif'` both return zero after the change).

## Tests

- `frontend/src/features/security/pages/harbor-vulnerabilities.test.tsx` — added `"does not render a decorative gif image on the summary cards"` asserting no `<img>` / `img[src*=".gif"]` renders. (No prior test asserted the GIF's presence.)

## Verification

- `npm run lint -w frontend` — clean
- `npm run typecheck -w frontend` — clean
- `npx vitest run src/features/security/pages/harbor-vulnerabilities.test.tsx` — **15/15 pass**

Frontend-only change; no backend, env, or API surface affected.