### PR TITLE
Response-schema batch: harbor vulns, settings, investigations, incidents (part of #1545)

### DIFF
--- a/backend/src/routes/settings.test.ts
+++ b/backend/src/routes/settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 import Fastify, { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { validatorCompiler } from 'fastify-type-provider-zod';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
 import { testAdminOnly } from '../test-utils/rbac-test-helper.js';
 import { settingsRoutes } from '@dashboard/foundation/routes/index.js';
 
@@ -64,6 +64,7 @@ describe('settings preference routes', () => {
   beforeAll(async () => {
     app = Fastify({ logger: false });
     app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
     app.decorate('authenticate', async () => undefined);
     app.decorate('requireRole', () => async () => undefined);
     app.decorateRequest('user', undefined);
@@ -130,6 +131,7 @@ describe('audit-log cursor pagination', () => {
   beforeAll(async () => {
     app = Fastify({ logger: false });
     app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
     app.decorate('authenticate', async () => undefined);
     app.decorate('requireRole', () => async () => undefined);
     app.decorateRequest('user', undefined);
@@ -230,6 +232,7 @@ describe('settings security', () => {
     currentRole = 'admin';
     secApp = Fastify({ logger: false });
     secApp.setValidatorCompiler(validatorCompiler);
+    secApp.setSerializerCompiler(serializerCompiler);
     secApp.decorate('authenticate', async () => undefined);
     secApp.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request: FastifyRequest, reply: FastifyReply) => {
       const rank = { viewer: 0, operator: 1, admin: 2 };
@@ -259,13 +262,16 @@ describe('settings security', () => {
   testAdminOnly(() => secApp, (r) => { currentRole = r; }, 'GET', '/api/settings/audit-log');
 
   it('redacts sensitive values for admin on GET /api/settings', async () => {
+    // updated_at is a NOT NULL column the real SELECT * always returns; the
+    // GET /api/settings response schema (SettingSchema) requires it (#1545).
+    const ts = '2026-07-13T00:00:00.000Z';
     mockQuery.mockResolvedValueOnce([
-      { key: 'oidc.client_secret', value: 'super-secret', category: 'authentication' },
-      { key: 'elasticsearch.api_key', value: 'es-key', category: 'logs' },
-      { key: 'notifications.smtp_password', value: 'smtp-pass', category: 'notifications' },
-      { key: 'notifications.teams_webhook_url', value: 'https://secret.webhook', category: 'notifications' },
-      { key: 'llm.custom_endpoint_token', value: 'llm-token', category: 'llm' },
-      { key: 'general.theme', value: 'apple-dark', category: 'general' },
+      { key: 'oidc.client_secret', value: 'super-secret', category: 'authentication', updated_at: ts },
+      { key: 'elasticsearch.api_key', value: 'es-key', category: 'logs', updated_at: ts },
+      { key: 'notifications.smtp_password', value: 'smtp-pass', category: 'notifications', updated_at: ts },
+      { key: 'notifications.teams_webhook_url', value: 'https://secret.webhook', category: 'notifications', updated_at: ts },
+      { key: 'llm.custom_endpoint_token', value: 'llm-token', category: 'llm', updated_at: ts },
+      { key: 'general.theme', value: 'apple-dark', category: 'general', updated_at: ts },
     ]);
 
     const response = await secApp.inject({
@@ -276,18 +282,19 @@ describe('settings security', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual([
-      { key: 'oidc.client_secret', value: '••••••••', category: 'authentication' },
-      { key: 'elasticsearch.api_key', value: '••••••••', category: 'logs' },
-      { key: 'notifications.smtp_password', value: '••••••••', category: 'notifications' },
-      { key: 'notifications.teams_webhook_url', value: '••••••••', category: 'notifications' },
-      { key: 'llm.custom_endpoint_token', value: '••••••••', category: 'llm' },
-      { key: 'general.theme', value: 'apple-dark', category: 'general' },
+      { key: 'oidc.client_secret', value: '••••••••', category: 'authentication', updated_at: ts },
+      { key: 'elasticsearch.api_key', value: '••••••••', category: 'logs', updated_at: ts },
+      { key: 'notifications.smtp_password', value: '••••••••', category: 'notifications', updated_at: ts },
+      { key: 'notifications.teams_webhook_url', value: '••••••••', category: 'notifications', updated_at: ts },
+      { key: 'llm.custom_endpoint_token', value: '••••••••', category: 'llm', updated_at: ts },
+      { key: 'general.theme', value: 'apple-dark', category: 'general', updated_at: ts },
     ]);
   });
 
   it('rejects invalid schemes for security-critical URL settings', async () => {
     const app = Fastify({ logger: false });
     app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
     app.decorate('authenticate', async () => undefined);
     app.decorate('requireRole', () => async () => undefined);
     app.decorateRequest('user', undefined);
@@ -316,6 +323,7 @@ describe('settings security', () => {
   it('accepts valid https URL for oidc.issuer_url', async () => {
     const app = Fastify({ logger: false });
     app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
     app.decorate('authenticate', async () => undefined);
     app.decorate('requireRole', () => async () => undefined);
     app.decorateRequest('user', undefined);
@@ -346,6 +354,7 @@ describe('settings security', () => {
   it('preserves existing category when update payload omits category', async () => {
     const app = Fastify({ logger: false });
     app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
     app.decorate('authenticate', async () => undefined);
     app.decorate('requireRole', () => async () => undefined);
     app.decorateRequest('user', undefined);
@@ -382,6 +391,7 @@ describe('prompt-features endpoint', () => {
     currentRole = 'admin';
     pfApp = Fastify({ logger: false });
     pfApp.setValidatorCompiler(validatorCompiler);
+    pfApp.setSerializerCompiler(serializerCompiler);
     pfApp.decorate('authenticate', async () => undefined);
     pfApp.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request: FastifyRequest, reply: FastifyReply) => {
       const rank = { viewer: 0, operator: 1, admin: 2 };
@@ -441,6 +451,7 @@ describe('prompt version history routes (#415)', () => {
   beforeAll(async () => {
     app = Fastify({ logger: false });
     app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
     app.decorate('authenticate', async () => undefined);
     app.decorate('requireRole', () => async () => undefined);
     app.decorateRequest('user', undefined);

--- a/docs/superpowers/plans/2026-07-13-issue-1545-response-schemas-batch.md
+++ b/docs/superpowers/plans/2026-07-13-issue-1545-response-schemas-batch.md
@@ -1,0 +1,254 @@
+# Issue #1545 — Response-schema batch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans or superpowers:test-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add Fastify `response: { 200: ... }` Zod schemas to 5 hot GET routes so they get fast-json-stringify serialization + field pruning, each verified field-by-field against its frontend consumer.
+
+**Architecture:** The global `serializerCompiler` (fastify-type-provider-zod v6, zod v4) is already wired (`packages/core/src/plugins/swagger.ts:13-14`). Each route gains a `response` schema built from an existing exact-match Zod model (settings/investigations/incidents) or a new domain-local schema (harbor). Field-presence tests live in each route's own package `__tests__` (run against `src`, sibling stores mocked) to prove no consumer-read field is stripped.
+
+**Tech Stack:** Fastify 5, zod 4.3.6, fastify-type-provider-zod 6.1.0, Vitest.
+
+## Global Constraints
+
+- zod v4 only; date/timestamp fields are ISO strings (pg type parsers at `postgres.ts:12-13` return `TIMESTAMPTZ`/`TIMESTAMP` as `toISOString()`), so `z.string()` is correct for them.
+- Error paths on a route that declares a `200` schema must cast: `return (reply as any).code(4xx|5xx).send(...)` (Zod type-provider narrows `reply` to the 200 shape). Pattern: `monitoring.ts:308`.
+- Do NOT touch excluded routes: `GET /api/containers` (stale `NormalizedContainerSchema` drops `networkIPs`; 3-way union) and `GET /api/monitoring/insights` (`SELECT *` superset of `InsightSchema`).
+- Tests: mock the sibling store (the boundary), not the DB driver; register `setValidatorCompiler`+`setSerializerCompiler` so pruning is actually exercised; decorate `authenticate` (and `requireRole` for admin routes).
+
+## Verified schema facts (columns audited against migrations)
+
+- `settings` table = exactly `key,value,category,updated_at` (002; no later ALTER) = `SettingSchema` (`packages/core/src/models/settings.ts:3`).
+- `incidents` table = `IncidentSchema`'s 16 fields + `signature` (added 029). `getIncidents` = `SELECT *` → `Incident[]`; frontend `Incident` type omits `signature`, so pruning it is safe.
+- `investigations` table = exactly `InvestigationSchema`'s 18 fields (007; ai_summary added 023; no other ALTER). `getInvestigations` = `SELECT i.*, ins.title AS insight_title, ins.severity AS insight_severity, ins.category AS insight_category` → `InvestigationWithInsight[]`. Frontend type is `InvestigationWithInsight`, so preserve the 3 join fields via an extended schema.
+- Harbor `VulnerabilityRecord` (17 fields) / `VulnerabilitySummary` (9 fields) mirror the frontend interfaces 1:1 (`use-harbor-vulnerabilities.ts:8-49`).
+
+---
+
+### Task 1: Harbor vulnerabilities list + summary schemas
+
+**Files:**
+- Modify: `packages/security/src/routes/harbor-vulnerabilities.ts` (imports `z` from `zod/v4` already at line 2)
+- Test: `packages/security/src/__tests__/harbor-vulnerabilities-response-schema.test.ts`
+
+**Schemas (module scope, after imports):**
+
+```ts
+const HarborVulnerabilityRecordSchema = z.object({
+  id: z.number(),
+  cve_id: z.string(),
+  severity: z.string(),
+  cvss_v3_score: z.number().nullable(),
+  package: z.string(),
+  version: z.string(),
+  fixed_version: z.string().nullable(),
+  status: z.string().nullable(),
+  description: z.string().nullable(),
+  links: z.string().nullable(),
+  project_id: z.number(),
+  repository_name: z.string(),
+  digest: z.string(),
+  tags: z.string().nullable(),
+  in_use: z.boolean(),
+  matching_containers: z.string().nullable(),
+  synced_at: z.string(),
+});
+
+const HarborVulnerabilitySummarySchema = z.object({
+  total: z.number(),
+  critical: z.number(),
+  high: z.number(),
+  medium: z.number(),
+  low: z.number(),
+  in_use_total: z.number(),
+  in_use_critical: z.number(),
+  fixable: z.number(),
+  excepted: z.number(),
+});
+
+const HarborVulnerabilityListResponseSchema = z.object({
+  vulnerabilities: z.array(HarborVulnerabilityRecordSchema),
+  summary: HarborVulnerabilitySummarySchema,
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+});
+```
+
+**Wiring:** add `response: { 200: HarborVulnerabilityListResponseSchema }` to the `/api/harbor/vulnerabilities` route schema (line ~98-110) and `response: { 200: HarborVulnerabilitySummarySchema }` to `/api/harbor/vulnerabilities/summary` (line ~135-140). Neither handler has an error reply, so no cast needed.
+
+- [ ] **Step 1: Write the failing test** — `harbor-vulnerabilities-response-schema.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+
+vi.mock('../services/harbor-vulnerability-store.js', () => ({
+  getVulnerabilities: vi.fn(),
+  getVulnerabilitySummary: vi.fn(),
+  getVulnerabilitiesCount: vi.fn(),
+  classifySyncStatus: vi.fn(),
+  getLatestSyncStatus: vi.fn(),
+}));
+vi.mock('../services/harbor-client.js', () => ({
+  isHarborConfiguredAsync: vi.fn().mockResolvedValue(true),
+  testConnection: vi.fn(), getSecuritySummary: vi.fn(),
+}));
+vi.mock('@dashboard/core/services/settings-store.js', () => ({
+  getEffectiveHarborConfig: vi.fn().mockResolvedValue({ enabled: false }),
+}));
+vi.mock('../services/harbor-sync.js', () => ({ runFullSync: vi.fn(), getIsSyncing: vi.fn() }));
+
+import * as vulnStore from '../services/harbor-vulnerability-store.js';
+import { harborVulnerabilityRoutes } from '../routes/harbor-vulnerabilities.js';
+
+const RECORD = {
+  id: 1, cve_id: 'CVE-2024-1', severity: 'Critical', cvss_v3_score: 9.8,
+  package: 'openssl', version: '1.1', fixed_version: null, status: null,
+  description: null, links: null, project_id: 2, repository_name: 'lib/app',
+  digest: 'sha256:x', tags: null, in_use: true, matching_containers: null,
+  synced_at: '2026-07-13T00:00:00.000Z',
+};
+const SUMMARY = { total: 1, critical: 1, high: 0, medium: 0, low: 0, in_use_total: 1, in_use_critical: 1, fixable: 0, excepted: 0 };
+
+function buildApp(): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.decorate('authenticate', async () => undefined);
+  app.decorate('requireRole', () => async () => undefined);
+  return app;
+}
+
+describe('GET /api/harbor/vulnerabilities response schema', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('preserves every VulnerabilityRecord + summary field the frontend reads', async () => {
+    vi.mocked(vulnStore.getVulnerabilities).mockResolvedValue([RECORD] as never);
+    vi.mocked(vulnStore.getVulnerabilitySummary).mockResolvedValue(SUMMARY as never);
+    vi.mocked(vulnStore.getVulnerabilitiesCount).mockResolvedValue(1 as never);
+    const app = buildApp();
+    await app.register(harborVulnerabilityRoutes);
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/api/harbor/vulnerabilities' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toMatchObject({ total: 1, limit: 200, offset: 0, summary: SUMMARY });
+    expect(body.vulnerabilities[0]).toEqual(RECORD);
+    await app.close();
+  });
+
+  it('summary route returns all 9 counters', async () => {
+    vi.mocked(vulnStore.getVulnerabilitySummary).mockResolvedValue(SUMMARY as never);
+    const app = buildApp();
+    await app.register(harborVulnerabilityRoutes);
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/api/harbor/vulnerabilities/summary' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual(SUMMARY);
+    await app.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (fields still present without schema, but the test also asserts `res.json().vulnerabilities[0]` equals RECORD exactly; before the schema, extra internal fields could differ). Run: `cd packages/security && npx vitest run src/__tests__/harbor-vulnerabilities-response-schema.test.ts`
+- [ ] **Step 3: Add the 3 schemas + `response` blocks** to `harbor-vulnerabilities.ts`.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** — `feat(#1545): response schema for harbor vulnerabilities list + summary`.
+
+---
+
+### Task 2: Settings list schema
+
+**Files:**
+- Modify: `packages/foundation/src/routes/settings.ts` — add `import { SettingSchema } from '@dashboard/core/models/settings.js';` and `import { z } from 'zod/v4';`
+- Test: `packages/foundation/src/__tests__/settings-response-schema.test.ts`
+
+**Wiring:** `GET /api/settings` (line 141) → add `response: { 200: z.array(SettingSchema) }`.
+
+- [ ] **Step 1: Write failing test** — mock the DB router so the route returns a controlled row incl. an extra internal column, and assert the response prunes to the 4 SettingSchema fields:
+
+```ts
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => ({ query: async () => [
+    { key: 'llm.model', value: 'gpt-4o-mini', category: 'ai', updated_at: '2026-07-13T00:00:00.000Z', internal_only: 'x' },
+  ] }),
+}));
+```
+Register `settingsRoutes`, inject `GET /api/settings`, assert `body[0]` `toEqual({ key, value, category, updated_at })` (internal_only pruned).
+
+- [ ] **Step 2: Run — expect FAIL** (`internal_only` leaks without the schema).
+- [ ] **Step 3: Add the `response` block.**
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** — `feat(#1545): response schema for GET /api/settings`.
+
+---
+
+### Task 3: Investigations list schema (+ contracts schema)
+
+**Files:**
+- Modify: `packages/contracts/src/schemas/investigation.ts` — add `InvestigationWithInsightSchema`
+- Modify: `packages/ai-intelligence/src/routes/investigations.ts` — add `import { z } from 'zod/v4';` and `import { InvestigationWithInsightSchema } from '@dashboard/contracts';`
+- Test: `packages/ai-intelligence/src/__tests__/investigations-response-schema.test.ts`
+
+**Contracts schema (mirror the existing `InvestigationWithInsight` interface):**
+
+```ts
+export const InvestigationWithInsightSchema = InvestigationSchema.extend({
+  insight_title: z.string().nullable().optional(),
+  insight_severity: z.string().nullable().optional(),
+  insight_category: z.string().nullable().optional(),
+});
+```
+
+**Wiring:** `GET /api/investigations` (line 14) → `response: { 200: z.object({ investigations: z.array(InvestigationWithInsightSchema) }) }`.
+
+- [ ] **Step 1: Write failing test** — `vi.mock('../services/investigation-store.js', () => ({ getInvestigations: vi.fn(), getInvestigation: vi.fn(), getInvestigationByInsightId: vi.fn() }))`; return one `InvestigationWithInsight` fixture (all 18 fields + insight_title/severity/category). Assert `body.investigations[0]` retains `id`, `insight_id`, `status`, `ai_summary`, AND `insight_title` (proves the join fields survive).
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Add contracts schema + route `response` block.**
+- [ ] **Step 4: Run — expect PASS.** Also run contracts + ai-intelligence typecheck.
+- [ ] **Step 5: Commit** — `feat(#1545): response schema for GET /api/investigations`.
+
+---
+
+### Task 4: Incidents list schema
+
+**Files:**
+- Modify: `packages/ai-intelligence/src/routes/incidents.ts` — add `import { IncidentSchema } from '@dashboard/contracts';`
+- Test: `packages/ai-intelligence/src/__tests__/incidents-response-schema.test.ts`
+
+**Schema (module scope, uses the route's existing `z`):**
+
+```ts
+const IncidentsListResponseSchema = z.object({
+  incidents: z.array(IncidentSchema),
+  counts: z.object({ active: z.number(), resolved: z.number(), total: z.number() }),
+  limit: z.number(),
+  offset: z.number(),
+});
+```
+
+**Wiring:** `GET /api/incidents` (line 23) → `response: { 200: IncidentsListResponseSchema }`. The 400 invalid-query reply (line 35) must become `return (reply as any).code(400).send({ error: 'invalid query', details: parsed.error.flatten() })`.
+
+- [ ] **Step 1: Write failing test** — `vi.mock('../services/incident-store.js', () => ({ getIncidents: vi.fn(), getIncident: vi.fn(), resolveIncident: vi.fn(), getIncidentCount: vi.fn(), getIncidentGroups: vi.fn(), resolveIncidentsBatch: vi.fn() }))`. Return one incident fixture that INCLUDES an extra `signature: 'sig-1'` field; `getIncidentCount → { active:1, resolved:0, total:1 }`. Assert: `body.counts` equals `{active:1,resolved:0,total:1}`; `body.incidents[0]` has all IncidentSchema fields (`related_insight_ids` array, `affected_containers` array, etc.); and `body.incidents[0].signature` is `undefined` (pruned).
+- [ ] **Step 2: Run — expect FAIL** (`signature` leaks; counts/limit/offset present already).
+- [ ] **Step 3: Add schema + `response` block + cast the 400 path.**
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** — `feat(#1545): response schema for GET /api/incidents`.
+
+---
+
+### Task 5: Full verification + docs + PR note
+
+- [ ] Run each touched package's full test + typecheck: `npx vitest run` in `packages/security`, `packages/foundation`, `packages/ai-intelligence`, `packages/contracts`; `npm run typecheck`.
+- [ ] Run frontend consumer tests to confirm no shape regression: `cd frontend && npx vitest run src/features/security src/features/core/hooks/use-settings.test.ts src/features/ai-intelligence` (whichever exist).
+- [ ] Update `docs/architecture.md` if it enumerates schema coverage (add the 5 routes).
+- [ ] No `docker/.env.example` change (no new env). No CLAUDE/AGENTS/GEMINI change (pure additive batch).
+- [ ] Leave a PR comment on #1545 listing the 5 routes covered + that the bulk remains (issue stays open).
+
+## Self-Review
+
+- **Spec coverage:** all 5 spec routes have a task (settings T2, harbor list+summary T1, investigations T3, incidents T4). Excluded routes untouched. ✓
+- **Placeholders:** none — every schema and test skeleton is concrete. ✓
+- **Type consistency:** `InvestigationWithInsightSchema` defined in T3 and consumed in the same task; `IncidentSchema`/`SettingSchema` are existing exports; harbor schemas are self-contained in T1. Date fields `z.string()` per Global Constraints. ✓
+- **Incidents caveat resolved:** served shape is `{incidents,counts,limit,offset}` (confirmed at `incidents.ts:42-47`); `signature` prune is safe (frontend `Incident` omits it). Not deferred. ✓

--- a/docs/superpowers/specs/2026-07-13-issue-1545-response-schemas-batch-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-1545-response-schemas-batch-design.md
@@ -1,0 +1,70 @@
+# Issue #1545 — Fastify response-schema adoption: one focused batch
+
+- **Issue:** #1545 (enhancement, refactoring, technical-debt, frontend, priority/low)
+- **Branch:** `feature/1545-response-schemas-batch` (off `dev`)
+- **Date:** 2026-07-13
+
+## Problem
+
+The app wires `fastify-type-provider-zod`'s `serializerCompiler` globally (`packages/core/src/plugins/swagger.ts:12-14`), so any route that declares a `response:` schema gets fast-json-stringify serialization, unknown-field pruning (defense against accidental sensitive-field leaks), and accurate OpenAPI output. But only ~20 of ~197 route registrations across `packages/*/src/routes` declare one (≈14 route files). The three original frontend/backend envelope mismatches were already fixed (#1553), and several route families gained schemas (#1557, #1559). What remains is the bulk of the schema-less routes, which the maintainers are adopting **incrementally** — because a `200`-only response schema **silently strips any field not enumerated**, so each batch must be verified against its frontend consumers and covered by a field-presence test.
+
+This spec is **one focused, low-risk batch**, not the whole sweep.
+
+## Scope: the batch
+
+Five hot/large GET routes, each backed by an existing exact-match Zod model or a trivially-mirrored one, each with a clearly identifiable frontend consumer:
+
+| # | Route | Handler | Schema source | Frontend consumer | Risk |
+|---|-------|---------|---------------|-------------------|------|
+| 1 | GET `/api/settings` | `packages/foundation/src/routes/settings.ts:141` | existing `SettingSchema` (`packages/core/src/models/settings.ts:3`) — exact 4-column DB match | `frontend/src/features/core/hooks/use-settings.ts:47` (reads key/value/category) | low |
+| 2 | GET `/api/harbor/vulnerabilities` | `packages/security/src/routes/harbor-vulnerabilities.ts:97` | new schema (1:1 mirror of frontend `VulnerabilityListResponse`) | `frontend/src/features/security/hooks/use-harbor-vulnerabilities.ts:40-49,105-131` | low |
+| 3 | GET `/api/harbor/vulnerabilities/summary` | `harbor-vulnerabilities.ts:135` | reuse the summary sub-schema from #2 | `use-harbor-vulnerabilities.ts:133-139` | low |
+| 4 | GET `/api/investigations` | `packages/ai-intelligence/src/routes/investigations.ts:14` | existing `InvestigationSchema` (`packages/contracts/src/schemas/investigation.ts`), wrapped `{ investigations: z.array(...) }` | `frontend/src/features/.../use-investigations.ts:29` | low |
+| 5 | GET `/api/incidents` | `packages/ai-intelligence/src/routes/incidents.ts:23` | existing `IncidentSchema` (`packages/contracts/src/schemas/incident.ts`) | `use-incidents.ts:31`, `incident-groups-view.tsx:140` | low-med |
+
+### Established pattern to copy
+- Response schema block: `packages/ai-intelligence/src/routes/monitoring.ts:288-311` (`response: { 200: SuccessResponseSchema }`).
+- Error-path cast: `return (reply as any).code(5xx).send({ error, details: errorDetails(err) })` (`monitoring.ts:308`, `settings.ts:320`). Required because the Zod type-provider narrows `reply` to the 200 shape. The alternative — declaring the error status in the response map like `dashboard.ts:223` (`response: { 200: ..., 502: ErrorWithDetailsSchema }`) — is acceptable where an error status is already returned.
+- New shared schemas go in `packages/core/src/models/api-schemas.ts` (or a dedicated `harbor` schema module) to match the import convention.
+
+## Non-negotiable verification per route
+
+For each route, before finalizing its schema:
+1. Read the exact object the handler returns (all top-level fields; for arrays, every field of the element).
+2. Read the frontend consumer's declared type and, critically, **which fields it actually reads** in the component tree.
+3. Confirm the Zod schema enumerates **every field the frontend reads** (superset-on-the-client fields that are already `undefined` today are fine to omit — they aren't sent).
+4. Add a field-presence test asserting the served payload still contains those fields after the schema prunes.
+
+Route-specific notes:
+- **#1 settings** — `SELECT *` over a 4-column table (`key,value,category,updated_at`); `SettingSchema` matches exactly. The frontend `Setting` type is a superset (`label/description/type/updatedBy/updatedAt`) but those are not sent today, so no regression.
+- **#4 investigations** — confirm the handler returns `{ investigations: [...] }` (not a bare array) and that `InvestigationSchema` covers all served fields; adjust the wrapper to match reality.
+- **#5 incidents** — confirm the list wrapper shape (bare `Incident[]` vs `{ incidents: [...] }`) against `incidents.ts:23` and the consumer before choosing `z.array(IncidentSchema)` vs a wrapper. This is the one route flagged low-med; if the served shape diverges from `IncidentSchema`, either extend the schema or defer this route from the batch rather than strip a field.
+
+## Explicitly excluded (need column-level audits first)
+
+- **GET `/api/containers`** (`packages/foundation/src/routes/containers.ts:71`) — a 3-way polymorphic union, and the only ready-made `NormalizedContainerSchema` is stale (omits `networkIPs`, which the frontend reads). High risk. Maintainers intend to leave the polymorphic shape unchanged.
+- **GET `/api/monitoring/insights`** (`monitoring.ts:76`) — returns raw `SELECT *` insight rows (superset of `InsightSchema`); a strict schema would strip extra DB columns. Needs a column audit first.
+
+## Tests
+
+- Backend: one field-presence test per route (in the route's existing test file, or a new `*.test.ts` alongside it), asserting the served 200 payload retains each field the frontend consumer reads. Follow the project pattern: real PostgreSQL via `test-db-helper.ts` where the route hits the DB, mock only external boundaries.
+- Keep existing route tests green (schema pruning must not break them).
+
+## Docs
+
+- `docs/architecture.md` — note the newly schema-covered routes if the doc enumerates coverage.
+- No `docker/.env.example` change (no new env).
+- CLAUDE/AGENTS/GEMINI trio — only if a rule/pattern changes (not expected for a pure additive batch).
+- PR comment on #1545 listing which routes this batch covered and what remains (mirroring the existing progress comments).
+
+## Acceptance criteria
+
+- [ ] Response schemas added to the 5 routes (or 4, if incidents is deferred after verification).
+- [ ] Each route's served payload verified field-by-field against its frontend consumer.
+- [ ] A field-presence test added/updated per route; full suite green.
+- [ ] Docs updated where relevant; PR links the issue and leaves the progress comment. Issue stays open (bulk remains).
+
+## Out of scope
+
+- The remaining ~150 schema-less routes (future batches).
+- Retiring the polymorphic `GET /api/containers` shape.

--- a/packages/ai-intelligence/src/__tests__/incidents-jsonb.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-jsonb.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 import Fastify from 'fastify';
+import { serializerCompiler } from 'fastify-type-provider-zod';
 import { getTestDb, truncateTestTables, closeTestDb } from '@dashboard/core/db/test-db-helper.js';
 import type { AppDb } from '@dashboard/core/db/app-db.js';
 import { incidentsRoutes } from '../routes/incidents.js';
@@ -71,6 +72,7 @@ describe('Incidents JSONB Type Regression Tests', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     app = Fastify();
+    app.setSerializerCompiler(serializerCompiler);
     app.decorate('authenticate', async () => {});
     app.decorate('requireRole', () => async () => undefined);
     await app.register(incidentsRoutes);

--- a/packages/ai-intelligence/src/__tests__/incidents-response-schema.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-response-schema.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Field-presence test for the GET /api/incidents response schema (#1545).
+ *
+ * getIncidents does SELECT * FROM incidents, so rows carry a `signature` column
+ * (added in migration 029) that is NOT part of the frontend Incident type. The
+ * response schema z.object({ incidents: z.array(IncidentSchema), counts, limit,
+ * offset }) must preserve every IncidentSchema field + counts/limit/offset and
+ * prune the internal `signature`. The store is mocked (the boundary).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+
+vi.mock('../services/incident-store.js', () => ({
+  getIncidents: vi.fn(),
+  getIncident: vi.fn(),
+  resolveIncident: vi.fn(),
+  getIncidentCount: vi.fn(),
+  getIncidentGroups: vi.fn(),
+  resolveIncidentsBatch: vi.fn(),
+}));
+
+import { getIncidents, getIncidentCount } from '../services/incident-store.js';
+import { incidentsRoutes } from '../routes/incidents.js';
+
+const INCIDENT = {
+  id: 'inc-1',
+  title: 'CPU spike across web tier',
+  severity: 'critical',
+  status: 'active',
+  root_cause_insight_id: 'ins-1',
+  related_insight_ids: ['ins-1', 'ins-2'],
+  affected_containers: ['c1', 'c2'],
+  endpoint_id: 1,
+  endpoint_name: 'ep-1',
+  correlation_type: 'temporal',
+  correlation_confidence: 'high',
+  insight_count: 2,
+  summary: 'Correlated CPU anomalies',
+  created_at: '2026-07-13T00:00:00.000Z',
+  updated_at: '2026-07-13T00:00:00.000Z',
+  resolved_at: null,
+};
+const COUNTS = { active: 1, resolved: 0, total: 1 };
+
+function buildApp(): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.decorate('authenticate', async () => undefined);
+  app.decorate('requireRole', () => async () => undefined);
+  return app;
+}
+
+describe('GET /api/incidents response schema', () => {
+  it('preserves IncidentSchema fields + counts/limit/offset and prunes signature', async () => {
+    // Row carries the internal `signature` column the schema must prune.
+    vi.mocked(getIncidents).mockResolvedValue([{ ...INCIDENT, signature: 'sig-1' }] as never);
+    vi.mocked(getIncidentCount).mockResolvedValue(COUNTS as never);
+
+    const app = buildApp();
+    await app.register(incidentsRoutes);
+    await app.ready();
+
+    const res = await app.inject({ method: 'GET', url: '/api/incidents' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.counts).toEqual(COUNTS);
+    expect(body.limit).toBe(50);
+    expect(body.offset).toBe(0);
+    expect(body.incidents[0]).toEqual(INCIDENT);
+    expect(body.incidents[0].signature).toBeUndefined();
+    await app.close();
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/incidents.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 import Fastify, { type FastifyInstance, type FastifyRequest, type FastifyReply } from 'fastify';
+import { serializerCompiler } from 'fastify-type-provider-zod';
 import { testAdminOnly } from '@dashboard/core/test-utils/rbac-test-helper.js';
 import { incidentsRoutes } from '../routes/incidents.js';
 import { getIncidents, getIncident, resolveIncident, getIncidentCount, resolveIncidentsBatch, getIncidentGroups } from '../services/incident-store.js';
@@ -45,6 +46,7 @@ describe('incidents routes', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     app = Fastify();
+    app.setSerializerCompiler(serializerCompiler);
 
     // Mock auth decorator
     app.decorate('authenticate', async () => {});
@@ -56,7 +58,24 @@ describe('incidents routes', () => {
   describe('GET /api/incidents', () => {
     it('should return incidents list with counts', async () => {
       mockedGetIncidents.mockResolvedValue([
-        { id: 'inc-1', title: 'Test incident', severity: 'critical', status: 'active' } as never,
+        {
+          id: 'inc-1',
+          title: 'Test incident',
+          severity: 'critical',
+          status: 'active',
+          root_cause_insight_id: null,
+          related_insight_ids: [],
+          affected_containers: [],
+          endpoint_id: null,
+          endpoint_name: null,
+          correlation_type: 'temporal',
+          correlation_confidence: 'medium',
+          insight_count: 1,
+          summary: null,
+          created_at: '2026-07-13T00:00:00.000Z',
+          updated_at: '2026-07-13T00:00:00.000Z',
+          resolved_at: null,
+        } as never,
       ]);
       mockedGetIncidentCount.mockResolvedValue({ active: 1, resolved: 0, total: 1 });
 
@@ -306,6 +325,7 @@ describe('incidents RBAC', () => {
   beforeAll(async () => {
     currentRole = 'admin';
     rbacApp = Fastify({ logger: false });
+    rbacApp.setSerializerCompiler(serializerCompiler);
     rbacApp.decorate('authenticate', async () => undefined);
     rbacApp.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request: FastifyRequest, reply: FastifyReply) => {
       const rank = { viewer: 0, operator: 1, admin: 2 };

--- a/packages/ai-intelligence/src/__tests__/investigations-response-schema.test.ts
+++ b/packages/ai-intelligence/src/__tests__/investigations-response-schema.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Field-presence test for the GET /api/investigations response schema (#1545).
+ *
+ * getInvestigations returns InvestigationWithInsight[] (SELECT i.* + the joined
+ * insight_title/insight_severity/insight_category). The response schema is
+ * z.object({ investigations: z.array(InvestigationWithInsightSchema) }) — it
+ * must preserve the 18 investigation columns AND the 3 join fields, while
+ * pruning anything else. The store is mocked (the boundary).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+
+vi.mock('../services/investigation-store.js', () => ({
+  getInvestigations: vi.fn(),
+  getInvestigation: vi.fn(),
+  getInvestigationByInsightId: vi.fn(),
+}));
+
+import { getInvestigations } from '../services/investigation-store.js';
+import { investigationRoutes } from '../routes/investigations.js';
+
+const INVESTIGATION = {
+  id: 'inv-1',
+  insight_id: 'ins-1',
+  endpoint_id: 1,
+  container_id: 'c1',
+  container_name: 'web',
+  status: 'complete',
+  evidence_summary: null,
+  root_cause: 'oom-kill',
+  contributing_factors: null,
+  severity_assessment: null,
+  recommended_actions: null,
+  confidence_score: 0.9,
+  analysis_duration_ms: 1200,
+  llm_model: 'gpt-4o-mini',
+  ai_summary: 'Container was OOM-killed',
+  error_message: null,
+  created_at: '2026-07-13T00:00:00.000Z',
+  completed_at: '2026-07-13T00:01:00.000Z',
+  // Joined insight metadata (InvestigationWithInsight)
+  insight_title: 'High CPU',
+  insight_severity: 'warning',
+  insight_category: 'performance',
+};
+
+function buildApp(): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.decorate('authenticate', async () => undefined);
+  app.decorate('requireRole', () => async () => undefined);
+  return app;
+}
+
+describe('GET /api/investigations response schema', () => {
+  it('preserves the 18 columns + insight_* join fields and prunes internals', async () => {
+    vi.mocked(getInvestigations).mockResolvedValue([
+      { ...INVESTIGATION, internal_secret: 'should-be-pruned' },
+    ] as never);
+
+    const app = buildApp();
+    await app.register(investigationRoutes);
+    await app.ready();
+
+    const res = await app.inject({ method: 'GET', url: '/api/investigations' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.investigations[0]).toEqual(INVESTIGATION);
+    await app.close();
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/investigations-route.test.ts
+++ b/packages/ai-intelligence/src/__tests__/investigations-route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import Fastify, { FastifyInstance } from 'fastify';
-import { validatorCompiler } from 'fastify-type-provider-zod';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
 import { investigationRoutes } from '../routes/investigations.js';
 
 // Kept: investigation-store mock — no PostgreSQL in CI
@@ -32,7 +32,20 @@ const sampleInvestigation = {
   container_id: 'abc123',
   container_name: 'web',
   status: 'complete' as const,
+  // Nullable columns must be present (the GET /api/investigations response
+  // schema validates the full InvestigationWithInsight shape, #1545).
+  evidence_summary: null,
+  root_cause: null,
+  contributing_factors: null,
+  severity_assessment: null,
+  recommended_actions: null,
+  confidence_score: null,
+  analysis_duration_ms: null,
+  llm_model: null,
+  ai_summary: null,
+  error_message: null,
   created_at: '2026-01-01T00:00:00.000Z',
+  completed_at: null,
   insight_title: 'High CPU usage',
   insight_severity: 'critical',
   insight_category: 'anomaly',
@@ -44,6 +57,7 @@ describe('Investigation Routes', () => {
   beforeAll(async () => {
     app = Fastify({ logger: false });
     app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
     app.decorate('authenticate', async () => undefined);
     app.decorate('requireRole', () => async () => undefined);
     app.decorateRequest('user', undefined);

--- a/packages/ai-intelligence/src/routes/incidents.ts
+++ b/packages/ai-intelligence/src/routes/incidents.ts
@@ -5,7 +5,10 @@ import { FastifyInstance } from 'fastify';
 import { getIncidents, getIncident, resolveIncident, getIncidentCount, getIncidentGroups, resolveIncidentsBatch } from '../services/incident-store.js';
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { cachedFetchSWR, getCacheKey, cache } from '@dashboard/core/portainer/portainer-cache.js';
-import { z } from 'zod';
+// Use the explicit zod/v4 entry point (as the rest of the codebase + the
+// serializer's schemas do) so the response schema composes IncidentSchema
+// (authored under zod/v4) from the same module instance. #1545.
+import { z } from 'zod/v4';
 import { IncidentSchema } from '@dashboard/contracts';
 
 // Response schema for the list route (#1545). getIncidents does SELECT *, so

--- a/packages/ai-intelligence/src/routes/incidents.ts
+++ b/packages/ai-intelligence/src/routes/incidents.ts
@@ -6,6 +6,18 @@ import { getIncidents, getIncident, resolveIncident, getIncidentCount, getIncide
 import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
 import { cachedFetchSWR, getCacheKey, cache } from '@dashboard/core/portainer/portainer-cache.js';
 import { z } from 'zod';
+import { IncidentSchema } from '@dashboard/contracts';
+
+// Response schema for the list route (#1545). getIncidents does SELECT *, so
+// rows also carry the internal `signature` column (migration 029) which the
+// frontend Incident type omits — IncidentSchema prunes it. counts/limit/offset
+// mirror the handler's returned envelope.
+const IncidentsListResponseSchema = z.object({
+  incidents: z.array(IncidentSchema),
+  counts: z.object({ active: z.number(), resolved: z.number(), total: z.number() }),
+  limit: z.number(),
+  offset: z.number(),
+});
 
 export async function incidentsRoutes(fastify: FastifyInstance) {
   // Bounded query schema — without this, limit/offset were read via a raw cast
@@ -25,6 +37,7 @@ export async function incidentsRoutes(fastify: FastifyInstance) {
       tags: ['Incidents'],
       summary: 'List correlated incidents',
       security: [{ bearerAuth: [] }],
+      response: { 200: IncidentsListResponseSchema },
     },
     preHandler: [fastify.authenticate],
   }, async (request, reply) => {
@@ -32,7 +45,8 @@ export async function incidentsRoutes(fastify: FastifyInstance) {
     // route does not depend on a Zod validator compiler being registered.
     const parsed = ListQ.safeParse(request.query);
     if (!parsed.success) {
-      return reply.code(400).send({ error: 'invalid query', details: parsed.error.flatten() });
+      // Cast: the 200 response schema narrows `reply.send` to the success shape.
+      return (reply as any).code(400).send({ error: 'invalid query', details: parsed.error.flatten() });
     }
     const { status, severity, signature, limit, offset } = parsed.data;
 

--- a/packages/ai-intelligence/src/routes/investigations.ts
+++ b/packages/ai-intelligence/src/routes/investigations.ts
@@ -2,6 +2,7 @@ import '@dashboard/core/plugins/auth.js';
 import '@dashboard/core/plugins/request-tracing.js';
 import '@fastify/swagger';
 import { FastifyInstance } from 'fastify';
+import { z } from 'zod/v4';
 import {
   getInvestigations,
   getInvestigation,
@@ -9,6 +10,7 @@ import {
 } from '../services/investigation-store.js';
 import type { InvestigationStatus } from '@dashboard/core/models/investigation.js';
 import { InvestigationsQuerySchema, InvestigationIdParamsSchema, InsightIdParamsForInvestigationSchema } from '@dashboard/core/models/api-schemas.js';
+import { InvestigationWithInsightSchema } from '@dashboard/contracts';
 
 export async function investigationRoutes(fastify: FastifyInstance) {
   fastify.get('/api/investigations', {
@@ -17,6 +19,7 @@ export async function investigationRoutes(fastify: FastifyInstance) {
       summary: 'List investigations with optional filters',
       security: [{ bearerAuth: [] }],
       querystring: InvestigationsQuerySchema,
+      response: { 200: z.object({ investigations: z.array(InvestigationWithInsightSchema) }) },
     },
     preHandler: [fastify.authenticate],
   }, async (request) => {

--- a/packages/contracts/src/schemas/investigation.ts
+++ b/packages/contracts/src/schemas/investigation.ts
@@ -56,6 +56,16 @@ export type MetricSnapshot = z.infer<typeof MetricSnapshotSchema>;
 export type EvidenceSummary = z.infer<typeof EvidenceSummarySchema>;
 export type Investigation = z.infer<typeof InvestigationSchema>;
 
+// The list/detail endpoints LEFT JOIN the triggering insight, so the wire shape
+// carries three extra columns (nullable because the join may miss). Kept in sync
+// with the InvestigationWithInsight interface below; used as the GET
+// /api/investigations response schema (#1545).
+export const InvestigationWithInsightSchema = InvestigationSchema.extend({
+  insight_title: z.string().nullable().optional(),
+  insight_severity: z.string().nullable().optional(),
+  insight_category: z.string().nullable().optional(),
+});
+
 export interface InvestigationWithInsight extends Investigation {
   insight_title?: string;
   insight_severity?: string;

--- a/packages/foundation/src/__tests__/settings-response-schema.test.ts
+++ b/packages/foundation/src/__tests__/settings-response-schema.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Field-presence test for the GET /api/settings response schema (#1545).
+ *
+ * The settings table is exactly { key, value, category, updated_at } and the
+ * frontend reads key/value/category. Declaring `response: { 200: z.array(
+ * SettingSchema) }` must preserve those fields and prune anything else. The DB
+ * router is mocked to return a controlled row incl. a synthetic internal field.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+
+const ROW = {
+  key: 'llm.model',
+  value: 'gpt-4o-mini',
+  category: 'ai',
+  updated_at: '2026-07-13T00:00:00.000Z',
+};
+
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => ({
+    // Return the row with a synthetic extra column the schema must prune.
+    query: async () => [{ ...ROW, internal_only: 'should-be-pruned' }],
+  }),
+}));
+
+import { settingsRoutes } from '../routes/settings.js';
+
+function buildApp(): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.decorate('authenticate', async () => undefined);
+  app.decorate('requireRole', () => async () => undefined);
+  return app;
+}
+
+describe('GET /api/settings response schema', () => {
+  it('returns key/value/category/updated_at and prunes internal columns', async () => {
+    const app = buildApp();
+    await app.register(settingsRoutes);
+    await app.ready();
+
+    const res = await app.inject({ method: 'GET', url: '/api/settings' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body[0]).toEqual(ROW);
+    await app.close();
+  });
+});

--- a/packages/foundation/src/routes/settings.ts
+++ b/packages/foundation/src/routes/settings.ts
@@ -17,6 +17,7 @@ import {
   AuditLogQuerySchema,
   PreferencesUpdateBodySchema,
 } from '@dashboard/core/models/api-schemas.js';
+import { SettingSchema } from '@dashboard/core/models/settings.js';
 import { getUserDefaultLandingPage, setUserDefaultLandingPage } from '@dashboard/core/services/user-store.js';
 import { PROMPT_FEATURES, DEFAULT_PROMPTS, getEffectivePrompt, createPromptVersion, getPromptHistory, getPromptVersionById } from '@dashboard/ai';
 
@@ -144,6 +145,7 @@ export async function settingsRoutes(fastify: FastifyInstance) {
       summary: 'Get all settings',
       security: [{ bearerAuth: [] }],
       querystring: SettingsQuerySchema,
+      response: { 200: z.array(SettingSchema) },
     },
     preHandler: [fastify.authenticate, fastify.requireRole('admin')],
   }, async (request, reply) => {

--- a/packages/security/src/__tests__/harbor-vulnerabilities-response-schema.test.ts
+++ b/packages/security/src/__tests__/harbor-vulnerabilities-response-schema.test.ts
@@ -7,9 +7,11 @@
  * (use-harbor-vulnerabilities.ts) reads survives serialization. The store is
  * mocked (the boundary); the DB is not under test here.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+import type { z } from 'zod/v4';
+import type { VulnerabilityRecord, VulnerabilitySummary } from '../services/harbor-vulnerability-store.js';
 
 vi.mock('../services/harbor-vulnerability-store.js', () => ({
   getVulnerabilities: vi.fn(),
@@ -29,7 +31,11 @@ vi.mock('@dashboard/core/services/settings-store.js', () => ({
 vi.mock('../services/harbor-sync.js', () => ({ runFullSync: vi.fn(), getIsSyncing: vi.fn() }));
 
 import * as vulnStore from '../services/harbor-vulnerability-store.js';
-import { harborVulnerabilityRoutes } from '../routes/harbor-vulnerabilities.js';
+import {
+  harborVulnerabilityRoutes,
+  HarborVulnerabilityRecordSchema,
+  HarborVulnerabilitySummarySchema,
+} from '../routes/harbor-vulnerabilities.js';
 
 const RECORD = {
   id: 1,
@@ -107,5 +113,19 @@ describe('GET /api/harbor/vulnerabilities response schema', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual(SUMMARY);
     await app.close();
+  });
+});
+
+// Compile-time drift guard (#1545): the response schemas are hand-written to
+// mirror the store's TS interfaces. These type assertions fail `tsc` if the two
+// ever diverge in either direction — a field added/removed/retyped on either
+// side breaks the build here, so the manual mirror can't silently rot.
+describe('harbor response schemas stay in sync with the store interfaces', () => {
+  it('record schema matches VulnerabilityRecord', () => {
+    expectTypeOf<z.infer<typeof HarborVulnerabilityRecordSchema>>().toEqualTypeOf<VulnerabilityRecord>();
+  });
+
+  it('summary schema matches VulnerabilitySummary', () => {
+    expectTypeOf<z.infer<typeof HarborVulnerabilitySummarySchema>>().toEqualTypeOf<VulnerabilitySummary>();
   });
 });

--- a/packages/security/src/__tests__/harbor-vulnerabilities-response-schema.test.ts
+++ b/packages/security/src/__tests__/harbor-vulnerabilities-response-schema.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Field-presence test for the Harbor vulnerabilities response schemas (#1545).
+ *
+ * Adds `response: { 200: ... }` to GET /api/harbor/vulnerabilities and
+ * /api/harbor/vulnerabilities/summary. fastify-type-provider-zod prunes any
+ * field not enumerated, so this test asserts every field the frontend consumer
+ * (use-harbor-vulnerabilities.ts) reads survives serialization. The store is
+ * mocked (the boundary); the DB is not under test here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
+
+vi.mock('../services/harbor-vulnerability-store.js', () => ({
+  getVulnerabilities: vi.fn(),
+  getVulnerabilitySummary: vi.fn(),
+  getVulnerabilitiesCount: vi.fn(),
+  classifySyncStatus: vi.fn(),
+  getLatestSyncStatus: vi.fn(),
+}));
+vi.mock('../services/harbor-client.js', () => ({
+  isHarborConfiguredAsync: vi.fn().mockResolvedValue(true),
+  testConnection: vi.fn(),
+  getSecuritySummary: vi.fn(),
+}));
+vi.mock('@dashboard/core/services/settings-store.js', () => ({
+  getEffectiveHarborConfig: vi.fn().mockResolvedValue({ enabled: false }),
+}));
+vi.mock('../services/harbor-sync.js', () => ({ runFullSync: vi.fn(), getIsSyncing: vi.fn() }));
+
+import * as vulnStore from '../services/harbor-vulnerability-store.js';
+import { harborVulnerabilityRoutes } from '../routes/harbor-vulnerabilities.js';
+
+const RECORD = {
+  id: 1,
+  cve_id: 'CVE-2024-1',
+  severity: 'Critical',
+  cvss_v3_score: 9.8,
+  package: 'openssl',
+  version: '1.1',
+  fixed_version: null,
+  status: null,
+  description: null,
+  links: null,
+  project_id: 2,
+  repository_name: 'lib/app',
+  digest: 'sha256:x',
+  tags: null,
+  in_use: true,
+  matching_containers: null,
+  synced_at: '2026-07-13T00:00:00.000Z',
+};
+const SUMMARY = {
+  total: 1,
+  critical: 1,
+  high: 0,
+  medium: 0,
+  low: 0,
+  in_use_total: 1,
+  in_use_critical: 1,
+  fixable: 0,
+  excepted: 0,
+};
+
+function buildApp(): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.decorate('authenticate', async () => undefined);
+  app.decorate('requireRole', () => async () => undefined);
+  return app;
+}
+
+describe('GET /api/harbor/vulnerabilities response schema', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('preserves every VulnerabilityRecord + summary field the frontend reads, and prunes internal fields', async () => {
+    // Inject synthetic internal fields the store might one day return; the
+    // response schema must prune them (proves the schema is active).
+    vi.mocked(vulnStore.getVulnerabilities).mockResolvedValue([{ ...RECORD, _internal_secret: 'leak' }] as never);
+    vi.mocked(vulnStore.getVulnerabilitySummary).mockResolvedValue({ ...SUMMARY, _internal: 1 } as never);
+    vi.mocked(vulnStore.getVulnerabilitiesCount).mockResolvedValue(1 as never);
+
+    const app = buildApp();
+    await app.register(harborVulnerabilityRoutes);
+    await app.ready();
+
+    const res = await app.inject({ method: 'GET', url: '/api/harbor/vulnerabilities' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toMatchObject({ total: 1, limit: 200, offset: 0 });
+    // Exact-equality asserts both presence of every frontend field AND pruning
+    // of the synthetic internal fields.
+    expect(body.vulnerabilities[0]).toEqual(RECORD);
+    expect(body.summary).toEqual(SUMMARY);
+    await app.close();
+  });
+
+  it('summary route returns all 9 counters and prunes internal fields', async () => {
+    vi.mocked(vulnStore.getVulnerabilitySummary).mockResolvedValue({ ...SUMMARY, _internal: 1 } as never);
+
+    const app = buildApp();
+    await app.register(harborVulnerabilityRoutes);
+    await app.ready();
+
+    const res = await app.inject({ method: 'GET', url: '/api/harbor/vulnerabilities/summary' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual(SUMMARY);
+    await app.close();
+  });
+});

--- a/packages/security/src/__tests__/harbor-vulnerabilities-route.test.ts
+++ b/packages/security/src/__tests__/harbor-vulnerabilities-route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import { testAdminOnly } from '@dashboard/core/test-utils/rbac-test-helper.js';
 import Fastify, { FastifyInstance } from 'fastify';
-import { validatorCompiler } from 'fastify-type-provider-zod';
+import { validatorCompiler, serializerCompiler } from 'fastify-type-provider-zod';
 import { harborVulnerabilityRoutes } from '../routes/harbor-vulnerabilities.js';
 
 // Kept: harbor-client mock — no Harbor registry in CI
@@ -62,6 +62,44 @@ vi.mock('@dashboard/core/services/audit-logger.js', () => ({
   writeAuditLog: vi.fn(),
 }));
 
+// Complete fixtures matching the real store output (#1545). GET
+// /api/harbor/vulnerabilities now declares a response schema, so its serializer
+// validates the payload; partial mocks (missing columns) would fail to
+// serialize. `makeVuln` mirrors the 17-column harbor_vulnerabilities row and
+// `makeSummary` the 9-field VulnerabilitySummary.
+const makeVuln = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  cve_id: 'CVE-0000-0000',
+  severity: 'High',
+  cvss_v3_score: null,
+  package: 'openssl',
+  version: '1.0.0',
+  fixed_version: null,
+  status: null,
+  description: null,
+  links: null,
+  project_id: 1,
+  repository_name: 'lib/app',
+  digest: 'sha256:abc',
+  tags: null,
+  in_use: false,
+  matching_containers: null,
+  synced_at: '2026-07-13T00:00:00.000Z',
+  ...overrides,
+});
+const makeSummary = (overrides: Record<string, unknown> = {}) => ({
+  total: 0,
+  critical: 0,
+  high: 0,
+  medium: 0,
+  low: 0,
+  in_use_total: 0,
+  in_use_critical: 0,
+  fixable: 0,
+  excepted: 0,
+  ...overrides,
+});
+
 describe('Harbor Vulnerability Routes', () => {
   let app: FastifyInstance;
   let currentRole: 'viewer' | 'operator' | 'admin';
@@ -70,6 +108,7 @@ describe('Harbor Vulnerability Routes', () => {
     currentRole = 'admin';
     app = Fastify({ logger: false });
     app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
     app.decorate('authenticate', async () => undefined);
     app.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request: any, reply: any) => {
       const rank = { viewer: 0, operator: 1, admin: 2 };
@@ -95,7 +134,7 @@ describe('Harbor Vulnerability Routes', () => {
     currentRole = 'admin';
     mockIsHarborConfiguredAsync.mockResolvedValue(true);
     mockGetIsSyncing.mockReturnValue(false);
-    mockGetVulnerabilitySummary.mockResolvedValue({ critical: 0, high: 0, medium: 0, low: 0, total: 0 });
+    mockGetVulnerabilitySummary.mockResolvedValue(makeSummary());
     mockGetVulnerabilities.mockResolvedValue([]);
     mockGetVulnerabilitiesCount.mockResolvedValue(0);
     mockGetExceptions.mockResolvedValue([]);
@@ -104,8 +143,8 @@ describe('Harbor Vulnerability Routes', () => {
 
   describe('GET /api/harbor/vulnerabilities', () => {
     it('returns vulnerabilities and summary', async () => {
-      const vulns = [{ id: 1, cve_id: 'CVE-2024-0001', severity: 'HIGH', package_name: 'openssl' }];
-      const summary = { critical: 0, high: 1, medium: 0, low: 0, total: 1 };
+      const vulns = [makeVuln({ cve_id: 'CVE-2024-0001', severity: 'High' })];
+      const summary = makeSummary({ high: 1, total: 1 });
       mockGetVulnerabilities.mockResolvedValue(vulns);
       mockGetVulnerabilitySummary.mockResolvedValue(summary);
 
@@ -125,8 +164,8 @@ describe('Harbor Vulnerability Routes', () => {
     it('returns the filtered total plus echoed limit/offset for pagination (#1546)', async () => {
       // total (filtered) is distinct from summary.total (global) — a severity
       // filter narrows the count without touching the global KPI summary.
-      mockGetVulnerabilities.mockResolvedValue([{ id: 1, cve_id: 'CVE-A', severity: 'Critical' }]);
-      mockGetVulnerabilitySummary.mockResolvedValue({ critical: 3, high: 5, medium: 0, low: 0, total: 8 });
+      mockGetVulnerabilities.mockResolvedValue([makeVuln({ cve_id: 'CVE-A', severity: 'Critical' })]);
+      mockGetVulnerabilitySummary.mockResolvedValue(makeSummary({ critical: 3, high: 5, total: 8 }));
       mockGetVulnerabilitiesCount.mockResolvedValue(3);
 
       const response = await app.inject({

--- a/packages/security/src/routes/harbor-vulnerabilities.ts
+++ b/packages/security/src/routes/harbor-vulnerabilities.ts
@@ -17,8 +17,9 @@ const log = createChildLogger('route:harbor-vulnerabilities');
 // VulnerabilitySummary (harbor-vulnerability-store.ts) and the frontend's
 // VulnerabilityListResponse (use-harbor-vulnerabilities.ts) 1:1. Declaring them
 // as `response: { 200: ... }` enables fast-json-stringify serialization and
-// unknown-field pruning. Keep field-for-field in sync with the store interfaces.
-const HarborVulnerabilityRecordSchema = z.object({
+// unknown-field pruning. Exported so a compile-time drift guard in the tests can
+// assert they stay field-for-field in sync with the store interfaces.
+export const HarborVulnerabilityRecordSchema = z.object({
   id: z.number(),
   cve_id: z.string(),
   severity: z.string(),
@@ -38,7 +39,7 @@ const HarborVulnerabilityRecordSchema = z.object({
   synced_at: z.string(),
 });
 
-const HarborVulnerabilitySummarySchema = z.object({
+export const HarborVulnerabilitySummarySchema = z.object({
   total: z.number(),
   critical: z.number(),
   high: z.number(),

--- a/packages/security/src/routes/harbor-vulnerabilities.ts
+++ b/packages/security/src/routes/harbor-vulnerabilities.ts
@@ -13,6 +13,51 @@ import { runFullSync, getIsSyncing } from '../services/harbor-sync.js';
 
 const log = createChildLogger('route:harbor-vulnerabilities');
 
+// Response schemas (#1545) — mirror the store's VulnerabilityRecord /
+// VulnerabilitySummary (harbor-vulnerability-store.ts) and the frontend's
+// VulnerabilityListResponse (use-harbor-vulnerabilities.ts) 1:1. Declaring them
+// as `response: { 200: ... }` enables fast-json-stringify serialization and
+// unknown-field pruning. Keep field-for-field in sync with the store interfaces.
+const HarborVulnerabilityRecordSchema = z.object({
+  id: z.number(),
+  cve_id: z.string(),
+  severity: z.string(),
+  cvss_v3_score: z.number().nullable(),
+  package: z.string(),
+  version: z.string(),
+  fixed_version: z.string().nullable(),
+  status: z.string().nullable(),
+  description: z.string().nullable(),
+  links: z.string().nullable(),
+  project_id: z.number(),
+  repository_name: z.string(),
+  digest: z.string(),
+  tags: z.string().nullable(),
+  in_use: z.boolean(),
+  matching_containers: z.string().nullable(),
+  synced_at: z.string(),
+});
+
+const HarborVulnerabilitySummarySchema = z.object({
+  total: z.number(),
+  critical: z.number(),
+  high: z.number(),
+  medium: z.number(),
+  low: z.number(),
+  in_use_total: z.number(),
+  in_use_critical: z.number(),
+  fixable: z.number(),
+  excepted: z.number(),
+});
+
+const HarborVulnerabilityListResponseSchema = z.object({
+  vulnerabilities: z.array(HarborVulnerabilityRecordSchema),
+  summary: HarborVulnerabilitySummarySchema,
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+});
+
 export async function harborVulnerabilityRoutes(fastify: FastifyInstance) {
   // ---------------------------------------------------------------------------
   // Connection & Status
@@ -107,6 +152,7 @@ export async function harborVulnerabilityRoutes(fastify: FastifyInstance) {
         limit: z.coerce.number().int().min(1).max(1000).default(200),
         offset: z.coerce.number().int().min(0).default(0),
       }),
+      response: { 200: HarborVulnerabilityListResponseSchema },
     },
     preHandler: [fastify.authenticate],
   }, async (request) => {
@@ -137,6 +183,7 @@ export async function harborVulnerabilityRoutes(fastify: FastifyInstance) {
       tags: ['Harbor'],
       summary: 'Get vulnerability summary statistics (from synced local data)',
       security: [{ bearerAuth: [] }],
+      response: { 200: HarborVulnerabilitySummarySchema },
     },
     preHandler: [fastify.authenticate],
   }, async () => {


### PR DESCRIPTION
## What & why

Part of #1545. One focused, low-risk batch of the incremental Fastify `response: { 200 }` schema adoption. Declaring a response schema on a route enables fast-json-stringify serialization + unknown-field pruning and locks the wire contract. This batch covers 5 hot GET routes, each backed by an existing exact-match Zod model or a trivially-mirrored one.

The issue stays **open** — this is one batch; the bulk of the ~150 schema-less routes remains for future batches.

## Routes covered

| Route | Schema | Notes |
|---|---|---|
| `GET /api/harbor/vulnerabilities` (+`/summary`) | new `HarborVulnerabilityRecordSchema` (17 cols) + `HarborVulnerabilitySummarySchema` (9 fields) | mirrors the store interfaces and the frontend `VulnerabilityListResponse` 1:1 |
| `GET /api/settings` | existing `SettingSchema` | exact 4-column DB match (key/value/category/updated_at) |
| `GET /api/investigations` | new `InvestigationWithInsightSchema` in `@dashboard/contracts` | extends `InvestigationSchema` with the nullable `insight_*` join columns |
| `GET /api/incidents` | existing `IncidentSchema` | prunes the internal `signature` column (not in the frontend `Incident` type) |

**Excluded pending column audits** (per the maintainers' incremental caution): `GET /api/containers` (stale `NormalizedContainerSchema` drops `networkIPs`; 3-way polymorphic union) and `GET /api/monitoring/insights` (`SELECT *` superset of `InsightSchema`).

## Field-safety

Every route's schema was verified **field-by-field against the audited table columns** (migrations) **and** its frontend consumer, so no field a consumer reads is stripped. Timestamp columns stay `z.string()` (the pg type parsers already return TIMESTAMPTZ as ISO strings). Nullable columns use `.nullable()` (present-but-null), matching `SELECT *` output.

## Tests

- Added a **field-presence test per route** (asserts consumer-read fields survive serialization + internal fields are pruned).
- Updated existing route-test harnesses to register `setSerializerCompiler` (a route with a `response` schema fails to boot without it) and completed partial fixtures that no longer satisfied the now-validated shapes.
- Full suites green: contracts 26, foundation 51, security 274, ai-intelligence 891, backend 115. (Local DB-backed tests were skipped due to an unrelated local test-DB auth drift — CI provisions the DB.)

## Docs

Design spec + implementation plan under `docs/superpowers/specs|plans/`. No `.env`/architecture/CLAUDE changes (pure additive batch; `architecture.md` does not enumerate per-route schema coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
