### PR TITLE
fix(system-info): bake product version at build (app showed 1.0.0 in Docker)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,6 +34,11 @@ COPY backend/src/ backend/src/
 RUN npm run build -w backend
 COPY packages/server/ ./packages/server/
 RUN npm run build -w @dashboard/server
+# Bake the product version (root package.json) into the server dist. The runtime
+# image ships @dashboard/server's package.json as /app/package.json (for ESM
+# resolution, see runtime stage), so the product version can't be read from cwd
+# — readProductVersion() reads this baked file instead.
+RUN node -e "require('fs').writeFileSync('packages/server/dist/product-version', require('./package.json').version)"
 
 # Separate stage to build production dependencies with native bindings
 FROM dhi.io/node:24-alpine3.23-dev AS prod-deps

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -3,6 +3,11 @@ DASHBOARD_USERNAME=dashboard-admin
 DASHBOARD_PASSWORD=replace-with-strong-random-password
 JWT_SECRET=generate-a-random-64-char-string
 
+# Optional: override the product version shown in Settings → General → System
+# Information. Normally unset — the Docker build bakes the real version into the
+# image automatically; set this only to override it.
+# APP_VERSION=2.0.0
+
 # JWT signing algorithm (default: HS256)
 # HS256 is recommended for single-service deployments. Switch to RS256 or ES256
 # only when multiple services need independent token verification, or when

--- a/docs/superpowers/specs/2026-06-02-system-info-component-versions-design.md
+++ b/docs/superpowers/specs/2026-06-02-system-info-component-versions-design.md
@@ -83,6 +83,22 @@ Graceful: `—` while loading, `unknown` on error.
 - `docs/api-reference.md` — add the `/api/admin/system-info` row.
 - No `.env.example` change (Approach A reads package.json; no new env var).
 
+## Correction (post-merge): app version in the Docker runtime
+
+The original "read `process.cwd()/package.json`" plan was **wrong for the
+production image**. The runtime stage intentionally ships
+`@dashboard/server`'s `package.json` (version `1.0.0`) as `/app/package.json`
+for ESM module resolution (see `backend/Dockerfile`), and the product root
+`package.json` (`2.0.0`) is never copied in — so `cwd/package.json` yielded
+`1.0.0`. Caught by running the rebuilt image and hitting
+`GET /api/admin/system-info` (returned `"app":"1.0.0"`).
+
+Fix: the Docker build **bakes** the product version into the server dist
+(`packages/server/dist/product-version`), read at runtime relative to the
+module. Resolution cascade (`resolveProductVersion`, pure + unit-tested):
+`APP_VERSION` env override → baked file (prod) → `cwd/package.json` (dev) →
+`'unknown'`.
+
 ## Non-goals
 
 - Live PostgreSQL / TimescaleDB / Redis / Docker / Portainer version queries.

