### PR TITLE
ci(security): make the production audit gate enforcing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Enforcing (#1578). This step used to carry `continue-on-error: true`,
+      # which made it advisory-only — three separate High advisories reached
+      # `dev` with CI green (undici x3, nodemailer, ws) before being found by
+      # hand. A gate that cannot fail is not a gate.
+      #
+      # If this blocks your PR on an advisory you did not introduce: prefer a
+      # lockfile refresh (`npm update <pkg>`) or a root `overrides` entry, which
+      # removes the vulnerable code rather than hiding it. Every production High
+      # this repo has seen so far was fixable that way — including one npm
+      # reported as `fixAvailable: false`.
+      #
+      # Do not re-add `continue-on-error`, `|| true`, or `--offline` here.
+      # `--offline` in particular exits 0 with an empty report, which is
+      # indistinguishable from a clean audit. backend/src/ci-audit-gate.test.ts
+      # asserts against all three.
       - name: Audit production dependencies (high+)
         run: npm audit --omit=dev --audit-level=high
-        continue-on-error: true
 
       - name: Audit all dependencies (critical gate)
         run: npm audit --audit-level=critical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,10 @@ For detailed specs (animation durations, easing curves, glass override patterns,
 - **Dependabot** creates weekly PRs for npm, monthly for Docker and GitHub Actions. Triage these PRs weekly.
 - **React is pinned to exact version** (no caret) since React 19 is a new major version. Update deliberately.
 - `pino-pretty` is a devDependency (not shipped to production Docker images).
-- Run `npm run audit:prod` to check production dependency vulnerabilities locally.
+- Run `npm run audit:prod` to check production dependency vulnerabilities locally. **CI enforces this** (#1578) — the `Security Audit` job fails on any high-severity *production* advisory. It previously carried `continue-on-error: true` and could not fail, which let three High advisories reach `dev` with CI green.
+- **Fixing a blocked audit:** prefer a lockfile refresh (`npm update <pkg>`) or a root `overrides` entry — both remove the vulnerable code rather than hiding it. Every production High this repo has hit was fixable that way, including one npm reported as `fixAvailable: false` (that field is not a reliable signal). There is deliberately no suppression allowlist; add one only when a genuinely unfixable advisory appears.
+- **Do not weaken the gate.** `continue-on-error`, `|| true`, `--offline`, and lowering `--audit-level` are all asserted against in `backend/src/ci-audit-gate.test.ts`. `npm audit --offline` is the dangerous one: it exits 0 with an empty report, indistinguishable from a clean audit.
+- Known gaps, so a green audit is not over-read: devDependency Highs are not gated (`audit:all` gates at critical only), moderate production advisories are not gated, and a red job only blocks a merge if `Security Audit` is a **required status check** in branch protection.
 - Run `npm outdated` monthly to review stale packages.
 
 ## Code Quality

--- a/backend/src/ci-audit-gate.test.ts
+++ b/backend/src/ci-audit-gate.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+const ROOT = resolve(__dirname, '../..');
+
+interface Step {
+  name?: string;
+  run?: string;
+  'continue-on-error'?: boolean | string;
+}
+
+interface Workflow {
+  jobs?: Record<string, { steps?: Step[] }>;
+}
+
+function readWorkflow(relativePath: string): Workflow {
+  const content = readFileSync(resolve(ROOT, `.github/workflows/${relativePath}`), 'utf-8');
+  return parseYaml(content) as Workflow;
+}
+
+/**
+ * Enforcing production audit gate (#1578).
+ *
+ * The `audit` job's high-severity production step used to carry
+ * `continue-on-error: true`, so only `--audit-level=critical` could ever fail
+ * the job. Nothing rated critical, so the job was permanently green while
+ * `npm run audit:prod` exited 1 locally. Three separate High advisories reached
+ * `dev` that way — undici (x3), nodemailer, and ws — each found by hand rather
+ * than by CI.
+ *
+ * These assertions guard the wiring, not the advisories themselves. A green
+ * audit job must mean the audit actually ran and actually passed.
+ *
+ * Deliberately NOT covered here, so this file is not mistaken for full
+ * coverage:
+ *   • devDependency Highs (`audit:all` gates at critical only)
+ *   • moderate production advisories
+ *   • Docker base images, GitHub Action pins, non-npm toolchains
+ *   • whether "Security Audit" is a *required* status check — that is a repo
+ *     settings concern outside this repo's files. Without it a red job does
+ *     not block a merge, which is `continue-on-error` by another name.
+ */
+describe('CI production audit gate (#1578)', () => {
+  const wf = readWorkflow('ci.yml');
+  const auditSteps = wf.jobs?.audit?.steps ?? [];
+
+  const auditRunSteps = auditSteps.filter((s) => (s.run ?? '').includes('npm audit'));
+
+  it('has an audit job that actually runs npm audit', () => {
+    expect(auditSteps.length).toBeGreaterThan(0);
+    expect(auditRunSteps.length).toBeGreaterThan(0);
+  });
+
+  it('gates production dependencies at high severity', () => {
+    const prodAudit = auditRunSteps.find((s) => (s.run ?? '').includes('--omit=dev'));
+
+    expect(prodAudit, 'no production-only audit step found').toBeDefined();
+    expect(prodAudit!.run).toContain('--audit-level=high');
+  });
+
+  it('does not let any npm audit step fail silently', () => {
+    // The whole point of #1578. `continue-on-error` on the high+ prod step is
+    // what made three High advisories invisible.
+    for (const step of auditRunSteps) {
+      expect(
+        step['continue-on-error'],
+        `audit step "${step.name ?? step.run}" carries continue-on-error`,
+      ).toBeUndefined();
+    }
+  });
+
+  it('does not swallow the exit code with a shell escape hatch', () => {
+    // `|| true`, `|| exit 0`, and `; true` are continue-on-error by other means.
+    for (const step of auditRunSteps) {
+      const run = step.run ?? '';
+      expect(run, `audit step "${step.name}" swallows its exit code`).not.toMatch(
+        /\|\|\s*(true|exit\s+0)|;\s*true\s*$/,
+      );
+    }
+  });
+
+  it('never runs the audit offline', () => {
+    // `npm audit --offline` exits 0 with an empty report and no error field —
+    // structurally identical to a clean audit. It is the one flag that turns
+    // this gate into a silent no-op, so it is called out separately from the
+    // generic escape-hatch check above.
+    for (const step of auditRunSteps) {
+      expect(step.run, `audit step "${step.name}" runs offline`).not.toMatch(
+        /--offline|--prefer-offline/,
+      );
+    }
+  });
+
+  it('keeps the audit job outside the test-gate fan-in so it cannot be skipped', () => {
+    // The audit job must not become a dependency of something that can be
+    // conditionally skipped, which would let it be bypassed without editing
+    // this file. It should stand alone.
+    const audit = wf.jobs?.audit as { needs?: unknown } | undefined;
+    expect(audit).toBeDefined();
+    expect(audit?.needs).toBeUndefined();
+  });
+});

--- a/backend/src/routes/security-regression-infra.test.ts
+++ b/backend/src/routes/security-regression-infra.test.ts
@@ -304,4 +304,32 @@ describe('Vulnerable Dependency Floors', () => {
       expect(atLeast(floor, WS_MIN), `${pkg} pins ws ${range}`).toBe(true);
     }
   });
+
+  // GHSA-88fw-hqm2-52qc (High, CVSS 7.1): the CORS middleware reflects any Origin with
+  // credentials enabled. Affected `< 4.12.25`.
+  //
+  // hono is transitive — pulled in by @hono/node-server (`^4`) and
+  // @modelcontextprotocol/sdk (`^4.11.4`), both of which already admit the patched line,
+  // so it is a lockfile refresh rather than a manifest change. Note that npm reported
+  // `fixAvailable: false` for it, which is wrong; do not trust that field to decide
+  // whether an advisory is actionable.
+  // @see https://github.com/kenhaesler/ai-portainer-dashboard/issues/1578
+  const HONO_MIN = [4, 12, 25] as const;
+
+  it('should resolve hono above the GHSA-88fw-hqm2-52qc patch floor in the lockfile', () => {
+    const file = path.resolve(process.cwd(), '..', 'package-lock.json');
+    const lock = JSON.parse(readFileSync(file, 'utf8')) as {
+      packages: Record<string, { version?: string }>;
+    };
+
+    const resolved = Object.entries(lock.packages).filter(([key]) =>
+      key.endsWith('node_modules/hono'),
+    );
+    expect(resolved.length).toBeGreaterThan(0);
+
+    for (const [key, entry] of resolved) {
+      expect(entry.version, `${key} is inside the advisory range`).toBeDefined();
+      expect(atLeast(entry.version!, HONO_MIN), `${key}@${entry.version}`).toBe(true);
+    }
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10542,9 +10542,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
Closes #1578

Two commits: clear the last production High, then turn on the gate. The PR validates itself — if the gate works, this PR passes only because the audit is genuinely clean.

## 1. `hono` 4.12.23 -> 4.12.31 (`417cd2e7`)

GHSA-88fw-hqm2-52qc (High, CVSS 7.1) — CORS middleware reflects any Origin with credentials. Affected `< 4.12.25`.

Transitive-only, same shape as the ws fix in #1580: `@hono/node-server` pins `^4` and `@modelcontextprotocol/sdk` pins `^4.11.4`, both of which already admit the patched line. Lockfile refresh, no manifest change.

npm reported `fixAvailable: false` for this one. **That was wrong** — the fix was reachable the whole time. Worth remembering: that field is not a reliable signal for whether an advisory is actionable.

`npm run audit:prod` now exits **0** (was 1). Production highs across this sequence: 6 -> 5 (#1576) -> 1 (#1580) -> **0**.

## 2. Remove `continue-on-error` (`dcdcbe72`)

```diff
       - name: Audit production dependencies (high+)
         run: npm audit --omit=dev --audit-level=high
-        continue-on-error: true
```

The step matching the documented `audit:prod` gate was advisory-only; only `--audit-level=critical` enforced, and nothing rated critical. So the job was permanently green while `audit:prod` exited 1 locally. Three High advisories reached `dev` that way — undici (x3), nodemailer, ws — each found by hand.

## Why no allowlist or wrapper script

I ran a design exercise on the richer alternative (script + GHSA allowlist + a runtime canary to detect a dead advisory endpoint), then red-teamed it. It was rejected on its own evidence:

- **Two silent bypasses** — `--report <path>` skipped the audit *and* the canary (a committed `clean.json` plus one word in ci.yml = total no-op); `--min-severity critical` exited 0 while a live High existed, with the canary passing first so the output looked trustworthy
- **Allowlist dates never compared to `now`** — an entry dated `2099-01-01` was accepted as active and suppressed a live High
- **Fail-closed with no escape** — an advisory whose URL has no parseable GHSA id threw, exit 2, every PR blocked, and the allowlist is keyed on the id the script refused to produce
- **Canary keyed to one exact advisory ID** — if GitHub withdraws it, every PR fails forever

The allowlist also solves a problem this repo has not had: all six production Highs seen so far were fixable by a lockfile refresh or `overrides`, both of which remove the vulnerable code instead of hiding it. Add the escape hatch when a genuinely unfixable advisory appears, not before.

One thing the red team **confirmed** and that is worth recording: `npm audit --offline` exits 0 with an empty report and no error field — structurally indistinguishable from a clean audit. Verified against a mock registry. Hence its own assertion below.

## Tests

`backend/src/ci-audit-gate.test.ts`, following the existing `ci-workflow-concurrency.test.ts` pattern (parse the YAML, assert on the job rather than string-matching). Guards the wiring, not the advisories:

| assertion | injected bad state | caught |
| --- | --- | --- |
| no `continue-on-error` | `continue-on-error: true` re-added | yes |
| no shell escape hatch | `\|\| true` appended | yes |
| never offline | `--offline` added | yes |
| severity not lowered | `--audit-level=moderate` | yes |
| prod scope kept | `--omit=dev` dropped | yes |

Each was verified to **fail** when its bad pattern is injected, not merely to pass on the good file. A guard that only passes proves nothing.

Also adds a `hono` lockfile floor guard alongside the existing nodemailer (#1576) and ws (#1580) ones.

## Verification

- `npm run lint` / `npm run typecheck` — exit 0
- `backend` — 493 passed, 1 skipped (29 files)
- `npm audit --omit=dev --audit-level=high` — exit 0
- `npm audit --audit-level=critical` — exit 0

## Action needed from a maintainer

**This does not block merges on its own.** `dev` has no branch protection — `{"protected": false}`, zero rulesets, no required status checks. A red `Security Audit` job is advisory, which is `continue-on-error` by another name.

To make it real, require `Security Audit` (and ideally `Test Gate (Required)`) as a status check on `dev`. That is a repo-settings change, outside this diff, and I have not made it.

## Known gaps, so a green audit is not over-read

- devDependency Highs are not gated (`audit:all` gates at critical only); two exist today via the vite/esbuild chain
- moderate production advisories are not gated (dompurify's remains)
- Docker base images, GitHub Action pins, and non-npm toolchains are out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)