### PR TITLE
fix(e2e): match smoke login heading selector to shipped UI (#1420 Cat. A)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -7,8 +7,9 @@ test.describe('Smoke Tests', () => {
   test('login flow redirects to dashboard', async ({ page }) => {
     await page.goto('/');
 
-    // Should see login form
-    await expect(page.getByRole('heading', { name: /sign in|login/i })).toBeVisible({ timeout: 10_000 });
+    // Should see the login page — the heading is "Docker Insights"
+    // (not "Sign in"; that copy is a <p> subtitle, not a heading).
+    await expect(page.getByRole('heading', { name: /docker insights/i })).toBeVisible({ timeout: 10_000 });
 
     // Fill credentials and submit
     await page.getByLabel(/username/i).fill(USERNAME);


### PR DESCRIPTION
## Summary

**Category A of #1420.** `e2e/smoke.spec.ts:11` asserted a login heading matching `/sign in|login/i`, but the login page's only heading is `<h1>Docker Insights</h1>` (the "Sign in to your account" copy is a `<p>` subtitle). The assertion failed *before any login*, cascading into all three smoke tests. This points the selector at the actual heading (`/docker insights/i`), aligning it with `e2e/auth.spec.ts` and `e2e/helpers/login.ts`, which already use that selector.

**Scope:** only the *heading* was drifted — the `getByLabel(/username|password/i)` fields and the `Sign in` button selectors already match the shipped `login.tsx`, so they're untouched.

One of three #1420 PRs: **this (Cat A)**, **PR 1 shell resilience (#1428)**, and **PR 2 mock Portainer (pending)**. The full nightly suite goes green once PR 1 + PR 2 land; this just unblocks the smoke login gate. `Refs #1420`.

## Test Plan
- [x] `npx playwright test smoke.spec.ts --list` — spec compiles; 3 smoke tests collected
- [ ] Reviewer / nightly (`e2e` label): the smoke login gate finds the heading and proceeds past login

🤖 Generated with [Claude Code](https://claude.com/claude-code)