### PR TITLE
fix(auth): do not prefill username/password on the login form

### DIFF
--- a/frontend/src/features/core/pages/login.test.tsx
+++ b/frontend/src/features/core/pages/login.test.tsx
@@ -82,10 +82,21 @@ describe('LoginPage', () => {
 
     expect(screen.getByTestId('login-gradient')).toBeInTheDocument();
     expect(screen.getByText(/Powered by AI/i)).toBeInTheDocument();
-    expect(screen.getByLabelText('Username')).toHaveValue('admin');
-    expect(screen.getByLabelText('Password')).toHaveValue('changeme123');
+    expect(screen.getByLabelText('Username')).toHaveValue('');
+    expect(screen.getByLabelText('Password')).toHaveValue('');
     expect(document.querySelectorAll('.login-particle')).toHaveLength(10);
     expect(screen.getByRole('img', { name: 'Brain logo' })).toBeInTheDocument();
+  });
+
+  it('renders the username and password fields empty on initial render', () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/username/i)).toHaveValue('');
+    expect(screen.getByLabelText(/password/i)).toHaveValue('');
   });
 
   it('respects reduced motion by disabling decorative particles', () => {

--- a/frontend/src/features/core/pages/login.tsx
+++ b/frontend/src/features/core/pages/login.tsx
@@ -45,8 +45,8 @@ export default function LoginPage() {
   const potatoMode = useUiStore((state) => state.potatoMode);
   const prefersReducedMotion = usePrefersReducedMotion();
   const reducedMotion = prefersReducedMotion || potatoMode;
-  const [username, setUsername] = useState("admin");
-  const [password, setPassword] = useState("changeme123");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitState, setSubmitState] = useState<"idle" | "loading" | "success">("idle");
   const [showPostLoginLoading, setShowPostLoginLoading] = useState(false);


### PR DESCRIPTION
## Summary

The login form shipped with its username and password inputs **pre-populated with default credentials** (`admin` / `changeme123`) as the initial field values. This is poor security hygiene — a login form should start empty so default credentials aren't suggested/submitted by accident.

## Changes

- `frontend/src/features/core/pages/login.tsx` — the two `useState` seeds now start empty:
  ```diff
  - const [username, setUsername] = useState("admin");
  - const [password, setPassword] = useState("changeme123");
  + const [username, setUsername] = useState("");
  + const [password, setPassword] = useState("");
  ```
  Inputs stay controlled; submit logic, validation, labels, and styling are unchanged. The defaults were plain `useState` seeds (not env/constant/form-library derived), so nothing else needed removing. Confirmed this is the only login form in `frontend/src`.

## Tests

- `frontend/src/features/core/pages/login.test.tsx`
  - Updated the existing render test (`toHaveValue('admin')`/`'changeme123'` → `toHaveValue('')`).
  - Added `"renders the username and password fields empty on initial render"`.
  - The submit-flow tests already type credentials explicitly via `fireEvent.change`, so they remain valid.

## Verification

- `npm run lint -w frontend` — clean
- `npm run typecheck -w frontend` — clean
- `npx vitest run src/features/core/pages/login.test.tsx` — **7/7 pass**

Frontend-only change; no backend, env, or API surface affected.