### PR TITLE
feat(system-info): show key component versions in General tab

### DIFF
--- a/backend/src/routes/security-regression-auth.test.ts
+++ b/backend/src/routes/security-regression-auth.test.ts
@@ -259,6 +259,7 @@ import {
   networksRoutes,
   searchRoutes,
   cacheAdminRoutes,
+  systemInfoRoutes,
   userRoutes,
 } from '@dashboard/foundation';
 import {
@@ -362,6 +363,7 @@ async function buildFullApp(): Promise<{ app: FastifyInstance; registeredRoutes:
   await app.register(searchRoutes);
   await app.register(notificationRoutes);
   await app.register(cacheAdminRoutes);
+  await app.register(systemInfoRoutes, { appVersion: 'test-version' });
   const mockLlm: LLMInterface = { isAvailable: vi.fn(), chatStream: vi.fn(), getEffectivePrompt: vi.fn(), buildInfrastructureContext: vi.fn() };
   await app.register(securityRoutes, { llm: mockLlm });
   await app.register(webhookRoutes);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -202,6 +202,7 @@ See [AI & Anomaly Detection](ai-anomaly-detection.md) for detector semantics and
 | `POST` | `/api/users` | [ADMIN] | Create a user |
 | `PATCH` | `/api/users/:id` | [ADMIN] | Update a user |
 | `DELETE` | `/api/users/:id` | [ADMIN] | Delete a user (cannot delete self) |
+| `GET` | `/api/admin/system-info` | [ADMIN] | Key component versions (app, Node.js, Fastify) shown in Settings → General |
 | `GET` | `/api/admin/cache/stats` | [ADMIN] | Cache statistics + active entries |
 | `POST` | `/api/admin/cache/clear` | [ADMIN] | Clear all cache entries |
 | `POST` | `/api/admin/cache/invalidate` | [ADMIN] | Invalidate cache by resource pattern |

--- a/docs/superpowers/specs/2026-06-02-system-info-component-versions-design.md
+++ b/docs/superpowers/specs/2026-06-02-system-info-component-versions-design.md
@@ -1,0 +1,90 @@
+# System Information: show key component versions
+
+**Date:** 2026-06-02
+**Status:** Approved (design)
+
+## Problem
+
+The General settings tab has a **System Information** section, but its values
+are hardcoded and stale (`tab-general.tsx`):
+
+- `Application: Docker Insight`
+- `Version: 1.0.0` (the real version is `2.0.0`)
+- `Mode: Observer Only`
+- plus a live `Theme` and `Redis Cache` card.
+
+There is no backend system-info endpoint, and nothing reads `process.version`.
+Operators can't see which runtime/framework versions the dashboard is running.
+
+## Goal
+
+Show key component versions in the System Information panel: **Node.js**, the
+**app version**, **Fastify**, and **React**. Scope is runtime + app + framework
+only — no live PostgreSQL/TimescaleDB/Redis/Docker queries, no OS/uptime.
+
+## Design
+
+### Authoritative sources
+
+Each version comes from where it is actually known:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `node` | `process.versions.node` (backend) | exact running version |
+| `fastify` | the Fastify instance's `.version` (backend) | exact |
+| `app` | composition-root `package.json` `version` (backend) | single source of truth (`2.0.0`); fixes the stale `1.0.0` |
+| React | `React.version` (frontend, client-side) | exact running version; no backend round-trip |
+
+### Backend — `GET /api/admin/system-info`
+
+New route file `packages/foundation/src/routes/system-info.ts`.
+
+- **Admin-gated:** `preHandler: [fastify.authenticate, fastify.requireRole('admin')]`,
+  consistent with `/api/admin/cache/stats` (which the same tab already calls).
+  Version strings are mild infrastructure disclosure, so admin-only per the
+  security checklist.
+- Plugin signature `systemInfoRoutes(fastify, opts: { appVersion: string })`,
+  matching the existing options-object pattern (`monitoringRoutes`,
+  `correlationRoutes`). The composition root reads its own `package.json`
+  version once at startup and passes it in (Approach A — no new env var).
+- Returns a Zod-validated body:
+  ```ts
+  SystemInfoResponseSchema = z.object({
+    app: z.string(),
+    node: z.string(),
+    fastify: z.string(),
+  })
+  ```
+  Values: `{ app: opts.appVersion, node: process.versions.node, fastify: fastify.version }`.
+
+### Frontend — `useSystemInfo()` hook
+
+`frontend/src/features/core/hooks/use-system-info.ts` — React Query against
+`/api/admin/system-info`, long `staleTime` (versions don't change mid-session).
+Graceful: `—` while loading, `unknown` on error.
+
+### Frontend — `GeneralTab` System Information cards
+
+- Replace hardcoded `Version 1.0.0` → `app` from the hook.
+- Add cards: **Node.js**, **Fastify**, **React** (`React.version`, client-side).
+- Keep Application / Mode / Theme / Redis Cache.
+
+## Testing
+
+- `packages/foundation/src/__tests__/system-info-route.test.ts`: returns
+  `app`/`node`/`fastify`; `app` echoes the injected `appVersion`; `node`/`fastify`
+  are non-empty. The existing auth-enforcement sweep already asserts the route
+  rejects unauthenticated requests; admin-gating verified there.
+- Frontend: `use-system-info` hook test (fetch shape) + `tab-general` renders
+  the Node.js / Fastify / React / app-version cards.
+
+## Docs
+
+- `docs/api-reference.md` — add the `/api/admin/system-info` row.
+- No `.env.example` change (Approach A reads package.json; no new env var).
+
+## Non-goals
+
+- Live PostgreSQL / TimescaleDB / Redis / Docker / Portainer version queries.
+- OS / platform / arch / uptime.
+- Per-dependency version inventory beyond the four named components.

--- a/frontend/src/features/core/components/settings/tab-general.test.tsx
+++ b/frontend/src/features/core/components/settings/tab-general.test.tsx
@@ -1,17 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GeneralTab } from './tab-general';
 
 const cacheStatsRef: { data: unknown } = { data: undefined };
+const systemInfoRef: { data: unknown } = { data: undefined };
 
 vi.mock('@/features/core/hooks/use-cache-admin', () => ({
   useCacheStats: () => cacheStatsRef,
   useCacheClear: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
+vi.mock('@/features/core/hooks/use-system-info', () => ({
+  useSystemInfo: () => systemInfoRef,
+}));
+
 beforeEach(() => {
   cacheStatsRef.data = undefined;
+  systemInfoRef.data = undefined;
 });
 
 function renderTab() {
@@ -34,6 +41,38 @@ describe('GeneralTab — caching model note (#1312)', () => {
     expect(note).toHaveTextContent(/clicking/i);
     expect(note).toHaveTextContent(/refresh/i);
     expect(note).toHaveTextContent(/non-admin clicks fall back to a plain refresh/i);
+  });
+});
+
+describe('GeneralTab — system component versions', () => {
+  it('shows Node.js, Fastify, React and the real app version', () => {
+    systemInfoRef.data = { app: '2.0.0', node: '22.11.0', fastify: '5.8.5' };
+
+    renderTab();
+
+    // App version comes from the backend (replaces the old hardcoded 1.0.0).
+    expect(screen.getByText('2.0.0')).toBeInTheDocument();
+    expect(screen.queryByText('1.0.0')).not.toBeInTheDocument();
+
+    // Node.js + Fastify cards (label + value).
+    expect(screen.getByText('Node.js')).toBeInTheDocument();
+    expect(screen.getByText('22.11.0')).toBeInTheDocument();
+    expect(screen.getByText('Fastify')).toBeInTheDocument();
+    expect(screen.getByText('5.8.5')).toBeInTheDocument();
+
+    // React version is reported client-side.
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText(React.version)).toBeInTheDocument();
+  });
+
+  it('renders a placeholder while versions are loading', () => {
+    systemInfoRef.data = undefined;
+
+    renderTab();
+
+    // Node.js / Fastify / app version fall back to an em dash until loaded.
+    expect(screen.getByText('Node.js')).toBeInTheDocument();
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/frontend/src/features/core/components/settings/tab-general.tsx
+++ b/frontend/src/features/core/components/settings/tab-general.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useMemo, version as reactVersion } from 'react';
 import { type ColumnDef } from '@tanstack/react-table';
 import { Loader2, RefreshCw, Settings2 } from 'lucide-react';
 import { DataTable } from '@/shared/components/tables/data-table';
 import { useCacheStats, useCacheClear } from '@/features/core/hooks/use-cache-admin';
+import { useSystemInfo } from '@/features/core/hooks/use-system-info';
 
 interface CacheEntryRow {
   key: string;
@@ -40,6 +41,7 @@ interface GeneralTabProps {
 
 export function GeneralTab({ theme }: GeneralTabProps) {
   const { data: cacheStats } = useCacheStats();
+  const { data: systemInfo } = useSystemInfo();
   const cacheClear = useCacheClear();
   const redisSystemInfo = getRedisSystemInfo(cacheStats);
 
@@ -92,11 +94,23 @@ export function GeneralTab({ theme }: GeneralTabProps) {
           </div>
           <div className="rounded-lg bg-muted/50 p-4">
             <p className="text-xs text-muted-foreground">Version</p>
-            <p className="font-medium mt-1">1.0.0</p>
+            <p className="font-medium mt-1">{systemInfo?.app ?? '—'}</p>
           </div>
           <div className="rounded-lg bg-muted/50 p-4">
             <p className="text-xs text-muted-foreground">Mode</p>
             <p className="font-medium mt-1">Observer Only</p>
+          </div>
+          <div className="rounded-lg bg-muted/50 p-4">
+            <p className="text-xs text-muted-foreground">Node.js</p>
+            <p className="font-medium mt-1">{systemInfo?.node ?? '—'}</p>
+          </div>
+          <div className="rounded-lg bg-muted/50 p-4">
+            <p className="text-xs text-muted-foreground">Fastify</p>
+            <p className="font-medium mt-1">{systemInfo?.fastify ?? '—'}</p>
+          </div>
+          <div className="rounded-lg bg-muted/50 p-4">
+            <p className="text-xs text-muted-foreground">React</p>
+            <p className="font-medium mt-1">{reactVersion}</p>
           </div>
           <div className="rounded-lg bg-muted/50 p-4">
             <p className="text-xs text-muted-foreground">Theme</p>

--- a/frontend/src/features/core/hooks/use-system-info.test.ts
+++ b/frontend/src/features/core/hooks/use-system-info.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { useSystemInfo } from './use-system-info';
+
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+import { api } from '@/shared/lib/api';
+
+const mockApi = vi.mocked(api);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('useSystemInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches component versions from /api/admin/system-info', async () => {
+    mockApi.get.mockResolvedValue({ app: '2.0.0', node: '22.11.0', fastify: '5.8.5' });
+
+    const { result } = renderHook(() => useSystemInfo(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockApi.get).toHaveBeenCalledWith('/api/admin/system-info');
+    expect(result.current.data).toEqual({ app: '2.0.0', node: '22.11.0', fastify: '5.8.5' });
+  });
+});

--- a/frontend/src/features/core/hooks/use-system-info.ts
+++ b/frontend/src/features/core/hooks/use-system-info.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/shared/lib/api';
+
+/**
+ * Key component versions surfaced in the General → System Information panel.
+ * React's version is reported client-side (from `React.version`) and is not
+ * part of this payload.
+ */
+export interface SystemInfo {
+  app: string;
+  node: string;
+  fastify: string;
+}
+
+/**
+ * Fetch backend component versions. Versions don't change during a session, so
+ * the result is cached indefinitely (`staleTime: Infinity`) — no polling.
+ */
+export function useSystemInfo() {
+  return useQuery<SystemInfo>({
+    queryKey: ['admin', 'system-info'],
+    queryFn: () => api.get<SystemInfo>('/api/admin/system-info'),
+    staleTime: Infinity,
+  });
+}

--- a/packages/foundation/src/__tests__/system-info-route.test.ts
+++ b/packages/foundation/src/__tests__/system-info-route.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+import { systemInfoRoutes } from '../routes/system-info.js';
+
+describe('GET /api/admin/system-info', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('requireRole', () => async () => undefined);
+    await app.register(systemInfoRoutes, { appVersion: '9.9.9-test' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns the injected app version plus the running node and fastify versions', async () => {
+    const response = await app.inject({ method: 'GET', url: '/api/admin/system-info' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.app).toBe('9.9.9-test');
+    expect(body.node).toBe(process.versions.node);
+    expect(typeof body.fastify).toBe('string');
+    expect(body.fastify.length).toBeGreaterThan(0);
+  });
+
+  it('wires requireRole("admin") as a preHandler and denies when it rejects', async () => {
+    const rolesChecked: string[] = [];
+    const denyApp = Fastify({ logger: false });
+    denyApp.setValidatorCompiler(validatorCompiler);
+    denyApp.setSerializerCompiler(serializerCompiler);
+    denyApp.decorate('authenticate', async () => undefined);
+    denyApp.decorate('requireRole', (role: string) => {
+      rolesChecked.push(role);
+      return async (_req: unknown, reply: { code: (n: number) => { send: (b: unknown) => void } }) => {
+        reply.code(403).send({ error: 'forbidden' });
+      };
+    });
+    await denyApp.register(systemInfoRoutes, { appVersion: 'x' });
+    await denyApp.ready();
+
+    const response = await denyApp.inject({ method: 'GET', url: '/api/admin/system-info' });
+
+    expect(rolesChecked).toContain('admin');
+    expect(response.statusCode).toBe(403);
+    await denyApp.close();
+  });
+});

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -16,4 +16,6 @@ export { oidcRoutes } from './routes/oidc.js';
 export { searchRoutes } from './routes/search.js';
 export { settingsRoutes } from './routes/settings.js';
 export { stacksRoutes } from './routes/stacks.js';
+export { systemInfoRoutes } from './routes/system-info.js';
+export type { SystemInfoRoutesOpts } from './routes/system-info.js';
 export { userRoutes } from './routes/users.js';

--- a/packages/foundation/src/routes/system-info.ts
+++ b/packages/foundation/src/routes/system-info.ts
@@ -1,0 +1,43 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+
+export interface SystemInfoRoutesOpts {
+  /**
+   * Product version, read from the composition-root package.json at startup
+   * and passed in by the caller (the route itself does no filesystem access).
+   */
+  appVersion: string;
+}
+
+/**
+ * Key component versions surfaced in the General → System Information panel.
+ * Each value comes from its authoritative source: `app` is injected from the
+ * product package.json, `node`/`fastify` are read from the running process.
+ * React's version is reported client-side and is not part of this payload.
+ */
+const SystemInfoResponseSchema = z.object({
+  app: z.string(),
+  node: z.string(),
+  fastify: z.string(),
+});
+
+export async function systemInfoRoutes(
+  fastify: FastifyInstance,
+  opts: SystemInfoRoutesOpts,
+) {
+  // Admin-gated: version strings are mild infrastructure disclosure, so this
+  // matches the other /api/admin/* reads (e.g. cache stats).
+  fastify.get('/api/admin/system-info', {
+    schema: {
+      tags: ['System'],
+      summary: 'Key component versions (Node.js, app, Fastify)',
+      security: [{ bearerAuth: [] }],
+      response: { 200: SystemInfoResponseSchema },
+    },
+    preHandler: [fastify.authenticate, fastify.requireRole('admin')],
+  }, async () => ({
+    app: opts.appVersion,
+    node: process.versions.node,
+    fastify: fastify.version,
+  }));
+}

--- a/packages/server/src/__tests__/product-version.test.ts
+++ b/packages/server/src/__tests__/product-version.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { readProductVersion } from '../app.js';
+
+describe('readProductVersion', () => {
+  it('returns a non-empty semver string read from the working-dir package.json', () => {
+    const version = readProductVersion();
+    expect(typeof version).toBe('string');
+    expect(version.length).toBeGreaterThan(0);
+    // A real package.json version, not the "unknown" fallback.
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -27,6 +27,7 @@ import {
   networksRoutes,
   searchRoutes,
   cacheAdminRoutes,
+  systemInfoRoutes,
   userRoutes,
   kubernetesRoutes,
 } from '@dashboard/foundation';
@@ -135,6 +136,27 @@ export function resolveTrustProxy(value: string | undefined): boolean | string[]
   return valid;
 }
 
+/**
+ * Read the product version from the working-directory package.json.
+ *
+ * In dev the process runs from the repo root, and the Docker image sets
+ * WORKDIR `/app` where the product package.json is copied — both place the
+ * product version (2.0.0) at `process.cwd()/package.json`. (Resolving relative
+ * to this module would instead hit `packages/server/package.json`, which is
+ * versioned independently.) Falls back to `'unknown'` so a missing/unreadable
+ * file never blocks startup.
+ */
+export function readProductVersion(): string {
+  try {
+    const parsed = JSON.parse(readFileSync(`${process.cwd()}/package.json`, 'utf8')) as {
+      version?: unknown;
+    };
+    return typeof parsed.version === 'string' && parsed.version ? parsed.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
 export async function buildApp() {
   const isDev = process.env.NODE_ENV !== 'production';
   const app = Fastify({
@@ -202,6 +224,7 @@ export async function buildApp() {
   await app.register(networksRoutes);
   await app.register(searchRoutes);
   await app.register(cacheAdminRoutes);
+  await app.register(systemInfoRoutes, { appVersion: readProductVersion() });
   await app.register(userRoutes);
   await app.register(kubernetesRoutes);
 


### PR DESCRIPTION
## Summary

Adds live component versions to **Settings → General → System Information**, replacing hardcoded/stale values.

| Card | Source |
|------|--------|
| **Version** (app) | `/api/admin/system-info` → product `package.json` (now `2.0.0`, was hardcoded `1.0.0`) |
| **Node.js** | `process.versions.node` |
| **Fastify** | the running Fastify instance's `.version` |
| **React** | `React.version` (client-side) |

- New **admin-gated** `GET /api/admin/system-info` returning `{ app, node, fastify }` (`packages/foundation/src/routes/system-info.ts`), consistent with the other `/api/admin/*` reads.
- App version read via `process.cwd()/package.json` — resolves to the product `2.0.0` in both dev (repo root) and the Docker image (`WORKDIR /app`); falls back to `unknown` if unreadable. React's version is reported client-side (each version from its authoritative source).
- Cards degrade to `—` while loading.

## Scope
Runtime + app + frameworks only. Out of scope: live PostgreSQL/TimescaleDB/Redis/Docker version queries, OS/uptime.

## Changes
- `packages/foundation/src/routes/system-info.ts` (+ barrel export) — the endpoint
- `packages/server/src/app.ts` — `readProductVersion()` helper + route registration
- `frontend/.../hooks/use-system-info.ts` — React Query hook
- `frontend/.../settings/tab-general.tsx` — version cards
- Docs: `docs/api-reference.md`, design spec under `docs/superpowers/specs/`

## Tests
- Route contract + admin-gating; `readProductVersion` helper; `useSystemInfo` hook; `tab-general` version cards (incl. loading `—`); new route added to the auth-enforcement sweep.
- server 48 · foundation 21 · backend-regression 32 · frontend 78 — all green; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)