### PR TITLE
fix(topology): offset network legend clear of the diagram controls

### DIFF
--- a/frontend/src/features/containers/components/network/topology-legend.test.tsx
+++ b/frontend/src/features/containers/components/network/topology-legend.test.tsx
@@ -8,6 +8,19 @@ describe('TopologyLegend', () => {
     expect(screen.getByRole('button', { name: /legend/i })).toBeTruthy();
   });
 
+  it('positions clear of the diagram controls (offset right and down)', () => {
+    // The React Flow zoom controls sit in the bottom-left corner; the legend
+    // must be offset right and toward the bottom so it does not overlap them.
+    const { container } = render(<TopologyLegend />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain('absolute');
+    expect(wrapper.className).toContain('left-16');
+    expect(wrapper.className).toContain('bottom-4');
+    // Guard against regressing onto the controls' bottom-left position.
+    expect(wrapper.className).not.toContain('left-3');
+    expect(wrapper.className).not.toContain('bottom-14');
+  });
+
   it('hides legend entries by default', () => {
     render(<TopologyLegend />);
     expect(screen.queryByText('Edge Load')).toBeNull();

--- a/frontend/src/features/containers/components/network/topology-legend.tsx
+++ b/frontend/src/features/containers/components/network/topology-legend.tsx
@@ -13,7 +13,7 @@ export function TopologyLegend() {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="absolute bottom-14 left-3 z-10">
+    <div className="absolute bottom-4 left-16 z-10">
       {open && (
         <div className="mb-2 rounded-lg border bg-card/95 backdrop-blur-sm p-3 shadow-lg">
           <p className="text-xs font-semibold text-foreground mb-2">Edge Load</p>


### PR DESCRIPTION
## Problem

On the Network Topology diagram, the **Edge Load** legend (`absolute bottom-14 left-3`) overlapped the React Flow zoom controls, which default to the **bottom-left** corner — so the legend sat on top of the controls.

## Fix

Move the legend right and down to `bottom-4 left-16` so it sits beside the controls instead of over them:
- `left-16` (64px) clears the ~40px-wide control column.
- `bottom-4` drops it to the controls' baseline.

## Test

Added a position-regression test in `topology-legend.test.tsx` asserting the wrapper uses `left-16`/`bottom-4` and guarding against regressing to the old overlapping `left-3`/`bottom-14`.

- Topology-legend suite: 5/5 pass
- Frontend typecheck + lint: clean

Pure styling change — no behavioral or data impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)