### PR TITLE
Fix flaky E2E: Radix Select anchor + settings cold-nav + E2E volume isolation (Closes #1560)

### DIFF
--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -3,6 +3,15 @@
 # exercisable offline. Layer it AFTER the base file:
 #   docker compose -f docker/docker-compose.yml -f docker/docker-compose.e2e.yml ...
 # The production compose file is never modified. (#1420, #1521)
+#
+# Isolated project name (#1560): the base compose has no `name:`, so on its own
+# it derives the project from the directory → `docker`, whose named volumes
+# materialize as docker_postgres-app-data / docker_timescale-data — the SAME
+# volumes the dev stack uses. Because CI (and local reproduction) tears the E2E
+# stack down with `down -v`, sharing that project would destroy the developer's
+# dev database. Setting the name here scopes every E2E volume to
+# ai-portainer-e2e_* so `down -v` can never touch the dev `docker_*` volumes.
+name: ai-portainer-e2e
 services:
   portainer-mock:
     image: wiremock/wiremock:3.13.1

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -54,6 +54,14 @@ services:
     # exceeded"). Raise it for the disposable CI stack only. (#1420)
     environment:
       - LOGIN_RATE_LIMIT=1000
+      # Every spec logs in as the SAME `admin` user (global-setup + auth.spec +
+      # remediation helpers + retries), so with the prod default of 5 the
+      # per-user concurrent-session cap evicts the OLDEST session — which is the
+      # storage-state session global-setup minted. Its token then 401s and the
+      # frontend redirects to /login, so late-running protected specs (settings,
+      # workload-explorer) intermittently fail with no sidebar. Raise the cap for
+      # the disposable CI stack so the shared-admin churn never evicts it. (#1560)
+      - MAX_CONCURRENT_SESSIONS_PER_USER=100
       # Point the backend at the deterministic LLM stub. The base compose reads
       # LLM_API_URL from the host env (empty in CI); this authoritative override
       # wins the environment merge so chat is always wired to the stub. (#1521)

--- a/docs/superpowers/specs/2026-07-13-issue-1560-e2e-flaky-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-1560-e2e-flaky-fixes-design.md
@@ -65,22 +65,21 @@ Docker commands run outside the Claude sandbox.
 - The two existing specs are the regression coverage and must pass.
 - Add/keep a focused unit assertion for the `themed-select` prop if practical (e.g. that `Content` carries `updatePositionStrategy="always"`), so the anchoring guarantee is pinned at the component level, mirroring the `.spotlight-card` guard comment.
 
-## Acceptance criteria
+## Acceptance criteria (as shipped)
 
-- [ ] All 11 previously-failing E2E tests pass locally against the isolated stack, repeatably.
-- [ ] `themed-select.tsx` sets `updatePositionStrategy="always"`.
-- [ ] `settings.tsx` tabs are lazy-loaded behind Suspense.
-- [ ] `docker-compose.e2e.yml` carries an isolated project `name:`.
-- [ ] No dev volume (`docker_postgres-app-data` / `docker_timescale-data`) is ever destroyed.
-- [ ] Docs updated where relevant; PR links `Closes #1560`.
+- [x] `themed-select.tsx` sets `updatePositionStrategy="always"` (+ a source-guard test); dropdown spec verified via CI (the `e2e` label), since it needs WireMock fleet data and can't run against the dev stack.
+- [x] `settings.spec.ts` cold-nav hardened (`domcontentloaded` + 30s bounded sidebar wait, 60s test timeout). **Not** the originally-planned `settings.tsx` lazy-load — symptom A does not reproduce locally, so the invasive/entangled refactor was dropped in favour of proportionate spec hardening (see Fix A above). Verified green locally (4/4).
+- [x] `docker-compose.e2e.yml` carries an isolated project `name:` (`ai-portainer-e2e`), verified via `docker compose config`.
+- [x] No dev volume (`docker_postgres-app-data` / `docker_timescale-data`) is destroyed — the isolated name scopes E2E volumes to `ai-portainer-e2e_*`; CI's `down -v` is now transparent to the dev stack (ci.yml uses the layered `-f` form throughout, service names only).
+- [x] Docs updated; PR links `Closes #1560`.
 
-## Files
+## Files (as shipped)
 
-- `frontend/src/shared/components/ui/themed-select.tsx` — add `updatePositionStrategy`.
-- `frontend/src/features/core/pages/settings.tsx` — lazy tabs + Suspense.
+- `frontend/src/shared/components/ui/themed-select.tsx` — add `updatePositionStrategy="always"`.
+- `frontend/src/shared/components/ui/themed-select.test.ts` — source-guard test (jsdom has no layout).
+- `e2e/settings.spec.ts` — cold-nav hardening (`gotoSettings` helper + `SHELL_TIMEOUT`).
 - `docker/docker-compose.e2e.yml` — isolated project `name`.
-- `e2e/workload-explorer-dropdown-position.spec.ts`, `e2e/settings.spec.ts` — hardening only if required.
-- `.github/workflows/ci.yml` — only if the compose `name` change needs a matching flag.
+- **Not changed:** `frontend/src/features/core/pages/settings.tsx` (lazy-load dropped — see Fix A) and `.github/workflows/ci.yml` (the compose `name` change is project-name-transparent to CI, which invokes every op via the layered `-f` form using service names).
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-13-issue-1560-e2e-flaky-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-1560-e2e-flaky-fixes-design.md
@@ -1,0 +1,86 @@
+# Issue #1560 — E2E flaky failures: settings sidebar timeout + workload-explorer dropdown (0,0)
+
+- **Issue:** #1560 (bug, frontend, priority/low, e2e)
+- **Branch:** `feature/1560-e2e-flaky-fixes` (off `dev`)
+- **Date:** 2026-07-13
+
+## Problem
+
+The label-gated Playwright E2E suite has 11 pre-existing flaky failures, in two unrelated clusters:
+
+1. **Workload Explorer filter dropdowns (8 tests, `e2e/workload-explorer-dropdown-position.spec.ts`)** — the Endpoint/Group/Stack/State selects sometimes render at viewport `(0,0)` instead of anchoring to their trigger.
+2. **Settings page (3 tests, `e2e/settings.spec.ts`)** — `expect(page.locator('[data-testid="sidebar"]')).toBeVisible()` in `beforeEach` times out (10s) on `/settings`.
+
+Both are render/timing failures independent of backend data.
+
+## Root Causes (traced)
+
+### B. Dropdown (0,0)
+`ThemedSelect` (`frontend/src/shared/components/ui/themed-select.tsx`) uses Radix Select with `position="popper"`. Radix computes the popper coordinates from `trigger.getBoundingClientRect()` **once at open time**, then relies on Floating UI's default `autoUpdate` (scroll / resize / ResizeObserver / layout-shift) to keep it anchored. `autoUpdate` does **not** observe an ancestor CSS-transform transition.
+
+AppLayout (`frontend/src/features/core/components/layout/app-layout.tsx`) animates the content region on entrance: `m.main` runs `initial={{ y: 12 }} → animate={{ y: 0 }}` and the per-pathname `m.div` runs `x: ±16 → 0`. Both put a live `transform` on ancestors of the trigger. When a dropdown is opened during that window (the specs deliberately race it with `force: true`), Radix snapshots a transient, offset trigger rect and never re-anchors after the transform settles — at the extreme the panel lands near viewport origin.
+
+The prior `.spotlight-card { transform: translateZ(0) }` fix (#1310) is already in place at `frontend/src/index.css:2012-2021` and is **correct** — because Radix Select portals to `document.body`, ancestor transforms don't re-parent the fixed popper; this is purely a position-snapshot timing race, not a containing-block bug.
+
+### A. Settings sidebar timeout
+`/settings` is the heaviest route chunk in the app. `frontend/src/features/core/pages/settings.tsx:22-29` **eagerly** (statically) imports all 8 tab modules (~1,900 lines of TSX; `tab-integrations.tsx` alone is 583 lines and several pull in `@tanstack/react-table` / `DataTable`). On the single-worker CI runner (`playwright.config.ts` `workers: 1`), downloading + parsing + evaluating that chunk contends for the main thread with the app-shell's first paint, the async `LazyMotion` features chunk, and the entrance animation. That contention occasionally pushes the sidebar's first paint past the 10s `expect` timeout — on `/settings` specifically, because `/workloads` is a lighter single-table page.
+
+The sidebar (`<aside data-testid="sidebar">` in `sidebar.tsx`) is a **sibling** of the page's Suspense boundary, so this is main-thread/resource contention, not a hard render dependency. `useSettings()` is a non-suspense `useQuery`, so data fetching is ruled out as the cause.
+
+Secondary (local-run only): the committed `e2e/.auth/user.json` JWT is expired (`exp` ~2026-02-21). CI regenerates it every run via the `setup` project (`e2e/global-setup.ts`, REST login), so it is stale-but-harmless in CI and for any local run that executes the `setup` project first.
+
+## Fixes
+
+### B. `updatePositionStrategy="always"`
+Add `updatePositionStrategy="always"` to `<SelectPrimitive.Content>` in `themed-select.tsx`. Radix Select's `Content` extends `PopperContentProps`, which supports `updatePositionStrategy?: 'optimized' | 'always'` (`@radix-ui/react-popper/dist/index.d.ts:38`). `"always"` passes `animationFrame: true` to Floating UI's `autoUpdate`, re-anchoring every animation frame while the panel is open. A dropdown opened mid-entrance-animation therefore self-corrects the instant the trigger's transform settles. One line; applies to every `ThemedSelect` app-wide; the `.spotlight-card` guard stays untouched. Cost: a rAF reposition loop, but only while a dropdown is open.
+
+### A. Lazy-load the settings tabs
+Convert the 7 heavy tab imports in `settings.tsx` to `React.lazy()` and render the active `TabsContent` inside a `<Suspense>` fallback using an existing skeleton primitive. This shrinks the initial `/settings` chunk so the shell paints promptly; tab bodies load on demand. Keep the lightest tab (or the default-selected one) eager if it avoids a visible flash on first paint. This addresses the leading root-cause hypothesis directly rather than only relaxing the test.
+
+### Spec hardening (only if needed after the code fixes)
+If, against a running stack, the two code fixes do not fully settle the specs, apply minimal hardening: wait for a stable shell signal before the sidebar assertion and/or scope a longer timeout to the initial cold navigation. No blanket timeout inflation.
+
+## Safe local verification (hard volume rule)
+
+The E2E stack (`docker compose -f docker/docker-compose.yml -f docker/docker-compose.e2e.yml`) defaults to compose project **`docker`**, whose named volumes materialize as `docker_postgres-app-data` / `docker_timescale-data` — the **same volumes the dev stack uses**. CI's teardown runs `down -v`. Running that locally would wipe the developer's dev data, which the project rules forbid.
+
+Mitigations (both applied):
+- **Run only under an isolated project:** `-p ai-portainer-e2e` for every `up`/`down`, so volumes become `ai-portainer-e2e_*`. Never run `down -v` (or any `-v` teardown) against the `docker` project. Teardown uses `down` without `-v`, or `down -v` scoped to `-p ai-portainer-e2e` only.
+- **Durable fix:** add `name: ai-portainer-e2e` to `docker/docker-compose.e2e.yml` so the E2E stack (including CI) can never share or destroy the dev `docker_*` volumes. Note: `redis-data` is not a real volume today (redis runs ephemerally), so only `postgres-app-data` and `timescale-data` are at risk.
+
+Docker commands run outside the Claude sandbox.
+
+## Verification flow
+
+1. Bring up the isolated E2E stack (`-p ai-portainer-e2e`); wait for `:3051/health`, `:8080/`, WireMock `:9000`.
+2. Run the two specs (the `setup` project regenerates fresh auth first). Reproduce the failures; capture timing/screenshots/trace as real evidence for the root causes.
+3. Apply the two code fixes (+ compose `name:`).
+4. Re-run the two specs → green. Run them a few times to confirm the flakiness is gone under `workers: 1`.
+5. Tear down the isolated stack safely.
+
+## Tests
+
+- The two existing specs are the regression coverage and must pass.
+- Add/keep a focused unit assertion for the `themed-select` prop if practical (e.g. that `Content` carries `updatePositionStrategy="always"`), so the anchoring guarantee is pinned at the component level, mirroring the `.spotlight-card` guard comment.
+
+## Acceptance criteria
+
+- [ ] All 11 previously-failing E2E tests pass locally against the isolated stack, repeatably.
+- [ ] `themed-select.tsx` sets `updatePositionStrategy="always"`.
+- [ ] `settings.tsx` tabs are lazy-loaded behind Suspense.
+- [ ] `docker-compose.e2e.yml` carries an isolated project `name:`.
+- [ ] No dev volume (`docker_postgres-app-data` / `docker_timescale-data`) is ever destroyed.
+- [ ] Docs updated where relevant; PR links `Closes #1560`.
+
+## Files
+
+- `frontend/src/shared/components/ui/themed-select.tsx` — add `updatePositionStrategy`.
+- `frontend/src/features/core/pages/settings.tsx` — lazy tabs + Suspense.
+- `docker/docker-compose.e2e.yml` — isolated project `name`.
+- `e2e/workload-explorer-dropdown-position.spec.ts`, `e2e/settings.spec.ts` — hardening only if required.
+- `.github/workflows/ci.yml` — only if the compose `name` change needs a matching flag.
+
+## Out of scope
+
+- Ungating the E2E job to run on every PR (issue calls this optional; revisit once green).
+- Broad restructuring of the entrance-animation system.

--- a/docs/superpowers/specs/2026-07-13-issue-1560-e2e-flaky-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-1560-e2e-flaky-fixes-design.md
@@ -1,4 +1,4 @@
-# Issue #1560 — E2E flaky failures: settings sidebar timeout + workload-explorer dropdown (0,0)
+# Issue #1560 — E2E flaky failures (settings + workload-explorer specs)
 
 - **Issue:** #1560 (bug, frontend, priority/low, e2e)
 - **Branch:** `feature/1560-e2e-flaky-fixes` (off `dev`)
@@ -6,82 +6,51 @@
 
 ## Problem
 
-The label-gated Playwright E2E suite has 11 pre-existing flaky failures, in two unrelated clusters:
+The label-gated Playwright E2E suite has 11 intermittently-failing tests — 3 in `e2e/settings.spec.ts` and 8 in `e2e/workload-explorer-dropdown-position.spec.ts`. Both clusters fail at the same point: `expect(page.locator('[data-testid="sidebar"]')).toBeVisible()` in `beforeEach`.
 
-1. **Workload Explorer filter dropdowns (8 tests, `e2e/workload-explorer-dropdown-position.spec.ts`)** — the Endpoint/Group/Stack/State selects sometimes render at viewport `(0,0)` instead of anchoring to their trigger.
-2. **Settings page (3 tests, `e2e/settings.spec.ts`)** — `expect(page.locator('[data-testid="sidebar"]')).toBeVisible()` in `beforeEach` times out (10s) on `/settings`.
+## Root cause (confirmed) — session eviction, not render timing
 
-Both are render/timing failures independent of backend data.
+The issue's title (and an initial pass on this branch) attributed these to **settings-chunk paint contention** and **Radix dropdown `(0,0)` positioning**. Both were wrong. Evidence disproving them:
 
-## Root Causes (traced)
+- Against a live stack, `settings.spec.ts` **passes locally** (sidebar renders well under 10s) — so it is not slow-paint contention.
+- In the failing CI run, the accessibility snapshot of the failing pages is the **login screen** (`"Sign in to your account"`): the specs are **unauthenticated**, redirected to `/login`, so the sidebar never mounts. The dropdown specs die at the same `beforeEach` sidebar wait and never reach any positioning assertion.
 
-### B. Dropdown (0,0)
-`ThemedSelect` (`frontend/src/shared/components/ui/themed-select.tsx`) uses Radix Select with `position="popper"`. Radix computes the popper coordinates from `trigger.getBoundingClientRect()` **once at open time**, then relies on Floating UI's default `autoUpdate` (scroll / resize / ResizeObserver / layout-shift) to keep it anchored. `autoUpdate` does **not** observe an ancestor CSS-transform transition.
+**Actual mechanism (traced end-to-end):**
 
-AppLayout (`frontend/src/features/core/components/layout/app-layout.tsx`) animates the content region on entrance: `m.main` runs `initial={{ y: 12 }} → animate={{ y: 0 }}` and the per-pathname `m.div` runs `x: ±16 → 0`. Both put a live `transform` on ancestors of the trigger. When a dropdown is opened during that window (the specs deliberately race it with `force: true`), Radix snapshots a transient, offset trigger rect and never re-anchors after the transform settles — at the extreme the panel lands near viewport origin.
+1. `e2e/global-setup.ts` REST-logs-in as `admin` **once**, minting session **A**; its JWT is written to `e2e/.auth/user.json` (the `storageState` every spec loads).
+2. The suite keeps logging in as the **same `admin`** — `auth.spec.ts`, `remediation-approval.spec.ts`, and the `e2e/helpers/{login,api}.ts` helpers all hardcode `admin` — and Playwright `retries: 2` amplifies it.
+3. `createSession` (`packages/core/src/services/session-store.ts:76-92`) enforces `MAX_CONCURRENT_SESSIONS_PER_USER` (default **5**, `env.schema.ts:58`) by **DELETE-ing the oldest** valid sessions. Session A is the oldest, so it is the first evicted.
+4. Once A is gone, every protected spec loading its token hits `authenticate` → `getSession(A)` returns undefined → **401** (`packages/core/src/plugins/auth.ts:54-57`).
+5. The frontend API client clears auth on 401 only (`frontend/src/shared/lib/api.ts:94-97` → `auth:expired`), `isAuthenticated` becomes `!!token === false` (`auth-provider.tsx:210`), and `ProtectedRoute` renders `<Navigate to="/login">`.
 
-The prior `.spotlight-card { transform: translateZ(0) }` fix (#1310) is already in place at `frontend/src/index.css:2012-2021` and is **correct** — because Radix Select portals to `document.body`, ancestor transforms don't re-parent the fixed popper; this is purely a position-snapshot timing race, not a containing-block bug.
+This is the **only** code path that turns a valid, non-expired token into a 401. Corroboration: the CI backend log shows **59 × 401** during the run. It's intermittent because it depends on how many `admin` logins have landed when each late-running protected spec loads (settings/workload sort last alphabetically). The `FST_ERR_REP_ALREADY_SENT` / `@fastify/compress` `ERR_HTTP_HEADERS_SENT` 500s on `/api/endpoints|stacks|harbor/enabled|remediation/actions` are **benign abort noise** — the redirect unmounts the page and cancels those in-flight GETs; they are a fingerprint of the redirect, not its cause (client never sees them; 500 ≠ 401).
 
-### A. Settings sidebar timeout
-`/settings` is the heaviest route chunk in the app. `frontend/src/features/core/pages/settings.tsx:22-29` **eagerly** (statically) imports all 8 tab modules (~1,900 lines of TSX; `tab-integrations.tsx` alone is 583 lines and several pull in `@tanstack/react-table` / `DataTable`). On the single-worker CI runner (`playwright.config.ts` `workers: 1`), downloading + parsing + evaluating that chunk contends for the main thread with the app-shell's first paint, the async `LazyMotion` features chunk, and the entrance animation. That contention occasionally pushes the sidebar's first paint past the 10s `expect` timeout — on `/settings` specifically, because `/workloads` is a lighter single-table page.
-
-The sidebar (`<aside data-testid="sidebar">` in `sidebar.tsx`) is a **sibling** of the page's Suspense boundary, so this is main-thread/resource contention, not a hard render dependency. `useSettings()` is a non-suspense `useQuery`, so data fetching is ruled out as the cause.
-
-Secondary (local-run only): the committed `e2e/.auth/user.json` JWT is expired (`exp` ~2026-02-21). CI regenerates it every run via the `setup` project (`e2e/global-setup.ts`, REST login), so it is stale-but-harmless in CI and for any local run that executes the `setup` project first.
+Ruled out: token expiry (JWT/session TTL = 60 min, run is ~12 min, refresh timer fires at ~50 min), the refresh timer, rate limiting (429 is not treated as auth-expiry), and the viewer-session invalidation in the remediation spec (scoped to a different `user_id`).
 
 ## Fixes
 
-### B. `updatePositionStrategy="always"`
-Add `updatePositionStrategy="always"` to `<SelectPrimitive.Content>` in `themed-select.tsx`. Radix Select's `Content` extends `PopperContentProps`, which supports `updatePositionStrategy?: 'optimized' | 'always'` (`@radix-ui/react-popper/dist/index.d.ts:38`). `"always"` passes `animationFrame: true` to Floating UI's `autoUpdate`, re-anchoring every animation frame while the panel is open. A dropdown opened mid-entrance-animation therefore self-corrects the instant the trigger's transform settles. One line; applies to every `ThemedSelect` app-wide; the `.spotlight-card` guard stays untouched. Cost: a rAF reposition loop, but only while a dropdown is open.
+### 1. Raise the E2E session cap (the fix)
+Add `MAX_CONCURRENT_SESSIONS_PER_USER=100` to the `backend` service env in `docker/docker-compose.e2e.yml`. This completes the existing mitigation there: the same block already raises `LOGIN_RATE_LIMIT=1000` for exactly the "many real logins from one admin" reason (#1420) — it just never raised the session cap. 100 is the schema max and far exceeds the suite's total admin logins (≈10-25 with retries), so the shared-admin churn can never evict the storage-state session. Product code and the production security feature are untouched; this is a disposable-CI-stack override only.
 
-### A. Harden the settings cold navigation (revised after reproduction)
-**Reproduction result (2026-07-13):** run against the live dev stack (`:8080` Vite-dev serving working-tree src, `:3051` backend), `e2e/settings.spec.ts` **passed all 4 tests** — the sidebar renders well under 10s locally. Symptom A does **not** reproduce on a fast machine; it is single-worker-CI main-thread contention from the heavy `/settings` chunk, not a real render dependency.
+### 2. Radix Select re-anchoring — defensive (kept)
+`updatePositionStrategy="always"` on `ThemedSelect`'s Radix `Content` (+ a source-guard test). This addresses the class of Radix-Select-opened-during-entrance-transform `(0,0)` bug the issue described. That bug could **not** be reproduced or verified here — the dropdown specs never reached positioning (they died at the auth redirect) — so this is low-risk insurance, and will be confirmed (or shown unnecessary) once the specs actually run under fix #1.
 
-Given that, the originally-planned `React.lazy()` tab split was **not** pursued: it is entangled (`settings.tsx:33-37` re-exports named members from four tab modules, keeping them eager regardless, so a true chunk split needs a broader refactor + consumer updates) and unverifiable locally (the spec already passes). The proportionate, evidence-based fix is to **harden the cold navigation** instead: in `e2e/settings.spec.ts`, navigate with `waitUntil: 'domcontentloaded'` and give the cold `/settings` sidebar assertion a 30s bounded budget (with 60s test-timeout headroom). The sidebar still renders — this only accommodates a slow, contended runner; a genuine regression still fails, just later. This is the "spec hardening" the plan reserved for exactly this case.
+### 3. E2E compose volume isolation (kept)
+`name: ai-portainer-e2e` in `docker/docker-compose.e2e.yml` so the stack's volumes are `ai-portainer-e2e_*` and CI's `down -v` can never destroy the dev `docker_postgres-app-data` / `docker_timescale-data` volumes. Verified transparent to CI via `docker compose config` (CI invokes every op via the layered `-f` form, service names only).
 
-### B verification
-The dropdown spec requires the WireMock canned fleet data; it cannot run against the dev stack (dev Portainer is unreachable → `/workloads` shows a "Failed to load containers" error state and the filter dropdowns never mount). The `updatePositionStrategy="always"` fix is therefore verified via CI (push the branch with the `e2e` label) rather than locally.
+### Reverted
+The settings cold-nav timeout hardening (`waitUntil: 'domcontentloaded'` + 30s sidebar budget) was based on the incorrect paint-contention diagnosis and is removed — with fix #1 the sidebar renders normally within the default budget.
 
-## Safe local verification (hard volume rule)
+## Verification
 
-The E2E stack (`docker compose -f docker/docker-compose.yml -f docker/docker-compose.e2e.yml`) defaults to compose project **`docker`**, whose named volumes materialize as `docker_postgres-app-data` / `docker_timescale-data` — the **same volumes the dev stack uses**. CI's teardown runs `down -v`. Running that locally would wipe the developer's dev data, which the project rules forbid.
+CI E2E run gated by the `e2e` label (the suite needs WireMock fleet data and can't run against a dev stack with an unreachable Portainer). Expect all 11 previously-failing specs to pass once the storage-state session is no longer evicted; the dropdown specs will then actually exercise positioning, validating (or retiring) fix #2.
 
-Mitigations (both applied):
-- **Run only under an isolated project:** `-p ai-portainer-e2e` for every `up`/`down`, so volumes become `ai-portainer-e2e_*`. Never run `down -v` (or any `-v` teardown) against the `docker` project. Teardown uses `down` without `-v`, or `down -v` scoped to `-p ai-portainer-e2e` only.
-- **Durable fix:** add `name: ai-portainer-e2e` to `docker/docker-compose.e2e.yml` so the E2E stack (including CI) can never share or destroy the dev `docker_*` volumes. Note: `redis-data` is not a real volume today (redis runs ephemerally), so only `postgres-app-data` and `timescale-data` are at risk.
-
-Docker commands run outside the Claude sandbox.
-
-## Verification flow
-
-1. Bring up the isolated E2E stack (`-p ai-portainer-e2e`); wait for `:3051/health`, `:8080/`, WireMock `:9000`.
-2. Run the two specs (the `setup` project regenerates fresh auth first). Reproduce the failures; capture timing/screenshots/trace as real evidence for the root causes.
-3. Apply the two code fixes (+ compose `name:`).
-4. Re-run the two specs → green. Run them a few times to confirm the flakiness is gone under `workers: 1`.
-5. Tear down the isolated stack safely.
-
-## Tests
-
-- The two existing specs are the regression coverage and must pass.
-- Add/keep a focused unit assertion for the `themed-select` prop if practical (e.g. that `Content` carries `updatePositionStrategy="always"`), so the anchoring guarantee is pinned at the component level, mirroring the `.spotlight-card` guard comment.
-
-## Acceptance criteria (as shipped)
-
-- [x] `themed-select.tsx` sets `updatePositionStrategy="always"` (+ a source-guard test); dropdown spec verified via CI (the `e2e` label), since it needs WireMock fleet data and can't run against the dev stack.
-- [x] `settings.spec.ts` cold-nav hardened (`domcontentloaded` + 30s bounded sidebar wait, 60s test timeout). **Not** the originally-planned `settings.tsx` lazy-load — symptom A does not reproduce locally, so the invasive/entangled refactor was dropped in favour of proportionate spec hardening (see Fix A above). Verified green locally (4/4).
-- [x] `docker-compose.e2e.yml` carries an isolated project `name:` (`ai-portainer-e2e`), verified via `docker compose config`.
-- [x] No dev volume (`docker_postgres-app-data` / `docker_timescale-data`) is destroyed — the isolated name scopes E2E volumes to `ai-portainer-e2e_*`; CI's `down -v` is now transparent to the dev stack (ci.yml uses the layered `-f` form throughout, service names only).
-- [x] Docs updated; PR links `Closes #1560`.
-
-## Files (as shipped)
-
-- `frontend/src/shared/components/ui/themed-select.tsx` — add `updatePositionStrategy="always"`.
-- `frontend/src/shared/components/ui/themed-select.test.ts` — source-guard test (jsdom has no layout).
-- `e2e/settings.spec.ts` — cold-nav hardening (`gotoSettings` helper + `SHELL_TIMEOUT`).
-- `docker/docker-compose.e2e.yml` — isolated project `name`.
-- **Not changed:** `frontend/src/features/core/pages/settings.tsx` (lazy-load dropped — see Fix A) and `.github/workflows/ci.yml` (the compose `name` change is project-name-transparent to CI, which invokes every op via the layered `-f` form using service names).
+## Files
+- `docker/docker-compose.e2e.yml` — `MAX_CONCURRENT_SESSIONS_PER_USER=100` (fix) + isolated project `name`.
+- `frontend/src/shared/components/ui/themed-select.tsx` (+ `.test.ts`) — defensive `updatePositionStrategy="always"`.
+- **Reverted:** `e2e/settings.spec.ts` (back to original).
+- **Not changed:** `frontend/src/features/core/pages/settings.tsx`, `.github/workflows/ci.yml`.
 
 ## Out of scope
-
-- Ungating the E2E job to run on every PR (issue calls this optional; revisit once green).
-- Broad restructuring of the entrance-animation system.
+- The `FST_ERR_REP_ALREADY_SENT` abort-noise on cancelled requests (cosmetic log noise; could be quieted by handling client-abort in the compress `onSend`, tracked separately if desired).
+- Making the login helpers use distinct ephemeral users (a more thorough test-hygiene change; the cap raise is the minimal fix).

--- a/docs/superpowers/specs/2026-07-13-issue-1560-e2e-flaky-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-1560-e2e-flaky-fixes-design.md
@@ -34,11 +34,13 @@ Secondary (local-run only): the committed `e2e/.auth/user.json` JWT is expired (
 ### B. `updatePositionStrategy="always"`
 Add `updatePositionStrategy="always"` to `<SelectPrimitive.Content>` in `themed-select.tsx`. Radix Select's `Content` extends `PopperContentProps`, which supports `updatePositionStrategy?: 'optimized' | 'always'` (`@radix-ui/react-popper/dist/index.d.ts:38`). `"always"` passes `animationFrame: true` to Floating UI's `autoUpdate`, re-anchoring every animation frame while the panel is open. A dropdown opened mid-entrance-animation therefore self-corrects the instant the trigger's transform settles. One line; applies to every `ThemedSelect` app-wide; the `.spotlight-card` guard stays untouched. Cost: a rAF reposition loop, but only while a dropdown is open.
 
-### A. Lazy-load the settings tabs
-Convert the 7 heavy tab imports in `settings.tsx` to `React.lazy()` and render the active `TabsContent` inside a `<Suspense>` fallback using an existing skeleton primitive. This shrinks the initial `/settings` chunk so the shell paints promptly; tab bodies load on demand. Keep the lightest tab (or the default-selected one) eager if it avoids a visible flash on first paint. This addresses the leading root-cause hypothesis directly rather than only relaxing the test.
+### A. Harden the settings cold navigation (revised after reproduction)
+**Reproduction result (2026-07-13):** run against the live dev stack (`:8080` Vite-dev serving working-tree src, `:3051` backend), `e2e/settings.spec.ts` **passed all 4 tests** — the sidebar renders well under 10s locally. Symptom A does **not** reproduce on a fast machine; it is single-worker-CI main-thread contention from the heavy `/settings` chunk, not a real render dependency.
 
-### Spec hardening (only if needed after the code fixes)
-If, against a running stack, the two code fixes do not fully settle the specs, apply minimal hardening: wait for a stable shell signal before the sidebar assertion and/or scope a longer timeout to the initial cold navigation. No blanket timeout inflation.
+Given that, the originally-planned `React.lazy()` tab split was **not** pursued: it is entangled (`settings.tsx:33-37` re-exports named members from four tab modules, keeping them eager regardless, so a true chunk split needs a broader refactor + consumer updates) and unverifiable locally (the spec already passes). The proportionate, evidence-based fix is to **harden the cold navigation** instead: in `e2e/settings.spec.ts`, navigate with `waitUntil: 'domcontentloaded'` and give the cold `/settings` sidebar assertion a 30s bounded budget (with 60s test-timeout headroom). The sidebar still renders — this only accommodates a slow, contended runner; a genuine regression still fails, just later. This is the "spec hardening" the plan reserved for exactly this case.
+
+### B verification
+The dropdown spec requires the WireMock canned fleet data; it cannot run against the dev stack (dev Portainer is unreachable → `/workloads` shows a "Failed to load containers" error state and the filter dropdowns never mount). The `updatePositionStrategy="always"` fix is therefore verified via CI (push the branch with the `e2e` label) rather than locally.
 
 ## Safe local verification (hard volume rule)
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -7,10 +7,29 @@ import { test, expect } from '@playwright/test';
  * for categories and stores theme preferences in Zustand with
  * localStorage persistence.
  */
+
+// The /settings route is the heaviest chunk in the app (it eagerly imports all
+// eight tab modules). On the single-worker CI runner its download+parse+eval
+// contends with the app-shell's first paint, occasionally pushing the sidebar
+// past the default 10s expect timeout — the flake tracked in #1560. The sidebar
+// still renders (it does so well under 10s locally); it just needs a more
+// generous, bounded budget on a cold, contended navigation. Waiting for
+// `domcontentloaded` first (rather than the default `load`, which blocks on the
+// full chunk graph) plus a longer sidebar timeout hardens the cold nav without
+// masking a genuine failure — a real regression still fails, just later.
+const SHELL_TIMEOUT = 30_000;
+
+async function gotoSettings(page: import('@playwright/test').Page) {
+  await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('[data-testid="sidebar"]')).toBeVisible({ timeout: SHELL_TIMEOUT });
+}
+
 test.describe('Settings Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/settings');
-    await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
+    // Give the heaviest route headroom over the 30s default test timeout so the
+    // generous sidebar wait can't collide with it on a slow runner.
+    test.setTimeout(60_000);
+    await gotoSettings(page);
   });
 
   test('theme change persists after page reload', async ({ page }) => {
@@ -31,9 +50,9 @@ test.describe('Settings Page', () => {
       // Theme class should have changed
       expect(newTheme).not.toBe(initialTheme);
 
-      // Reload the page
-      await page.reload();
-      await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
+      // Reload the page (same cold-nav contention as the initial load, #1560)
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(page.locator('[data-testid="sidebar"]')).toBeVisible({ timeout: SHELL_TIMEOUT });
 
       // Theme should persist after reload
       const afterReloadTheme = await page

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -7,29 +7,10 @@ import { test, expect } from '@playwright/test';
  * for categories and stores theme preferences in Zustand with
  * localStorage persistence.
  */
-
-// The /settings route is the heaviest chunk in the app (it eagerly imports all
-// eight tab modules). On the single-worker CI runner its download+parse+eval
-// contends with the app-shell's first paint, occasionally pushing the sidebar
-// past the default 10s expect timeout — the flake tracked in #1560. The sidebar
-// still renders (it does so well under 10s locally); it just needs a more
-// generous, bounded budget on a cold, contended navigation. Waiting for
-// `domcontentloaded` first (rather than the default `load`, which blocks on the
-// full chunk graph) plus a longer sidebar timeout hardens the cold nav without
-// masking a genuine failure — a real regression still fails, just later.
-const SHELL_TIMEOUT = 30_000;
-
-async function gotoSettings(page: import('@playwright/test').Page) {
-  await page.goto('/settings', { waitUntil: 'domcontentloaded' });
-  await expect(page.locator('[data-testid="sidebar"]')).toBeVisible({ timeout: SHELL_TIMEOUT });
-}
-
 test.describe('Settings Page', () => {
   test.beforeEach(async ({ page }) => {
-    // Give the heaviest route headroom over the 30s default test timeout so the
-    // generous sidebar wait can't collide with it on a slow runner.
-    test.setTimeout(60_000);
-    await gotoSettings(page);
+    await page.goto('/settings');
+    await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
   });
 
   test('theme change persists after page reload', async ({ page }) => {
@@ -50,9 +31,9 @@ test.describe('Settings Page', () => {
       // Theme class should have changed
       expect(newTheme).not.toBe(initialTheme);
 
-      // Reload the page (same cold-nav contention as the initial load, #1560)
-      await page.reload({ waitUntil: 'domcontentloaded' });
-      await expect(page.locator('[data-testid="sidebar"]')).toBeVisible({ timeout: SHELL_TIMEOUT });
+      // Reload the page
+      await page.reload();
+      await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
 
       // Theme should persist after reload
       const afterReloadTheme = await page

--- a/frontend/src/shared/components/ui/themed-select.test.ts
+++ b/frontend/src/shared/components/ui/themed-select.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guard for the Radix Select popper anchoring fix (#1560).
+ *
+ * The Workload Explorer filter dropdowns (ThemedSelect) intermittently rendered
+ * at viewport (0,0) when opened during AppLayout's entrance transform. Radix
+ * Select snapshots the trigger rect once at open time; Floating UI's default
+ * autoUpdate does not observe an ancestor CSS-transform transition, so the panel
+ * never re-anchors after the transform settles. `updatePositionStrategy="always"`
+ * passes `animationFrame: true` to autoUpdate, re-anchoring every frame while
+ * open so a mid-animation open self-corrects.
+ *
+ * jsdom has no layout engine, so it cannot exercise popper positioning; mirroring
+ * `native-control-color-scheme.test.ts`, we read the source and assert the prop is
+ * present, failing loudly if it is ever removed.
+ */
+const source = fs.readFileSync(
+  path.resolve(process.cwd(), 'src/shared/components/ui/themed-select.tsx'),
+  'utf8',
+);
+
+describe('ThemedSelect popper anchoring (#1560)', () => {
+  it('renders the Select content as a popper', () => {
+    expect(source).toContain('position="popper"');
+  });
+
+  it('keeps the panel re-anchored to the trigger while open', () => {
+    expect(source).toContain('updatePositionStrategy="always"');
+  });
+});

--- a/frontend/src/shared/components/ui/themed-select.tsx
+++ b/frontend/src/shared/components/ui/themed-select.tsx
@@ -83,6 +83,13 @@ export function ThemedSelect({
         <SelectPrimitive.Content
           position="popper"
           sideOffset={4}
+          // Re-anchor every animation frame while open (#1560). Radix Select
+          // snapshots the trigger rect once at open time; if opened while an
+          // ancestor entrance transform (AppLayout m.main/m.div) is still
+          // animating, Floating UI's default autoUpdate never re-reads it and
+          // the panel detaches (worst case: viewport 0,0). 'always' passes
+          // animationFrame:true so it self-corrects once the transform settles.
+          updatePositionStrategy="always"
           className={cn(
             'relative z-50 max-h-72 min-w-[8rem] overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-md',
             'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',


### PR DESCRIPTION
## What & why

Closes #1560. Fixes the 11 intermittently-failing E2E specs — but **not** for the reason the issue (or the first iteration of this PR) assumed.

### Real root cause (confirmed): session eviction
All 11 failures render the **login page** — the specs are unauthenticated. Traced end-to-end:
- `global-setup` logs in `admin` once → session **A**, whose JWT is the `storageState` every spec loads.
- The suite keeps logging in as the **same `admin`** (auth.spec + remediation helpers + `retries: 2`).
- `createSession` enforces `MAX_CONCURRENT_SESSIONS_PER_USER` (default **5**) by **DELETE-ing the oldest** session — session A. Its token then 401s → the frontend clears auth (`api.ts` 401 → `auth:expired`) → `<Navigate to="/login">` → no sidebar.
- Confirmed by **59× 401** in the CI backend log. It's the only path that turns a valid token into a 401; the `FST_ERR_REP_ALREADY_SENT` 500s are benign abort-noise from the redirect cancelling in-flight GETs.

Not paint-timing, not dropdown `(0,0)`. Disproved by: settings.spec passing locally, and the CI login-page snapshot.

## Changes
1. **The fix —** `MAX_CONCURRENT_SESSIONS_PER_USER=100` on the E2E backend (`docker-compose.e2e.yml`), completing the existing `LOGIN_RATE_LIMIT=1000` mitigation in the same block. Schema max; far exceeds the suite's ~10-25 admin logins. Disposable-CI-stack only; production security feature untouched.
2. **Defensive (kept) —** `updatePositionStrategy="always"` on `ThemedSelect` for the Radix-during-entrance `(0,0)` class of bug the issue described. Couldn't be verified (the dropdown specs died at the auth redirect before reaching positioning); low-risk insurance, validated once the specs actually run under fix #1. Source-guard test included.
3. **Volume isolation (kept) —** `name: ai-portainer-e2e` so the E2E `down -v` can never destroy the dev `docker_*` volumes. Verified transparent to CI.
4. **Reverted —** the misdiagnosed settings cold-nav timeout hardening.

## Verification
CI E2E (this PR carries the `e2e` label). Expect all 11 to pass once the storage-state session is no longer evicted; the dropdown specs then actually exercise positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
