### PR TITLE
docs(portainer): record what the lifecycle 400 was actually observed on

### DIFF
--- a/packages/core/src/portainer/portainer-client.ts
+++ b/packages/core/src/portainer/portainer-client.ts
@@ -585,19 +585,27 @@ function isAlreadyInTargetStateError(err: unknown): boolean {
  * 2-byte `{}` clears both arms and Docker ignores the contents (HostConfig on
  * /start has been deprecated since API v1.22).
  *
- * MECHANISM UNCONFIRMED — deliberately not guessed at here. The 400 reproduces
- * (no -d → 400, -d '{}' → 204), so something in the chain presents the request
- * as ContentLength == -1, but we have not located what. The obvious explanation
- * is ruled out: Go's httputil.ReverseProxy, which Portainer builds its Docker
- * proxy on, nils the body of a zero-length request *before* any Director or
- * Rewrite hook runs —
+ * MECHANISM UNCONFIRMED — deliberately not guessed at here.
+ *
+ * Sole recorded observation: a Type 4 (Edge Agent Standard) endpoint, where
+ * no -d → 400 and -d '{}' → 204. That environment no longer exists, so it
+ * cannot be re-verified — treat this as one data point, not a general law. It
+ * was never observed on a Type 1 (direct socket) or Type 2 (Agent) endpoint;
+ * the body goes out on every endpoint type regardless, because it is harmless
+ * where it is unnecessary.
+ *
+ * Something in that chain presents the request as ContentLength == -1, but we
+ * have not located what. The first hop is ruled out: Portainer proxies with a
+ * stock httputil.ReverseProxy, and Go nils the body of a zero-length request
+ * *before* any Director or Rewrite hook runs —
  *
  *   if req.ContentLength == 0 { outreq.Body = nil }  // reverseproxy.go, #16036
  *
- * — so a plain proxy hop does not turn 0 into chunked. Verified against go1.23
- * source. The unaudited suspect is the Agent / Edge Agent second hop, which
- * re-proxies through a separate service and tunnel. Start there rather than
- * re-deriving the stdlib behaviour.
+ * — while Portainer's own createRewriteFn rewrites only URL, Host, User-Agent
+ * and a header allowlist, never Body or ContentLength. (Checked against go1.23
+ * and Portainer 2.21/2.39.) On a Type 4 endpoint the request then crosses the
+ * Edge Agent's reverse tunnel and is re-proxied to the Docker socket by a
+ * separate service. That hop is unaudited and is where to start.
  *
  * IMPORTANT: this body must stay <= 7 bytes. Replacing it with a more
  * self-documenting payload such as {"noop":true} (13 bytes) trips the `> 7`


### PR DESCRIPTION
## Problem

The `LIFECYCLE_NOOP_BODY` comment (merged in #1589) points the next debugger at the Portainer **Agent / Edge Agent** hop as the unaudited suspect for the `ContentLength == -1` that triggers Docker's 400 — but it never recorded **which endpoint type the curl repro actually ran against**.

That gap is load-bearing in both directions:

- If the repro had been on a **Type 1** (direct socket) endpoint, the Agent-hop pointer would be **already falsified** — we proved the first proxy hop cannot produce the `-1` — and the comment would be actively misdirecting.
- If it was an Agent/Edge type, the pointer is supported and can be narrowed.

Without the datum a reader cannot tell which, so the most useful sentence in the comment was unverifiable.

## What it was

**Type 4 — Edge Agent Standard.** That endpoint adds a genuine second hop: the request crosses the Edge Agent's reverse tunnel and is re-proxied to the Docker socket by a separate service. The existing pointer is therefore **supported**, and now narrowed to that specific path rather than "Agent or Edge Agent, somewhere".

Recorded honestly:

- The environment **no longer exists**, so it cannot be re-verified. Written down as one data point, explicitly not a general law.
- It was **never** observed on Type 1 or Type 2. The `{}` body still goes out on every endpoint type, because it is harmless where unnecessary — now stated, so nobody infers it is required everywhere.
- `MECHANISM UNCONFIRMED` stays. This narrows the suspect; it does not identify the cause.

## Also: the first hop is now properly ruled out

The previous wording ruled out Go's stdlib generally, but did not confirm Portainer's own hook doesn't re-attach a body *after* the guard runs. Read at both 2.21 and 2.39 — each constructs a stock `httputil.ReverseProxy`, and `createRewriteFn` rewrites only URL scheme/host/path/query, `Out.Host`, `User-Agent`, and a header allowlist:

```go
proxyReq.Out.URL.Scheme = target.Scheme
proxyReq.Out.URL.Host   = target.Host
proxyReq.Out.URL.Path   = singleJoiningSlash(...)
proxyReq.Out.Host       = proxyReq.Out.URL.Host
// ... User-Agent, then a delete-loop over allowedHeaders
```

Never `Body`, never `ContentLength`. So the ruling-out holds for Portainer specifically, not just for a hypothetical stock proxy.

## Verification

- `packages/core` **49/49** pass; `npm run lint:packages` exits 0.
- Both source claims re-read at the tags cited, not recalled: go1.23 `reverseproxy.go` (`if req.ContentLength == 0 { outreq.Body = nil }`, issue 16036) and Portainer `2.21.0` / `2.39.0` `api/http/proxy/factory/reverse_proxy.go`.

## Notes

- **Comment-only.** No code, no behaviour change, no runtime surface. The one changed file is a doc block above an unchanged constant.
- **Observer-first:** untouched. No mutating path added or widened.
- Follow-up to #1589; the endpoint type came from the author, who confirmed the environment is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)