### PR TITLE
fix(security): refresh socket.io transitives to clear ws DoS (GHSA-96hv-2xvq-fx4p)

### DIFF
--- a/backend/src/routes/security-regression-infra.test.ts
+++ b/backend/src/routes/security-regression-infra.test.ts
@@ -254,4 +254,54 @@ describe('Vulnerable Dependency Floors', () => {
       expect(atLeast(entry.version!, NODEMAILER_MIN), `${key}@${entry.version}`).toBe(true);
     }
   });
+
+  // GHSA-96hv-2xvq-fx4p (High, CVSS 7.5): memory-exhaustion DoS — a peer can crash a
+  // ws server or client with a high volume of tiny fragments and data chunks using only
+  // modest network traffic. Affected `>= 8.0.0, < 8.21.0`; 8.21.0 adds the maxFragments /
+  // maxBufferedChunks caps that fix it.
+  //
+  // `ws` is transitive (no manifest of ours declares it), so the lockfile is the only
+  // place this can be asserted. It is reachable production code: ws is the engine under
+  // Socket.IO, which is the app's live transport. It reached 8.20.1 because engine.io,
+  // engine.io-client and socket.io-adapter all pinned `ws: ~8.20.1` — so a downgrade of
+  // any one of those three silently drags ws back into the advisory range.
+  // @see https://github.com/kenhaesler/ai-portainer-dashboard/issues/1577
+  const WS_MIN = [8, 21, 0] as const;
+
+  it('should resolve ws above the GHSA-96hv-2xvq-fx4p patch floor in the lockfile', () => {
+    const file = path.resolve(process.cwd(), '..', 'package-lock.json');
+    const lock = JSON.parse(readFileSync(file, 'utf8')) as {
+      packages: Record<string, { version?: string }>;
+    };
+
+    const resolved = Object.entries(lock.packages).filter(([key]) =>
+      key.endsWith('node_modules/ws'),
+    );
+    expect(resolved.length).toBeGreaterThan(0);
+
+    for (const [key, entry] of resolved) {
+      expect(entry.version, `${key} is inside the advisory range`).toBeDefined();
+      expect(atLeast(entry.version!, WS_MIN), `${key}@${entry.version}`).toBe(true);
+    }
+  });
+
+  it('should keep the socket.io transitives on ws ranges that cannot resolve below the floor', () => {
+    const file = path.resolve(process.cwd(), '..', 'package-lock.json');
+    const lock = JSON.parse(readFileSync(file, 'utf8')) as {
+      packages: Record<string, { dependencies?: Record<string, string> }>;
+    };
+
+    // These three are what actually pin ws. Guarding only the resolved ws version would
+    // let a transitive downgrade re-pin it to ~8.20.1 on the next lockfile regeneration.
+    for (const pkg of ['engine.io', 'engine.io-client', 'socket.io-adapter']) {
+      const entry = lock.packages[`node_modules/${pkg}`];
+      expect(entry, `${pkg} missing from lockfile`).toBeDefined();
+
+      const range = entry!.dependencies?.ws;
+      expect(range, `${pkg} no longer declares a ws dependency`).toBeDefined();
+
+      const floor = range!.replace(/^[\^~>=v\s]+/, '');
+      expect(atLeast(floor, WS_MIN), `${pkg} pins ws ${range}`).toBe(true);
+    }
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8758,9 +8758,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.8",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
-      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
@@ -8772,22 +8772,22 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.20.1"
+        "ws": "~8.21.0"
       },
       "engines": {
         "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
-      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.20.1",
+        "ws": "~8.21.0",
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
@@ -15279,13 +15279,13 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
-      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.20.1"
+        "ws": "~8.21.0"
       }
     },
     "node_modules/socket.io-client": {
@@ -17432,9 +17432,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
Closes #1577

## What

Lockfile-only refresh of three Socket.IO transitives, plus regression guards. No manifest change.

| package | before | after | ws pin |
| --- | --- | --- | --- |
| `engine.io` | 6.6.8 | **6.6.9** | `~8.20.1` -> `~8.21.0` |
| `engine.io-client` | 6.6.5 | **6.6.6** | `~8.20.1` -> `~8.21.0` |
| `socket.io-adapter` | 2.5.7 | **2.5.8** | `~8.20.1` -> `~8.21.0` |
| `ws` | 8.20.1 | **8.21.1** | — |

## Why

`ws@8.20.1` is inside **GHSA-96hv-2xvq-fx4p** (High, CVSS 7.5) — a peer can crash a ws server or client with a high volume of tiny fragments and data chunks using only modest network traffic. Affected `>= 8.0.0, < 8.21.0`.

Reachable production code: ws is the engine under Socket.IO, the app's live transport (remediation namespace, chat, metrics streams).

## No `overrides` hack needed

ws was pinned at 8.20.1 by three transitives using tilde ranges. Upstream has already shipped versions pinning `~8.21.0`, and `socket.io@4.8.3` / `socket.io-client@4.8.3` already depend on `engine.io ~6.6.0`, `socket.io-adapter ~2.5.2`, `engine.io-client ~6.6.1` — all three targets sit inside those ranges. Only the lockfile was stale, so `npm update engine.io engine.io-client socket.io-adapter` was sufficient.

The #1573 review suggested a root `overrides` entry or a socket.io upgrade. Neither is needed — that suggestion predated checking the upstream pins.

## Risk assessment

ws 8.21.0 fixes the DoS by **adding caps**, which is the thing worth scrutinising: `maxFragments` (server default 16384) and `maxBufferedChunks` (262144). Could those reject legitimate large payloads?

No. They bound fragment *counts*, not bytes — `maxPayload` still governs size, and `packages/core/src/plugins/socket-io.ts` already sets `maxHttpBufferSize: 1e6`. Hitting 16384 fragments inside a 1 MB cap means ~61-byte fragments, which is the abuse pattern rather than anything a real client produces.

## Tests

Extends the **Vulnerable Dependency Floors** block in `backend/src/routes/security-regression-infra.test.ts` (added in #1576) with two guards:

1. Every lockfile copy of `ws` resolves >= 8.21.0
2. All three transitives still declare a ws range whose floor is >= 8.21.0

The second matters: asserting only the resolved ws version would let a transitive downgrade silently re-pin ws to `~8.20.1` on the next lockfile regeneration — which is exactly how it got stuck at 8.20.1.

Verified the guard rejects the vulnerable states rather than passing vacuously: `8.20.1`, `8.20.9`, and the range `~8.20.1` all fail; `8.21.0`, `8.21.1`, `~8.21.0` pass.

## Verification

- `@dashboard/core` — 970 passed (66 files)
- `@dashboard/ai` — 1063 passed
- `@dashboard/operations` — 225 passed
- `@dashboard/server` — 79 passed
- `backend` — 484 passed, 1 skipped (28 files)
- `security-regression-infra` — 22 passed
- `npm run typecheck` / `npm run lint` — exit 0
- `npm audit --omit=dev` — highs **5 -> 1** (only `hono`, carried by #1575)

Labelled `e2e`: this changes the live WebSocket transport, and E2E is the only CI path that boots the real server and exercises Socket.IO end to end.

## After this

Only `hono` remains in the production audit. Once #1575 lands, #1578 (removing `continue-on-error` from the CI audit gate) becomes viable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)