### PR TITLE
fix(e2e): real #1420 fixes — nginx /health SPA route + 6 test/config corrections

### DIFF
--- a/docs/superpowers/plans/2026-06-04-e2e-real-fixes.md
+++ b/docs/superpowers/plans/2026-06-04-e2e-real-fixes.md
@@ -177,10 +177,11 @@ The name cell renders `<FavoriteButton>` (a star `<button>`) **then** the naviga
 ```
 with:
 ```ts
-    // The name cell is the first column; it holds a FavoriteButton (star) and
-    // then the container-name button that navigates to the detail page. Click
-    // the name button (the last button in that cell), not the star.
-    const containerLink = firstRow.locator('td').first().getByRole('button').last();
+    // The DataTable prepends a row-selection checkbox column, so td[0] is the
+    // checkbox cell and the name column is td[1]. The name cell holds a
+    // FavoriteButton (star) then the container-name button that navigates.
+    // Click the name button (last button in that cell), not the star.
+    const containerLink = firstRow.locator('td').nth(1).getByRole('button').last();
     await containerLink.click();
 ```
 

--- a/docs/superpowers/plans/2026-06-04-e2e-real-fixes.md
+++ b/docs/superpowers/plans/2026-06-04-e2e-real-fixes.md
@@ -1,0 +1,260 @@
+# Real #1420 E2E Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `e2e` suite pass 0-failed by fixing the one real bug (nginx hijacks the SPA `/health` route → 404) and four test-only defects (smoke cached-auth, metrics label regex, containers click-target, dropdown timing).
+
+**Architecture:** One product change in `frontend/nginx.conf` (an exact-match `location = /health` so bare `/health` serves the SPA, with a static regression test) plus four edits under `e2e/` and `playwright.config.ts`. Definitive validation is a single combined `e2e` CI run on a branch carrying Cat A (#1430) + PR 2 (#1431) + these fixes.
+
+**Tech Stack:** nginx, Vitest (config assertion), Playwright, React Router.
+
+**Branch:** `feature/1420-e2e-real-fixes` (off `dev`; carries `docs/superpowers/specs/2026-06-03-e2e-real-fixes-design.md`). Pre-existing unstaged `.gitignore`/`CLAUDE.md` (Semgrep plugin) must NOT be staged.
+
+---
+
+## File Structure
+- **Modify** `frontend/nginx.conf` — add `location = /health` (exact match → SPA).
+- **Modify** `frontend/src/nginx-config.test.ts` — assert the bare-`/health` SPA rule + that `/health/` still proxies.
+- **Modify** `playwright.config.ts` — run `smoke.spec.ts` in a no-`storageState` project; ignore it in `chromium`.
+- **Modify** `e2e/metrics.spec.ts` — range-button regex matches real labels.
+- **Modify** `e2e/containers.spec.ts` — click the container-name button, not the favorite star.
+- **Modify** `e2e/workload-explorer-dropdown-position.spec.ts` — drop the too-tight 100 ms force-click timeout.
+
+---
+
+## Task 1: nginx serves the SPA for bare `/health` (real bug + regression test)
+
+**Files:**
+- Modify: `frontend/nginx.conf`
+- Test: `frontend/src/nginx-config.test.ts`
+
+- [ ] **Step 1: Write the failing test.** Append to the `describe('nginx hardening config', ...)` block in `frontend/src/nginx-config.test.ts`:
+
+```ts
+  it('serves the SPA for the bare /health route instead of proxying to the backend (#1420)', () => {
+    const nginxPath = path.resolve(process.cwd(), 'nginx.conf');
+    const config = fs.readFileSync(nginxPath, 'utf8');
+
+    // Exact-match location so a direct navigation/refresh of the SPA Health
+    // page serves index.html and is never 301'd into the /health/ backend proxy.
+    expect(config).toMatch(
+      /location\s*=\s*\/health\s*\{[^}]*try_files\s+\/index\.html/s,
+    );
+    // The /health/ sub-path backend liveness proxy is preserved.
+    expect(config).toContain('location /health/');
+  });
+```
+
+- [ ] **Step 2: Run it, confirm it FAILS.**
+Run: `cd frontend && npx vitest run src/nginx-config.test.ts`
+Expected: FAIL on the `location = /health` matcher (no such block yet).
+
+- [ ] **Step 3: Add the exact-match block to `frontend/nginx.conf`.** Immediately *before* the existing `location /health/ {` block, insert:
+
+```nginx
+        # Bare /health is the SPA Health & Monitoring route. Exact-match wins
+        # over the /health/ backend proxy and the SPA catch-all, so a direct
+        # navigation or refresh serves index.html instead of 301'ing into the
+        # backend (which 404s). (#1420)
+        location = /health {
+            include /etc/nginx/security-headers.conf;
+            include /etc/nginx/cache-nocache.conf;
+            try_files /index.html =404;
+        }
+
+```
+(Leave the existing `location /health/ { ... proxy_pass http://backend:3051; ... }` block exactly as-is, directly after this.)
+
+- [ ] **Step 4: Run the test, confirm it PASSES.**
+Run: `cd frontend && npx vitest run src/nginx-config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Lint the nginx test file.**
+Run: `cd frontend && npx eslint src/nginx-config.test.ts`
+Expected: clean.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add frontend/nginx.conf frontend/src/nginx-config.test.ts
+git commit -m "fix(frontend): serve the SPA for bare /health (was 404 via backend proxy) (#1420)
+
+Direct navigation/refresh of the Health & Monitoring page (/health) was
+301'd to /health/ and proxied to the backend, which 404s. Add an exact-match
+nginx location so bare /health serves index.html; keep /health/ proxying
+backend liveness sub-paths.
+
+Refs #1420"
+```
+
+> Note: the static test asserts the rule exists; the behavioural proof (bare `/health` → 200 SPA) is the combined E2E run in Task 4.
+
+---
+
+## Task 2: smoke.spec.ts runs without cached auth
+
+**Files:**
+- Modify: `playwright.config.ts`
+
+Context: `playwright.config.ts` defines projects `setup` (writes auth state), `auth` (`testMatch: /auth\.spec\.ts/`, no `storageState`), and `chromium` (`testIgnore: [/auth\.spec\.ts/, /global-setup\.ts/]`, `dependencies: ['setup']`, `storageState: 'e2e/.auth/user.json'`). `smoke.spec.ts` currently runs under `chromium` (cached auth), so `goto('/')` is already authenticated and the login form never appears.
+
+- [ ] **Step 1: Add a no-auth `smoke` project and exclude smoke from `chromium`.** In `playwright.config.ts`:
+
+Add this project to the `projects` array (after the `auth` project):
+```ts
+    /* Smoke tests drive the login *form*, so they must NOT use cached auth. */
+    {
+      name: 'smoke',
+      testMatch: /smoke\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+```
+And extend the `chromium` project's `testIgnore` to also ignore smoke:
+```ts
+        testIgnore: [/auth\.spec\.ts/, /global-setup\.ts/, /smoke\.spec\.ts/],
+```
+
+- [ ] **Step 2: Verify the projects resolve and smoke is collected once, without cached auth.**
+Run: `npx playwright test smoke.spec.ts --list`
+Expected: the three `smoke.spec.ts` tests are listed under the `[smoke]` project (NOT `[chromium]`), and each appears exactly once.
+
+- [ ] **Step 3: Confirm smoke tests are self-contained logins (no hidden reliance on cached state).** Read `e2e/smoke.spec.ts`: each test must `page.goto('/')` and either assert the login UI or fill `username`/`password` and submit. (They do — test 1 asserts the heading then logs in; tests 2/3 log in then assert dashboard.) No code change expected; if any test assumed pre-seeded auth, add the login steps. Record what you confirmed.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add playwright.config.ts
+git commit -m "test(e2e): run smoke specs without cached auth so the login flow is exercised (#1420)
+
+smoke.spec.ts drives the login form but ran under the chromium project's
+cached storageState, so goto('/') was already authenticated and the login
+page never rendered. Give smoke its own no-storageState project and exclude
+it from chromium.
+
+Refs #1420"
+```
+
+---
+
+## Task 3: three test-only assertion fixes (metrics, containers, dropdown)
+
+**Files:**
+- Modify: `e2e/metrics.spec.ts`
+- Modify: `e2e/containers.spec.ts`
+- Modify: `e2e/workload-explorer-dropdown-position.spec.ts`
+
+### 3a — metrics range-button labels
+
+The UI renders full labels (`TIME_RANGES` = `15 min`, `30 min`, `1 hour`, `6 hours`, `24 hours`, `7 days`), but the test matches compact `1h`-style labels → 0 matches.
+
+- [ ] **Step 1:** In `e2e/metrics.spec.ts` (the `renders the time-range selector with multiple options` test, ~line 52), replace:
+```ts
+    const ranges = page.getByRole('button', {
+      name: /^\s*\d+\s*(m|h|d)\s*$/i,
+    });
+```
+with:
+```ts
+    // Buttons render full labels: "15 min", "1 hour", "6 hours", "7 days".
+    const ranges = page.getByRole('button', {
+      name: /^\s*\d+\s*(min|hour|day)s?\s*$/i,
+    });
+```
+
+- [ ] **Step 2:** `npx playwright test metrics.spec.ts --list` → parses, test still listed. Commit:
+```bash
+git add e2e/metrics.spec.ts
+git commit -m "test(e2e): match metrics time-range buttons by their real labels (#1420)"
+```
+
+### 3b — containers click the name button, not the favorite star
+
+The name cell renders `<FavoriteButton>` (a star `<button>`) **then** the navigating name `<button>` (which `stopPropagation`s). `firstRow.locator('button, a').first()` clicks the star → no navigation.
+
+- [ ] **Step 1:** In `e2e/containers.spec.ts` (the `clicking a container name opens the detail view` test, ~lines 60-65), replace:
+```ts
+    // Click the container name link (first link/button in the row)
+    const containerLink = firstRow.locator('button, a').first();
+    await containerLink.click();
+```
+with:
+```ts
+    // The name cell is the first column; it holds a FavoriteButton (star) and
+    // then the container-name button that navigates to the detail page. Click
+    // the name button (the last button in that cell), not the star.
+    const containerLink = firstRow.locator('td').first().getByRole('button').last();
+    await containerLink.click();
+```
+
+- [ ] **Step 2:** `npx playwright test containers.spec.ts --list` → parses. Commit:
+```bash
+git add e2e/containers.spec.ts
+git commit -m "test(e2e): click the container-name button (not the favorite star) for detail nav (#1420)"
+```
+
+### 3c — relax the dropdown entrance-animation click
+
+The variant verifies the dropdown *anchors* (regression for #1310); the `{ timeout: 100 }` force-click is too tight on a CI runner. `force: true` already skips actionability waits, so it still races the entrance animation without the artificial 100 ms cap.
+
+- [ ] **Step 1:** In `e2e/workload-explorer-dropdown-position.spec.ts` (the `first-click during MotionStagger entrance animation still anchors` test, ~line 76), replace:
+```ts
+    await trigger.click({ timeout: 100, force: true });
+```
+with:
+```ts
+    // force:true skips the actionability waits, so the click still races the
+    // entrance animation; the artificial 100ms cap just flaked on CI runners.
+    await trigger.click({ force: true });
+```
+Also update the preceding comment if it references the 100 ms cap (lines ~73-75) so it stays accurate.
+
+- [ ] **Step 2:** `npx playwright test workload-explorer-dropdown-position.spec.ts --list` → parses. Commit:
+```bash
+git add e2e/workload-explorer-dropdown-position.spec.ts
+git commit -m "test(e2e): drop the too-tight 100ms force-click on the dropdown entrance variant (#1420)"
+```
+
+---
+
+## Task 4: Combined E2E validation (the real proof)
+
+**Files:** none (operational). Requires the billed `e2e` CI run — get the user's go-ahead before triggering.
+
+- [ ] **Step 1: Build the combined branch.** From `dev`, create a fresh integration branch and merge Cat A + PR 2 + this branch:
+```bash
+git switch dev && git switch -c integration/1420-combined-v2
+git merge --no-ff --no-edit feature/1420-fix-e2e-login-heading-selector   # Cat A
+git merge --no-ff --no-edit feature/1420-ci-mock-portainer                # PR 2
+git merge --no-ff --no-edit feature/1420-e2e-real-fixes                   # this
+```
+Resolve any conflicts (none expected; `architecture.md` notes are in different sections).
+
+- [ ] **Step 2: Push + dispatch CI.**
+```bash
+git push -u origin integration/1420-combined-v2
+gh workflow run ci.yml --ref integration/1420-combined-v2
+```
+Find the run: `gh run list --workflow ci.yml --branch integration/1420-combined-v2 --event workflow_dispatch --limit 1`.
+
+- [ ] **Step 3: Watch + read the result.**
+```bash
+gh run watch <run-id> --interval 60
+gh run view --job <e2e-job-id> --log | grep -E "[0-9]+ (passed|failed)"
+```
+Expected: **0 failed** (41 passed). If failures remain, pull the `playwright-report` artifact and read the error-context `.md` page snapshots in `data/` (NOT just the backend logs) to classify, fix on `feature/1420-e2e-real-fixes`, re-merge, re-run.
+
+- [ ] **Step 4: Clean up the throwaway branches** once green:
+```bash
+git push origin --delete integration/1420-combined-v2 integration/1420-combined-e2e-validation
+git branch -D integration/1420-combined-v2 integration/1420-combined-e2e-validation
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** Fix 1 (nginx /health)→Task 1; Fix 2 (smoke auth)→Task 2; Fix 3 (metrics regex)→Task 3a; Fix 4 (containers selector)→Task 3b; Fix 5 (dropdown timing)→Task 3c; validation→Task 4. Merge strategy (Cat A + PR 2 + this; PR 1 decoupled)→Task 4 Step 1. ✅ All spec fixes covered.
+
+**2. Placeholder scan:** Every code step has the exact before/after. Task 2 Step 3 is a confirmation step (read + verify smoke self-logs), not a placeholder. No "TBD"/"handle edge cases". ✅
+
+**3. Consistency:** Selectors/labels match the investigated source — metrics labels (`min|hour|day`), the name-cell structure (`td` first → FavoriteButton then name button → `.last()`), the dropdown line (`click({ timeout: 100, force: true })`), and the nginx blocks (`location = /health` / `location /health/`). The `smoke` project name is used consistently in Task 2. ✅
+
+**Honesty note:** Tasks 1–3 are verifiable offline only at the parse/static level (nginx-config vitest; `playwright --list`). The behavioural proof for all five is the Task 4 combined CI run — inherent to E2E. Only Fix 1 changes product behaviour; 2–5 correct tests to match real, working UI.

--- a/docs/superpowers/specs/2026-06-03-e2e-real-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-03-e2e-real-fixes-design.md
@@ -1,0 +1,84 @@
+# Design — The real #1420 E2E fixes (corrected)
+
+**Status:** corrected design, pending review
+**Issue:** #1420 — E2E smoke suite fails in CI
+**Date:** 2026-06-03
+**Supersedes the diagnosis in:** `2026-06-03-e2e-ci-meaningful-suite-design.md` (PR 1's "shell-resilience" premise was a misdiagnosis)
+
+## Why this exists
+
+The first attempt assumed the E2E failures came from the app shell unmounting when a page threw (→ PR 1, the Outlet `ErrorBoundary`). A **combined-branch CI run** (`26896200138` = `dev` + Cat A #1430 + PR 1 #1428 + PR 2 #1431) still failed **11/41**, *with no improvement from PR 1*. Reading the Playwright **traces + error-context page snapshots** (the ground truth that should have been consulted first) gives the real causes. None are PR 1's domain.
+
+## Evidence-based root causes (all 11 combined-run failures)
+
+| Failing tests | Ground-truth evidence | Real cause |
+|---|---|---|
+| `ai-monitor.spec.ts` :42 :56 :88 (+ `navigation.spec.ts` :16 :39, which route via `/health`) | trace: `GET /health` → **nginx 301** → `/health/` → `proxy_pass backend` → **backend 404** ("404 Not Found", 13 bytes) | **nginx.conf `/health` collision** — the `location /health/` block (#1229) makes bare `/health` redirect into the backend. The SPA Health route is unreachable on navigate/refresh. **Real prod bug.** |
+| `smoke.spec.ts` :7 :23 :38 | snapshot = the **authenticated dashboard** (sidebar brand "Docker Insights"), not the login form | **Test design:** smoke drives the login *form* but runs in the `chromium` project, which loads cached `storageState`. `goto('/')` is already authenticated → no login page. |
+| `metrics.spec.ts` :46 | shell fine; `rangeCount` = **0**. Buttons render `range.label` = "1 hour"/"6 hours"; the test regex is `/^\s*\d+\s*(m\|h\|d)\s*$/i` | **Test↔UI mismatch** — regex expects compact labels (`1h`) that the UI doesn't use. |
+| `containers.spec.ts` :56 | URL stayed `/workloads` after the click. Name cell = `<FavoriteButton>` **then** the name `<button>` (which `stopPropagation`s) | **Test selector** — `firstRow.locator('button, a').first()` clicks the **favorite star**, not the name link → no navigation. |
+| `workload-explorer-dropdown-position.spec.ts` :61 | `#endpoint-select` *resolved* (exists), but `click({ timeout: 100, force: true })` timed out | **Flaky timing** — the intentionally-aggressive 100 ms force-click during the entrance animation is too tight on a CI runner. (The other 4 dropdown variants pass.) |
+
+**Standing facts:** PR 2 (mock) works — it's a prerequisite for metrics/containers/dropdown to have data, and took the suite 22→11. Cat A's selector fix (`/docker insights/i`) is *correct and still needed* — once smoke runs unauthenticated, the login heading "Docker Insights" must match. PR 1 (#1428) is decoupled (kept as standalone defense-in-depth).
+
+## Goals
+
+- The `e2e` suite passes **0-failed** with Cat A + PR 2 + these fixes merged.
+- The real product bug — `/health` returning 404 on navigate/refresh — is fixed and regression-tested.
+- Test-only fixes are minimal and don't paper over real behavior.
+
+## Non-goals
+
+- PR 1 (#1428) — separate, defense-in-depth; not required for green.
+- Reworking the PWA service worker (the trace proved nginx, not the SW, returns the 404).
+
+## The five fixes
+
+### Fix 1 — nginx `/health` serves the SPA (real bug)
+`frontend/nginx.conf`: add an **exact-match** location so bare `/health` is served the SPA, taking precedence over the `/health/` proxy and the catch-all:
+```nginx
+# Bare /health is the SPA Health & Monitoring route. Exact-match so it is
+# never redirected into the backend's /health/ liveness proxy (#1420).
+location = /health {
+    include /etc/nginx/security-headers.conf;
+    include /etc/nginx/cache-nocache.conf;
+    try_files /index.html =404;
+}
+```
+Keep `location /health/` for backend liveness sub-paths. (Investigate whether anything actually calls the frontend's `/health/`; if not, a follow-up can drop it — out of scope here.)
+**Test:** extend `frontend/src/nginx-config.test.ts` to assert the `location = /health` block exists and serves `/index.html` (and that `/health/` still proxies to the backend). *Note:* this is a static-config assertion; the true proof is the E2E run (Fix-6 validation).
+**Fixes:** ai-monitor ×3, navigation ×2.
+
+### Fix 2 — smoke runs without cached auth
+`playwright.config.ts`: smoke's three tests exercise the login form, so they must run with **no `storageState`**. Add `smoke.spec.ts` to a no-auth project (mirror the existing `auth` project: `testMatch: /smoke\.spec\.ts/`, no `storageState`) and add `/smoke\.spec\.ts/` to the `chromium` project's `testIgnore`. (Confirm each smoke test either logs in itself or only asserts pre-login UI.)
+**Fixes:** smoke ×3. (Relies on Cat A's heading selector.)
+
+### Fix 3 — metrics time-range regex matches real labels
+`e2e/metrics.spec.ts:46`: change the range-button matcher to the actual labels, e.g. `/^\s*\d+\s*(min|hour|day)s?\s*$/i` (matches "15 min", "1 hour", "6 hours", "7 days"). Test-only.
+**Fixes:** metrics:46.
+
+### Fix 4 — containers test clicks the name, not the favorite star
+`e2e/containers.spec.ts:56`: replace `firstRow.locator('button, a').first()` with a click on the **container-name** control (the styled name `<button>`), e.g. the last button in the name cell or `firstRow.getByRole('button').nth(1)` / a name-text match — or click the row body (the table has `onRowClick` → navigate). Test-only.
+**Fixes:** containers:56.
+
+### Fix 5 — relax the dropdown first-click timing
+`e2e/workload-explorer-dropdown-position.spec.ts:61`: the variant's value is verifying the dropdown *anchors* (regression for #1310), not sub-100 ms responsiveness. Give the force-click a realistic budget (e.g. drop `{ timeout: 100 }`, keep `force: true`) so a CI runner can land the click while still racing the entrance animation. Test-only.
+**Fixes:** dropdown:61.
+
+## Where the work lands / merge strategy
+
+- **This branch** `feature/1420-e2e-real-fixes` → a new PR (call it the "real fix"): Fixes 1–5 + the nginx regression test. Carries the corrected design doc.
+- **Cat A #1430** and **PR 2 #1431** stay open and are **required** for green; merge order: Cat A + PR 2 + this. (Optionally this PR could be rebased to include them, but keeping them separate keeps review small.)
+- **PR 1 #1428** — decoupled (retitled); merge on its own merits, not needed for #1420.
+- This PR `Closes #1420` (it's the last piece).
+
+## Validation
+
+Unit-level (no Docker): the nginx-config test + `npm run test -w frontend`/lint for the spec/config edits. Definitive: one **combined** `e2e`-labelled (or `workflow_dispatch`) CI run on a branch carrying Cat A + PR 2 + these fixes → target **0 failed**. Reuse the throwaway `integration/1420-combined-e2e-validation` pattern (re-merge with these fixes) rather than merging unproven.
+
+## Risks
+
+- **nginx 301 source:** the exact-match `location = /health` should stop the redirect, but nginx location interactions can surprise — the combined E2E run is the real proof; if `/health` still 301s, inspect `merge_slashes`/`absolute_redirect off;`.
+- **smoke self-login:** confirm smoke tests perform their own login (they fill credentials) — if any assumed pre-seeded auth, it needs a login step.
+- **navigation:39:** snapshot was ambiguous; if it fails for a non-`/health` reason after Fix 1, diagnose separately.
+- **metrics/containers** are test-only assumptions; ensure the fixes assert real, stable UI (prefer testids if the labels churn).

--- a/e2e/ai-monitor.spec.ts
+++ b/e2e/ai-monitor.spec.ts
@@ -43,12 +43,13 @@ test.describe('AI Monitor (Health & Monitoring)', () => {
     await page.goto('/health');
     await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
 
-    // The page renders four stat cards (Total / Critical / Warning / Info) once
-    // loading completes, or an empty-state copy if no insights exist.
+    // The page renders the stat cards (Total / Critical / Warning / Info) AND,
+    // when no insights exist, an empty-state copy — both can be present at once,
+    // so assert at least one is visible (.first() avoids a strict-mode match of 2).
     const statsHeading = page.getByText(/total insights/i);
     const emptyHeading = page.getByRole('heading', { name: /no insights/i });
 
-    await expect(statsHeading.or(emptyHeading)).toBeVisible({
+    await expect(statsHeading.or(emptyHeading).first()).toBeVisible({
       timeout: 15_000,
     });
   });

--- a/e2e/containers.spec.ts
+++ b/e2e/containers.spec.ts
@@ -61,10 +61,12 @@ test.describe('Container List (Workload Explorer)', () => {
     const firstRow = table.locator('tbody tr').first();
     await expect(firstRow).toBeVisible();
 
-    // The name cell is the first column; it holds a FavoriteButton (star) and
-    // then the container-name button that navigates to the detail page. Click
-    // the name button (the last button in that cell), not the star.
-    const containerLink = firstRow.locator('td').first().getByRole('button').last();
+    // The table has row selection enabled, so the first td is the selection
+    // checkbox cell (an <input>/<label>, no buttons). The name cell is the
+    // SECOND td: it holds a FavoriteButton (star) and then the container-name
+    // button that navigates to the detail page. Click the name button (the
+    // last button in that cell), not the star.
+    const containerLink = firstRow.locator('td').nth(1).getByRole('button').last();
     await containerLink.click();
 
     // Should navigate to a container detail page

--- a/e2e/containers.spec.ts
+++ b/e2e/containers.spec.ts
@@ -61,8 +61,10 @@ test.describe('Container List (Workload Explorer)', () => {
     const firstRow = table.locator('tbody tr').first();
     await expect(firstRow).toBeVisible();
 
-    // Click the container name link (first link/button in the row)
-    const containerLink = firstRow.locator('button, a').first();
+    // The name cell is the first column; it holds a FavoriteButton (star) and
+    // then the container-name button that navigates to the detail page. Click
+    // the name button (the last button in that cell), not the star.
+    const containerLink = firstRow.locator('td').first().getByRole('button').last();
     await containerLink.click();
 
     // Should navigate to a container detail page

--- a/e2e/metrics.spec.ts
+++ b/e2e/metrics.spec.ts
@@ -50,8 +50,9 @@ test.describe('Metrics Dashboard', () => {
       page.getByRole('heading', { name: /metrics dashboard/i, level: 1 }),
     ).toBeVisible({ timeout: 15_000 });
 
+    // Buttons render full labels: "15 min", "1 hour", "6 hours", "7 days".
     const ranges = page.getByRole('button', {
-      name: /^\s*\d+\s*(m|h|d)\s*$/i,
+      name: /^\s*\d+\s*(min|hour|day)s?\s*$/i,
     });
     const rangeCount = await ranges.count();
     expect(rangeCount).toBeGreaterThanOrEqual(2);

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -22,10 +22,10 @@ test.describe('Sidebar Navigation', () => {
     ];
 
     for (const route of routes) {
-      // Click sidebar link
+      // Sidebar nav items render as <button> (client-side navigate), not <a>.
       await page
         .locator('[data-testid="sidebar"]')
-        .getByRole('link', { name: route.label })
+        .getByRole('button', { name: route.label })
         .click();
 
       // Verify URL updated
@@ -40,7 +40,7 @@ test.describe('Sidebar Navigation', () => {
     // Navigate to a nested page
     await page
       .locator('[data-testid="sidebar"]')
-      .getByRole('link', { name: /workload explorer/i })
+      .getByRole('button', { name: /workload explorer/i })
       .click();
 
     await expect(page).toHaveURL(/\/workloads/);

--- a/e2e/workload-explorer-dropdown-position.spec.ts
+++ b/e2e/workload-explorer-dropdown-position.spec.ts
@@ -69,11 +69,12 @@ test.describe('Workload Explorer filter dropdowns anchor to trigger', () => {
     await page.goto('/workloads', { waitUntil: 'domcontentloaded' });
     const trigger = page.locator('#endpoint-select');
     await expect(trigger).toBeAttached({ timeout: 15_000 });
-    // `{ timeout: 100 }` keeps the click attempt from blocking on a slow
-    // mount; `force: true` skips the actionability checks (visible, stable,
+    // `force: true` skips the actionability checks (visible, stable,
     // enabled) that would otherwise wait until the entrance animation
     // settles — defeating the point of the variation.
-    await trigger.click({ timeout: 100, force: true });
+    // force:true skips the actionability waits, so the click still races the
+    // entrance animation; the artificial 100ms cap just flaked on CI runners.
+    await trigger.click({ force: true });
     await expectAnchored(page, 'endpoint-select');
     await page.keyboard.press('Escape');
   });

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -97,10 +97,19 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # The bare `/health` path is owned by the SPA (Health & Monitoring
-        # page) — falls through to the SPA `try_files` block below. Backend
-        # liveness sub-paths still proxy. External callers that want bare-path
-        # liveness should hit the backend directly at port 3051.
+        # Bare /health is the SPA Health & Monitoring route. Exact-match wins
+        # over the /health/ backend proxy and the SPA catch-all, so a direct
+        # navigation or refresh serves index.html instead of 301'ing into the
+        # backend (which 404s). (#1420)
+        location = /health {
+            include /etc/nginx/security-headers.conf;
+            include /etc/nginx/cache-nocache.conf;
+            try_files /index.html =404;
+        }
+
+        # Backend liveness sub-paths (e.g. /health/live, /health/ready) still
+        # proxy to the backend. External callers that want bare-path liveness
+        # should hit the backend directly at port 3051.
         location /health/ {
             include /etc/nginx/security-headers.conf;
             proxy_pass http://backend:3051;

--- a/frontend/src/nginx-config.test.ts
+++ b/frontend/src/nginx-config.test.ts
@@ -10,4 +10,17 @@ describe('nginx hardening config', () => {
     expect(config).toContain('server_tokens off;');
     expect(config).toContain('listen 8080 default_server;');
   });
+
+  it('serves the SPA for the bare /health route instead of proxying to the backend (#1420)', () => {
+    const nginxPath = path.resolve(process.cwd(), 'nginx.conf');
+    const config = fs.readFileSync(nginxPath, 'utf8');
+
+    // Exact-match location so a direct navigation/refresh of the SPA Health
+    // page serves index.html and is never 301'd into the /health/ backend proxy.
+    expect(config).toMatch(
+      /location\s*=\s*\/health\s*\{[^}]*try_files\s+\/index\.html/s,
+    );
+    // The /health/ sub-path backend liveness proxy is preserved.
+    expect(config).toContain('location /health/');
+  });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,10 +45,17 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
 
+    /* Smoke tests drive the login *form*, so they must NOT use cached auth. */
+    {
+      name: 'smoke',
+      testMatch: /smoke\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+
     /* All other specs reuse the cached auth state */
     {
       name: 'chromium',
-      testIgnore: [/auth\.spec\.ts/, /global-setup\.ts/],
+      testIgnore: [/auth\.spec\.ts/, /global-setup\.ts/, /smoke\.spec\.ts/],
       dependencies: ['setup'],
       use: {
         ...devices['Desktop Chrome'],


### PR DESCRIPTION
## Summary

The evidence-based fix for #1420 — **validated 41/41 green** in a combined CI run (`dev` + #1430 + #1431 + this; run [26959256777](https://github.com/kenhaesler/ai-portainer-dashboard/actions/runs/26959256777)). An earlier combined run still failed 11/41; reading the Playwright **traces + page snapshots** gave the real causes — none of which were PR 1's "shell-resilience" premise (#1428, now decoupled).

**One real product bug + six test/config corrections:**

1. **nginx `/health` (real prod bug)** — `frontend/nginx.conf`. A trace showed bare `/health` → nginx **301** → `/health/` → `proxy_pass backend` → **404**: the SPA Health & Monitoring page was unreachable on direct navigation/refresh (prod too). Exact-match `location = /health` serves `index.html` (precedence over the `/health/` proxy + SPA catch-all); regression test in `nginx-config.test.ts`. → ai-monitor ×3, navigation ×2.
2. **smoke cached-auth** — `playwright.config.ts`. smoke drives the login *form* but ran under the `chromium` project's cached `storageState`; gave it its own no-auth `smoke` project. → smoke ×3.
3. **metrics labels** — `e2e/metrics.spec.ts`. Range buttons render `1 hour`/`6 hours`, not `1h`. → metrics:46.
4. **containers click target** — `e2e/containers.spec.ts`. The DataTable prepends a selection-checkbox column, so the name cell is `td[1]`. → containers:56.
5. **dropdown timing** — `e2e/workload-explorer-dropdown-position.spec.ts`. Dropped a too-tight 100 ms force-click (CI-flaky); `force:true` still races the entrance animation. → dropdown:61.
6. **sidebar nav role** — `e2e/navigation.spec.ts`. Sidebar items render `<button>` (client-side navigate), not `<a>`; use `getByRole('button')`. → navigation:16/39.
7. **ai-monitor stats-or-empty** — `e2e/ai-monitor.spec.ts`. With `/health` reachable, the page renders the Total-Insights card AND the No-insights empty state at once; `.or(...).first()` avoids a strict-mode match of 2. → ai-monitor:42.

> Items 6–7 were surfaced during combined validation (each fix made the page render further, exposing the next latent spec bug — the suite had never run against a live page).

Design + plan: `docs/superpowers/specs/2026-06-03-e2e-real-fixes-design.md`, `docs/superpowers/plans/2026-06-04-e2e-real-fixes.md`.

⚠️ **`Closes #1420`, but green only with #1430 (Cat A) + #1431 (PR 2 mock + `LOGIN_RATE_LIMIT` raise) also on `dev`.** Merge the three together (or land this last) — merging this alone leaves the nightly E2E red and prematurely closes the issue. PR 1 (#1428) is decoupled/optional.

## Test Plan
- [x] `nginx-config.test.ts` — 2/2 (bare `/health` serves the SPA; `/health/` still proxies)
- [x] `npx playwright test --list` — 41 tests collect; smoke under `[smoke]`
- [x] **Combined `e2e` CI run — 41/41 passed** (run 26959256777)

🤖 Generated with [Claude Code](https://claude.com/claude-code)