### PR TITLE
fix(llm-obs): widen KPI card spacing to gap-6

### DIFF
--- a/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
@@ -117,6 +117,38 @@ describe('LlmObservabilityPage', () => {
     expect(screen.getByText('Error Rate')).toBeTruthy();
   });
 
+  it('spaces the KPI cards with a gap-6 grid', () => {
+    vi.mocked(useLlmStats).mockReturnValue({
+      data: mockStats,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as ReturnType<typeof useLlmStats>);
+
+    const { container } = renderPage();
+    // The KPI grid wraps the four metric cards; it must use the wider gap-6
+    // spacing so the cards are not cramped together (gap-4 was too tight).
+    const grids = container.querySelectorAll('div.grid.md\\:grid-cols-4');
+    expect(grids.length).toBeGreaterThan(0);
+    grids.forEach((grid) => {
+      expect(grid.className).toContain('gap-6');
+      expect(grid.className).not.toContain('gap-4');
+    });
+  });
+
+  it('spaces the loading skeleton KPI grid with the same gap-6', () => {
+    vi.mocked(useLlmStats).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useLlmStats>);
+
+    const { container } = renderPage();
+    const grid = container.querySelector('div.grid.md\\:grid-cols-4');
+    expect(grid).not.toBeNull();
+    expect(grid?.className).toContain('gap-6');
+    expect(grid?.className).not.toContain('gap-4');
+  });
+
   it('renders model breakdown table with data', () => {
     vi.mocked(useLlmStats).mockReturnValue({
       data: mockStats,

--- a/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
@@ -252,14 +252,14 @@ export default function LlmObservabilityPage() {
 
       {/* KPI Cards */}
       {showStatsSkeleton ? (
-        <div className="grid gap-4 md:grid-cols-4">
+        <div className="grid gap-6 md:grid-cols-4">
           <SkeletonKpi />
           <SkeletonKpi />
           <SkeletonKpi />
           <SkeletonKpi />
         </div>
       ) : (
-        <div className="grid gap-4 md:grid-cols-4">
+        <div className="grid gap-6 md:grid-cols-4">
           <TiltCard>
             <KpiCard
               label="Total Queries"


### PR DESCRIPTION
## What

Increases the spacing between the four KPI cards (Total Queries, Total Tokens, Avg Latency, Error Rate) on the **LLM Observability** page. They were cramped together with `gap-4`.

## Change

In `frontend/src/features/ai-intelligence/pages/llm-observability.tsx`, both the loaded KPI grid and the loading-skeleton grid go from `gap-4` → `gap-6`:

- `grid gap-4 md:grid-cols-4` → `grid gap-6 md:grid-cols-4` (skeleton)
- `grid gap-4 md:grid-cols-4` → `grid gap-6 md:grid-cols-4` (cards)

`gap-6` is the established wider grid gap already used across the dashboard (Settings, Reports, Metrics), so the cards now breathe while staying visually consistent with the rest of the UI.

## Tests

Two new tests in `llm-observability.test.tsx` assert the KPI grid (and skeleton grid) carry `gap-6` and not `gap-4`. Full frontend suite green.

- `npx vitest run` (page file): 12/12 pass
- `npm run lint -w frontend`: clean
- `npm run typecheck -w frontend`: clean
- pre-push full suite: 2122/2122 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)