### PR TITLE
fix(security): bump nodemailer to ^9.0.3 (GHSA-p6gq-j5cr-w38f)

### DIFF
--- a/backend/src/routes/security-regression-infra.test.ts
+++ b/backend/src/routes/security-regression-infra.test.ts
@@ -200,3 +200,58 @@ describe('Docker Non-Root User Enforcement', () => {
     expect(content).toMatch(/useradd|adduser/);
   });
 });
+
+// =====================================================================
+//  VULNERABLE DEPENDENCY FLOORS
+// =====================================================================
+describe('Vulnerable Dependency Floors', () => {
+  // GHSA-p6gq-j5cr-w38f (High, CVSS 7.1): a message-level `raw` option bypasses
+  // disableFileAccess/disableUrlAccess, enabling arbitrary file read and full-response
+  // SSRF in the delivered message. The affected range is `<= 9.0.0` — note that the
+  // whole 8.x line is affected, so a downgrade to any 8.x reintroduces it.
+  // @see https://github.com/kenhaesler/ai-portainer-dashboard/issues/1574
+  const NODEMAILER_MIN = [9, 0, 1] as const;
+
+  const atLeast = (version: string, min: readonly [number, number, number]): boolean => {
+    const parts = version.split('.').map((n) => Number.parseInt(n, 10));
+    for (let i = 0; i < min.length; i++) {
+      const part = parts[i] ?? 0;
+      if (part > min[i]) return true;
+      if (part < min[i]) return false;
+    }
+    return true;
+  };
+
+  it('should declare a nodemailer range that cannot resolve to a vulnerable version', () => {
+    const file = path.resolve(process.cwd(), '..', 'packages', 'operations', 'package.json');
+    const manifest = JSON.parse(readFileSync(file, 'utf8')) as {
+      dependencies?: Record<string, string>;
+    };
+
+    const range = manifest.dependencies?.nodemailer;
+    expect(range).toBeDefined();
+
+    // A caret range's floor is its lower bound, so ^9.0.1 can never resolve below 9.0.1.
+    const floor = range!.replace(/^[\^~>=v\s]+/, '');
+    expect(atLeast(floor, NODEMAILER_MIN)).toBe(true);
+  });
+
+  it('should resolve nodemailer above the GHSA-p6gq-j5cr-w38f patch floor in the lockfile', () => {
+    const file = path.resolve(process.cwd(), '..', 'package-lock.json');
+    const lock = JSON.parse(readFileSync(file, 'utf8')) as {
+      packages: Record<string, { version?: string }>;
+    };
+
+    // Guard every copy in the tree, not just the hoisted one — a nested entry that
+    // violates its own manifest range still installs silently under `npm ci`.
+    const resolved = Object.entries(lock.packages).filter(([key]) =>
+      key.endsWith('node_modules/nodemailer'),
+    );
+    expect(resolved.length).toBeGreaterThan(0);
+
+    for (const [key, entry] of resolved) {
+      expect(entry.version, `${key} is inside the advisory range`).toBeDefined();
+      expect(atLeast(entry.version!, NODEMAILER_MIN), `${key}@${entry.version}`).toBe(true);
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13202,9 +13202,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
-      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -17765,7 +17765,7 @@
         "@dashboard/infrastructure": "*",
         "fastify": "^5.8.5",
         "fastify-type-provider-zod": "^6.1.0",
-        "nodemailer": "^8.0.10",
+        "nodemailer": "^9.0.3",
         "socket.io": "^4.8.1",
         "undici": "^8.7.0",
         "zod": "^4.3.6"

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -29,7 +29,7 @@
     "@dashboard/infrastructure": "*",
     "fastify": "^5.8.5",
     "fastify-type-provider-zod": "^6.1.0",
-    "nodemailer": "^8.0.10",
+    "nodemailer": "^9.0.3",
     "socket.io": "^4.8.1",
     "undici": "^8.7.0",
     "zod": "^4.3.6"


### PR DESCRIPTION
Closes #1574

## What

`nodemailer` `^8.0.10` -> `^9.0.3` in `packages/operations` (a production dependency), plus a dependency-floor regression guard.

## Why

`dev` ships nodemailer 8.0.10, which is inside **GHSA-p6gq-j5cr-w38f** (High, CVSS 7.1) — a message-level `raw` option bypasses `disableFileAccess`/`disableUrlAccess`, enabling arbitrary file read and full-response SSRF in the delivered message. The affected range is `<= 9.0.0`, so the **entire 8.x line is vulnerable** and **9.0.1** is the first patched version.

Surfaced reviewing #1573, which held the security-group PR #1561. Three PRs carried this fix — #1561 (held), #1556 and #1487 — and #1573 merged without any of them, leaving a High advisory on `dev` with no owner. Closing #1556/#1487 as superseded without this would drop the fix entirely.

**Exploitability here is low.** The advisory needs the app to pass a message-level `raw` built from untrusted input; `notification-service.ts` composes its own mail (`from`/`to`/`subject`/`html`) and never accepts a caller-supplied `raw`. Supply-chain hygiene, not a live path.

## Breaking-change assessment

nodemailer 9.0.0's only breaking change: HTTPS requests fetching remote content (attachment `href`/`path` URLs, OAuth2 token endpoints, HTTP/HTTPS proxy CONNECT) now validate TLS certificates by default.

**Not reachable here.** `notification-service.ts:350` builds a plain SMTP transport (`host`/`port`/`secure`/optional `auth`); the body is built in-process and `sendMail` passes no attachments, OAuth2, or proxy config.

`@types/nodemailer` stays at `^8.0.0`: DefinitelyTyped has published no 9.x, and neither nodemailer 8 nor 9 bundles its own types.

## Tests

Per the mandatory security-regression rule, adds a **Vulnerable Dependency Floors** block to `backend/src/routes/security-regression-infra.test.ts`, matching that file's static file-content assertion style. It guards both the declared range and **every** lockfile copy of nodemailer — a nested entry violating its own manifest still installs silently under `npm ci`, which is exactly how the `@types/node` defect in #1573 passed 14 green checks.

The floor comparison was verified to actually reject the vulnerable versions rather than pass vacuously: `8.0.10`, `8.0.11`, `9.0.0` all fail; `9.0.1`, `9.0.3`, `9.1.0`, `10.0.0` pass.

## Verification

- `npm run typecheck` — exit 0, zero `error TS`
- `npm run lint` — exit 0
- operations suite — 57 passed
- `security-regression-infra` — 20 passed (18 existing + 2 new)
- `npm audit --omit=dev` — nodemailer no longer listed; prod highs 6 -> 5

## Still red after this (pre-existing, not in scope)

`ws` 8.20.1 (GHSA-96hv-2xvq-fx4p, High DoS) reached via engine.io / engine.io-client / socket.io-adapter, all pinning `~8.20.1` — needs a socket.io bump or a root `overrides` entry. Plus `hono`. Worth their own issue, as is the CI Security Audit job's `continue-on-error: true` on the high-severity prod step, which is why these ship unflagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)