### PR TITLE
fix(typecheck): wire packages/ test files into npm run typecheck

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,17 @@ For detailed specs (animation durations, easing curves, glass override patterns,
   Cross-domain behaviour obtained via DI (`LLMInterface`, `MetricsInterface`, … from
   `@dashboard/contracts`, wired in `packages/server/src/wiring.ts`) is not an import and needs no
   exception.
+- **`npm run typecheck` covers packages/ test files too (#1586).** Every `packages/*/tsconfig.build.json`
+  excludes `**/*.test.ts` and `**/__tests__/**` — correctly, tests must not ship to `dist/` — but the
+  root `typecheck` script used to run only `tsc --build tsconfig.build.json`, so those excluded test
+  files were never typechecked by anything, hiding 49 errors across 5 packages from both local
+  `npm run typecheck` and CI's `Type Check` job. Each package already had its own non-build
+  `tsconfig.json` (no test exclusion) and its own `"typecheck": "tsc --noEmit"` script; the root
+  script now also chains `npm run typecheck -w <pkg>` for all 9 packages before typechecking
+  frontend. `backend/src/typecheck-gate.test.ts` guards both halves of the wiring — that the root
+  script still invokes every package's script, and that no package's plain `tsconfig.json` regains a
+  test-file exclusion — following the same "drive the actual shipped config, don't describe it"
+  pattern as `ci-audit-gate.test.ts` (#1578) and `packages-boundaries.test.ts` (#1585).
 
 ## Git Workflow
 

--- a/backend/src/typecheck-gate.test.ts
+++ b/backend/src/typecheck-gate.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(__dirname, '../..');
+
+/**
+ * Guards the root `typecheck` script wiring (#1586).
+ *
+ * Every package under packages/ already had its own non-build `tsconfig.json`
+ * (no `**\/*.test.ts` / `**\/__tests__/**` exclusion) and its own
+ * `"typecheck": "tsc --noEmit"` npm script — both existed and worked in
+ * isolation. But the root `typecheck` script only ever ran
+ * `tsc --build tsconfig.build.json`, which builds `tsconfig.build.json` — and
+ * EVERY `packages/*\/tsconfig.build.json` excludes test files (correctly:
+ * tests must not ship to `dist/`). Nothing else ever invoked the per-package
+ * script, so 49 type errors across 5 packages were invisible to
+ * `npm run typecheck` and to CI's "Type Check" job (`.github/workflows/ci.yml`,
+ * job `typecheck`), which just runs `npm run typecheck`.
+ *
+ * These assertions guard the WIRING, not the individual errors fixed
+ * alongside it. A green `npm run typecheck` must mean every package's test
+ * files were actually typechecked, not just its shipped `src/`.
+ *
+ * Deliberately NOT covered here:
+ *   • the CONTENT of any package's `tsconfig.json` beyond the test-exclusion
+ *     check below — only that tests are in scope, not e.g. strict mode.
+ *   • whether "Type Check" is a *required* status check in branch protection
+ *     — a repo-settings concern outside this repo's files, and without it a
+ *     red job does not block a merge (`continue-on-error` by another name).
+ */
+describe('root typecheck wiring covers packages/ tests (#1586)', () => {
+  const rootPkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
+    scripts?: Record<string, string>;
+  };
+  const typecheckScript = rootPkg.scripts?.typecheck ?? '';
+
+  // Discovered, not hardcoded — the whole point is to catch the NEXT package
+  // added without typecheck wiring, not just the 9 that exist today. A
+  // hardcoded list would be satisfied by the ones we already know about while
+  // a 10th sits unchecked, same failure mode ci-audit-gate.test.ts guards
+  // against for lockfiles.
+  const packageDirs = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+  const packages = packageDirs.map((dir) => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(ROOT, 'packages', dir, 'package.json'), 'utf-8'),
+    ) as { name: string; scripts?: Record<string, string> };
+    return { dir, name: pkg.name, typecheckScript: pkg.scripts?.typecheck };
+  });
+
+  it('discovers at least the known packages, so the loop below is not vacuous', () => {
+    expect(packageDirs.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it('still builds the production tsconfig graph first', () => {
+    // The composite build is still useful on its own: it validates project
+    // references and the cross-package build graph, which the per-package
+    // `tsc --noEmit` runs below (each scoped to its own standalone
+    // tsconfig.json) do not exercise.
+    expect(typecheckScript).toContain('tsc --build tsconfig.build.json');
+  });
+
+  it('still typechecks frontend', () => {
+    expect(typecheckScript).toContain('npm run typecheck -w frontend');
+  });
+
+  it.each(packages.map((p) => [p.dir, p.name, p.typecheckScript] as const))(
+    'root typecheck runs %s (%s) own typecheck script, which itself runs tsc --noEmit',
+    (dir, name, pkgScript) => {
+      // Half A: the root script actually references this package's workspace.
+      expect(
+        typecheckScript,
+        `root "typecheck" script does not invoke "npm run typecheck -w ${name}"`,
+      ).toContain(`npm run typecheck -w ${name}`);
+
+      // Half B: that reference points at something real. A correct reference
+      // to a gutted/renamed script (e.g. downgraded to `echo skip`) would
+      // pass Half A while checking nothing — same class of silent-pass this
+      // file exists to prevent.
+      expect(pkgScript, `packages/${dir}/package.json has no "typecheck" script`).toBeDefined();
+      expect(pkgScript).toContain('tsc');
+      expect(pkgScript).toContain('--noEmit');
+    },
+  );
+
+  it('does not swallow the exit code with a shell escape hatch', () => {
+    // `|| true`, `|| exit 0`, `; true` are continue-on-error by other means —
+    // the same escape hatch that neutered the production audit gate (#1578).
+    expect(typecheckScript).not.toMatch(/\|\|\s*(true|exit\s+0)|;\s*true\s*$/);
+  });
+});
+
+describe("per-package tsconfig.json doesn't exclude the tests it's meant to cover (#1586)", () => {
+  const packageDirs = readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+  it.each(packageDirs)('packages/%s/tsconfig.json does not exclude test files', (dir) => {
+    const tsconfigPath = resolve(ROOT, 'packages', dir, 'tsconfig.json');
+    const tsconfig = JSON.parse(readFileSync(tsconfigPath, 'utf-8')) as {
+      exclude?: string[];
+    };
+
+    // tsconfig.build.json correctly excludes tests so they never ship to
+    // dist/. The PLAIN tsconfig.json — the one `npm run typecheck -w <pkg>`
+    // actually drives — must NOT carry the same exclusion, or the wiring
+    // asserted above would run a typecheck that still sees zero test files:
+    // green for the wrong reason, indistinguishable from the original bug.
+    for (const pattern of tsconfig.exclude ?? []) {
+      expect(
+        pattern,
+        `packages/${dir}/tsconfig.json excludes "${pattern}" — its tests would be invisible again`,
+      ).not.toMatch(/\.test\.ts|__tests__/);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "npm run lint:bash && npm run lint -w backend && npm run lint -w frontend && npm run lint:packages",
     "lint:bash": "bash scripts/lint-bash.sh",
     "lint:packages": "eslint --config eslint.packages.config.mjs --max-warnings=0 'packages/*/src/**/*.ts' 'packages/*/scripts/**/*.ts'",
-    "typecheck": "tsc --build tsconfig.build.json && npm run typecheck -w frontend",
+    "typecheck": "tsc --build tsconfig.build.json && npm run typecheck -w @dashboard/contracts && npm run typecheck -w @dashboard/core && npm run typecheck -w @dashboard/infrastructure && npm run typecheck -w @dashboard/security && npm run typecheck -w @dashboard/observability && npm run typecheck -w @dashboard/operations && npm run typecheck -w @dashboard/ai && npm run typecheck -w @dashboard/foundation && npm run typecheck -w @dashboard/server && npm run typecheck -w frontend",
     "test": "npm run test -w @dashboard/contracts && npm run test -w @dashboard/core && npm run test -w @dashboard/infrastructure && npm run test -w @dashboard/security && npm run test -w @dashboard/observability && npm run test -w @dashboard/operations && npm run test -w @dashboard/ai && npm run test -w @dashboard/foundation && npm run test -w backend && npm run test -w @dashboard/server && npm run test -w frontend",
     "loadtest:build": "docker compose -f docker/docker-compose.loadtest.yml build",
     "loadtest:rest": "docker compose -f docker/docker-compose.loadtest.yml run --rm rest",

--- a/packages/ai-intelligence/scripts/backfill-incident-signatures.ts
+++ b/packages/ai-intelligence/scripts/backfill-incident-signatures.ts
@@ -1,92 +1,18 @@
 #!/usr/bin/env tsx
 /**
- * Populates the `signature` column on incidents that don't yet have one.
- *
- * Idempotent: only updates rows where signature IS NULL by default.
- * Use --force to re-derive every row.
+ * CLI entry point. The actual logic lives in
+ * `../src/services/incident-signature-backfill.ts` (see that file for why —
+ * #1586) so it is typechecked and unit-tested as a normal service; this
+ * wrapper just re-exports it and adds the `--force` CLI flag.
  *
  * Usage:
  *   POSTGRES_APP_URL=… npm run -w @dashboard/ai backfill:signatures
  *   POSTGRES_APP_URL=… npm run -w @dashboard/ai backfill:signatures -- --force
  */
-import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
-import { deriveSignature, deriveSignatureFromTitle } from '../src/services/signature.js';
+import { backfillSignatures } from '../src/services/incident-signature-backfill.js';
 
-export interface BackfillOptions { batchSize: number; force: boolean; }
-export interface BackfillResult { updated: number; bySignature: Record<string, number>; }
-
-interface IncidentRow {
-  id: string;
-  title: string;
-  root_cause_insight_id: string | null;
-}
-interface InsightRow {
-  category: string;
-  metric_type: string | null;
-  detection_method: string | null;
-  title: string;
-}
-
-export async function backfillSignatures(
-  opts: BackfillOptions = { batchSize: 500, force: false },
-): Promise<BackfillResult> {
-  const db = getDbForDomain('incidents');
-  const where = opts.force ? '1=1' : 'signature IS NULL';
-  const bySignature: Record<string, number> = {};
-  let updated = 0;
-
-  while (true) {
-    const incidents = await db.query<IncidentRow>(
-      `SELECT id, title, root_cause_insight_id FROM incidents WHERE ${where} ORDER BY created_at LIMIT ?`,
-      [opts.batchSize],
-    );
-    if (incidents.length === 0) break;
-
-    for (const inc of incidents) {
-      let signature: string;
-
-      if (inc.root_cause_insight_id) {
-        const ins = await db.queryOne<InsightRow>(
-          'SELECT category, metric_type, detection_method, title FROM insights WHERE id = ?',
-          [inc.root_cause_insight_id],
-        );
-        if (ins) {
-          signature = deriveSignature({
-            category: ins.category,
-            metric_type: ins.metric_type as 'cpu' | 'memory' | 'disk' | 'network' | 'restart' | undefined,
-            detection_method: ins.detection_method as 'threshold' | 'ml-anomaly' | 'prediction' | 'health-check' | 'log-pattern' | 'security-scan' | undefined,
-            title: ins.title,
-          });
-        } else {
-          // Root insight row is gone — fall back to title regex
-          signature = deriveSignatureFromTitle(inc.title);
-        }
-      } else {
-        // No root insight reference at all — fall back to title regex
-        signature = deriveSignatureFromTitle(inc.title);
-      }
-
-      if (opts.force) {
-        await db.execute(
-          'UPDATE incidents SET signature = ? WHERE id = ?',
-          [signature, inc.id],
-        );
-      } else {
-        await db.execute(
-          'UPDATE incidents SET signature = ? WHERE id = ? AND signature IS NULL',
-          [signature, inc.id],
-        );
-      }
-
-      bySignature[signature] = (bySignature[signature] ?? 0) + 1;
-      updated++;
-    }
-
-    if (incidents.length < opts.batchSize) break;
-  }
-
-  return { updated, bySignature };
-}
+export { backfillSignatures } from '../src/services/incident-signature-backfill.js';
+export type { BackfillOptions, BackfillResult } from '../src/services/incident-signature-backfill.js';
 
 async function cli(): Promise<void> {
   const force = process.argv.includes('--force');

--- a/packages/ai-intelligence/src/__tests__/anomaly-autotune-job.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-autotune-job.test.ts
@@ -5,6 +5,7 @@ import {
   type AutoTuneJobPrimitives,
 } from '../services/anomaly-autotune-job.js';
 import type { FeedbackRow } from '../services/anomaly-labels.js';
+import type { FeedbackDb } from '../services/anomaly-feedback-source.js';
 
 const FP_HEAVY: FeedbackRow[] = Array.from({ length: 30 }, (_, i) => ({
   anomaly_id: `a${i}`,
@@ -19,7 +20,10 @@ function primitives(over: Partial<AutoTuneJobPrimitives> = {}): AutoTuneJobPrimi
     targetFpRate: 0.05,
     minSamples: 20,
     lookbackDays: 30,
-    db: { query: vi.fn(async () => FP_HEAVY as unknown[]) },
+    // FeedbackDb.query is generic (<T>(sql, params?) => Promise<T[]>); a plain
+    // vi.fn() can't express that generic signature, so the mock is cast to it
+    // rather than widening the interface for one test fixture.
+    db: { query: vi.fn(async () => FP_HEAVY) as unknown as FeedbackDb['query'] },
     getSetting: vi.fn(async () => ({ value: '3.5' })),
     setSetting: vi.fn(async () => {}),
     writeAuditLog: vi.fn(async () => {}),

--- a/packages/ai-intelligence/src/__tests__/anomaly-feedback-source.test.ts
+++ b/packages/ai-intelligence/src/__tests__/anomaly-feedback-source.test.ts
@@ -7,7 +7,10 @@ import type { FeedbackRow } from '../services/anomaly-labels.js';
 
 /** Minimal AppDb-shaped stub — only `query` is exercised. */
 function fakeDb(rows: FeedbackRow[]) {
-  const query = vi.fn(async () => rows as unknown[]);
+  // Declares the (sql, params?) signature explicitly — without it vi.fn infers
+  // a zero-arg function, so `query.mock.calls[0]` types as the empty tuple `[]`
+  // and destructuring `[sql, params]` below fails to typecheck.
+  const query = vi.fn(async (_sql: string, _params?: unknown[]) => rows as unknown[]);
   return { db: { query, queryOne: vi.fn(), execute: vi.fn() }, query };
 }
 

--- a/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-correlator-db.test.ts
@@ -60,7 +60,7 @@ function makeInsight(overrides: Partial<Insight> & Pick<Insight, 'id' | 'contain
 
 beforeAll(async () => { testDb = await getTestDb(); });
 afterAll(async () => { await closeTestDb(); });
-beforeEach(async () => { await truncateTestTables(['incidents', 'insights']); });
+beforeEach(async () => { await truncateTestTables('incidents', 'insights'); });
 
 describe('correlateInsights — writes signature', () => {
   it('writes signature derived from structured fields (metric_type + detection_method)', async () => {

--- a/packages/ai-intelligence/src/__tests__/incident-correlator.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-correlator.test.ts
@@ -269,6 +269,7 @@ describe('incident-correlator', () => {
         correlation_confidence: 'medium',
         insight_count: 2,
         summary: null,
+        signature: 'cascade:web',
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
         resolved_at: null,

--- a/packages/ai-intelligence/src/__tests__/incidents-backfill.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-backfill.test.ts
@@ -8,11 +8,11 @@ vi.mock('@dashboard/core/db/app-db-router.js', () => ({
   getDbForDomain: () => testDb,
 }));
 
-import { backfillSignatures } from '../../scripts/backfill-incident-signatures.js';
+import { backfillSignatures } from '../services/incident-signature-backfill.js';
 
 beforeEach(async () => {
   testDb = await getTestDb();
-  await truncateTestTables(['incidents', 'insights']);
+  await truncateTestTables('incidents', 'insights');
 });
 afterAll(async () => { await closeTestDb(); });
 

--- a/packages/ai-intelligence/src/__tests__/incidents-jsonb.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-jsonb.test.ts
@@ -56,6 +56,7 @@ function mockIncidentRow(overrides: Partial<Incident> = {}): Incident {
     correlation_confidence: 'high',
     insight_count: 4,
     summary: 'Test summary',
+    signature: 'temporal:docker-nginx,docker-redis',
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     resolved_at: null,

--- a/packages/ai-intelligence/src/__tests__/incidents-list.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-list.test.ts
@@ -12,7 +12,7 @@ import { getIncidents } from '../services/incident-store.js';
 
 beforeEach(async () => {
   testDb = await getTestDb();
-  await truncateTestTables(['incidents']);
+  await truncateTestTables('incidents');
 });
 afterAll(async () => { await closeTestDb(); });
 

--- a/packages/ai-intelligence/src/__tests__/llm-observability.test.ts
+++ b/packages/ai-intelligence/src/__tests__/llm-observability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import Fastify from 'fastify';
+import Fastify, { type FastifyRequest } from 'fastify';
 import { validatorCompiler } from 'fastify-type-provider-zod';
 import { llmObservabilityRoutes } from '../routes/llm-observability.js';
 import { testAdminOnly, type Role } from '@dashboard/core/test-utils/rbac-test-helper.js';
@@ -26,12 +26,12 @@ describe('LLM Observability Routes', () => {
     app.decorate('requireRole', (minRole: Role) => async (request: any, reply: any) => {
       const rank = { viewer: 0, operator: 1, admin: 2 };
       const userRole = request.user?.role ?? 'viewer';
-      if (rank[userRole] < rank[minRole]) {
+      if (rank[userRole as keyof typeof rank] < rank[minRole]) {
         reply.code(403).send({ error: 'Insufficient permissions' });
       }
     });
     app.decorateRequest('user', undefined);
-    app.addHook('preHandler', async (request) => {
+    app.addHook('preHandler', async (request: FastifyRequest) => {
       (request as any).user = { sub: 'u1', username: 'admin', sessionId: 's1', role: currentRole };
     });
     await app.register(llmObservabilityRoutes);

--- a/packages/ai-intelligence/src/services/incident-signature-backfill.ts
+++ b/packages/ai-intelligence/src/services/incident-signature-backfill.ts
@@ -1,0 +1,92 @@
+/**
+ * Populates the `signature` column on incidents that don't yet have one.
+ *
+ * Idempotent: only updates rows where signature IS NULL by default.
+ * Use --force to re-derive every row.
+ *
+ * The CLI entry point lives at `scripts/backfill-incident-signatures.ts` (run via
+ * `npm run -w @dashboard/ai backfill:signatures`); the logic itself lives here,
+ * under `src/`, so it is covered by the package's own `tsconfig.json` (and thus
+ * `npm run typecheck`) and can be unit-tested like every other service (#1586 —
+ * a `scripts/` import previously tripped `tsc`'s `rootDir` check, which is why
+ * this file — and its test, `src/__tests__/incidents-backfill.test.ts` — were
+ * invisible to `npm run typecheck` in the first place).
+ */
+import { getDbForDomain } from '@dashboard/core/db/app-db-router.js';
+import { deriveSignature, deriveSignatureFromTitle } from './signature.js';
+
+export interface BackfillOptions { batchSize: number; force: boolean; }
+export interface BackfillResult { updated: number; bySignature: Record<string, number>; }
+
+interface IncidentRow {
+  id: string;
+  title: string;
+  root_cause_insight_id: string | null;
+}
+interface InsightRow {
+  category: string;
+  metric_type: string | null;
+  detection_method: string | null;
+  title: string;
+}
+
+export async function backfillSignatures(
+  opts: BackfillOptions = { batchSize: 500, force: false },
+): Promise<BackfillResult> {
+  const db = getDbForDomain('incidents');
+  const where = opts.force ? '1=1' : 'signature IS NULL';
+  const bySignature: Record<string, number> = {};
+  let updated = 0;
+
+  while (true) {
+    const incidents = await db.query<IncidentRow>(
+      `SELECT id, title, root_cause_insight_id FROM incidents WHERE ${where} ORDER BY created_at LIMIT ?`,
+      [opts.batchSize],
+    );
+    if (incidents.length === 0) break;
+
+    for (const inc of incidents) {
+      let signature: string;
+
+      if (inc.root_cause_insight_id) {
+        const ins = await db.queryOne<InsightRow>(
+          'SELECT category, metric_type, detection_method, title FROM insights WHERE id = ?',
+          [inc.root_cause_insight_id],
+        );
+        if (ins) {
+          signature = deriveSignature({
+            category: ins.category,
+            metric_type: ins.metric_type as 'cpu' | 'memory' | 'disk' | 'network' | 'restart' | undefined,
+            detection_method: ins.detection_method as 'threshold' | 'ml-anomaly' | 'prediction' | 'health-check' | 'log-pattern' | 'security-scan' | undefined,
+            title: ins.title,
+          });
+        } else {
+          // Root insight row is gone — fall back to title regex
+          signature = deriveSignatureFromTitle(inc.title);
+        }
+      } else {
+        // No root insight reference at all — fall back to title regex
+        signature = deriveSignatureFromTitle(inc.title);
+      }
+
+      if (opts.force) {
+        await db.execute(
+          'UPDATE incidents SET signature = ? WHERE id = ?',
+          [signature, inc.id],
+        );
+      } else {
+        await db.execute(
+          'UPDATE incidents SET signature = ? WHERE id = ? AND signature IS NULL',
+          [signature, inc.id],
+        );
+      }
+
+      bySignature[signature] = (bySignature[signature] ?? 0) + 1;
+      updated++;
+    }
+
+    if (incidents.length < opts.batchSize) break;
+  }
+
+  return { updated, bySignature };
+}

--- a/packages/core/src/portainer/portainer-client.test.ts
+++ b/packages/core/src/portainer/portainer-client.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// Type-only: mockFetch is typed off undiciFetch's return, which is undici's own
+// Response (has `textStream`) — not the ambient global `Response` from
+// undici-types/@types/node, which lacks it. Casting through the wrong one is
+// what left this file invisible to `tsc --noEmit` before packages/ tests were
+// wired into `npm run typecheck` (#1586).
+import type { Response as UndiciResponse } from 'undici';
 
 // Kept: undici mock — external dependency. Lets us assert behavior of
 // startContainer / stopContainer against fabricated Docker responses.
@@ -274,7 +280,7 @@ function buildResponse({
     json: async () => body,
     text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
     headers: new Headers(),
-  } as unknown as Response;
+  } as unknown as UndiciResponse;
 }
 
 describe('startContainer / stopContainer — 304 idempotency (#1230)', () => {
@@ -352,7 +358,7 @@ function buildEmptyBodyResponse(status: number, statusText: string) {
     },
     text: async () => '',
     headers: new Headers(),
-  } as unknown as Response;
+  } as unknown as UndiciResponse;
 }
 
 function buildJsonResponse(status: number, statusText: string, body: unknown) {
@@ -364,7 +370,7 @@ function buildJsonResponse(status: number, statusText: string, body: unknown) {
     json: async () => JSON.parse(serialized),
     text: async () => serialized,
     headers: new Headers(),
-  } as unknown as Response;
+  } as unknown as UndiciResponse;
 }
 
 describe('portainerFetch parse guard (#1232)', () => {

--- a/packages/core/src/services/oidc-redirect-uri.test.ts
+++ b/packages/core/src/services/oidc-redirect-uri.test.ts
@@ -17,6 +17,7 @@ const fullConfig: OIDCConfig = {
   groups_claim: 'groups',
   group_role_mappings: {},
   auto_provision: true,
+  allow_unmapped_viewer: false,
   allow_insecure_transport: false,
 };
 

--- a/packages/foundation/src/__tests__/oidc-route.test.ts
+++ b/packages/foundation/src/__tests__/oidc-route.test.ts
@@ -296,7 +296,7 @@ describe('OIDC Routes', () => {
       mockedInvalidateAll.mockClear();
       mockedWriteAuditLog.mockClear();
       mockedGetUserById.mockReset();
-      mockedGetUserById.mockResolvedValue(null);
+      mockedGetUserById.mockResolvedValue(undefined);
     });
 
     it('denies login with 403 and no session when restrictive and no group matches', async () => {

--- a/packages/operations/src/__tests__/logs-route.test.ts
+++ b/packages/operations/src/__tests__/logs-route.test.ts
@@ -30,7 +30,7 @@ describe('Logs Routes', () => {
     app.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request: any, reply: any) => {
       const rank = { viewer: 0, operator: 1, admin: 2 };
       const userRole = request.user?.role ?? 'viewer';
-      if (rank[userRole] < rank[minRole]) {
+      if (rank[userRole as keyof typeof rank] < rank[minRole]) {
         reply.code(403).send({ error: 'Insufficient permissions' });
       }
     });
@@ -52,7 +52,12 @@ describe('Logs Routes', () => {
     mockGetElasticsearchConfig.mockResolvedValue(defaultEsConfig);
     // Mock global fetch used by the route for ES queries
     mockFetch = vi.fn();
-    global.fetch = mockFetch;
+    // mockFetch resolves with partial Response-like fixtures ({ ok, json })
+    // throughout this file, not a real global fetch Response, so it is kept
+    // loosely typed (ReturnType<typeof vi.fn>) rather than `Mock<typeof fetch>`
+    // — this cast is the one place that loose typing needs reconciling with
+    // the real `global.fetch` signature.
+    global.fetch = mockFetch as unknown as typeof fetch;
   });
 
   describe('GET /api/logs/search', () => {

--- a/packages/operations/src/__tests__/remediation-service.test.ts
+++ b/packages/operations/src/__tests__/remediation-service.test.ts
@@ -54,6 +54,13 @@ const mockMetrics = {
   getLatestMetrics: vi.fn().mockResolvedValue({ cpu_percent: 95, mem_percent: 80 }),
   getMetrics: vi.fn().mockResolvedValue([]),
   detectAnomalies: vi.fn().mockResolvedValue([]),
+  // Unused by remediation-service, but required by MetricsInterface — kept
+  // as inert defaults so the mock satisfies the real (widened) interface.
+  getLatestMetricsBatch: vi.fn().mockResolvedValue(new Map()),
+  getMovingAverage: vi.fn().mockResolvedValue(null),
+  getCapacityForecasts: vi.fn().mockResolvedValue([]),
+  generateForecast: vi.fn().mockResolvedValue(null),
+  findSimilarInsights: vi.fn().mockReturnValue([]),
 };
 
 let mockGetContainerLogs: any;

--- a/packages/security/src/__tests__/ebpf-coverage-route.test.ts
+++ b/packages/security/src/__tests__/ebpf-coverage-route.test.ts
@@ -20,10 +20,21 @@ import {
 } from '../services/ebpf-coverage.js';
 import { setConfigForTest, resetConfig } from '@dashboard/core/config/index.js';
 
+// Return type is widened to Record<string, ...> (not the narrower literal
+// TypeScript would infer from the `en0`-only fixture below) so
+// mockReturnValueOnce can supply other interface names (eth0, docker0, ...)
+// further down without a type error.
+type MockNetworkInterfaces = Record<
+  string,
+  Array<{ address: string; family: string; internal: boolean }>
+>;
+
 const { mockedNetworkInterfaces } = vi.hoisted(() => ({
-  mockedNetworkInterfaces: vi.fn(() => ({
-    en0: [{ address: '192.168.178.20', family: 'IPv4', internal: false }],
-  })),
+  mockedNetworkInterfaces: vi.fn(
+    (): MockNetworkInterfaces => ({
+      en0: [{ address: '192.168.178.20', family: 'IPv4', internal: false }],
+    }),
+  ),
 }));
 
 // Kept: node:os mock — external dependency

--- a/packages/security/src/__tests__/harbor-vulnerabilities-response-schema.test.ts
+++ b/packages/security/src/__tests__/harbor-vulnerabilities-response-schema.test.ts
@@ -212,7 +212,11 @@ describe('POST /api/harbor/sync response schema', () => {
   it('returns { message, status } when a sync is started', async () => {
     vi.mocked(harborClient.isHarborConfiguredAsync).mockResolvedValue(true);
     vi.mocked(getIsSyncing).mockReturnValue(false);
-    vi.mocked(runFullSync).mockResolvedValue(undefined);
+    vi.mocked(runFullSync).mockResolvedValue({
+      vulnerabilitiesSynced: 0,
+      inUseMatched: 0,
+      durationMs: 0,
+    });
 
     const app = buildApp();
     await app.register(harborVulnerabilityRoutes);

--- a/packages/security/src/__tests__/harbor-vulnerabilities-route.test.ts
+++ b/packages/security/src/__tests__/harbor-vulnerabilities-route.test.ts
@@ -113,7 +113,7 @@ describe('Harbor Vulnerability Routes', () => {
     app.decorate('requireRole', (minRole: 'viewer' | 'operator' | 'admin') => async (request: any, reply: any) => {
       const rank = { viewer: 0, operator: 1, admin: 2 };
       const userRole = request.user?.role ?? 'viewer';
-      if (rank[userRole] < rank[minRole]) {
+      if (rank[userRole as keyof typeof rank] < rank[minRole]) {
         reply.code(403).send({ error: 'Insufficient permissions' });
       }
     });


### PR DESCRIPTION
Closes #1586

## Root cause

The root `typecheck` script only ran `tsc --build tsconfig.build.json`. Every `packages/*/tsconfig.build.json` excludes `**/*.test.ts` and `**/__tests__/**` (correctly — tests must not ship to `dist/`), but nothing else ever typechecked those excluded files. So 49 type errors across 5 packages were invisible to both local `npm run typecheck` and CI's `Type Check` job.

Each package already had its own non-build `tsconfig.json` (no test exclusion) and its own `"typecheck": "tsc --noEmit"` npm script — both worked correctly in isolation, just never invoked by anything.

## Fix

- Chained `npm run typecheck -w <pkg>` for all 9 packages into the root `typecheck` script (same pattern the existing root `test` script already uses), keeping the build-graph check and the frontend typecheck.
- Fixed every real error this surfaced (no allowlist needed — everything was in safe scope):
  - `packages/operations/src/__tests__/remediation-service.test.ts` — stale `MetricsInterface` mock missing `getLatestMetricsBatch`, `getMovingAverage`, `getCapacityForecasts`, `generateForecast`, `findSimilarInsights` (interface widened without the mock being updated).
  - `packages/core/src/portainer/portainer-client.test.ts` — mock `Response` objects cast to the ambient global `Response` (undici-types, lacks `textStream`) instead of undici's own `Response` type, which is what `undiciFetch`'s return type actually resolves to.
  - `packages/core/src/services/oidc-redirect-uri.test.ts` — `OIDCConfig` fixture missing the `allow_unmapped_viewer` field added after the fixture was written.
  - `packages/foundation/src/__tests__/oidc-route.test.ts` — `getUserById` returns `User | undefined`, not `User | null`.
  - `packages/security` / `packages/operations` / `packages/ai-intelligence` — three copies of the same `rank[userRole] < rank[minRole]` RBAC test helper missing the `as keyof typeof rank` cast every other copy already had.
  - `packages/ai-intelligence/src/__tests__/incidents-list.test.ts`, `incidents-backfill.test.ts`, `incident-correlator-db.test.ts` — `truncateTestTables(['a', 'b'])` called with an array instead of the variadic `truncateTestTables('a', 'b')` the function actually declares (`...tables: string[]`). Worked at runtime by accident (array `.join()` coercion produced valid SQL) but was never type-correct.
  - `packages/ai-intelligence/src/__tests__/incident-correlator.test.ts`, `incidents-jsonb.test.ts` — fixtures missing the `Incident.signature` field added later.
  - `packages/ai-intelligence/src/__tests__/anomaly-autotune-job.test.ts`, `anomaly-feedback-source.test.ts` — `vi.fn()` mocks whose inferred signatures were too narrow for the generic/parameterised functions they stood in for.
  - `packages/ai-intelligence/src/__tests__/incidents-backfill.test.ts` — imported a script living outside the package's `tsconfig.json` `rootDir` (`scripts/backfill-incident-signatures.ts`). Moved the actual logic into `packages/ai-intelligence/src/services/incident-signature-backfill.ts` (now typechecked and unit-tested like every other service); `scripts/backfill-incident-signatures.ts` is now a thin CLI wrapper that re-exports it.
  - `packages/operations/src/__tests__/logs-route.test.ts` — a `Mock<Procedure | Constructable>` assigned directly to `global.fetch`; narrowly cast at the one assignment site rather than widening every `mockResolvedValue({ ok, json })` fixture in the file.
- Added `backend/src/typecheck-gate.test.ts` as a regression guard, mirroring `ci-audit-gate.test.ts` / `packages-boundaries.test.ts`: it drives the real root `package.json` and every real `packages/*/package.json` + `tsconfig.json` (discovered, not hardcoded), asserting the root script invokes every package's typecheck script, that script actually runs `tsc --noEmit`, and no package's plain `tsconfig.json` regains a test-file exclusion. Verified this test fails against the pre-fix root script (reverted the wiring locally, watched 9 of 22 cases go red, restored it).
- Documented the fix in `CLAUDE.md` (Code Quality section, alongside the #1578 and #1585 precedents this follows the same pattern as).

## Verification

- `npm run typecheck` from repo root exits 0.
- Each of the 9 `cd packages/<pkg> && npx tsc -p tsconfig.json --noEmit` exits 0.
- `cd backend && npx vitest run src/typecheck-gate.test.ts` — 22/22 passing.
- Guard test confirmed to fail (9/22 red) against the old wiring, confirming it isn't vacuous.
- Pre-push hook additionally ran the full `npm run typecheck` and `npm run test -w frontend` (2234/2234 passing).

No env vars involved, so `docker/.env.example` is untouched. `docs/architecture.md` doesn't document CI/build-script mechanics (neither do the #1578/#1585 precedents), so it's left as-is.