### PR TITLE
fix(security-audit): invalidate audit cache when ignore list changes

### DIFF
--- a/packages/security/src/__tests__/security-audit.test.ts
+++ b/packages/security/src/__tests__/security-audit.test.ts
@@ -377,3 +377,33 @@ describe('security-audit service', () => {
     expect(resolveAuditSeverity([{ severity: 'critical', category: 'x', title: 'x', description: 'x' }])).toBe('critical');
   });
 });
+
+// Separate block: uses the REAL cache (the suite above mocks cachedFetch away).
+describe('setSecurityAuditIgnoreList — cache invalidation (Home "Security Findings" KPI staleness)', () => {
+  beforeEach(async () => {
+    await cache.clear();
+    vi.restoreAllMocks();
+    mockGetSetting.mockResolvedValue(undefined);
+    mockSetSetting.mockResolvedValue(undefined);
+  });
+
+  it('busts every cached security-audit entry so the next read recomputes ignored flags', async () => {
+    // A prior audit run cached its entries with each `ignored` flag baked in,
+    // under the fleet-wide ('all') key and a per-endpoint key. The Home
+    // "Security Findings" KPI (/api/dashboard/summary) reads from these.
+    const allKey = portainerCache.getCacheKey('security-audit', 'all');
+    const endpointKey = portainerCache.getCacheKey('security-audit', 1);
+    await cache.set(allKey, [{ containerName: 'foo', ignored: false }], 300);
+    await cache.set(endpointKey, [{ containerName: 'foo', ignored: false }], 300);
+    expect(await cache.get(allKey)).toBeDefined();
+    expect(await cache.get(endpointKey)).toBeDefined();
+
+    // Admin adds 'foo' to the ignore list.
+    await setSecurityAuditIgnoreList(['foo']);
+
+    // Both cached audits must be cleared — otherwise the KPI keeps counting
+    // 'foo' for up to SECURITY_AUDIT_TTL (5 min) after it was ignored.
+    expect(await cache.get(allKey)).toBeUndefined();
+    expect(await cache.get(endpointKey)).toBeUndefined();
+  });
+});

--- a/packages/security/src/services/security-audit.ts
+++ b/packages/security/src/services/security-audit.ts
@@ -1,5 +1,5 @@
 import { getEndpoints, getContainers, getContainerHostConfig } from '@dashboard/core/portainer/portainer-client.js';
-import { cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
+import { cache, cachedFetch, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { type Container, isDockerEndpoint } from '@dashboard/core/models/portainer.js';
 import { getSetting, setSetting } from '@dashboard/core/services/settings-store.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
@@ -133,6 +133,14 @@ export async function setSecurityAuditIgnoreList(patterns: string[]): Promise<st
     .filter((value) => value.length > 0);
 
   await setSetting(SECURITY_AUDIT_IGNORE_KEY, JSON.stringify(cleaned), 'security');
+
+  // Each entry's `ignored` flag is baked in when the audit is computed and the
+  // whole result is cached for SECURITY_AUDIT_TTL (5 min). Without busting that
+  // cache here, the Home "Security Findings" KPI and the Audit page keep
+  // counting now-ignored containers until the TTL expires. Pattern-invalidate
+  // every variant (`security-audit:all` + per-endpoint `security-audit:<id>`).
+  await cache.invalidatePattern('security-audit').catch(() => undefined);
+
   return cleaned;
 }
 


### PR DESCRIPTION
## Problem

The Home **Security Findings** KPI keeps counting containers that are in the ignore list.

The data path is otherwise correct: Home reads `security.flagged` (`home.tsx:150`), and `buildSecurityAuditSummary` correctly computes `flagged` as *findings present **and** not ignored* (tested at `security-audit.test.ts:376`). The defect is **cache coherence**:

- Each entry's `ignored` flag is computed **once**, when the audit runs (`security-audit.ts:235`), and the whole result is cached for 5 min (`SECURITY_AUDIT_TTL = 300`) under `security-audit:all` / `security-audit:<id>`.
- `PUT /api/security/ignore-list` (`monitoring.ts:602`) wrote the new patterns to settings but **never invalidated that cache** — there was no `security-audit:*` invalidation anywhere in the repo.

Result: after an admin adds a container/pattern to the ignore list, the Home KPI (and the Security Audit page, which shares the same cached audit) keeps counting now-ignored containers until the TTL expires. A full page reload doesn't help — it re-hits the same cached audit.

## Fix

Bust the `security-audit:*` cache inside `setSecurityAuditIgnoreList`, right after persisting the new list. Colocating the invalidation with the mutation means **every** caller (the route today, any future caller) is correct, and the next audit read recomputes `ignored` flags immediately. Mirrors the existing pattern in `incidents.ts` (`cache.invalidatePattern('incidents-groups').catch(...)`).

## Test

New regression test in `packages/security/src/__tests__/security-audit.test.ts` (in a separate block that uses the **real** cache — the existing suite mocks `cachedFetch` away). It seeds the fleet-wide and a per-endpoint `security-audit:*` entry, calls `setSecurityAuditIgnoreList`, and asserts both are cleared. Verified red→green (fails without the fix).

- `packages/security` suite: 21/21 pass
- Full `npm run typecheck`: clean
- Pre-push hook ran the full suite: 2120/2120 pass

## Notes

- No env var / architecture / public-contract changes, so `docs/architecture.md` / `docker/.env.example` / `CLAUDE.md` need no updates.
- **Follow-up (not in this PR):** the default ignore patterns `portainer`, `portainer_edge_agent`, `traefik` are exact-match, so Compose/stack-deployed infra (e.g. `proxy-traefik-1`) won't match and persistently counts. Broadening these to wildcards changes security posture (risk of false negatives), so it's left as a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)