--- a/packages/server/src/__tests__/product-version.test.ts
+++ b/packages/server/src/__tests__/product-version.test.ts
@@ -1,12 +1,52 @@
-import { describe, it, expect } from 'vitest';
-import { readProductVersion } from '../app.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import { readProductVersion, resolveProductVersion } from '../app.js';
+
+describe('resolveProductVersion (pure cascade)', () => {
+  it('prefers the APP_VERSION env override above all', () => {
+    expect(
+      resolveProductVersion({ env: '3.1.4', bakedFile: '2.0.0', cwdPackageVersion: '1.0.0' }),
+    ).toBe('3.1.4');
+  });
+
+  it('uses the build-baked version file when no env override is set', () => {
+    // The runtime Docker image ships @dashboard/server's package.json (1.0.0) as
+    // /app/package.json, so the product version must come from the baked file.
+    expect(
+      resolveProductVersion({ bakedFile: '2.0.0', cwdPackageVersion: '1.0.0' }),
+    ).toBe('2.0.0');
+  });
+
+  it('falls back to the working-dir package.json (dev) when nothing is baked', () => {
+    expect(resolveProductVersion({ cwdPackageVersion: '2.0.0' })).toBe('2.0.0');
+  });
+
+  it('returns "unknown" when no source is available', () => {
+    expect(resolveProductVersion({})).toBe('unknown');
+  });
+
+  it('ignores blank/whitespace sources and continues the cascade', () => {
+    expect(
+      resolveProductVersion({ env: '   ', bakedFile: '', cwdPackageVersion: '2.0.0' }),
+    ).toBe('2.0.0');
+  });
+});
 
 describe('readProductVersion', () => {
-  it('returns a non-empty semver string read from the working-dir package.json', () => {
+  const original = process.env.APP_VERSION;
+  afterEach(() => {
+    if (original === undefined) delete process.env.APP_VERSION;
+    else process.env.APP_VERSION = original;
+  });
+
+  it('honors the APP_VERSION env override', () => {
+    process.env.APP_VERSION = '9.9.9-from-env';
+    expect(readProductVersion()).toBe('9.9.9-from-env');
+  });
+
+  it('returns a non-empty semver string from the filesystem when env is unset', () => {
+    delete process.env.APP_VERSION;
     const version = readProductVersion();
     expect(typeof version).toBe('string');
-    expect(version.length).toBeGreaterThan(0);
-    // A real package.json version, not the "unknown" fallback.
     expect(version).toMatch(/^\d+\.\d+\.\d+/);
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -137,24 +137,54 @@ export function resolveTrustProxy(value: string | undefined): boolean | string[]
 }
 
 /**
- * Read the product version from the working-directory package.json.
- *
- * In dev the process runs from the repo root, and the Docker image sets
- * WORKDIR `/app` where the product package.json is copied — both place the
- * product version (2.0.0) at `process.cwd()/package.json`. (Resolving relative
- * to this module would instead hit `packages/server/package.json`, which is
- * versioned independently.) Falls back to `'unknown'` so a missing/unreadable
- * file never blocks startup.
+ * Pure resolution cascade for the product version. Kept separate from the IO so
+ * every branch is unit-testable. First non-blank source wins:
+ *   1. `env`  — explicit `APP_VERSION` override (set at build/deploy time).
+ *   2. `bakedFile` — contents of the version file baked into the server dist by
+ *      the Docker build (the runtime image ships @dashboard/server's
+ *      package.json as /app/package.json, so the product version isn't in cwd).
+ *   3. `cwdPackageVersion` — version field of the working-dir package.json,
+ *      which is the product root in dev (the process runs from the repo root).
+ * Falls back to `'unknown'` so a missing source never blocks startup.
+ */
+export function resolveProductVersion(sources: {
+  env?: string;
+  bakedFile?: string;
+  cwdPackageVersion?: string;
+}): string {
+  const candidates = [sources.env, sources.bakedFile, sources.cwdPackageVersion];
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim();
+    if (trimmed) return trimmed;
+  }
+  return 'unknown';
+}
+
+/**
+ * Read the product version from its build/runtime sources (see
+ * {@link resolveProductVersion}). Each read is guarded so a missing file never
+ * throws during startup.
  */
 export function readProductVersion(): string {
+  let bakedFile: string | undefined;
+  try {
+    // Baked next to this module by the Docker build (see backend/Dockerfile).
+    bakedFile = readFileSync(new URL('./product-version', import.meta.url), 'utf8');
+  } catch {
+    /* not baked (e.g. local dev) — fall through to the cwd package.json */
+  }
+
+  let cwdPackageVersion: string | undefined;
   try {
     const parsed = JSON.parse(readFileSync(`${process.cwd()}/package.json`, 'utf8')) as {
       version?: unknown;
     };
-    return typeof parsed.version === 'string' && parsed.version ? parsed.version : 'unknown';
+    if (typeof parsed.version === 'string') cwdPackageVersion = parsed.version;
   } catch {
-    return 'unknown';
+    /* ignore */
   }
+
+  return resolveProductVersion({ env: process.env.APP_VERSION, bakedFile, cwdPackageVersion });
 }
 
 export async function buildApp() {


### PR DESCRIPTION
## Summary

Follow-up to #1426. Live verification of that PR found the System Information panel reported app version **`1.0.0`** in the Docker image, not the product `2.0.0`.

**Root cause:** the runtime image *intentionally* ships `@dashboard/server`'s `package.json` (`1.0.0`) as `/app/package.json` for ESM module resolution (see `backend/Dockerfile`), and never copies the product root `package.json` (`2.0.0`). So `readProductVersion()`'s `process.cwd()/package.json` read returned `1.0.0`.

**Fix:** the Docker build bakes the product version into the server dist (`packages/server/dist/product-version`), read at runtime relative to the module (cwd-independent). `readProductVersion()` now resolves via a pure, unit-tested cascade:
`APP_VERSION` env override → baked file (prod) → `cwd/package.json` (dev) → `'unknown'`.

## Changes
- `packages/server/src/app.ts` — `resolveProductVersion()` (pure cascade) + `readProductVersion()` refactor
- `backend/Dockerfile` — bake `product-version` into the server dist after build
- `docker/.env.example` — document optional `APP_VERSION` override
- design spec — correction addendum

## Verification
Rebuilt the backend image and hit the live API: `GET /api/admin/system-info` → `{"app":"2.0.0","node":"24.16.0","fastify":"5.8.5"}` (was `app:1.0.0`). Baked file `/app/dist/product-version` = `2.0.0`. Dev path (cwd fallback) preserved.

Tests: `resolveProductVersion` cascade (env/baked/cwd/unknown, blank-skipping) + `readProductVersion` env override; server suite 54/54; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)