### PR TITLE
fix(ui): whole-app design critique remediation — honest labelling, real controls, one navigation source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,9 @@ frontend/vite.config.d.ts
 # `/` anchors to repo root only, leaving frontend/public/*.png tracked.
 /*.png
 .superpowers/
+
+# Design-review tooling scratch (critique snapshots, live-preview state, caches).
+# Only `frontend/.gitignore` covered this, so a `.impeccable/` at the repo root
+# — and the one the tool writes beside it — showed up as untracked and was one
+# `git add -A` away from being committed.
+.impeccable/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Backend uses npm workspaces under `packages/` with a `core/` kernel (`@dashboard
 **Unknown metric samples are excluded, never zero-filled (#1567):** `collectMetrics()` (`packages/observability/src/services/metrics-collector.ts`) returns `cpu`/`memory` as `number | null` — `null` when `system_cpu_usage` (CPU), `memory_stats.usage`, or `memory_stats.limit` (memory) is missing/non-positive in the Docker stats payload, i.e. the percentage genuinely cannot be computed this cycle. The scheduler (`packages/server/src/scheduler.ts`) skips writing that `metric_type` row entirely rather than persisting a fabricated `0` (the `metrics.value` column stays `NOT NULL` — no migration; "unknown" is the row's absence, not a null cell). Latest reads return only rows sharing each container's newest collection timestamp, so an omitted metric is not silently carried forward from an older cycle. `buildFleetResources()` (`packages/foundation/src/routes/dashboard.ts`) tracks independent CPU/memory sample counts so a container with a known memory reading but unknown CPU doesn't dilute the fleet CPU average (and vice versa), while independently known `memory_bytes` still contributes to per-stack totals. No total-node-memory fallback is used for a missing memory limit: Docker already reports host-total memory as `limit` when a container has no explicit cap, so a still-missing limit signals a malformed payload, not an unlimited container.
 
 **Design-critique remediation (2026-07-26):** a whole-app review produced 173 findings; see
-`@docs/architecture.md` ("Design-critique remediation") for the full rationale. Four invariants
+`@docs/architecture.md` ("Design-critique remediation") for the full rationale. Six invariants
 worth knowing before touching UI:
 
 1. **Navigation comes from one manifest.** `frontend/src/features/core/lib/navigation-manifest.ts`
@@ -60,15 +60,34 @@ worth knowing before touching UI:
    at the call site. Six pages previously showed a pulsing "live" dot over a dropdown that
    scheduled nothing. Pass a page-specific `storageKey` unless the page should share the global
    cadence. Prefer `setRefreshInterval` over the deprecated `setInterval` alias — destructuring the
-   latter shadows `window.setInterval` in the consuming module.
+   latter shadows `window.setInterval` in the consuming module. The hook **does not persist on
+   mount**: only a cadence the user actually picked is written, because a page that merely stored
+   its own default to the *shared* key changed every other page's cadence (opening Image Footprint,
+   which asks for 60s, slowed every dashboard query). The mount-skip compares the state object by
+   identity — a boolean first-run flag is spent by StrictMode's mount/cleanup/mount and writes anyway.
 3. **Never render a default as if it were a measurement.** `clampConfidenceScore` and
-   `parseSeverity` return `null` when the model supplied nothing; omit the badge rather than
-   showing a fallback number. Likewise, label rule-derived text as such (`rationaleSource`) — a
-   threshold rule presented under a Brain icon as "ML-Detected" is the failure this review named
-   most often. The maths is sound; it is the framing that must not overclaim.
+   `parseSeverity` live in `packages/core/src/utils/model-confidence.ts` and return `null` when the
+   model supplied nothing; omit the badge rather than showing a fallback number. They are in `core`
+   because all three analysers need them — remediation (`@dashboard/operations`), investigation
+   (`@dashboard/ai`) and PCAP (`@dashboard/security`) — and those packages may not import one
+   another, so the previous single-package fix left the other two still defaulting to `0.5`. Use the
+   shared helpers; do not re-add a local copy. A view that renders confidence must guard on null
+   (`null * 100` is `0`, which prints a confident "Confidence: 0%" — worse than the default it
+   replaced). Likewise, label rule-derived text as such (`rationaleSource`) — a threshold rule
+   presented under a Brain icon as "ML-Detected" is the failure this review named most often. The
+   maths is sound; it is the framing that must not overclaim.
 4. **Use `PageHeader` and `PRODUCT_NAME`.** One `<h1>` per page from
    `shared/components/layout/page-header.tsx` (no gradient/icon/size-override prop, deliberately);
    the product's name comes from `shared/lib/product.ts` and is **Container Insights**.
+5. **A navigating table row is an anchor, not a `role="link"` row.** `DataTable`'s `rowHref` wraps
+   the first data cell in a real `<a>`; the `<tr>` deliberately keeps its implicit `row` role. An
+   explicit role on the `<tr>` replaces `row` — which each `<td>`'s `cell` role requires as an
+   ancestor, and the virtual scroll container declares `role="grid"` — collapsing table navigation
+   for assistive tech, and nesting a link inside a link announces the destination twice.
+6. **A capped list travels with its real count.** When a payload caps an array (`ALL_NAMES_CAP` in
+   `incident-store.ts`, `RULE_CONTAINER_NAMES_CAP` in `reports.ts`), send the uncapped total
+   alongside it and have the UI count with that. Counting the truncated array under-reports exactly
+   the large fleet the cap exists for.
 
 ## Security (Mandatory)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,32 @@ Backend uses npm workspaces under `packages/` with a `core/` kernel (`@dashboard
 
 **Unknown metric samples are excluded, never zero-filled (#1567):** `collectMetrics()` (`packages/observability/src/services/metrics-collector.ts`) returns `cpu`/`memory` as `number | null` — `null` when `system_cpu_usage` (CPU), `memory_stats.usage`, or `memory_stats.limit` (memory) is missing/non-positive in the Docker stats payload, i.e. the percentage genuinely cannot be computed this cycle. The scheduler (`packages/server/src/scheduler.ts`) skips writing that `metric_type` row entirely rather than persisting a fabricated `0` (the `metrics.value` column stays `NOT NULL` — no migration; "unknown" is the row's absence, not a null cell). Latest reads return only rows sharing each container's newest collection timestamp, so an omitted metric is not silently carried forward from an older cycle. `buildFleetResources()` (`packages/foundation/src/routes/dashboard.ts`) tracks independent CPU/memory sample counts so a container with a known memory reading but unknown CPU doesn't dilute the fleet CPU average (and vice versa), while independently known `memory_bytes` still contributes to per-stack totals. No total-node-memory fallback is used for a missing memory limit: Docker already reports host-total memory as `limit` when a container has no explicit cap, so a still-missing limit signals a malformed payload, not an unlimited container.
 
+**Design-critique remediation (2026-07-26):** a whole-app review produced 173 findings; see
+`@docs/architecture.md` ("Design-critique remediation") for the full rationale. Four invariants
+worth knowing before touching UI:
+
+1. **Navigation comes from one manifest.** `frontend/src/features/core/lib/navigation-manifest.ts`
+   feeds the sidebar, breadcrumb, command palette, mobile nav and shortcuts overlay. There were
+   previously six hand-maintained copies and they had drifted (breadcrumb read "Dashboard /
+   Dashboard" on 7 of 20 routes; Cmd-K was missing 5 destinations). Do not add a seventh — add to
+   the manifest. `navigation-manifest.test.ts` fails if an entry lacks a breadcrumb label or a
+   palette entry. `NAV_CHORDS` lives there too, not in `app-layout.tsx`, because the shortcuts
+   overlay needs it and `app-layout` renders that overlay (the cycle left it `undefined` at
+   module-init).
+2. **`useAutoRefresh` owns the timer.** Pass `{ onTick }`; never hand-roll a `window.setInterval`
+   at the call site. Six pages previously showed a pulsing "live" dot over a dropdown that
+   scheduled nothing. Pass a page-specific `storageKey` unless the page should share the global
+   cadence. Prefer `setRefreshInterval` over the deprecated `setInterval` alias — destructuring the
+   latter shadows `window.setInterval` in the consuming module.
+3. **Never render a default as if it were a measurement.** `clampConfidenceScore` and
+   `parseSeverity` return `null` when the model supplied nothing; omit the badge rather than
+   showing a fallback number. Likewise, label rule-derived text as such (`rationaleSource`) — a
+   threshold rule presented under a Brain icon as "ML-Detected" is the failure this review named
+   most often. The maths is sound; it is the framing that must not overclaim.
+4. **Use `PageHeader` and `PRODUCT_NAME`.** One `<h1>` per page from
+   `shared/components/layout/page-header.tsx` (no gradient/icon/size-override prop, deliberately);
+   the product's name comes from `shared/lib/product.ts` and is **Container Insights**.
+
 ## Security (Mandatory)
 
 1. **Auth & RBAC** — JWT via `jose` (32+ char secrets); session store in PostgreSQL, validated server-side per request. OIDC/SSO via `openid-client` v6 with PKCE; login rate-limited (`LOGIN_RATE_LIMIT`). OIDC roles derive only from group→role mappings on every login; the `oidc.allow_unmapped_viewer` setting (Settings → Security, default **off**/restrictive) controls the fallback: off ⇒ a login resolving to no mapped role (and no `*` wildcard) is denied `403` (`oidc_login_denied` audit) and the user's lingering sessions are revoked (`invalidateAllUserSessions`, best-effort), enforced for new *and* existing users; on ⇒ unmatched *new* users get `viewer` while existing users keep their stored role (the `resolvedRole || existingUser?.role || 'viewer'` fallback). A `*` wildcard applies even to users who present no groups. Local auth is unaffected. Gate lives in `packages/foundation/src/routes/oidc.ts`. `fastify.authenticate` on all protected routes; mutating endpoints (POST/PUT/DELETE) and sensitive reads (Backups, Settings, Cache, User Management) MUST also use `fastify.requireRole('admin')` — never assume `authenticate` alone is sufficient for admin actions. Role changes, password resets, user deletions, and OIDC group-mapping downgrades revoke all of the target's sessions immediately (`invalidateAllUserSessions`, best-effort) — the role is frozen into the signed JWT, so without revocation a demotion only takes effect at token expiry. Live Socket.IO connections re-validate their session (and the `admin` role on the remediation namespace) every 60s and are disconnected on revocation/demotion (`packages/core/src/plugins/socket-io.ts`). Insight acknowledgement is gated `requireRole('operator')`; `/health/ready/detail` is admin-only.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,15 +113,71 @@ an interval another page had stored. The returned setter is `setRefreshInterval`
 kept as a deprecated alias because destructuring it shadows `window.setInterval` in the consuming
 module, which is exactly what made hand-wiring the timer error-prone.
 
+The hook also does **not** write to localStorage on mount. Persisting on mount recorded a default the
+user never chose, and on the shared key that was not merely cosmetic: Image Footprint asks for 60s
+while the dashboards ask for 30s, so opening that one page wrote 60 to the fleet-wide key and quietly
+slowed every dashboard query elsewhere in the app. The mount-skip compares the state object by
+*identity* against the value the hook mounted with, not by value — `setRefreshInterval` and `toggle`
+always build a fresh object, so re-selecting the cadence already displayed still persists, and a ref
+survives StrictMode's mount/cleanup/mount whereas a boolean first-run flag is spent on the first
+invocation and lets the second write the default anyway.
+
 A shared `DataFreshness` ("Updated Ns ago") component now sits beside the refresh control on the
 polling pages, so a stalled poll is visible rather than inferred.
 
+**Attributing LLM narratives to the thing they describe.** `parseInsightsResponse`
+(`packages/ai-intelligence/src/routes/correlations.ts`) matches model narratives to container pairs
+by list index, then by container names appearing in a block, then — weakest — positionally.
+
+A block is used at most once, and a block that *overlaps* one already used counts as used. Exact
+string matching is not enough: `paragraphs` entries are space-joins of the same lines held
+individually in `lineBlocks`, so an equality test let one pair be handed a paragraph containing
+another pair's sentence, putting overlapping claims about different containers on two cards while
+reporting `ok`.
+
+Positional attribution is accepted **only within an explicitly bulleted list** of exactly one item
+per pair. Position is evidence only where the model asserted an order; a run of bare prose asserts
+none, and reading it positionally is a guess dressed as an answer. An intermediate version did keep
+prose and tried to screen out headings by testing for a trailing full stop — that was worse than the
+problem it addressed, because it also deleted a bolded or unpunctuated narrative from the *middle* of
+the list and silently shifted every later sentence onto the wrong pair, reporting `ok` where the
+unfiltered code had correctly returned nothing. Prose that genuinely explains a pair almost always
+names its containers, which the content pass already attributes on real evidence.
+
+Under-attributing is the intended direction of failure: a null narrative costs the operator a
+sentence, a misattributed one tells them something untrue about a container. `narrativeStatus`
+reports which happened, once, rather than per row.
+
+**Capped lists carry their real count.** `recommendationSummary` in `packages/observability/src/routes/reports.ts`
+caps `container_names` at `RULE_CONTAINER_NAMES_CAP` (mirroring `ALL_NAMES_CAP` in
+`incident-store.ts`) and sets `names_truncated`, but `container_count` stays uncapped and is what the
+UI counts with. Counting the truncated array would report "500 containers" for a fleet of 525 — an
+under-count presented as fact, on precisely the large fleet the cap exists for.
+
 **Real anchors.** `DataTable` takes optional `rowHref` / `rowLabel`; when supplied, the first
-non-selection cell renders inside a react-router `<Link>` and the row carries `role="link"`. Sidebar
+non-selection cell renders inside a react-router `<Link>`, and `rowLabel` names that anchor. Sidebar
 destinations are `<Link>` too. Nothing in the product was previously an anchor, so cmd-click,
 middle-click, copy-link and open-in-background did not exist anywhere, and assistive tech announced
 a focusable row rather than a link to a container. Note an `<a>` may not contain a `<button>`, which
 is why the Workload Explorer's favourite star moved to its own column.
+
+The `<tr>` itself carries **no** `role`. It briefly carried `role="link"`, which was a regression in
+the behaviour this change set out to improve: an explicit role replaces the row's implicit `row`
+role, which each `<td>`'s `cell` role requires as its ancestor and which the virtual scroll
+container's `role="grid"` assumes — so screen-reader table navigation broke on exactly the fleet
+tables that most need it. It also nested a link inside a link with the same accessible name, an axe
+`nested-interactive` violation that announced the destination twice, while the row-level role
+carried no `href` and so could not be middle-clicked anyway. The anchor is what makes a row a link.
+
+**Port bind addresses.** Docker's host-side bind address is the most security-relevant fact about a
+published port, and the only thing distinguishing the IPv4 and IPv6 bindings it emits for the same
+mapping. `frontend/src/features/containers/lib/port-bindings.ts` holds the shared reading of it —
+`UNSPECIFIED_BIND_ADDRESSES`, `isLoopbackBind`, `isPubliclyBound`, `formatPortMapping` — used by both
+surfaces that render ports: the container detail table (which had hardcoded `0.0.0.0` for every row)
+and the network-topology side panel (which omitted the address entirely, so a dual-stack publish
+printed the same line twice and a loopback-only publish looked world-facing). `Container['ports']`
+in `use-containers.ts` now declares `ip` itself, retiring the local intersection type that
+`container-overview.tsx` had been carrying.
 
 **`PageHeader`.** `frontend/src/shared/components/layout/page-header.tsx` renders the single `<h1>`,
 an optional subtitle and an actions slot. It is deliberately without a gradient, icon-tile or
@@ -135,7 +191,19 @@ inference. `identifyPattern` (`packages/observability`) now returns a structured
 (`PATTERN_Z_SCORE_THRESHOLD`) — instead of one of three fixed English sentences, so the UI can print
 the rule that fired. `clampConfidenceScore` and `parseSeverity` return `null` rather than the
 constants `0.5` / `'warning'`, so "the model did not supply this" is representable and the badge can
-be omitted instead of showing a default dressed as a measurement. Remediation payloads carry
+be omitted instead of showing a default dressed as a measurement.
+
+Those two helpers live in `packages/core/src/utils/model-confidence.ts`. They started out beside the
+remediation analyser, which meant the fix reached one of the three services that had the defect: the
+investigation analyser (`packages/ai-intelligence`) still substituted `0.5` for a missing score,
+`0.3` for unstructured output and `0.1` on the "insufficient evidence" abort — a confidence for an
+analysis that never ran — and the PCAP analyser (`packages/security`) substituted `0.5` and `0.3`.
+Those packages may not import one another, so a shared home in `core` is what makes the rule one rule
+rather than three copies, two of which had already drifted. Renderers must guard on null: `null * 100`
+is `0`, so an unguarded badge reads "Confidence: 0%" — a more confident claim than the default it
+replaced. `investigation-detail.tsx` shows `N/A`, `insight-card.tsx` and the PCAP analysis panel omit
+the badge entirely. `severity_assessment` deliberately keeps its `'unknown'` string: unlike a number,
+it is honest about itself. Remediation payloads carry
 `rationaleSource` ('pattern-match' | 'llm-analysis') so rule-derived seed text is distinguishable
 from real LLM output, which previously shared identical chrome. **The underlying maths was always
 sound and is unchanged** — z-scores, the RMS composite and the seasonal baselines are legitimate;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,3 +81,79 @@ A second batch extended coverage across `packages/observability/src/routes/trace
 - The Network Topology graph (`frontend/src/features/containers/components/network/`) renders containers grouped into Docker Compose stacks with `@xyflow/react`, laid out by `elkjs`: the root packs the (mostly disconnected) stack boxes into a compact, deterministic grid via `rectpacking` + `SEPARATE_CHILDREN`, while each stack lays out its interior with `stress`. The canvas is **static** — pan / zoom / click-to-select only, no node dragging and no force simulation — so the layout is fully reproducible from elkjs. The viewport uses a low `minZoom` (0.1) with a capped `fitView` and `onlyRenderVisibleElements` so a large fleet (~200 containers) stays readable in one zoomed-out overview. Layout/viewport constants live in `topology-graph.tsx` (`ROOT_LAYOUT_OPTIONS`, `GROUP_LAYOUT_OPTIONS`, `FIT_VIEW_OPTIONS`); see the design spec under `docs/superpowers/specs/2026-05-30-topology-overview-scale-design.md`. elkjs runs in a **Web Worker** (`use-elk-layout.ts` uses `elkjs/lib/elk-api` + a `?worker` factory in `elk-worker-factory.ts`, #1508): the ~1.4MB GWT engine is a separate lazily-fetched asset and layout solves never block the main thread.
 - **Page-level error isolation:** `AppLayout` (`frontend/src/features/core/components/layout/app-layout.tsx`) wraps the router `<Outlet>` in an `ErrorBoundary` (`PageBoundary`). A render error in one page degrades to an inline error card while the sidebar and header stay mounted, instead of bubbling to the `/` route's `errorElement` and replacing the whole shell. The boundary renders inside the route-keyed wrapper, so it resets on navigation. This also kept the CI E2E suite's authenticated shell alive on Portainer-backed routes when Portainer was unreachable. See #1420.
 - Frontend bundle strategy (#1507): route pages are lazy (`router.tsx`), vendor chunking uses Rolldown's `output.codeSplitting` groups in `frontend/vite.config.ts` (react-vendor, query-vendor only — recharts and framer-motion are deliberately ungrouped so chart code stays out of the eager graph and the LazyMotion feature bundle can split). All animated components import `m` from framer-motion; the `domMax` featureset loads asynchronously via `frontend/src/lib/motion-features.ts` (regression-guarded by `frontend/src/lazy-motion-features.test.ts`). jsPDF loads via dynamic import on Export PDF click (`management-pdf-export.ts`); the Metrics Dashboard chat panel and its react-markdown/highlight.js payload load on first open. React Compiler is enabled through `@rolldown/plugin-babel` + `reactCompilerPreset` (#1524). `frontend/scripts/check-bundle-size.ts` fails if recharts code ever re-enters the entry's static-import closure.
+
+## Design-critique remediation (2026-07-26)
+
+A whole-application design review produced 173 findings; the fixes are grouped below by the
+structural cause rather than by page, because most of them shared one.
+
+**One navigation manifest.** `frontend/src/features/core/lib/navigation-manifest.ts` is the single
+source of truth for every destination (path, label, short label, group, icon, palette-only and
+feature-gate flags) and for the `g`-chord assignments (`NAV_CHORDS`). The sidebar, the breadcrumb,
+the command palette, the mobile bottom nav and the keyboard-shortcuts overlay all derive from it.
+Before this there were **six** independently hand-maintained copies of the route list, and they had
+drifted far enough to be user-visible: the breadcrumb fell through to a literal `'Dashboard'` on 7
+of 20 routes (rendering "Dashboard / Dashboard"), the palette was missing 5 destinations including
+Log Viewer and Packet Capture, and the shortcuts overlay still advertised labels the nav had
+renamed. `navigation-manifest.test.ts` fails if a destination lacks a breadcrumb label or a palette
+entry, so the drift cannot silently return.
+
+Note the chords live in the manifest rather than in `app-layout.tsx`: the shortcuts overlay needs
+them to label itself and `app-layout` renders that overlay, so declaring them there created an
+import cycle in which `NAV_CHORDS` read as `undefined` at module-init time whenever the graph was
+entered through the router.
+
+**`useAutoRefresh` owns its timer.** The hook used to own only interval state and schedule nothing,
+so every consumer had to remember its own `window.setInterval` effect. One page did (with a comment
+naming the trap); six did not — and `refresh-controls.tsx` renders a pulsing "live" dot whenever
+`interval > 0`, so those pages showed a live indicator over a dropdown that scheduled no fetch. The
+hook now takes `{ onTick, storageKey }` and runs the timer itself. `storageKey` exists because a
+single shared localStorage key meant a page requesting `useAutoRefresh(0)` could open *displaying*
+an interval another page had stored. The returned setter is `setRefreshInterval`; `setInterval` is
+kept as a deprecated alias because destructuring it shadows `window.setInterval` in the consuming
+module, which is exactly what made hand-wiring the timer error-prone.
+
+A shared `DataFreshness` ("Updated Ns ago") component now sits beside the refresh control on the
+polling pages, so a stalled poll is visible rather than inferred.
+
+**Real anchors.** `DataTable` takes optional `rowHref` / `rowLabel`; when supplied, the first
+non-selection cell renders inside a react-router `<Link>` and the row carries `role="link"`. Sidebar
+destinations are `<Link>` too. Nothing in the product was previously an anchor, so cmd-click,
+middle-click, copy-link and open-in-background did not exist anywhere, and assistive tech announced
+a focusable row rather than a link to a container. Note an `<a>` may not contain a `<button>`, which
+is why the Workload Explorer's favourite star moved to its own column.
+
+**`PageHeader`.** `frontend/src/shared/components/layout/page-header.tsx` renders the single `<h1>`,
+an optional subtitle and an actions slot. It is deliberately without a gradient, icon-tile or
+size-override prop: 20 pages previously hand-rolled the block, 11 of them writing the title string
+twice (loading branch and loaded branch), and that absence is why one page's `<h1>` had drifted into
+a blue-purple gradient while its 19 siblings were plain.
+
+**Honest labelling of computed values.** Several surfaces described deterministic rules as
+inference. `identifyPattern` (`packages/observability`) now returns a structured `MetricPatternMatch`
+— pattern id, the triggering metrics and their z-scores, and the threshold crossed
+(`PATTERN_Z_SCORE_THRESHOLD`) — instead of one of three fixed English sentences, so the UI can print
+the rule that fired. `clampConfidenceScore` and `parseSeverity` return `null` rather than the
+constants `0.5` / `'warning'`, so "the model did not supply this" is representable and the badge can
+be omitted instead of showing a default dressed as a measurement. Remediation payloads carry
+`rationaleSource` ('pattern-match' | 'llm-analysis') so rule-derived seed text is distinguishable
+from real LLM output, which previously shared identical chrome. **The underlying maths was always
+sound and is unchanged** — z-scores, the RMS composite and the seasonal baselines are legitimate;
+only the framing overclaimed.
+
+The fleet health number is now `calculateHealthcheckPassRate` and states its exclusion inline. It
+measures Docker healthcheck status and cannot see insights, so it used to render "100.0%" in green
+beside "14 Critical" on the same card. The hero slot belongs to a "needs attention" count derived
+from unhealthy/stopped containers plus unacknowledged critical and warning insights. Both are
+derived internally from stats so no caller can pass a number that disagrees with them.
+
+**Timestamps.** `getIncidentGroups` rendered its timestamps with `::text`, which drops the
+`timestamptz` OID and so bypasses the global `pg.types` parser — the same class of pg-driver gotcha
+documented above for `COUNT(*)` and `AVG()`. That is why `/health` rendered "Invalid date" ~20
+times. `formatDate` also now falls back to an em dash rather than user-facing English prose.
+
+**One product name.** `frontend/src/shared/lib/product.ts` exports `PRODUCT_NAME`. The product
+answered to four names depending on the surface: `Docker Insights` (login and sidebar wordmarks),
+`Docker Insight` (its own Settings → System Information), `Container Insights` (`PRODUCT.md`) and
+`container-insights` (the compose project it displayed back to the operator in its own Workloads
+table). `Container Insights` is canonical.

--- a/e2e/containers.spec.ts
+++ b/e2e/containers.spec.ts
@@ -62,11 +62,13 @@ test.describe('Container List (Workload Explorer)', () => {
     await expect(firstRow).toBeVisible();
 
     // The table has row selection enabled, so the first td is the selection
-    // checkbox cell (an <input>/<label>, no buttons). The name cell is the
-    // SECOND td: it holds a FavoriteButton (star) and then the container-name
-    // button that navigates to the detail page. Click the name button (the
-    // last button in that cell), not the star.
-    const containerLink = firstRow.locator('td').nth(1).getByRole('button').last();
+    // checkbox cell. The name cell is the SECOND td and now holds a real
+    // <a href> to the container detail page — an anchor may not contain a
+    // button, so the favourite star moved out to its own column. Asserting on
+    // the link role is the point of the change: it is what restores cmd-click,
+    // middle-click and copy-link on a triage list.
+    const containerLink = firstRow.locator('td').nth(1).getByRole('link');
+    await expect(containerLink).toHaveAttribute('href', /\/containers\/\d+\//);
     await containerLink.click();
 
     // Should navigate to a container detail page

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -15,17 +15,19 @@ test.describe('Sidebar Navigation', () => {
 
   test('navigates to major pages via sidebar links', async ({ page }) => {
     const routes = [
-      { label: /workload explorer/i, urlPattern: /\/workloads/ },
+      { label: /workloads/i, urlPattern: /\/workloads/ },
       { label: /health & monitoring/i, urlPattern: /\/health/ },
       { label: /metrics dashboard/i, urlPattern: /\/metrics/ },
       { label: /settings/i, urlPattern: /\/settings/ },
     ];
 
     for (const route of routes) {
-      // Sidebar nav items render as <button> (client-side navigate), not <a>.
+      // Sidebar destinations are real <a href> anchors so that middle-click and
+      // cmd-click open a new tab (#design-critique). They must expose the link
+      // role, not button.
       await page
         .locator('[data-testid="sidebar"]')
-        .getByRole('button', { name: route.label })
+        .getByRole('link', { name: route.label })
         .click();
 
       // Verify URL updated
@@ -40,18 +42,20 @@ test.describe('Sidebar Navigation', () => {
     // Navigate to a nested page
     await page
       .locator('[data-testid="sidebar"]')
-      .getByRole('button', { name: /workload explorer/i })
+      .getByRole('link', { name: /workloads/i })
       .click();
 
     await expect(page).toHaveURL(/\/workloads/);
 
-    // Breadcrumb should show Dashboard / Workload Explorer
+    // Breadcrumb reads "Home / Workloads": the root crumb matches the sidebar
+    // label and the h1 rather than inventing a third name ("Dashboard"), and
+    // every crumb label comes from the single navigation manifest.
     const breadcrumb = page.locator(
       '[data-testid="header"] nav[aria-label="Breadcrumb"]',
     );
     await expect(breadcrumb).toBeVisible();
-    await expect(breadcrumb).toContainText('Dashboard');
-    await expect(breadcrumb).toContainText('Workload Explorer');
+    await expect(breadcrumb).toContainText('Home');
+    await expect(breadcrumb).toContainText('Workloads');
   });
 
   test('direct URL access loads the correct page', async ({ page }) => {
@@ -71,10 +75,24 @@ test.describe('Sidebar Navigation', () => {
     await expect(page).toHaveURL(/\/health/);
   });
 
-  test('unknown routes redirect to home', async ({ page }) => {
-    // The router has a catch-all `*` that redirects to `/`
+  test('unknown routes render a 404 instead of silently landing on Home', async ({
+    page,
+  }) => {
+    // Previously the catch-all `*` redirected to `/` with `replace`, so a stale
+    // bookmark or typo'd deep link dropped the operator on Home believing it
+    // was the page they asked for — and Back could not return them.
     await page.goto('/this-route-does-not-exist');
 
-    await expect(page).toHaveURL(/\/(home)?$/);
+    await expect(page).toHaveURL(/\/this-route-does-not-exist/);
+    await expect(
+      page.getByText('/this-route-does-not-exist', { exact: false }),
+    ).toBeVisible();
+  });
+
+  test('explicit legacy redirects still work', async ({ page }) => {
+    // The six deliberate aliases must keep redirecting; only *unknown* paths
+    // get the 404.
+    await page.goto('/fleet');
+    await expect(page).toHaveURL(/\/infrastructure/);
   });
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Docker Insights powered by AI</title>
+    <title>Container Insights</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/features/ai-intelligence/components/fleet-health-summary.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/fleet-health-summary.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { ShieldAlert, PackageOpen } from 'lucide-react';
-import { FleetHealthSummary } from './fleet-health-summary';
+import { FleetHealthSummary, type InsightStats } from './fleet-health-summary';
 import type { HealthStats } from '@/shared/lib/health-score';
 
 const stats: HealthStats = {
@@ -15,9 +16,22 @@ const stats: HealthStats = {
   noHealthcheck: 0,
 };
 
+const insightStats: InsightStats = {
+  total: 20,
+  critical: 14,
+  warning: 2,
+  info: 4,
+  unacknowledgedCritical: 14,
+  unacknowledgedWarning: 2,
+};
+
+function renderSummary(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
 describe('FleetHealthSummary', () => {
   it('renders the four container-status tiles by default', () => {
-    render(<FleetHealthSummary stats={stats} isLoading={false} />);
+    renderSummary(<FleetHealthSummary stats={stats} isLoading={false} />);
     const hero = screen.getByTestId('fleet-health-hero');
     expect(within(hero).getByText('Running')).toBeInTheDocument();
     expect(within(hero).getByText('Healthy')).toBeInTheDocument();
@@ -26,13 +40,13 @@ describe('FleetHealthSummary', () => {
   });
 
   it('does not render extra tiles when none are provided (backward compatible)', () => {
-    render(<FleetHealthSummary stats={stats} isLoading={false} />);
+    renderSummary(<FleetHealthSummary stats={stats} isLoading={false} />);
     expect(screen.queryByText('Security Findings')).not.toBeInTheDocument();
     expect(screen.queryByText('Stopped')).not.toBeInTheDocument();
   });
 
   it('renders provided extraTiles after the container tiles', () => {
-    render(
+    renderSummary(
       <FleetHealthSummary
         stats={stats}
         isLoading={false}
@@ -47,21 +61,19 @@ describe('FleetHealthSummary', () => {
     expect(within(hero).getByText('Stopped')).toBeInTheDocument();
     expect(within(hero).getByText('Security Findings')).toBeInTheDocument();
     expect(within(hero).getByText('4')).toBeInTheDocument();
-    // Non-clickable extra tiles must NOT be buttons (only onClick tiles are).
+    // Non-interactive extra tiles must NOT be buttons.
     expect(within(hero).queryByRole('button', { name: /Stopped/i })).not.toBeInTheDocument();
     expect(within(hero).queryByRole('button', { name: /Security Findings/i })).not.toBeInTheDocument();
   });
 
   it('renders an extraTile with onClick as a button and fires the handler', () => {
     const onClick = vi.fn();
-    render(
+    renderSummary(
       <FleetHealthSummary
         stats={stats}
         isLoading={false}
         statusColumns={3}
-        extraTiles={[
-          { icon: ShieldAlert, label: 'Security Findings', value: 4, onClick },
-        ]}
+        extraTiles={[{ icon: ShieldAlert, label: 'Security Findings', value: 4, onClick }]}
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /Security Findings/i }));
@@ -69,8 +81,77 @@ describe('FleetHealthSummary', () => {
   });
 
   it('applies the requested column count to the status grid', () => {
-    render(<FleetHealthSummary stats={stats} isLoading={false} statusColumns={3} />);
+    renderSummary(<FleetHealthSummary stats={stats} isLoading={false} statusColumns={3} />);
     const running = screen.getByText('Running');
     expect(running.closest('[class*="sm:grid-cols-3"]')).not.toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // One denominator per row. Each tile used to print its own percentage of
+  // `total` (11 · 85%) beside a hero reading 100.0% (11/11).
+  // -------------------------------------------------------------------------
+
+  it('states the denominator once and prints counts, not per-tile percentages', () => {
+    renderSummary(<FleetHealthSummary stats={stats} isLoading={false} />);
+
+    expect(screen.getByTestId('fleet-status-denominator')).toHaveTextContent('of 10 containers');
+    const hero = screen.getByTestId('fleet-health-hero');
+    // 8/10 running and 7/10 healthy used to render as "80%" / "70%" on the tiles.
+    expect(within(hero).queryByText('80%')).not.toBeInTheDocument();
+    expect(within(hero).queryByText('70%')).not.toBeInTheDocument();
+  });
+
+  it('links the Running and Unhealthy tiles to the rows behind them', () => {
+    renderSummary(<FleetHealthSummary stats={stats} isLoading={false} />);
+
+    expect(screen.getByTestId('fleet-tile-link-Running')).toHaveAttribute(
+      'href',
+      '/workloads?state=running',
+    );
+    expect(screen.getByTestId('fleet-tile-link-Unhealthy')).toHaveAttribute('href', '/health');
+  });
+
+  it('does not link a tile whose count is zero', () => {
+    const clean: HealthStats = { ...stats, unhealthy: 0 };
+    renderSummary(<FleetHealthSummary stats={clean} isLoading={false} />);
+
+    expect(screen.queryByTestId('fleet-tile-link-Unhealthy')).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Layout — /health asks the shared component for a different emphasis rather
+  // than duplicating Home's top band verbatim.
+  // -------------------------------------------------------------------------
+
+  it('leads with insight tiles and collapses container status to one line', () => {
+    renderSummary(
+      <FleetHealthSummary
+        stats={stats}
+        isLoading={false}
+        insightStats={insightStats}
+        layout="insights-first"
+      />,
+    );
+
+    expect(screen.getByTestId('fleet-status-line')).toHaveTextContent(
+      '10 containers · 8 running · 7 healthy · 1 unhealthy · 0 without a healthcheck',
+    );
+    // The full status tile grid is not rendered in this layout.
+    expect(screen.queryByText('No Healthcheck')).not.toBeInTheDocument();
+    expect(screen.getByText('Total Insights')).toBeInTheDocument();
+  });
+
+  it('feeds unacknowledged critical + warning insights into the hero count', () => {
+    renderSummary(
+      <FleetHealthSummary
+        stats={stats}
+        isLoading={false}
+        insightStats={insightStats}
+        layout="insights-first"
+      />,
+    );
+
+    // 1 unhealthy + 2 stopped containers + 14 critical + 2 warning = 19.
+    expect(screen.getByTestId('needs-attention-count')).toHaveTextContent('19');
   });
 });

--- a/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
+++ b/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
@@ -1,37 +1,47 @@
-import { Activity, AlertCircle, AlertTriangle, CheckCircle2, HelpCircle, Info } from 'lucide-react';
+import { Activity, AlertCircle, AlertTriangle, CheckCircle2, ChevronRight, HelpCircle, Info } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { HealthScoreCard } from '@/shared/components/data-display/health-score-card';
 import {
   calculateHealthStats,
-  calculateHealthScore,
+  calculateHealthcheckPassRate,
   type HealthStats,
 } from '@/shared/lib/health-score';
 
 // Re-export the shared helpers so existing imports from this module keep
 // working. The canonical home for the types and calculators is
-// `@/shared/lib/health-score` — see that file for the score formula.
-export { calculateHealthStats, calculateHealthScore };
+// `@/shared/lib/health-score` — see that file for the pass-rate formula and
+// for `calculateNeedsAttention`, which drives the hero.
+export { calculateHealthStats, calculateHealthcheckPassRate };
 export type { HealthStats };
 
 /**
- * Compact horizontal stat tile used in the Fleet Vitals strip. Replaces the
- * earlier 4-card grid of large boxed stats — keeps all four numbers visible
- * but in roughly half the vertical mass so the hero score still dominates.
+ * Compact horizontal stat tile used in the Fleet Vitals strip.
+ *
+ * Deliberately count-only. Each tile used to carry its own percentage of
+ * `stats.total`, which put `11 · 85%` (11/13) forty pixels from a hero reading
+ * `100.0%` (11/11) with neither denominator labelled. One denominator per row
+ * now: the row states `of N containers` once and the tiles state counts.
  */
 function HealthStatTile({
   icon: Icon,
   label,
   value,
-  percentage,
   variant = 'default',
   onClick,
+  to,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   label: string;
   value: number;
-  percentage?: number;
   variant?: 'default' | 'success' | 'warning' | 'danger' | 'info';
   onClick?: () => void;
+  /**
+   * Destination for a tile that drills into the rows behind its number. Pass
+   * it conditionally — a tile reading `0` that links to an empty filtered
+   * table is a dead end wearing a chevron.
+   */
+  to?: string;
 }) {
   const iconVariantClasses = {
     default: 'text-muted-foreground',
@@ -47,25 +57,32 @@ function HealthStatTile({
         <Icon className="h-4 w-4" />
       </div>
       <div className="flex-1 min-w-0">
-        <div className="flex items-baseline gap-2">
-          <span className="text-xl font-bold tabular-nums leading-none">{value}</span>
-          {percentage !== undefined && value > 0 && (
-            <span className="text-xs text-muted-foreground tabular-nums">{percentage.toFixed(0)}%</span>
-          )}
-        </div>
+        <span className="text-xl font-bold tabular-nums leading-none">{value}</span>
         <p className="text-xs text-muted-foreground mt-0.5 truncate">{label}</p>
       </div>
     </>
   );
 
+  // A tile that navigates says so. Without the chevron the five dead tiles and
+  // the one live one were styled identically.
+  const affordance = <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />;
+  const interactiveClasses =
+    'flex w-full items-center gap-3 rounded-md bg-muted/40 px-3 py-2 text-left transition-colors hover:bg-muted/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer';
+
+  if (to) {
+    return (
+      <Link to={to} className={interactiveClasses} data-testid={`fleet-tile-link-${label}`}>
+        {inner}
+        {affordance}
+      </Link>
+    );
+  }
+
   if (onClick) {
     return (
-      <button
-        type="button"
-        onClick={onClick}
-        className="flex w-full items-center gap-3 rounded-md bg-muted/40 px-3 py-2 text-left transition-colors hover:bg-muted/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer"
-      >
+      <button type="button" onClick={onClick} className={interactiveClasses}>
         {inner}
+        {affordance}
       </button>
     );
   }
@@ -79,31 +96,44 @@ function HealthStatTile({
 
 /**
  * Optional second row of stat tiles for insight counts (Total / Critical /
- * Warning / Info). When provided, renders below the container-status row
- * inside the same hero pane so the page only has one Vitals card to scan.
+ * Warning / Info).
+ *
+ * `unacknowledgedCritical` / `unacknowledgedWarning` are what the hero's
+ * "Needs attention" number is built from; they are optional so a caller that
+ * has not computed them yet degrades to a container-only count rather than to
+ * a wrong one.
  */
 export interface InsightStats {
   total: number;
   critical: number;
   warning: number;
   info: number;
+  unacknowledgedCritical?: number;
+  unacknowledgedWarning?: number;
 }
 
 /**
  * Caller-supplied tile appended after the four container-status tiles (e.g.
  * Stopped, Security Findings on the Home page). Rendered with the same
- * `HealthStatTile`; an `onClick` turns it into a button.
+ * `HealthStatTile`; `to` makes it a link, `onClick` a button.
  */
 export interface ExtraTile {
   icon: React.ComponentType<{ className?: string }>;
   label: string;
   value: number;
-  percentage?: number;
   variant?: 'default' | 'success' | 'warning' | 'danger' | 'info';
   onClick?: () => void;
+  to?: string;
 }
 
-export function FleetHealthSummary({ stats, isLoading, insightStats, statusColumns = 4, extraTiles }: {
+export function FleetHealthSummary({
+  stats,
+  isLoading,
+  insightStats,
+  statusColumns = 4,
+  extraTiles,
+  layout = 'status-first',
+}: {
   stats: HealthStats | null;
   isLoading: boolean;
   insightStats?: InsightStats;
@@ -111,10 +141,94 @@ export function FleetHealthSummary({ stats, isLoading, insightStats, statusColum
   statusColumns?: 3 | 4;
   /** Tiles appended after the four container-status tiles. */
   extraTiles?: ExtraTile[];
+  /**
+   * `'status-first'` (Home) renders the container-status tiles in full.
+   * `'insights-first'` (Health & Monitoring) leads with the insight tiles and
+   * collapses container status to one line — Home has already carried that
+   * strip in full, and navigating Home → Health used to leave the top ~180px
+   * of the viewport unchanged.
+   */
+  layout?: 'status-first' | 'insights-first';
 }) {
   if (isLoading || !stats) {
     return <SkeletonChart size="md" className="h-44" />;
   }
+
+  const insightCounts = insightStats
+    ? {
+        critical: insightStats.unacknowledgedCritical ?? 0,
+        warning: insightStats.unacknowledgedWarning ?? 0,
+      }
+    : undefined;
+
+  const insightTiles = insightStats ? (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+      <HealthStatTile icon={Activity} label="Total Insights" value={insightStats.total} />
+      <HealthStatTile
+        icon={AlertTriangle}
+        label="Critical"
+        value={insightStats.critical}
+        variant="danger"
+      />
+      <HealthStatTile
+        icon={AlertCircle}
+        label="Warnings"
+        value={insightStats.warning}
+        variant="warning"
+      />
+      <HealthStatTile icon={Info} label="Info" value={insightStats.info} variant="info" />
+    </div>
+  ) : null;
+
+  const statusTiles = (
+    <div className="flex flex-col gap-1.5">
+      {/* One denominator for the whole row, stated once. */}
+      <p className="text-xs text-muted-foreground" data-testid="fleet-status-denominator">
+        of {stats.total} containers
+      </p>
+      <div className={`grid grid-cols-2 gap-2 ${statusColumns === 3 ? 'sm:grid-cols-3' : 'sm:grid-cols-4'}`}>
+        <HealthStatTile
+          icon={Activity}
+          label="Running"
+          value={stats.running}
+          variant="success"
+          to={stats.running > 0 ? '/workloads?state=running' : undefined}
+        />
+        <HealthStatTile icon={CheckCircle2} label="Healthy" value={stats.healthy} variant="success" />
+        <HealthStatTile
+          icon={AlertTriangle}
+          label="Unhealthy"
+          value={stats.unhealthy}
+          variant="danger"
+          to={stats.unhealthy > 0 ? '/health' : undefined}
+        />
+        <HealthStatTile
+          icon={HelpCircle}
+          label="No Healthcheck"
+          value={stats.noHealthcheck}
+          variant={stats.noHealthcheck > 0 ? 'warning' : 'default'}
+        />
+        {extraTiles?.map((tile) => (
+          <HealthStatTile
+            key={tile.label}
+            icon={tile.icon}
+            label={tile.label}
+            value={tile.value}
+            variant={tile.variant}
+            onClick={tile.onClick}
+            to={tile.to}
+          />
+        ))}
+      </div>
+    </div>
+  );
+
+  const collapsedStatusLine = (
+    <p className="text-xs text-muted-foreground" data-testid="fleet-status-line">
+      {stats.total} containers · {stats.running} running · {stats.healthy} healthy ·{' '}
+      {stats.unhealthy} unhealthy · {stats.noHealthcheck} without a healthcheck
+    </p>
+  );
 
   return (
     <div
@@ -122,79 +236,20 @@ export function FleetHealthSummary({ stats, isLoading, insightStats, statusColum
       data-testid="fleet-health-hero"
     >
       <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-        {/* Hero — score + issue count */}
-        <HealthScoreCard stats={stats} />
+        {/* Hero — needs-attention count + healthcheck pass rate */}
+        <HealthScoreCard stats={stats} insightCounts={insightCounts} />
 
-        {/* Compact status strip — container stats on row 1, insights stats on
-            row 2 (when supplied). Two rows of 4 tiles inside the same hero. */}
         <div className="flex flex-col gap-2 lg:w-auto">
-          <div className={`grid grid-cols-2 gap-2 ${statusColumns === 3 ? 'sm:grid-cols-3' : 'sm:grid-cols-4'}`}>
-            <HealthStatTile
-              icon={Activity}
-              label="Running"
-              value={stats.running}
-              percentage={stats.total > 0 ? (stats.running / stats.total) * 100 : 0}
-              variant="success"
-            />
-            <HealthStatTile
-              icon={CheckCircle2}
-              label="Healthy"
-              value={stats.healthy}
-              percentage={stats.total > 0 ? (stats.healthy / stats.total) * 100 : 0}
-              variant="success"
-            />
-            <HealthStatTile
-              icon={AlertTriangle}
-              label="Unhealthy"
-              value={stats.unhealthy}
-              percentage={stats.total > 0 ? (stats.unhealthy / stats.total) * 100 : 0}
-              variant="danger"
-            />
-            <HealthStatTile
-              icon={HelpCircle}
-              label="No Healthcheck"
-              value={stats.noHealthcheck}
-              percentage={stats.total > 0 ? (stats.noHealthcheck / stats.total) * 100 : 0}
-              variant={stats.noHealthcheck > 0 ? 'warning' : 'default'}
-            />
-            {extraTiles?.map((tile) => (
-              <HealthStatTile
-                key={tile.label}
-                icon={tile.icon}
-                label={tile.label}
-                value={tile.value}
-                percentage={tile.percentage}
-                variant={tile.variant}
-                onClick={tile.onClick}
-              />
-            ))}
-          </div>
-          {insightStats && (
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-              <HealthStatTile
-                icon={Activity}
-                label="Total Insights"
-                value={insightStats.total}
-              />
-              <HealthStatTile
-                icon={AlertTriangle}
-                label="Critical"
-                value={insightStats.critical}
-                variant="danger"
-              />
-              <HealthStatTile
-                icon={AlertCircle}
-                label="Warnings"
-                value={insightStats.warning}
-                variant="warning"
-              />
-              <HealthStatTile
-                icon={Info}
-                label="Info"
-                value={insightStats.info}
-                variant="info"
-              />
-            </div>
+          {layout === 'insights-first' ? (
+            <>
+              {insightTiles}
+              {collapsedStatusLine}
+            </>
+          ) : (
+            <>
+              {statusTiles}
+              {insightTiles}
+            </>
           )}
         </div>
       </div>

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
@@ -75,5 +75,27 @@ describe('IncidentGroupsView — endpoint chip overflow', () => {
     });
     render(wrap(<IncidentGroupsView />));
     expect(screen.getByText(/\+4 more/i)).toBeInTheDocument();
+  });
+
+  it('renders the endpoint facets as counts, not as dead filter buttons', () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        total_active: 33,
+        groups: [dummyGroup],
+        endpoint_facets: [
+          { endpoint_id: 3, endpoint_name: 'docker-dev-1', incident_count: 23 },
+          { endpoint_id: 1, endpoint_name: 'local', incident_count: 10 },
+        ],
+      } as IncidentGroupsResponse,
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView />));
+
+    const row = screen.getByTestId('endpoint-chip-row');
+    expect(row).toHaveTextContent('docker-dev-1');
+    expect(row).toHaveTextContent('23');
+    // They used to be <button type="button"> with no onClick and no state,
+    // in the same pill language as the working severity filter chips above.
+    expect(within(row).queryByRole('button')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.row-meta.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.row-meta.test.tsx
@@ -82,4 +82,16 @@ describe('IncidentGroupsView — row meta (Phase A)', () => {
     render(wrap(<IncidentGroupsView />));
     expect(screen.queryByText(/^(ML|Threshold|Prediction|Health Check|Scan|Pattern|Network)$/)).not.toBeInTheDocument();
   });
+
+  it('renders the row severity in the shared Title Case vocabulary', () => {
+    (useIncidentGroups as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { total_active: 1, endpoint_facets: [], groups: [mockGroup()] },
+      isLoading: false,
+    });
+    render(wrap(<IncidentGroupsView />));
+    // The raw lowercase enum used to print inches from a "Critical" badge.
+    const sev = screen.getByTestId('row-severity');
+    expect(sev).toHaveTextContent('critical');
+    expect(sev.className).toContain('capitalize');
+  });
 });

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
@@ -330,7 +330,12 @@ export function IncidentGroupsView({ search = '' }: { search?: string }) {
                             <div className="flex items-center gap-2 text-xs text-muted-foreground whitespace-nowrap">
                               <span>{formatDate(row.created_at)}</span>
                               <span aria-hidden="true">·</span>
-                              <span>{row.severity}</span>
+                              {/* Title Case, same vocabulary as `SeverityBadge`
+                                  — the raw lowercase enum ("critical") used to
+                                  print inches from a "Critical" badge. */}
+                              <span className="capitalize" data-testid="row-severity">
+                                {row.severity}
+                              </span>
                               <span aria-hidden="true">·</span>
                               <span>{row.endpoint_name ?? 'unknown'}</span>
                               {isExpanded
@@ -475,6 +480,17 @@ function rankSeverity(s: IncidentGroup['severity']): number {
   return s === 'critical' ? 0 : s === 'warning' ? 1 : 2;
 }
 
+/**
+ * Per-endpoint incident counts, as a read-only breakdown.
+ *
+ * These were `<button type="button">` elements with no `onClick` and no state,
+ * rendered in the same rounded-pill language as the working severity filter
+ * chips directly above them — so they read as filters and did nothing when
+ * clicked. There is no endpoint filter behind them to wire (a group can span
+ * endpoints, so filtering groups by endpoint would silently drop rows), so they
+ * are counts and now look like counts. The `+N more` disclosure stays
+ * interactive because it genuinely discloses.
+ */
 function EndpointChips({
   facets,
 }: {
@@ -484,21 +500,22 @@ function EndpointChips({
   const inline = facets.slice(0, 8);
   const overflow = facets.slice(8);
   return (
-    <div data-testid="endpoint-chip-row" className="flex flex-wrap items-center gap-2">
+    <div data-testid="endpoint-chip-row" className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+      <span>Active incidents by endpoint:</span>
       {inline.map((f) => (
-        <button key={`${f.endpoint_id ?? 'none'}`} type="button" className="rounded-full border px-3 py-1 text-xs">
-          {f.endpoint_name ?? 'unknown'} ({f.incident_count})
-        </button>
+        <span key={`${f.endpoint_id ?? 'none'}`} className="tabular-nums">
+          <span className="font-mono text-foreground">{f.endpoint_name ?? 'unknown'}</span>{' '}
+          {f.incident_count}
+        </span>
       ))}
       {overflow.length > 0 && (
         <details className="relative">
-          <summary className="cursor-pointer rounded-full border px-3 py-1 text-xs">+{overflow.length} more</summary>
+          <summary className="cursor-pointer underline decoration-dotted">+{overflow.length} more</summary>
           <ul className="absolute z-10 mt-1 max-h-64 w-64 overflow-auto rounded-md border bg-popover p-1 shadow">
             {overflow.map((f) => (
-              <li key={`${f.endpoint_id ?? 'none'}`}>
-                <button type="button" className="w-full rounded px-2 py-1 text-left text-xs hover:bg-muted">
-                  {f.endpoint_name ?? 'unknown'} ({f.incident_count})
-                </button>
+              <li key={`${f.endpoint_id ?? 'none'}`} className="px-2 py-1 tabular-nums">
+                <span className="font-mono text-foreground">{f.endpoint_name ?? 'unknown'}</span>{' '}
+                {f.incident_count}
               </li>
             ))}
           </ul>

--- a/frontend/src/features/ai-intelligence/components/insight-card.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/insight-card.test.tsx
@@ -75,9 +75,11 @@ describe('InsightCard — dimensions breakdown (#1296)', () => {
     // One row per dimension, each labelled with its `type`.
     expect(screen.getByTestId('insight-dimension-latency_p95')).toBeInTheDocument();
     expect(screen.getByTestId('insight-dimension-error_rate')).toBeInTheDocument();
-    // Z-score labels reflect the underlying values to one decimal place.
-    expect(within(bars).getByText('4.8')).toBeInTheDocument();
-    expect(within(bars).getByText('2.3')).toBeInTheDocument();
+    // Z-score labels reflect the underlying values to one decimal place, and
+    // carry their sign — the bar is drawn as an offset from a centre line, so
+    // a -2.8 no longer renders identically to a +2.8.
+    expect(within(bars).getByText('+4.8')).toBeInTheDocument();
+    expect(within(bars).getByText('+2.3')).toBeInTheDocument();
 
     // Value + baseline detail block surfaces both signals.
     expect(screen.getByText(/baseline 20\.00/)).toBeInTheDocument();

--- a/frontend/src/features/ai-intelligence/components/insight-card.tsx
+++ b/frontend/src/features/ai-intelligence/components/insight-card.tsx
@@ -45,6 +45,13 @@ export interface InsightCardProps {
     is_acknowledged: number;
     created_at: string;
     /**
+     * Typed detector identifier written by the backend
+     * (`packages/ai-intelligence/src/services/monitoring-service.ts`). Optional
+     * because non-anomaly insights and pre-migration-030 rows carry none — in
+     * which case no detector badge is rendered.
+     */
+    detection_method?: string;
+    /**
      * Optional multi-signal payload — present when correlated suppression
      * collapsed co-occurring anomalies (e.g. latency p95 + error rate) for
      * the same `(service, minute)` window into a single insight (#1296).
@@ -61,12 +68,64 @@ export interface InsightCardProps {
 }
 
 /**
+ * One signed z-score bar, drawn as an offset from a centre line. Shared by the
+ * insight dimension breakdown and the correlated-anomaly cards on
+ * Health & Monitoring so the two surfaces cannot drift.
+ *
+ * Two things it fixes. The bar used to be drawn as `|z| / 5` from the left
+ * edge, so `memory -2.8` rendered identically to `+2.8` — and the sign is the
+ * difference between "spiking" and "collapsed". And the colour band is now
+ * keyed to the *displayed* one-decimal value, so two bars both labelled "2.0"
+ * can no longer render in different colours and different lengths because one
+ * was 1.96 and the other 2.04.
+ *
+ * Half the track is one direction, so |z| = 5 fills a half. The bands
+ * themselves are unchanged: red ≥ 3, amber ≥ 2, blue below.
+ */
+export function ZScoreBar({
+  label,
+  zScore,
+  labelWidthClass = 'w-20',
+  testId,
+}: {
+  label: string;
+  zScore: number;
+  labelWidthClass?: string;
+  testId?: string;
+}) {
+  const displayed = Number(zScore.toFixed(1));
+  const absZ = Math.abs(displayed);
+  const halfPct = Math.min((absZ / 5) * 50, 50);
+  const barColor = absZ >= 3 ? 'bg-red-500' : absZ >= 2 ? 'bg-amber-500' : 'bg-blue-500';
+  const negative = displayed < 0;
+
+  return (
+    <div className="flex items-center gap-2" data-testid={testId ?? `zscore-bar-${label}`}>
+      <span className={cn('text-xs text-muted-foreground truncate font-mono', labelWidthClass)}>
+        {label}
+      </span>
+      <div className="relative h-2 flex-1 rounded-full bg-muted">
+        <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" aria-hidden />
+        <span
+          className={cn('absolute inset-y-0 rounded-full transition-all', barColor)}
+          data-testid={`zscore-fill-${label}`}
+          data-direction={negative ? 'negative' : 'positive'}
+          style={negative ? { right: '50%', width: `${halfPct}%` } : { left: '50%', width: `${halfPct}%` }}
+        />
+      </div>
+      <span className="w-12 text-right text-xs tabular-nums text-muted-foreground" title="z-score">
+        {`${displayed > 0 ? '+' : ''}${displayed.toFixed(1)}`}
+      </span>
+    </div>
+  );
+}
+
+/**
  * Per-dimension z-score / value / baseline breakdown for a correlated
- * anomaly insight. Visual language deliberately mirrors
- * `CorrelatedAnomalyCard` on the AI monitor page (z-bar widths capped at
- * z=5, severity colour bands red ≥ 3 / amber ≥ 2 / blue < 2) so the two
- * surfaces feel like the same product. Renders nothing when the array is
- * empty so single-dimension insights keep their existing look.
+ * anomaly insight. Uses the same `ZScoreBar` as `CorrelatedAnomalyCard` on the
+ * Health & Monitoring page so the two surfaces feel like the same product.
+ * Renders nothing when the array is empty so single-dimension insights keep
+ * their existing look.
  */
 export function InsightDimensionBreakdown({ dimensions }: { dimensions: AnomalyDimension[] }) {
   if (dimensions.length === 0) return null;
@@ -74,28 +133,15 @@ export function InsightDimensionBreakdown({ dimensions }: { dimensions: AnomalyD
     <div>
       <h4 className="text-sm font-medium mb-2">Correlated Signals</h4>
       <div className="space-y-1.5" data-testid="insight-dimension-bars">
-        {dimensions.map((d) => {
-          const absZ = Math.abs(d.zScore);
-          const widthPct = Math.min((absZ / 5) * 100, 100);
-          // Match CorrelatedAnomalyCard's severity bands (ai-monitor.tsx
-          // lines 58-79): red ≥ 3, amber ≥ 2, blue < 2.
-          const barColor = absZ >= 3 ? 'bg-red-500' : absZ >= 2 ? 'bg-amber-500' : 'bg-blue-500';
-
-          return (
-            <div key={d.type} className="flex items-center gap-2" data-testid={`insight-dimension-${d.type}`}>
-              <span className="text-xs text-muted-foreground w-24 truncate font-mono">{d.type}</span>
-              <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
-                <div
-                  className={cn('h-full rounded-full transition-all', barColor)}
-                  style={{ width: `${widthPct}%` }}
-                />
-              </div>
-              <span className="text-xs tabular-nums text-muted-foreground w-12 text-right" title="z-score">
-                {d.zScore.toFixed(1)}
-              </span>
-            </div>
-          );
-        })}
+        {dimensions.map((d) => (
+          <ZScoreBar
+            key={d.type}
+            label={d.type}
+            zScore={d.zScore}
+            labelWidthClass="w-24"
+            testId={`insight-dimension-${d.type}`}
+          />
+        ))}
       </div>
       <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground sm:grid-cols-3">
         {dimensions.map((d) => (
@@ -188,30 +234,45 @@ export function SeverityBadge({ severity }: { severity: Severity }) {
   );
 }
 
+/**
+ * Which detector produced this insight, read from the typed
+ * `insights.detection_method` column.
+ *
+ * It used to be scraped out of the description with `/method:\s*(\w+)/`. `\w`
+ * excludes the hyphen, so a row reading "method: isolation-forest" captured
+ * `isolation`, missed the lookup, and fell through to a `?? config.zscore`
+ * default — badging isolation-forest anomalies "Z-Score" and leaving the
+ * 'isolation-forest' entry as unreachable code.
+ *
+ * Two consequences of reading the typed column, both deliberate. The labels are
+ * the persisted detector identifiers, not the statistical technique — the
+ * backend writes `ml-anomaly` for both the adaptive z-score path and the
+ * isolation-forest path, so the column genuinely cannot tell them apart and
+ * this badge must not pretend otherwise (hence "Metric anomaly", not "ML"). And
+ * an unrecognised or absent method renders nothing at all rather than
+ * defaulting: a badge is a claim about what ran, and there is no honest default.
+ */
+const DETECTION_METHOD_LABELS: Record<string, string> = {
+  threshold: 'Threshold',
+  'ml-anomaly': 'Metric anomaly',
+  prediction: 'Forecast',
+  'health-check': 'Healthcheck',
+  'log-pattern': 'Log pattern',
+  'security-scan': 'Security scan',
+};
+
 export function DetectionMethodBadge({ method }: { method: string }) {
-  const config: Record<string, { label: string; className: string }> = {
-    zscore: {
-      label: 'Z-Score',
-      className: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-    },
-    bollinger: {
-      label: 'Bollinger',
-      className: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
-    },
-    adaptive: {
-      label: 'Adaptive',
-      className: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
-    },
-    'isolation-forest': {
-      label: 'Isolation Forest',
-      className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-    },
-  };
-  const entry = config[method] ?? config.zscore;
+  const label = DETECTION_METHOD_LABELS[method];
+  if (!label) return null;
   return (
-    <span className={cn('inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium', entry.className)}>
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+      title={`Detector: ${method}`}
+      data-testid="detection-method-badge"
+      data-detection-method={method}
+    >
       <Activity className="h-3 w-3" />
-      {entry.label}
+      {label}
     </span>
   );
 }
@@ -397,9 +458,7 @@ export function InsightCard({
   const hasInvestigation = !!investigation;
   const isInvestigating = investigation && ['pending', 'gathering', 'analyzing'].includes(investigation.status);
 
-  const detectionMethod = insight.category === 'anomaly'
-    ? insight.description.match(/method:\s*(\w+)/)?.[1] ?? null
-    : null;
+  const detectionMethod = insight.detection_method ?? null;
 
   return (
     <div

--- a/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LlmLatencyBreakdown } from './llm-latency-breakdown';
+import { LlmLatencyBreakdown, formatWindowLabel } from './llm-latency-breakdown';
 
 const mockApiGet = vi.fn();
 
@@ -50,6 +50,59 @@ describe('LlmLatencyBreakdown', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('no-trace-data-callout')).toBeInTheDocument();
+    });
+  });
+
+  // Regression: the empty branch used to `return` a bare callout, which left
+  // this the only card on /llm-observability with no heading at all.
+  it('keeps the section heading in the empty state', async () => {
+    mockApiGet.mockResolvedValue({ traces: [] });
+
+    renderWithProviders(<LlmLatencyBreakdown peers={['api.anthropic.com']} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('no-trace-data-callout')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/LLM latency breakdown/i)).toBeInTheDocument();
+  });
+
+  // Regression: the callout hardcoded "in the last hour" while the page's
+  // range selector above it read 24h.
+  it('interpolates the selected window into both the caption and the empty state', async () => {
+    mockApiGet.mockResolvedValue({ traces: [] });
+
+    renderWithProviders(<LlmLatencyBreakdown peers={['api.anthropic.com']} hours={24} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('no-trace-data-callout')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/No outbound LLM spans seen in the last 24h\./)).toBeInTheDocument();
+    expect(screen.getByText(/per upstream provider, last 24h\./)).toBeInTheDocument();
+    expect(screen.queryByText(/last hour/)).toBeNull();
+  });
+
+  it('queries the window implied by the hours prop', async () => {
+    mockApiGet.mockResolvedValue({ traces: [] });
+
+    renderWithProviders(<LlmLatencyBreakdown peers={['api.anthropic.com']} hours={168} />);
+
+    await waitFor(() => expect(mockApiGet).toHaveBeenCalled());
+    const params = mockApiGet.mock.calls[0][1] as { from: string; to: string };
+    const spanHours = (Date.parse(params.to) - Date.parse(params.from)) / 3_600_000;
+    expect(Math.round(spanHours)).toBe(168);
+  });
+
+  describe('formatWindowLabel', () => {
+    it('renders hours below two days and days above', () => {
+      expect(formatWindowLabel(1)).toBe('last 1h');
+      expect(formatWindowLabel(6)).toBe('last 6h');
+      expect(formatWindowLabel(24)).toBe('last 24h');
+      expect(formatWindowLabel(168)).toBe('last 7d');
+    });
+
+    it('falls back to 1h for nonsense input rather than rendering NaN', () => {
+      expect(formatWindowLabel(0)).toBe('last 1h');
+      expect(formatWindowLabel(Number.NaN)).toBe('last 1h');
     });
   });
 

--- a/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.tsx
+++ b/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.tsx
@@ -49,9 +49,22 @@ interface BreakdownRow {
 interface LlmLatencyBreakdownProps {
   /** LLM provider hostnames to query (one /api/traces call per peer). */
   peers?: string[];
-  /** Override the lookback window. Default = last 1 hour. */
+  /**
+   * Lookback window in hours. Drives both the query and every string that
+   * names a window, so the panel cannot claim "last hour" while the page's
+   * range selector reads 24h — which is exactly what it used to do.
+   */
+  hours?: number;
+  /** Explicit window override; wins over `hours` when supplied. */
   fromIso?: string;
   toIso?: string;
+}
+
+/** "last 1h" / "last 24h" / "last 7d" — never a hardcoded window. */
+export function formatWindowLabel(hours: number): string {
+  if (!Number.isFinite(hours) || hours <= 0) return 'last 1h';
+  if (hours < 48) return `last ${Math.round(hours)}h`;
+  return `last ${Math.round(hours / 24)}d`;
 }
 
 function percentile(values: number[], p: number): number {
@@ -78,15 +91,19 @@ function durationOf(span: PeerSpan): number {
  * When no correlation is available we fall back to showing total duration
  * as a single "network + model" bar so the panel stays informative.
  */
-export function LlmLatencyBreakdown({ peers, fromIso, toIso }: LlmLatencyBreakdownProps) {
+export function LlmLatencyBreakdown({ peers, hours = 1, fromIso, toIso }: LlmLatencyBreakdownProps) {
   const peerList = peers && peers.length > 0 ? peers : DEFAULT_LLM_PEER_HOSTNAMES;
 
-  // Stable window per render — 1h lookback by default.
+  // Stable window per render — 1h lookback by default. Memoised on the inputs
+  // (not recomputed per render) so the query key does not change on every
+  // paint and re-trigger the fan-out.
   const window = useMemo(() => {
     const to = toIso ?? new Date().toISOString();
-    const from = fromIso ?? new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const from = fromIso ?? new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
     return { from, to };
-  }, [fromIso, toIso]);
+  }, [fromIso, toIso, hours]);
+
+  const windowLabel = formatWindowLabel(hours);
 
   const queries = useQueries({
     queries: peerList.map((peer) => ({
@@ -183,44 +200,55 @@ export function LlmLatencyBreakdown({ peers, fromIso, toIso }: LlmLatencyBreakdo
     },
   ], []);
 
-  if (!isLoading && allSpans.length === 0) {
-    return (
-      <NoTraceDataCallout
-        description="No outbound LLM spans seen in the last hour. Deploy Beyla on the host running the dashboard to capture HTTPS calls to your provider."
-      />
-    );
-  }
+  const isEmpty = !isLoading && allSpans.length === 0;
 
   return (
     <section data-testid="llm-latency-breakdown">
+      {/* The heading renders in the empty branch too. Previously the empty
+          branch returned a bare callout, so this was the one card on
+          /llm-observability with no heading — bracketed by "Model Breakdown"
+          and "Recent Traces" with nothing saying what it was. */}
       <h3 className="text-base font-semibold tracking-tight">LLM latency breakdown</h3>
       <p className="text-sm text-muted-foreground">
-        Network roundtrip vs estimated model latency per upstream provider, last 1h.
+        Network roundtrip vs estimated model latency per upstream provider, {windowLabel}.
       </p>
 
-      <div className="mt-4 h-72">
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={chartData} margin={{ top: 10, right: 12, left: 4, bottom: 24 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
-            <XAxis dataKey="peer" fontSize={11} angle={-15} dy={10} />
-            <YAxis fontSize={11} label={{ value: 'ms', angle: -90, position: 'insideLeft', fontSize: 11 }} />
-            <Tooltip />
-            <Legend />
-            <Bar dataKey="network" stackId="latency" fill="#60a5fa" name="Network roundtrip (avg ms)" />
-            <Bar dataKey="model" stackId="latency" fill="#a78bfa" name="Model latency (avg ms)" />
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
-
-      <div className="mt-4">
-        <DataTable
-          columns={columns}
-          data={chartData}
-          hideSearch
-          pageSize={100}
-          getRowId={(row) => row.peer}
+      {isEmpty ? (
+        <NoTraceDataCallout
+          className="mt-4"
+          description={`No outbound LLM spans seen in the ${windowLabel}. Deploy Beyla on the host running the dashboard to capture HTTPS calls to your provider.`}
         />
-      </div>
+      ) : (
+        <>
+          {/* Explicit pixel height, not height="100%": a percentage height on
+              ResponsiveContainer resolves to -1 on first paint here and made
+              this the only component in the app logging a Recharts console
+              warning. Matches metrics-line-chart / workload-top-bar. */}
+          <div className="mt-4">
+            <ResponsiveContainer width="100%" height={288}>
+              <BarChart data={chartData} margin={{ top: 10, right: 12, left: 4, bottom: 24 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                <XAxis dataKey="peer" fontSize={11} angle={-15} dy={10} />
+                <YAxis fontSize={11} label={{ value: 'ms', angle: -90, position: 'insideLeft', fontSize: 11 }} />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="network" stackId="latency" fill="var(--color-chart-1)" name="Network roundtrip (avg ms)" />
+                <Bar dataKey="model" stackId="latency" fill="var(--color-chart-2)" name="Model latency (avg ms)" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="mt-4">
+            <DataTable
+              columns={columns}
+              data={chartData}
+              hideSearch
+              pageSize={100}
+              getRowId={(row) => row.peer}
+            />
+          </div>
+        </>
+      )}
     </section>
   );
 }

--- a/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.test.tsx
@@ -5,7 +5,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 const mockUseCorrelations = vi.fn();
 const mockUseCorrelationInsights = vi.fn();
 
-vi.mock('@/features/observability/hooks/use-correlations', () => ({
+// Passthrough mock: only the two data hooks are stubbed. `correlationPairKey`
+// is a pure function and stays real — it is the join key the component and the
+// server agree on, so a stubbed version would let a mismatch pass unnoticed.
+vi.mock('@/features/observability/hooks/use-correlations', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/features/observability/hooks/use-correlations')>()),
   useCorrelations: (...args: unknown[]) => mockUseCorrelations(...args),
   useCorrelationInsights: (...args: unknown[]) => mockUseCorrelationInsights(...args),
 }));

--- a/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.test.tsx
@@ -162,27 +162,57 @@ describe('CorrelationInsightsPanel', () => {
     expect(skeletons.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('shows fallback text when narrative is null', () => {
+  it('states why narratives are missing once, not per row', () => {
+    // Previously each row printed an italic "Insight unavailable", so a single
+    // unparseable model response rendered the same failure ten times with no
+    // cause and no retry. The reason is now said once above the list, and the
+    // correlation values — which are computed from metrics and stand on their
+    // own — keep the panel useful when the model does not answer.
+    mockUseCorrelations.mockReturnValue({
+      data: { pairs: samplePairs },
+      isLoading: false,
+    });
+    mockUseCorrelationInsights.mockReturnValue({
+      data: {
+        insights: [],
+        summary: null,
+        narrativeStatus: 'unparsed',
+        narrativeUnavailableReason:
+          'The model returned an unrecognised format, so explanations are unavailable for these pairs.',
+      },
+      isLoading: false,
+    });
+    renderPanel({ llmAvailable: true });
+
+    const reason = screen.getByTestId('narrative-unavailable-reason');
+    expect(reason).toBeInTheDocument();
+    expect(reason).toHaveAttribute('data-narrative-status', 'unparsed');
+    expect(screen.getAllByTestId('narrative-unavailable-reason')).toHaveLength(1);
+    expect(screen.queryByText('Insight unavailable')).not.toBeInTheDocument();
+
+    // The correlation data itself still renders.
+    expect(screen.getAllByText('nginx-proxy').length).toBeGreaterThan(0);
+  });
+
+  it('does not show an unavailable reason when narratives parsed cleanly', () => {
     mockUseCorrelations.mockReturnValue({
       data: { pairs: [samplePairs[0]] },
       isLoading: false,
     });
     mockUseCorrelationInsights.mockReturnValue({
       data: {
-        insights: [{
-          containerA: 'nginx-proxy',
-          containerB: 'api-server',
-          metricType: 'cpu',
-          correlation: 0.94,
-          narrative: null,
-        }],
+        insights: [],
         summary: null,
+        narrativeStatus: 'ok',
+        narrativeUnavailableReason: null,
       },
       isLoading: false,
     });
     renderPanel({ llmAvailable: true });
 
-    expect(screen.getByText('Insight unavailable')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('narrative-unavailable-reason'),
+    ).not.toBeInTheDocument();
   });
 
   it('renders correlation coefficient values', () => {

--- a/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const mockUseCorrelations = vi.fn();
@@ -14,7 +14,11 @@ vi.mock('@/features/observability/hooks/use-correlations', async (importOriginal
   useCorrelationInsights: (...args: unknown[]) => mockUseCorrelationInsights(...args),
 }));
 
-import { CorrelationInsightsPanel } from './correlation-insights-panel';
+import {
+  CorrelationInsightsPanel,
+  commonAxisPrefix,
+  shortenAxisLabels,
+} from './correlation-insights-panel';
 
 function renderPanel(props: { llmAvailable: boolean; hours?: number }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -271,5 +275,120 @@ describe('CorrelationInsightsPanel', () => {
     renderPanel({ llmAvailable: false, selectedContainerId: 'a1' });
 
     expect(screen.getByText(/Relationships for selected container/)).toBeInTheDocument();
+  });
+
+  // Red meant "container crashes" and green meant "healthy" in this palette, so
+  // painting r = -0.87 red asserted the pair was broken. Colour now carries
+  // |r| only; the sign is in the printed coefficient and the trend glyph.
+  describe('coefficient colour is keyed to magnitude, not sign', () => {
+    function badgeFor(text: string): HTMLElement {
+      const el = screen.getByText((_content, node) => node?.textContent?.trim() === text
+        && node.classList.contains('rounded-full'));
+      return el;
+    }
+
+    beforeEach(() => {
+      mockUseCorrelations.mockReturnValue({
+        data: { pairs: samplePairs },
+        isLoading: false,
+      });
+    });
+
+    it('gives the same classes to r = 0.94 and r = -0.94', () => {
+      mockUseCorrelations.mockReturnValue({
+        data: {
+          pairs: [
+            { ...samplePairs[0], correlation: 0.94 },
+            {
+              ...samplePairs[1],
+              correlation: -0.94,
+              direction: 'negative' as const,
+              strength: 'very_strong' as const,
+            },
+          ],
+        },
+        isLoading: false,
+      });
+      renderPanel({ llmAvailable: false });
+
+      const positive = badgeFor('r = 0.94');
+      const negative = badgeFor('r = -0.94');
+      expect(positive.className).toBe(negative.className);
+    });
+
+    it('uses no status colour for either sign', () => {
+      renderPanel({ llmAvailable: false });
+
+      for (const text of ['r = 0.94', 'r = -0.87']) {
+        const cls = badgeFor(text).className;
+        expect(cls).not.toMatch(/emerald|red-|orange|green/);
+      }
+    });
+
+    it('still shows the direction glyph and the signed value', () => {
+      renderPanel({ llmAvailable: false });
+
+      expect(badgeFor('r = -0.87').querySelector('svg')).toBeTruthy();
+      expect(screen.getByText('r = -0.87')).toBeInTheDocument();
+    });
+  });
+
+  describe('heatmap axis labels', () => {
+    it('drops the prefix every container shares and keeps the tail', () => {
+      // In a compose fleet the shared project prefix is the *only* part the old
+      // `slice(0, 10)` kept, so six of twelve columns read "container-…".
+      const names = [
+        'container-insights-backend-1',
+        'container-insights-frontend-1',
+        'container-insights-postgres-app-1',
+      ];
+      expect(commonAxisPrefix(names)).toBe('container-insights-');
+
+      const labels = shortenAxisLabels(names);
+      expect(labels.get('container-insights-backend-1')).toBe('backend-1');
+      expect(labels.get('container-insights-frontend-1')).toBe('frontend-1');
+      // Still too long after stripping → truncate from the LEFT, keep the tail.
+      expect(labels.get('container-insights-postgres-app-1')).toBe('…stgres-app-1');
+      expect(labels.get('container-insights-postgres-app-1')).toMatch(/-1$/);
+    });
+
+    it('leaves labels alone when they share no prefix at a word boundary', () => {
+      const names = ['nginx-proxy', 'api-server', 'postgres'];
+      expect(commonAxisPrefix(names)).toBe('');
+      expect(shortenAxisLabels(names).get('nginx-proxy')).toBe('nginx-proxy');
+    });
+
+    it('does not strip a prefix that would empty a label', () => {
+      // 'web-' is common but 'web-' IS one of the names once stripped.
+      expect(commonAxisPrefix(['web-1', 'web-'])).toBe('');
+      expect(commonAxisPrefix(['solo'])).toBe('');
+    });
+
+    it('renders the shortened labels and keeps the full name in the title', () => {
+      mockUseCorrelations.mockReturnValue({
+        data: {
+          pairs: [
+            {
+              ...samplePairs[0],
+              containerA: { id: 'a1', name: 'container-insights-backend-1' },
+              containerB: { id: 'b1', name: 'container-insights-frontend-1' },
+            },
+            {
+              ...samplePairs[1],
+              containerA: { id: 'c1', name: 'container-insights-backend-1' },
+              containerB: { id: 'd1', name: 'container-insights-redis-1' },
+            },
+          ],
+        },
+        isLoading: false,
+      });
+      renderPanel({ llmAvailable: false });
+
+      const heatmap = screen.getByTestId('correlation-heatmap');
+      const header = within(heatmap).getAllByRole('columnheader')[1];
+      expect(header.textContent).toBe('backend-1');
+      expect(header).toHaveAttribute('title', 'container-insights-backend-1');
+      expect(screen.getByTestId('heatmap-prefix-note').textContent).toContain('container-insights-');
+    });
   });
 });

--- a/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.tsx
@@ -1,6 +1,11 @@
 import { memo, useMemo } from 'react';
-import { Link2, Bot, ArrowUpDown, TrendingUp, TrendingDown } from 'lucide-react';
-import { useCorrelations, useCorrelationInsights, type CorrelationPair } from '@/features/observability/hooks/use-correlations';
+import { Link2, Bot, ArrowUpDown, TrendingUp, TrendingDown, Info } from 'lucide-react';
+import {
+  useCorrelations,
+  useCorrelationInsights,
+  correlationPairKey,
+  type CorrelationPair,
+} from '@/features/observability/hooks/use-correlations';
 import { cn } from '@/shared/lib/utils';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
@@ -136,12 +141,17 @@ export const CorrelationInsightsPanel = memo(function CorrelationInsightsPanel({
     );
   }, [allPairs, selectedContainerId]);
   const summary = insightsData?.summary ?? null;
+  const narrativeStatus = insightsData?.narrativeStatus ?? 'ok';
+  const narrativeUnavailableReason = insightsData?.narrativeUnavailableReason ?? null;
 
-  // Build a map from pair key to narrative
+  // Keyed by the server's `pairKey`, not by array position. Both sides slice
+  // their own top-10 — the server from the unfiltered list, this panel from a
+  // list that may be filtered to one container — so position is not a safe
+  // join key and silently mismatched narratives were possible.
   const narrativeMap = useMemo(() => {
     const map = new Map<string, string | null>();
     for (const insight of insights) {
-      map.set(`${insight.containerA}:${insight.containerB}:${insight.metricType}`, insight.narrative);
+      map.set(insight.pairKey, insight.narrative);
     }
     return map;
   }, [insights]);
@@ -193,11 +203,27 @@ export const CorrelationInsightsPanel = memo(function CorrelationInsightsPanel({
         />
       ) : (
         <div className="space-y-4">
+          {/* Why the narratives are missing — said once, above the list, rather
+              than as an italic failure repeated on every row. The correlation
+              values are computed from metrics and stand on their own, so the
+              panel stays useful when the model does not answer. */}
+          {llmAvailable && !insightsLoading && narrativeUnavailableReason && (
+            <div
+              role="status"
+              data-testid="narrative-unavailable-reason"
+              data-narrative-status={narrativeStatus}
+              className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+            >
+              <Info className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" aria-hidden />
+              <span>{narrativeUnavailableReason}</span>
+            </div>
+          )}
+
           {/* Correlation pair cards */}
           <div className="space-y-3">
             {pairs.slice(0, 10).map((pair) => {
               const narrative = narrativeMap.get(
-                `${pair.containerA.name}:${pair.containerB.name}:${pair.metricType}`,
+                correlationPairKey(pair.containerA.name, pair.containerB.name, pair.metricType),
               );
               const DirectionIcon = pair.direction === 'positive' ? TrendingUp : TrendingDown;
 
@@ -226,20 +252,17 @@ export const CorrelationInsightsPanel = memo(function CorrelationInsightsPanel({
                     </span>
                   </div>
 
-                  {/* AI narrative */}
-                  {llmAvailable && (
+                  {/* AI narrative — omitted entirely when absent. A row with no
+                      narrative shows the correlation alone; the banner above
+                      already explains why, once. */}
+                  {llmAvailable && (insightsLoading || narrative) && (
                     <div className="mt-2">
                       {insightsLoading ? (
                         <div className="h-5 animate-pulse rounded bg-muted" />
-                      ) : narrative ? (
+                      ) : (
                         <p className="text-xs leading-relaxed text-foreground/80">
                           <Bot className="inline h-3 w-3 text-purple-500 mr-1" />
                           {narrative}
-                        </p>
-                      ) : (
-                        <p className="text-xs text-muted-foreground italic">
-                          <Bot className="inline h-3 w-3 text-purple-500/50 mr-1" />
-                          Insight unavailable
                         </p>
                       )}
                     </div>

--- a/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.tsx
@@ -16,33 +16,86 @@ interface CorrelationInsightsPanelProps {
   selectedContainerId?: string | null;
 }
 
-function strengthColor(pair: CorrelationPair): string {
-  const absR = Math.abs(pair.correlation);
-  if (absR >= 0.9) {
-    return pair.direction === 'positive'
-      ? 'text-emerald-600 dark:text-emerald-400'
-      : 'text-red-600 dark:text-red-400';
-  }
-  return pair.direction === 'positive'
-    ? 'text-blue-600 dark:text-blue-400'
-    : 'text-orange-600 dark:text-orange-400';
+/**
+ * Badge colour keyed to |r| — never to its sign.
+ *
+ * This palette reads green as "healthy" and red as "error", so painting
+ * `r = -0.99` red asserted that the pair was broken. A strong negative
+ * correlation is neither bad news nor good news, only strong. Colour now
+ * carries strength alone: direction is on the TrendingUp/TrendingDown glyph
+ * inside the same badge, and the sign is printed in the coefficient beside it.
+ */
+function strengthClasses(pair: CorrelationPair): string {
+  return Math.abs(pair.correlation) >= 0.9
+    ? 'bg-primary/15 text-primary'
+    : 'bg-muted text-muted-foreground';
 }
 
-function strengthBg(pair: CorrelationPair): string {
-  const absR = Math.abs(pair.correlation);
-  if (absR >= 0.9) {
-    return pair.direction === 'positive'
-      ? 'bg-emerald-100 dark:bg-emerald-900/30'
-      : 'bg-red-100 dark:bg-red-900/30';
+const AXIS_LABEL_BOUNDARIES = new Set(['-', '_', '.']);
+
+/**
+ * Longest prefix shared by every label, trimmed back to a `-`/`_`/`.` boundary
+ * so a word is never cut in half. Empty when the labels share nothing useful
+ * (fewer than two labels, no common prefix, or one label *is* the prefix).
+ */
+export function commonAxisPrefix(names: string[]): string {
+  if (names.length < 2) return '';
+  let prefix = names[0];
+  for (const name of names.slice(1)) {
+    let i = 0;
+    while (i < prefix.length && i < name.length && prefix[i] === name[i]) i += 1;
+    prefix = prefix.slice(0, i);
+    if (!prefix) return '';
   }
-  return pair.direction === 'positive'
-    ? 'bg-blue-100 dark:bg-blue-900/30'
-    : 'bg-orange-100 dark:bg-orange-900/30';
+  let boundary = -1;
+  for (let i = prefix.length - 1; i >= 0; i -= 1) {
+    if (AXIS_LABEL_BOUNDARIES.has(prefix[i])) {
+      boundary = i;
+      break;
+    }
+  }
+  if (boundary < 0) return '';
+  const trimmed = prefix.slice(0, boundary + 1);
+  // Stripping must leave every label with something to read.
+  return names.every((name) => name.length > trimmed.length) ? trimmed : '';
+}
+
+/**
+ * Axis labels for the heatmap, shortened without deleting what distinguishes
+ * them. Every container in a compose fleet shares a project prefix, so the old
+ * `slice(0, 10) + '…'` turned six of twelve columns into "container-…". Strip
+ * the shared prefix first, then — if a name is still too long — drop characters
+ * from the LEFT and keep the tail, which is where the instance number lives.
+ * The full name stays in the cell's `title`.
+ */
+export function shortenAxisLabels(names: string[], maxLength = 12): Map<string, string> {
+  const prefix = commonAxisPrefix(names);
+  const labels = new Map<string, string>();
+  for (const name of names) {
+    const stripped = prefix ? name.slice(prefix.length) : name;
+    labels.set(
+      name,
+      stripped.length > maxLength ? `…${stripped.slice(stripped.length - maxLength)}` : stripped,
+    );
+  }
+  return labels;
+}
+
+/**
+ * Cell fill keyed to |r| on a single ramp of the theme's primary token. It used
+ * to be green for a positive r and red for a negative one — status colours for
+ * a non-status quantity. The signed value is printed in the cell, so the fill
+ * only needs to carry strength.
+ */
+function heatmapCellStyle(r: number): { backgroundColor: string } {
+  const absR = Math.min(1, Math.abs(r));
+  const mix = Math.round(8 + absR * 37);
+  return { backgroundColor: `color-mix(in srgb, var(--color-primary) ${mix}%, transparent)` };
 }
 
 function HeatmapGrid({ pairs }: { pairs: CorrelationPair[] }) {
   // Build unique container list and correlation map
-  const { containers, matrix } = useMemo(() => {
+  const { containers, matrix, labels, strippedPrefix } = useMemo(() => {
     const nameSet = new Set<string>();
     for (const p of pairs) {
       nameSet.add(p.containerA.name);
@@ -56,20 +109,31 @@ function HeatmapGrid({ pairs }: { pairs: CorrelationPair[] }) {
       matrix.set(keyAB, p.correlation);
       matrix.set(keyBA, p.correlation);
     }
-    return { containers, matrix };
+    return {
+      containers,
+      matrix,
+      labels: shortenAxisLabels(containers),
+      strippedPrefix: commonAxisPrefix(containers),
+    };
   }, [pairs]);
 
   if (containers.length === 0) return null;
 
   return (
-    <div className="overflow-x-auto">
+    <div className="space-y-2">
+      {strippedPrefix && (
+        <p className="text-[11px] text-muted-foreground" data-testid="heatmap-prefix-note">
+          Shared prefix <span className="font-mono">{strippedPrefix}</span> removed from axis labels.
+        </p>
+      )}
+      <div className="overflow-x-auto">
       <table className="text-xs" data-testid="correlation-heatmap">
         <thead>
           <tr>
             <th className="px-1 py-1 text-left font-normal text-muted-foreground" />
             {containers.map((name) => (
-              <th key={name} className="px-1 py-1 font-normal text-muted-foreground truncate max-w-[80px]" title={name}>
-                {name.length > 10 ? name.slice(0, 10) + '…' : name}
+              <th key={name} className="px-1 py-1 font-normal text-muted-foreground whitespace-nowrap" title={name}>
+                {labels.get(name)}
               </th>
             ))}
           </tr>
@@ -77,8 +141,8 @@ function HeatmapGrid({ pairs }: { pairs: CorrelationPair[] }) {
         <tbody>
           {containers.map((rowName) => (
             <tr key={rowName}>
-              <td className="px-1 py-1 text-muted-foreground truncate max-w-[80px] font-medium" title={rowName}>
-                {rowName.length > 10 ? rowName.slice(0, 10) + '…' : rowName}
+              <td className="px-1 py-1 text-muted-foreground whitespace-nowrap font-medium" title={rowName}>
+                {labels.get(rowName)}
               </td>
               {containers.map((colName) => {
                 if (rowName === colName) {
@@ -103,14 +167,11 @@ function HeatmapGrid({ pairs }: { pairs: CorrelationPair[] }) {
                     </td>
                   );
                 }
-                const absR = Math.abs(r);
-                const opacity = Math.max(0.3, absR);
-                const bgColor = r > 0 ? `rgba(16,185,129,${opacity})` : `rgba(239,68,68,${opacity})`;
                 return (
                   <td key={colName} className="px-1 py-1">
                     <div
-                      className="h-6 w-6 rounded flex items-center justify-center text-[10px] font-medium text-white"
-                      style={{ backgroundColor: bgColor }}
+                      className="h-6 w-6 rounded flex items-center justify-center text-[10px] font-medium text-foreground"
+                      style={heatmapCellStyle(r)}
                       title={`${rowName} ↔ ${colName}: r=${r.toFixed(2)}`}
                     >
                       {r.toFixed(1)}
@@ -122,6 +183,7 @@ function HeatmapGrid({ pairs }: { pairs: CorrelationPair[] }) {
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }
@@ -240,14 +302,19 @@ export const CorrelationInsightsPanel = memo(function CorrelationInsightsPanel({
                   key={`${pair.containerA.id}-${pair.containerB.id}-${pair.metricType}`}
                   className="rounded-md border border-border/60 bg-background/50 px-4 py-3"
                 >
-                  <div className="flex flex-wrap items-center gap-2 text-sm">
-                    <span className="font-medium">{pair.containerA.name}</span>
-                    <span className="text-muted-foreground">↔</span>
-                    <span className="font-medium">{pair.containerB.name}</span>
+                  {/* Two deliberate lines — the pair, then its measurements.
+                      As one flex-wrap run of six children this collapsed to
+                      three ragged lines at tablet width, where the persistent
+                      sidebar takes ~28% of the viewport. */}
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                    <span className="font-medium break-all">{pair.containerA.name}</span>
+                    <span className="text-muted-foreground" aria-hidden>↔</span>
+                    <span className="font-medium break-all">{pair.containerB.name}</span>
+                  </div>
+                  <div className="mt-1.5 flex flex-wrap items-center gap-2">
                     <span className={cn(
                       'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
-                      strengthBg(pair),
-                      strengthColor(pair),
+                      strengthClasses(pair),
                     )}>
                       <DirectionIcon className="h-3 w-3" />
                       r = {pair.correlation.toFixed(2)}

--- a/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/correlation-insights-panel.tsx
@@ -151,7 +151,15 @@ export const CorrelationInsightsPanel = memo(function CorrelationInsightsPanel({
   const narrativeMap = useMemo(() => {
     const map = new Map<string, string | null>();
     for (const insight of insights) {
-      map.set(insight.pairKey, insight.narrative);
+      // Prefer the server-supplied key — it is what stops this list and the
+      // route's own top-N from drifting apart when a container filter is
+      // active. Fall back to deriving it so a payload from an older backend
+      // degrades to "narratives still shown" rather than "every narrative
+      // silently missing".
+      const key =
+        insight.pairKey ??
+        correlationPairKey(insight.containerA, insight.containerB, insight.metricType);
+      map.set(key, insight.narrative);
     }
     return map;
   }, [insights]);

--- a/frontend/src/features/ai-intelligence/components/metrics/inline-chat-panel.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/inline-chat-panel.test.tsx
@@ -236,3 +236,85 @@ describe('InlineChatPanel', () => {
     expect(mockCancelGeneration).toHaveBeenCalledOnce();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Design-critique fixes: the panel opted out of the theme system alongside the
+// full-page assistant, and spoke in the first person about capabilities it
+// does not have.
+// ---------------------------------------------------------------------------
+
+describe('InlineChatPanel presentation', () => {
+  // `vi.clearAllMocks()` clears calls but keeps implementations, and the
+  // preceding block leaves `useLlmChat` returning a streaming session — so the
+  // empty state would never render here without an explicit reset.
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { useLlmChat } = await import('@/features/ai-intelligence/hooks/use-llm-chat');
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      sendMessage: mockSendMessage,
+      cancelGeneration: mockCancelGeneration,
+      clearHistory: mockClearHistory,
+    } as unknown as ReturnType<typeof useLlmChat>);
+  });
+
+  it('states what it reads instead of claiming access in the first person', () => {
+    render(
+      <InlineChatPanel open={true} onClose={vi.fn()} context={defaultContext} />,
+      { wrapper: createWrapper() },
+    );
+    expect(screen.queryByText(/I have access to/)).toBeNull();
+    expect(
+      screen.getByText(/Reads metrics, logs, anomalies and traces for this container/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/cannot change anything/)).toBeInTheDocument();
+  });
+
+  it('uses theme tokens for its chrome rather than blue/purple gradients', () => {
+    const { container } = render(
+      <InlineChatPanel open={true} onClose={vi.fn()} context={defaultContext} />,
+      { wrapper: createWrapper() },
+    );
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/from-blue-\d+/);
+    expect(html).not.toMatch(/to-purple-\d+/);
+    expect(html).not.toMatch(/from-emerald-\d+/);
+  });
+
+  it('gives the send button the primary token, not a gradient', () => {
+    render(
+      <InlineChatPanel open={true} onClose={vi.fn()} context={defaultContext} />,
+      { wrapper: createWrapper() },
+    );
+    const send = screen.getByRole('button', { name: 'Send message' });
+    expect(send.className).toContain('bg-primary');
+    expect(send.className).not.toContain('gradient');
+  });
+
+  // Green means healthy in this palette; the operator's own message is the one
+  // thing on screen they already know, so it gets the quietest treatment.
+  it('renders the user message on a muted surface, not in status green', async () => {
+    const { useLlmChat } = await import('@/features/ai-intelligence/hooks/use-llm-chat');
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [{ id: '1', role: 'user', content: 'Why is CPU spiking?', timestamp: '' }],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      sendMessage: mockSendMessage,
+      cancelGeneration: mockCancelGeneration,
+      clearHistory: mockClearHistory,
+    } as unknown as ReturnType<typeof useLlmChat>);
+
+    render(
+      <InlineChatPanel open={true} onClose={vi.fn()} context={defaultContext} />,
+      { wrapper: createWrapper() },
+    );
+
+    const bubble = screen.getByText('Why is CPU spiking?').closest('div');
+    expect(bubble?.className).toContain('bg-muted');
+    expect(bubble?.className).not.toContain('emerald');
+  });
+});

--- a/frontend/src/features/ai-intelligence/components/metrics/inline-chat-panel.tsx
+++ b/frontend/src/features/ai-intelligence/components/metrics/inline-chat-panel.tsx
@@ -156,8 +156,8 @@ export const InlineChatPanel = memo(function InlineChatPanel({ open, onClose, co
         {/* Header */}
         <div className="flex items-center justify-between border-b px-4 py-3">
           <div className="flex items-center gap-2.5 min-w-0">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-purple-600">
-              <Bot className="h-4 w-4 text-white" />
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-primary/20 bg-primary/10">
+              <Bot className="h-4 w-4 text-primary" />
             </div>
             <div className="min-w-0">
               <p className="text-sm font-semibold truncate">Ask AI</p>
@@ -180,14 +180,14 @@ export const InlineChatPanel = memo(function InlineChatPanel({ open, onClose, co
           {/* Empty state with suggestions */}
           {messages.length === 0 && !isStreaming && !isSending && (
             <div className="flex flex-col items-center text-center pt-8">
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500/10 to-purple-500/10 border border-blue-500/20">
-                <Bot className="h-7 w-7 text-blue-500" />
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-primary/10">
+                <Bot className="h-7 w-7 text-primary" />
               </div>
               <p className="mt-4 text-sm font-medium">
                 Ask anything about {context.containerName}
               </p>
               <p className="mt-1 text-xs text-muted-foreground max-w-[280px]">
-                I have access to metrics, logs, anomalies, and traces for this container.
+                Reads metrics, logs, anomalies and traces for this container. It cannot change anything.
               </p>
               <div className="mt-5 flex flex-col gap-2 w-full">
                 {SUGGESTED_QUESTIONS.map((q) => (
@@ -268,7 +268,7 @@ export const InlineChatPanel = memo(function InlineChatPanel({ open, onClose, co
             <button
               type="submit"
               disabled={!input.trim() || isStreaming || isSending}
-              className="inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-blue-600 to-purple-600 p-2 text-white shadow-sm transition-all hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex items-center justify-center rounded-lg bg-primary p-2 text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
               aria-label="Send message"
             >
               <Send className="h-4 w-4" />
@@ -282,8 +282,8 @@ export const InlineChatPanel = memo(function InlineChatPanel({ open, onClose, co
 
 function BotAvatar() {
   return (
-    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-purple-600">
-      <Bot className="h-3.5 w-3.5 text-white" />
+    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-primary/20 bg-primary/10">
+      <Bot className="h-3.5 w-3.5 text-primary" />
     </div>
   );
 }
@@ -291,9 +291,9 @@ function BotAvatar() {
 function LoadingDots() {
   return (
     <div className="flex gap-1">
-      <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce [animation-delay:-0.3s]" />
-      <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce [animation-delay:-0.15s]" />
-      <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce" />
+      <span className="h-1.5 w-1.5 rounded-full bg-primary animate-bounce [animation-delay:-0.3s]" />
+      <span className="h-1.5 w-1.5 rounded-full bg-primary animate-bounce [animation-delay:-0.15s]" />
+      <span className="h-1.5 w-1.5 rounded-full bg-primary animate-bounce" />
     </div>
   );
 }
@@ -311,7 +311,7 @@ function CompactThinkingIndicator({ statusMessage }: { statusMessage: string | n
       <BotAvatar />
       <div className="rounded-xl bg-muted/50 p-3 border border-border/50">
         <div className="flex items-center gap-2">
-          <Loader2 className="h-3.5 w-3.5 text-blue-500 animate-spin" />
+          <Loader2 className="h-3.5 w-3.5 text-primary animate-spin" />
           <span className="text-xs text-muted-foreground">{statusMessage || 'Thinking...'}</span>
           <span className="text-[10px] text-muted-foreground/60 tabular-nums">{elapsed}s</span>
         </div>
@@ -358,8 +358,8 @@ const CompactMessage = memo(function CompactMessage({ message, userQuery }: Comp
     <div className={cn('flex gap-3', isUser && 'flex-row-reverse')}>
       <div className="shrink-0">
         {isUser ? (
-          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-gradient-to-br from-emerald-500 to-teal-600">
-            <User className="h-3.5 w-3.5 text-white" />
+          <div className="flex h-7 w-7 items-center justify-center rounded-lg border border-border bg-muted">
+            <User className="h-3.5 w-3.5 text-muted-foreground" />
           </div>
         ) : (
           <BotAvatar />
@@ -383,7 +383,7 @@ const CompactMessage = memo(function CompactMessage({ message, userQuery }: Comp
           className={cn(
             'rounded-xl p-3 text-[13px]',
             isUser
-              ? 'bg-gradient-to-br from-emerald-500 to-teal-600 text-white ml-auto border border-emerald-400/20'
+              ? 'bg-muted/60 text-foreground ml-auto border border-border'
               : 'bg-muted/50 border border-border/50',
           )}
         >

--- a/frontend/src/features/ai-intelligence/hooks/use-incident-groups.ts
+++ b/frontend/src/features/ai-intelligence/hooks/use-incident-groups.ts
@@ -9,18 +9,27 @@ export interface IncidentGroup {
   incident_count: number;
   container_count: number;
   alert_count: number;
-  earliest_at: string;
-  latest_update_at: string;
+  /**
+   * ISO-8601 UTC, or null when the column is null.
+   *
+   * These used to be typed non-null while the server sent Postgres' own text
+   * form (`2026-07-26 08:46:29.123456+00`) via a `::text` cast. That is not
+   * valid ISO-8601 once `formatDate` swaps the space for a `T`, so `new Date()`
+   * rejected it and every row rendered the literal string "Invalid date". The
+   * cast is gone; null is now the honest signal for "no timestamp".
+   */
+  earliest_at: string | null;
+  latest_update_at: string | null;
   top_containers: Array<{
     incident_id: string;
     container_name: string;
     endpoint_id: number | null;
     endpoint_name: string | null;
     severity: 'critical' | 'warning' | 'info';
-    created_at: string;
+    created_at: string | null;
     incident_ids: string[];
     incident_count: number;
-    latest_at: string;
+    latest_at: string | null;
     latest_summary: string | null;
     latest_description: string | null;
   }>;

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
@@ -208,7 +208,18 @@ describe('AiMonitorPage', () => {
             { type: 'memory', currentValue: 80, mean: 50, zScore: 2.1 },
           ],
           compositeScore: 4.08,
-          pattern: 'Resource Exhaustion: Both CPU and memory are elevated',
+          pattern: 'cpu z=3.50, memory z=2.10 — both above the z>2 rule threshold',
+          patternMatch: {
+            id: 'cpu-and-memory-deviation' as const,
+            label: 'CPU and memory both deviating',
+            zScoreThreshold: 2,
+            triggeredBy: [
+              { type: 'cpu', zScore: 3.5 },
+              { type: 'memory', zScore: 2.1 },
+            ],
+            withinThreshold: [],
+            summary: 'cpu z=3.50, memory z=2.10 — both above the z>2 rule threshold',
+          },
           severity: 'high' as const,
           timestamp: '2025-01-15T10:00:00Z',
         },
@@ -222,7 +233,7 @@ describe('AiMonitorPage', () => {
     // sections: "ML-Detected Anomalies" + "Container Health".
     expect(screen.getByText('ML-Detected Anomalies')).toBeTruthy();
     expect(screen.getByText('web-server')).toBeTruthy();
-    expect(screen.getByText('Resource Exhaustion')).toBeTruthy();
+    expect(screen.getByText('CPU and memory both deviating')).toBeTruthy();
     expect(screen.getByText('4.08')).toBeTruthy();
     // z-score values shown
     expect(screen.getByText('3.5')).toBeTruthy();
@@ -318,7 +329,7 @@ describe('AiMonitorPage', () => {
     expect(screen.queryByText('Adaptive')).toBeNull();
   });
 
-  it('renders pattern badge with correct short label extracted from full pattern string', () => {
+  it('renders the rule label and the z-scores it fired on, not a diagnosis', () => {
     vi.mocked(useCorrelatedAnomalies).mockReturnValue({
       data: [
         {
@@ -328,7 +339,15 @@ describe('AiMonitorPage', () => {
             { type: 'memory', currentValue: 90, mean: 45, zScore: 2.8 },
           ],
           compositeScore: 2.8,
-          pattern: 'Memory Leak Suspected: Memory usage is elevated while CPU remains normal',
+          pattern: 'memory z=2.80 above the z>2 rule threshold, cpu z=0.40 within it',
+          patternMatch: {
+            id: 'memory-only-deviation' as const,
+            label: 'Memory deviating, CPU within threshold',
+            zScoreThreshold: 2,
+            triggeredBy: [{ type: 'memory', zScore: 2.8 }],
+            withinThreshold: [{ type: 'cpu', zScore: 0.4 }],
+            summary: 'memory z=2.80 above the z>2 rule threshold, cpu z=0.40 within it',
+          },
           severity: 'medium' as const,
           timestamp: '2025-01-15T10:00:00Z',
         },
@@ -338,12 +357,47 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
-    // Short label only, not full description
-    expect(screen.getByText('Memory Leak Suspected')).toBeTruthy();
-    // The description part appears separately
-    expect(
-      screen.getByText('Memory usage is elevated while CPU remains normal'),
-    ).toBeTruthy();
+    // The badge names what was observed, keyed off the stable rule id.
+    const badge = screen.getByTestId('pattern-badge');
+    expect(badge.textContent).toBe('Memory deviating, CPU within threshold');
+    expect(badge.getAttribute('data-pattern-id')).toBe('memory-only-deviation');
+
+    // The body restates the rule and the numbers it fired on.
+    expect(screen.getByTestId('pattern-rule-summary').textContent).toBe(
+      'memory z=2.80 above the z>2 rule threshold, cpu z=0.40 within it',
+    );
+
+    // The old hardcoded diagnosis must not come back. It rendered
+    // byte-identically on every card that hit the same rule branch.
+    expect(screen.queryByText(/suggesting gradual memory accumulation/)).toBeNull();
+    expect(screen.queryByText('Memory Leak Suspected')).toBeNull();
+  });
+
+  it('falls back to the pattern string when patternMatch is absent (stale server build)', () => {
+    vi.mocked(useCorrelatedAnomalies).mockReturnValue({
+      data: [
+        {
+          containerId: 'c3',
+          containerName: 'legacy-api',
+          metrics: [{ type: 'memory', currentValue: 90, mean: 45, zScore: 2.8 }],
+          compositeScore: 2.8,
+          pattern: 'memory z=2.80 above the z>2 rule threshold',
+          patternMatch: null,
+          severity: 'medium' as const,
+          timestamp: '2025-01-15T10:00:00Z',
+        },
+      ],
+      isLoading: false,
+    } as ReturnType<typeof useCorrelatedAnomalies>);
+
+    renderPage();
+
+    // Body degrades to the legacy string rather than to a blank card...
+    expect(screen.getByTestId('pattern-rule-summary').textContent).toBe(
+      'memory z=2.80 above the z>2 rule threshold',
+    );
+    // ...but no badge, since there is no rule id to label it with.
+    expect(screen.queryByTestId('pattern-badge')).toBeNull();
   });
 
   it('acknowledges an unacknowledged insight from the insight card', () => {

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -57,8 +57,15 @@ vi.mock('@/features/ai-intelligence/hooks/use-incidents', () => ({
   }),
 }));
 
+// Captures the `onTick` the page passes. The page used to hand-roll its own
+// `window.setInterval` effect; the hook owns the timer now, so the wiring is
+// one argument and this is what asserts it is still there.
+const capturedAutoRefresh: { onTick?: () => void } = {};
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: vi.fn().mockReturnValue({ interval: 0, setInterval: vi.fn() }),
+  useAutoRefresh: vi.fn((_default?: number, opts?: { onTick?: () => void }) => {
+    capturedAutoRefresh.onTick = opts?.onTick;
+    return { interval: 0, setRefreshInterval: vi.fn(), setInterval: vi.fn() };
+  }),
 }));
 
 vi.mock('@/features/observability/hooks/use-correlated-anomalies', () => ({
@@ -229,15 +236,24 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
-    // Section was renamed from "Anomalies & Health Issues" to clearer twin
-    // sections: "ML-Detected Anomalies" + "Container Health".
-    expect(screen.getByText('ML-Detected Anomalies')).toBeTruthy();
+    // The section is named for what actually runs: a root-mean-square of
+    // per-metric z-scores plus a z-score threshold rule. "ML-Detected
+    // Anomalies" under a Brain glyph claimed inference that never happened.
+    expect(screen.getByText('Correlated metric deviations')).toBeTruthy();
+    expect(screen.queryByText('ML-Detected Anomalies')).toBeNull();
     expect(screen.getByText('web-server')).toBeTruthy();
     expect(screen.getByText('CPU and memory both deviating')).toBeTruthy();
     expect(screen.getByText('4.08')).toBeTruthy();
-    // z-score values shown
-    expect(screen.getByText('3.5')).toBeTruthy();
-    expect(screen.getByText('2.1')).toBeTruthy();
+    // Signed z-score values shown.
+    expect(screen.getByText('+3.5')).toBeTruthy();
+    expect(screen.getByText('+2.1')).toBeTruthy();
+    // One severity vocabulary: a composite-score "high" reads as Warning, the
+    // same word the filter chips, KPI tiles and insight feed use. The card
+    // used to say Critical/High/Medium/Low with no way to rank it against the
+    // feed's Critical/Warning/Info.
+    const card = within(screen.getByTestId('correlated-anomaly-card'));
+    expect(card.getByText('Warning')).toBeTruthy();
+    expect(card.queryByText('High')).toBeNull();
   });
 
   it('hides correlated anomalies section when array is empty', () => {
@@ -247,7 +263,7 @@ describe('AiMonitorPage', () => {
     } as ReturnType<typeof useCorrelatedAnomalies>);
 
     renderPage();
-    expect(screen.queryByText('ML-Detected Anomalies')).toBeNull();
+    expect(screen.queryByText('Correlated metric deviations')).toBeNull();
   });
 
   it('renders IncidentGroupsView section (rollup replaces flat list)', () => {
@@ -273,6 +289,10 @@ describe('AiMonitorPage', () => {
           suggested_action: 'Check for runaway processes',
           is_acknowledged: 0,
           created_at: '2025-01-15T10:00:00Z',
+          // The typed column the backend writes. The badge used to be scraped
+          // out of the description with /method:\\s*(\\w+)/, which cannot match
+          // a hyphen — so "method: isolation-forest" was badged "Z-Score".
+          detection_method: 'ml-anomaly',
         },
       ],
       isLoading: false,
@@ -289,7 +309,12 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
-    expect(screen.getByText('Adaptive')).toBeTruthy();
+    const badge = screen.getByTestId('detection-method-badge');
+    expect(badge).toHaveAttribute('data-detection-method', 'ml-anomaly');
+    expect(badge).toHaveTextContent('Metric anomaly');
+    // The description still says "method: adaptive"; the badge no longer
+    // invents a technique the persisted column cannot distinguish.
+    expect(screen.queryByText('Z-Score')).toBeNull();
   });
 
   it('hides detection method badge on non-anomaly insight', () => {
@@ -324,9 +349,10 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
+    // No `detection_method` on the record -> no badge at all, rather than a
+    // `?? config.zscore` default asserting a detector that never ran.
+    expect(screen.queryByTestId('detection-method-badge')).toBeNull();
     expect(screen.queryByText('Z-Score')).toBeNull();
-    expect(screen.queryByText('Bollinger')).toBeNull();
-    expect(screen.queryByText('Adaptive')).toBeNull();
   });
 
   it('renders the rule label and the z-scores it fired on, not a diagnosis', () => {
@@ -464,19 +490,23 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
-    // New score formula: healthy / (healthy + unhealthy). 1 healthy + 1
-    // unhealthy = 50.0%. The db (no healthcheck) and cache (exited) are
-    // excluded from the denominator so the operator's healthcheck coverage
-    // gap doesn't penalise the score.
-    expect(screen.getByText('Overall Health Score')).toBeTruthy();
-    expect(screen.getAllByText('50.0%').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('Running')).toBeTruthy();
-    expect(screen.getByText('Healthy')).toBeTruthy();
-    expect(screen.getAllByText('Unhealthy').length).toBeGreaterThanOrEqual(1);
-    // The "Stopped" stat card was replaced by "No Healthcheck" — surfacing
-    // the cohort that's actually excluded from scoring is more useful than
-    // counting exited containers (already shown elsewhere as health issues).
-    expect(screen.getByText('No Healthcheck')).toBeTruthy();
+    // The hero is a count now, not a percentage: 1 unhealthy + 1 stopped
+    // container, and no unacknowledged insights in this fixture.
+    expect(screen.getByTestId('needs-attention-count')).toHaveTextContent('2');
+    expect(screen.queryByText('Overall Health Score')).toBeNull();
+    // The healthcheck pass rate is still here, named for what it measures and
+    // stating its exclusion: healthy / (healthy + unhealthy) = 50%, with the
+    // db (no healthcheck) and cache (exited) outside the denominator.
+    expect(screen.getByTestId('healthcheck-pass-rate')).toHaveTextContent('50%');
+    expect(screen.getByTestId('healthcheck-pass-rate')).toHaveTextContent(
+      '1 of 2 containers with a healthcheck',
+    );
+    // /health collapses the container-status strip to a single line — Home
+    // already carried the full tile grid.
+    expect(screen.getByTestId('fleet-status-line')).toHaveTextContent(
+      '4 containers · 3 running · 1 healthy · 1 unhealthy · 1 without a healthcheck',
+    );
+    expect(screen.queryByText('No Healthcheck')).toBeNull();
   });
 
   it('shows skeleton loading state for health section', () => {
@@ -507,11 +537,12 @@ describe('AiMonitorPage', () => {
 
     renderPage();
 
-    // Empty fleet now shows "No healthchecks configured" instead of an
-    // arbitrary 0.0% — the new score formula returns null when no container
-    // reports a health signal and we surface that as N/A so operators are
-    // not misled by a bogus zero.
-    expect(screen.getByTestId('health-score-na')).toBeTruthy();
+    // Empty fleet: no pass rate can be computed, so we say so rather than
+    // rendering an arbitrary 0%.
+    expect(screen.getByTestId('healthcheck-pass-rate')).toHaveTextContent(
+      /Healthcheck pass rate unavailable/,
+    );
+    expect(screen.getByTestId('needs-attention-count')).toHaveTextContent('0');
     // No NaN should ever leak into the rendered DOM.
     expect(document.body.textContent ?? '').not.toContain('NaN');
   });
@@ -797,5 +828,132 @@ describe('AiMonitorPage — false-positive feedback (#1298)', () => {
 
     renderPage();
     expect(screen.queryByTestId('anomaly-feedback-rate-row')).toBeNull();
+  });
+
+  it('wires the auto-refresh dropdown through the hook onTick, not a hand-rolled timer', () => {
+    const refetch = vi.fn();
+    const containerRefetch = vi.fn();
+    vi.mocked(useMonitoring).mockReturnValue({
+      insights: [],
+      isLoading: false,
+      error: null,
+      subscribedSeverities: new Set(['critical', 'warning', 'info']),
+      subscribeSeverity: vi.fn(),
+      unsubscribeSeverity: vi.fn(),
+      acknowledgeInsight: vi.fn(),
+      acknowledgeError: null,
+      isAcknowledging: false,
+      acknowledgingInsightId: null,
+      refetch,
+    } as unknown as ReturnType<typeof useMonitoring>);
+    vi.mocked(useContainers).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: containerRefetch,
+      isFetching: false,
+    } as unknown as ReturnType<typeof useContainers>);
+
+    renderPage();
+
+    expect(capturedAutoRefresh.onTick).toBeTypeOf('function');
+    capturedAutoRefresh.onTick?.();
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(containerRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the page title through the shared PageHeader with live-state subtitle', () => {
+    renderPage();
+
+    const header = screen.getByTestId('page-header');
+    expect(within(header).getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Health & Monitoring',
+    );
+    // The old subtitle promised "real-time AI-powered insights".
+    expect(screen.queryByText(/AI-powered/i)).toBeNull();
+    expect(screen.getByTestId('page-header-subtitle')).toHaveTextContent(/insight/);
+  });
+
+  it('collapses re-emissions of the same fact into one row with a disclosure', async () => {
+    // A missing HEALTHCHECK is a configuration state, not an event; 12 of 20
+    // Info insights on a real fleet were two facts restated hourly, each with
+    // the same 40-word remediation paragraph.
+    const repeated = [3, 2, 1].map((hour) => ({
+      id: `hc-${hour}`,
+      endpoint_id: 1,
+      endpoint_name: 'local',
+      container_id: 'c-lcm-web',
+      container_name: 'lcm-web',
+      severity: 'info' as const,
+      category: 'health-check',
+      title: 'Container "lcm-web" has no health check configured',
+      description: 'Add a HEALTHCHECK instruction to the image.',
+      suggested_action: null,
+      is_acknowledged: 0,
+      created_at: `2026-07-26T0${hour}:00:00Z`,
+    }));
+    vi.mocked(useMonitoring).mockReturnValue({
+      insights: repeated,
+      isLoading: false,
+      error: null,
+      subscribedSeverities: new Set(['critical', 'warning', 'info']),
+      subscribeSeverity: vi.fn(),
+      unsubscribeSeverity: vi.fn(),
+      acknowledgeInsight: vi.fn(),
+      acknowledgeError: null,
+      isAcknowledging: false,
+      acknowledgingInsightId: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMonitoring>);
+
+    renderPage();
+
+    // One group, one visible card, and the other two behind a disclosure that
+    // prints its own count so the "Info" tile still reconciles.
+    expect(screen.getAllByTestId('insight-group')).toHaveLength(1);
+    const toggle = screen.getByTestId('insight-group-toggle');
+    expect(toggle).toHaveTextContent('Show 2 earlier occurrences');
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+
+    fireEvent.click(toggle);
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(3);
+  });
+
+  it('does not group insights that differ by container or title', () => {
+    const distinct = [
+      {
+        id: 'a', endpoint_id: 1, endpoint_name: 'local', container_id: 'c1',
+        container_name: 'lcm-web', severity: 'info' as const, category: 'health-check',
+        title: 'Container "lcm-web" has no health check configured',
+        description: '', suggested_action: null, is_acknowledged: 0,
+        created_at: '2026-07-26T03:00:00Z',
+      },
+      {
+        id: 'b', endpoint_id: 1, endpoint_name: 'local', container_id: 'c2',
+        container_name: 'docker-portainer-1', severity: 'info' as const, category: 'health-check',
+        title: 'Container "docker-portainer-1" has no health check configured',
+        description: '', suggested_action: null, is_acknowledged: 0,
+        created_at: '2026-07-26T03:00:00Z',
+      },
+    ];
+    vi.mocked(useMonitoring).mockReturnValue({
+      insights: distinct,
+      isLoading: false,
+      error: null,
+      subscribedSeverities: new Set(['critical', 'warning', 'info']),
+      subscribeSeverity: vi.fn(),
+      unsubscribeSeverity: vi.fn(),
+      acknowledgeInsight: vi.fn(),
+      acknowledgeError: null,
+      isAcknowledging: false,
+      acknowledgingInsightId: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMonitoring>);
+
+    renderPage();
+
+    expect(screen.getAllByTestId('insight-group')).toHaveLength(2);
+    expect(screen.queryByTestId('insight-group-toggle')).toBeNull();
   });
 });

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -1,7 +1,11 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useMonitoring } from '@/features/ai-intelligence/hooks/use-monitoring';
 import { useInvestigations } from '@/features/ai-intelligence/hooks/use-investigations';
-import { useCorrelatedAnomalies, type CorrelatedAnomaly } from '@/features/observability/hooks/use-correlated-anomalies';
+import {
+  useCorrelatedAnomalies,
+  type CorrelatedAnomaly,
+  type MetricPatternMatch,
+} from '@/features/observability/hooks/use-correlated-anomalies';
 import {
   useMarkFalsePositive,
   useAnomalyFeedbackRates,
@@ -32,7 +36,6 @@ import {
   Clock,
   Brain,
   Layers,
-  Zap,
   ThumbsDown,
 } from 'lucide-react';
 import { Link, useSearchParams } from 'react-router-dom';
@@ -46,9 +49,12 @@ function CorrelatedAnomalyCard({
   onMarkFalsePositive: (anomaly: CorrelatedAnomaly) => void;
   isPending: boolean;
 }) {
-  const patternDescription = anomaly.pattern?.includes(':')
-    ? anomaly.pattern.split(':').slice(1).join(':').trim()
-    : null;
+  // `patternMatch.summary` restates the rule that fired and the z-scores it
+  // fired on. It replaced a hardcoded sentence per rule branch, which rendered
+  // byte-identically on every card hitting the same branch and read as a
+  // diagnosis nothing had made. `pattern` is kept as a fallback so a stale
+  // server build degrades to the old string rather than to a blank card.
+  const ruleSummary = anomaly.patternMatch?.summary ?? anomaly.pattern ?? null;
 
   return (
     <SpotlightCard className="h-full">
@@ -65,7 +71,7 @@ function CorrelatedAnomalyCard({
 
         <div className="flex items-center gap-2 flex-wrap mb-3">
           <CorrelationSeverityBadge severity={anomaly.severity} />
-          {anomaly.pattern && <PatternBadge pattern={anomaly.pattern} />}
+          {anomaly.patternMatch && <PatternBadge patternMatch={anomaly.patternMatch} />}
         </div>
 
         {/* Per-metric z-score bars */}
@@ -92,8 +98,10 @@ function CorrelatedAnomalyCard({
           })}
         </div>
 
-        {patternDescription && (
-          <p className="mt-2 text-xs text-muted-foreground">{patternDescription}</p>
+        {ruleSummary && (
+          <p className="mt-2 text-xs text-muted-foreground" data-testid="pattern-rule-summary">
+            {ruleSummary}
+          </p>
         )}
 
         {/* False-positive feedback affordance (#1298). Optimistic dismissal
@@ -259,21 +267,27 @@ function CorrelationSeverityBadge({ severity }: { severity: 'low' | 'medium' | '
   );
 }
 
-function PatternBadge({ pattern }: { pattern: string }) {
-  const shortLabel = pattern.includes(':') ? pattern.split(':')[0].trim() : pattern;
-
-  const colorMap: Record<string, string> = {
-    'Resource Exhaustion': 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-    'Memory Leak Suspected': 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
-    'CPU Spike': 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-  };
-
-  const colorClass = colorMap[shortLabel] ?? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400';
-
+/**
+ * Which deviation rule fired, as a neutral classificatory chip.
+ *
+ * Deliberately uncoloured. The `CorrelationSeverityBadge` beside it already
+ * encodes urgency from the composite score; colouring this one too would put
+ * two competing severity signals on one row for the same anomaly. It is also
+ * deliberately not purple — DESIGN.md reserves purple for AI insight, and this
+ * chip reports a deterministic z-score threshold rule, not an inference. The
+ * previous version keyed its colours off English pattern names and fell back to
+ * purple whenever it did not recognise one, which is what made every unmatched
+ * rule look like an AI finding.
+ */
+function PatternBadge({ patternMatch }: { patternMatch: MetricPatternMatch }) {
   return (
-    <span className={cn('inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium', colorClass)}>
-      <Zap className="h-3 w-3" />
-      {shortLabel}
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground"
+      title={`Rule: metrics with z-score above ${patternMatch.zScoreThreshold}`}
+      data-testid="pattern-badge"
+      data-pattern-id={patternMatch.id}
+    >
+      {patternMatch.label}
     </span>
   );
 }

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { useMonitoring } from '@/features/ai-intelligence/hooks/use-monitoring';
-import { useInvestigations } from '@/features/ai-intelligence/hooks/use-investigations';
+import { useInvestigations, type Investigation } from '@/features/ai-intelligence/hooks/use-investigations';
 import {
   useCorrelatedAnomalies,
   type CorrelatedAnomaly,
@@ -14,7 +15,7 @@ import {
 import { useContainers } from '@/features/containers/hooks/use-containers';
 import { FleetHealthSummary, calculateHealthStats } from '@/features/ai-intelligence/components/fleet-health-summary';
 import { IncidentGroupsView } from '@/features/ai-intelligence/components/incident-groups-view';
-import { InsightCard } from '@/features/ai-intelligence/components/insight-card';
+import { InsightCard, SeverityBadge, ZScoreBar } from '@/features/ai-intelligence/components/insight-card';
 import { SensitivityControl } from '@/features/ai-intelligence/components/sensitivity-control';
 import type { Severity } from '@/features/ai-intelligence/components/insight-card';
 import { useForceRefresh } from '@/shared/hooks/use-force-refresh';
@@ -23,7 +24,7 @@ import { RefreshControls } from '@/shared/components/ui/refresh-controls';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { SkeletonChart, SkeletonList } from '@/shared/components/feedback/skeleton';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
-import { cn } from '@/shared/lib/utils';
+import { cn, formatDate } from '@/shared/lib/utils';
 import {
   AlertTriangle,
   Info,
@@ -33,12 +34,30 @@ import {
   Filter,
   Search,
   XCircle,
-  Clock,
-  Brain,
-  Layers,
+  Sigma,
   ThumbsDown,
 } from 'lucide-react';
 import { Link, useSearchParams } from 'react-router-dom';
+
+/**
+ * Map the correlated-anomaly ladder onto the product's insight severity
+ * vocabulary.
+ *
+ * This screen used to speak two severity languages at once: these cards said
+ * Critical / High / Medium / Low while the filter chips, the KPI tiles and the
+ * insight feed said Critical / Warning / Info — with no way to tell whether a
+ * card's "High" outranked the feed's "Warning". Nothing is lost collapsing
+ * high and medium into Warning: both already rendered in the same
+ * orange-on-cream badge, and the finer ordering is carried numerically by the
+ * composite score printed on the same card.
+ */
+export function correlationSeverityToInsightSeverity(
+  severity: 'low' | 'medium' | 'high' | 'critical',
+): Severity {
+  if (severity === 'critical') return 'critical';
+  if (severity === 'high' || severity === 'medium') return 'warning';
+  return 'info';
+}
 
 function CorrelatedAnomalyCard({
   anomaly,
@@ -58,7 +77,10 @@ function CorrelatedAnomalyCard({
 
   return (
     <SpotlightCard className="h-full">
-      <div className="h-full rounded-lg border bg-card p-6 shadow-sm transition-all duration-200 hover:shadow-md hover:-translate-y-0.5 hover:border-primary/20">
+      <div
+        className="h-full rounded-lg border bg-card p-6 shadow-sm transition-all duration-200 hover:shadow-md hover:-translate-y-0.5 hover:border-primary/20"
+        data-testid="correlated-anomaly-card"
+      >
         <div className="flex items-start justify-between gap-3 mb-3">
           <div className="flex items-center gap-2 min-w-0">
             <Box className="h-4 w-4 text-muted-foreground flex-shrink-0" />
@@ -70,32 +92,15 @@ function CorrelatedAnomalyCard({
         </div>
 
         <div className="flex items-center gap-2 flex-wrap mb-3">
-          <CorrelationSeverityBadge severity={anomaly.severity} />
+          <SeverityBadge severity={correlationSeverityToInsightSeverity(anomaly.severity)} />
           {anomaly.patternMatch && <PatternBadge patternMatch={anomaly.patternMatch} />}
         </div>
 
-        {/* Per-metric z-score bars */}
+        {/* Per-metric z-score bars, signed from a centre line. */}
         <div className="space-y-1.5" data-testid="zscore-bars">
-          {anomaly.metrics.map((m) => {
-            const absZ = Math.abs(m.zScore);
-            const widthPct = Math.min((absZ / 5) * 100, 100);
-            const barColor = absZ >= 3 ? 'bg-red-500' : absZ >= 2 ? 'bg-amber-500' : 'bg-blue-500';
-
-            return (
-              <div key={m.type} className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground w-20 truncate font-mono">{m.type}</span>
-                <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
-                  <div
-                    className={cn('h-full rounded-full transition-all', barColor)}
-                    style={{ width: `${widthPct}%` }}
-                  />
-                </div>
-                <span className="text-xs tabular-nums text-muted-foreground w-10 text-right">
-                  {m.zScore.toFixed(1)}
-                </span>
-              </div>
-            );
-          })}
+          {anomaly.metrics.map((m) => (
+            <ZScoreBar key={m.type} label={m.type} zScore={m.zScore} />
+          ))}
         </div>
 
         {ruleSummary && (
@@ -174,103 +179,10 @@ function HealthIssueCard({ container }: { container: { id: string; name: string;
   );
 }
 
-function CorrelationTypeBadge({ type }: { type: string }) {
-  const config: Record<string, { icon: typeof Clock; label: string; className: string }> = {
-    temporal: {
-      icon: Clock,
-      label: 'Temporal',
-      className: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-    },
-    cascade: {
-      icon: Layers,
-      label: 'Cascade',
-      className: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
-    },
-    dedup: {
-      icon: Filter,
-      label: 'Dedup',
-      className: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
-    },
-    semantic: {
-      icon: Brain,
-      label: 'Semantic',
-      className: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
-    },
-  };
-
-  const entry = config[type] ?? config.temporal;
-  const Icon = entry.icon;
-
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium',
-        entry.className,
-      )}
-    >
-      <Icon className="h-3 w-3" />
-      {entry.label}
-    </span>
-  );
-}
-
-function ConfidenceBadge({ confidence }: { confidence: 'high' | 'medium' | 'low' }) {
-  const config = {
-    high: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-    medium: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-    low: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
-  }[confidence];
-
-  return (
-    <span className={cn('inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize', config)}>
-      {confidence} confidence
-    </span>
-  );
-}
-
-function CorrelationSeverityBadge({ severity }: { severity: 'low' | 'medium' | 'high' | 'critical' }) {
-  const config = {
-    critical: {
-      icon: AlertTriangle,
-      label: 'Critical',
-      className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-    },
-    high: {
-      icon: AlertCircle,
-      label: 'High',
-      className: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
-    },
-    medium: {
-      icon: AlertCircle,
-      label: 'Medium',
-      className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-    },
-    low: {
-      icon: Info,
-      label: 'Low',
-      className: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-    },
-  }[severity];
-
-  const Icon = config.icon;
-
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium',
-        config.className,
-      )}
-    >
-      <Icon className="h-3 w-3" />
-      {config.label}
-    </span>
-  );
-}
-
 /**
  * Which deviation rule fired, as a neutral classificatory chip.
  *
- * Deliberately uncoloured. The `CorrelationSeverityBadge` beside it already
+ * Deliberately uncoloured. The `SeverityBadge` beside it already
  * encodes urgency from the composite score; colouring this one too would put
  * two competing severity signals on one row for the same anomaly. It is also
  * deliberately not purple — DESIGN.md reserves purple for AI insight, and this
@@ -292,10 +204,100 @@ function PatternBadge({ patternMatch }: { patternMatch: MetricPatternMatch }) {
   );
 }
 
+type FeedInsight = React.ComponentProps<typeof InsightCard>['insight'];
+
+/**
+ * Group consecutive re-emissions of the same fact for the same container.
+ *
+ * Twelve of twenty "Info" insights on a real fleet were two facts restated
+ * hourly — `Container "lcm-web" has no health check configured` at 03:40,
+ * 04:43, 05:47, … each carrying the same 40-word remediation paragraph. A
+ * missing HEALTHCHECK is a configuration state, not an event.
+ *
+ * Deliberately a display-time grouping and not a filter: every occurrence is
+ * still in the feed behind a disclosure, so acknowledging stays per-insight and
+ * the "20 Info" tile still reconciles against what is on screen (the group
+ * header prints its own occurrence count).
+ */
+export function groupRepeatedInsights<T extends FeedInsight>(insights: T[]): T[][] {
+  const byKey = new Map<string, T[]>();
+  const order: string[] = [];
+  for (const insight of insights) {
+    const key = `${insight.severity}|${insight.container_id ?? ''}|${insight.title}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.push(insight);
+    } else {
+      byKey.set(key, [insight]);
+      order.push(key);
+    }
+  }
+  return order.map((key) => byKey.get(key)!);
+}
+
+function RepeatedInsightGroup({
+  insights,
+  getInvestigationForInsight,
+  onAcknowledge,
+  acknowledgingInsightId,
+  acknowledgeErrorMessage,
+}: {
+  insights: FeedInsight[];
+  getInvestigationForInsight: (id: string) => Investigation | undefined;
+  onAcknowledge: (insightId: string) => void;
+  acknowledgingInsightId: string | null;
+  acknowledgeErrorMessage?: string;
+}) {
+  const [showEarlier, setShowEarlier] = useState(false);
+  const [latest, ...earlier] = insights;
+  const oldest = insights[insights.length - 1];
+
+  return (
+    <div className="space-y-2" data-testid="insight-group">
+      <InsightCard
+        insight={latest}
+        investigation={getInvestigationForInsight(latest.id)}
+        onAcknowledge={onAcknowledge}
+        isAcknowledging={acknowledgingInsightId === latest.id}
+        acknowledgeErrorMessage={acknowledgeErrorMessage}
+      />
+      {earlier.length > 0 && (
+        <>
+          <button
+            type="button"
+            onClick={() => setShowEarlier((v) => !v)}
+            aria-expanded={showEarlier}
+            data-testid="insight-group-toggle"
+            className="ml-4 text-xs text-muted-foreground underline decoration-dotted hover:text-foreground"
+          >
+            {showEarlier ? 'Hide' : 'Show'} {earlier.length} earlier occurrence
+            {earlier.length === 1 ? '' : 's'} · first seen {formatDate(oldest.created_at)}
+          </button>
+          {showEarlier && (
+            <div className="ml-4 space-y-2 border-l pl-3">
+              {earlier.map((insight) => (
+                <InsightCard
+                  key={insight.id}
+                  insight={insight}
+                  investigation={getInvestigationForInsight(insight.id)}
+                  onAcknowledge={onAcknowledge}
+                  isAcknowledging={acknowledgingInsightId === insight.id}
+                  acknowledgeErrorMessage={acknowledgeErrorMessage}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+const PAGE_TITLE = 'Health & Monitoring';
+
 export default function AiMonitorPage() {
   const [severityFilter, setSeverityFilter] = useState<'all' | Severity>('all');
   const [acknowledgementFilter, setAcknowledgementFilter] = useState<'all' | 'unacknowledged'>('all');
-  const { interval, setInterval } = useAutoRefresh(30);
 
   // URL-synced controls so reloads, deep links, and back-navigation preserve
   // the operator's filter context. Trade-off: each control change invalidates
@@ -394,21 +396,16 @@ export default function AiMonitorPage() {
   const { data: containers, isLoading: containersLoading, refetch: containerRefetch, isFetching: containersFetching } = useContainers();
   const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', containerRefetch);
 
-  // Wire the auto-refresh dropdown to actual refetches. The hook only owns
-  // the interval state; without this effect, switching the dropdown to "30s"
-  // would advertise a behaviour that never happens. We refetch the page's
+  // The hook owns the timer now, so this is one argument instead of a
+  // hand-rolled `window.setInterval` effect per page. We refetch the page's
   // two operator-controlled queries (insights + containers); incidents and
   // correlated anomalies have their own internal refetch cadences set in
   // their respective hooks.
-  useEffect(() => {
-    if (interval <= 0) return;
-    const tick = () => {
-      refetch();
-      containerRefetch();
-    };
-    const id = window.setInterval(tick, interval * 1000);
-    return () => window.clearInterval(id);
-  }, [interval, refetch, containerRefetch]);
+  const handleTick = useCallback(() => {
+    refetch();
+    containerRefetch();
+  }, [refetch, containerRefetch]);
+  const { interval, setRefreshInterval } = useAutoRefresh(30, { onTick: handleTick });
 
   const healthStats = useMemo(() => {
     if (!containers) return null;
@@ -472,28 +469,49 @@ export default function AiMonitorPage() {
     return healthIssues.filter((c) => matchesSearch([c.name, c.image, c.healthStatus]));
   }, [healthIssues, searchLower]);
 
-  // Stats
+  // Stats. The unacknowledged critical/warning split feeds the hero's
+  // "Needs attention" count — the number an operator still has to act on,
+  // which is not the same as the total the tiles show.
   const stats = useMemo(() => {
-    const result = { total: 0, critical: 0, warning: 0, info: 0 };
+    const result = {
+      total: 0,
+      critical: 0,
+      warning: 0,
+      info: 0,
+      unacknowledgedCritical: 0,
+      unacknowledgedWarning: 0,
+    };
     for (const i of insights) {
       result.total++;
-      if (i.severity === 'critical') result.critical++;
-      else if (i.severity === 'warning') result.warning++;
-      else if (i.severity === 'info') result.info++;
+      if (i.severity === 'critical') {
+        result.critical++;
+        if (!i.is_acknowledged) result.unacknowledgedCritical++;
+      } else if (i.severity === 'warning') {
+        result.warning++;
+        if (!i.is_acknowledged) result.unacknowledgedWarning++;
+      } else if (i.severity === 'info') {
+        result.info++;
+      }
     }
     return result;
   }, [insights]);
+
+  const repeatedInsightGroups = useMemo(
+    () => groupRepeatedInsights(filteredInsights),
+    [filteredInsights],
+  );
+
+  // Live state, not a restatement of the title. The old subtitle promised
+  // "real-time AI-powered insights" over a feed whose largest population is a
+  // deterministic missing-healthcheck check.
+  const subtitle = `${stats.total} insight${stats.total === 1 ? '' : 's'} · ` +
+    `${stats.unacknowledgedCritical + stats.unacknowledgedWarning} unacknowledged`;
 
   // Error state
   if (error) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Health & Monitoring</h1>
-          <p className="text-muted-foreground">
-            Fleet health analysis and real-time AI-powered insights
-          </p>
-        </div>
+        <PageHeader title={PAGE_TITLE} />
         <EmptyState
           variant="error"
           icon={AlertTriangle}
@@ -512,24 +530,19 @@ export default function AiMonitorPage() {
 
   return (
     <div className="space-y-6 pb-12">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Health & Monitoring</h1>
-          <p className="text-muted-foreground">
-            Fleet health analysis and real-time AI-powered insights
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
+      <PageHeader
+        title={PAGE_TITLE}
+        subtitle={subtitle}
+        actions={
           <RefreshControls
             interval={interval}
-            onIntervalChange={setInterval}
+            onIntervalChange={setRefreshInterval}
             onRefresh={() => { refetch(); containerRefetch(); }}
             onForceRefresh={forceRefresh}
             isLoading={containersFetching || isForceRefreshing}
           />
-        </div>
-      </div>
+        }
+      />
 
       {/* Per-detector false-positive rate badges (#1298). Rendered in
           the Health & Monitoring header (location decision: header
@@ -582,13 +595,16 @@ export default function AiMonitorPage() {
         </div>
       )}
 
-      {/* Fleet Health Summary — includes insight counts (Total / Critical /
-          Warning / Info) as a second row of stat tiles inside the same hero. */}
+      {/* Fleet Vitals — the same shared component Home renders, asked for a
+          different emphasis: insight counts lead, container status collapses to
+          one line. Home carries that strip in full, and navigating Home →
+          Health used to leave the top ~180px of the viewport unchanged. */}
       <SpotlightCard>
         <FleetHealthSummary
           stats={healthStats}
           isLoading={containersLoading}
           insightStats={stats}
+          layout="insights-first"
         />
       </SpotlightCard>
 
@@ -711,13 +727,18 @@ export default function AiMonitorPage() {
         </div>
       </SpotlightCard>
 
-      {/* ML-Detected Anomalies */}
+      {/* Correlated metric deviations. Renamed from "ML-Detected Anomalies":
+          the composite score is a root-mean-square of per-metric z-scores and
+          the pattern is a z-score threshold rule — real multivariate
+          statistics, but not inference, so it gets neither the Brain glyph nor
+          the AI purple that DESIGN.md reserves for model output. The maths
+          below is unchanged. */}
       {(correlatedLoading || (filteredCorrelatedAnomalies && filteredCorrelatedAnomalies.length > 0)) && (
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <Brain className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+            <Sigma className="h-5 w-5 text-muted-foreground" />
             <h2 className="text-lg font-semibold">
-              ML-Detected Anomalies
+              Correlated metric deviations
               {!correlatedLoading && (
                 <span className="ml-2 text-sm font-normal text-muted-foreground">
                   ({filteredCorrelatedAnomalies?.length ?? 0})
@@ -804,13 +825,13 @@ export default function AiMonitorPage() {
           />
         ) : (
           <div className="space-y-3">
-            {filteredInsights.map((insight) => (
-              <InsightCard
-                key={insight.id}
-                insight={insight}
-                investigation={getInvestigationForInsight(insight.id)}
+            {repeatedInsightGroups.map((group) => (
+              <RepeatedInsightGroup
+                key={group[0].id}
+                insights={group}
+                getInvestigationForInsight={getInvestigationForInsight}
                 onAcknowledge={acknowledgeInsight}
-                isAcknowledging={acknowledgingInsightId === insight.id}
+                acknowledgingInsightId={acknowledgingInsightId}
                 acknowledgeErrorMessage={acknowledgeError instanceof Error ? acknowledgeError.message : undefined}
               />
             ))}

--- a/frontend/src/features/ai-intelligence/pages/llm-assistant.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-assistant.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import type { Insight } from '@dashboard/contracts';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -107,7 +108,20 @@ vi.mock('sonner', () => ({
   },
 }));
 
-import LlmAssistantPage from './llm-assistant';
+// The suggestion grid is now generated from live insights, so the HTTP
+// boundary is mocked (per CLAUDE.md: mock the call, not the hook wrapping it).
+const mockApiGet = vi.fn().mockResolvedValue({ insights: [], total: 0 });
+vi.mock('@/shared/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+import LlmAssistantPage, { suggestionsFromInsights, buildSuggestions } from './llm-assistant';
 import { useLlmChat } from '@/features/ai-intelligence/hooks/use-llm-chat';
 import { useLlmModels } from '@/features/ai-intelligence/hooks/use-llm-models';
 import { useAuth } from '@/providers/auth-provider';
@@ -130,10 +144,47 @@ describe('LlmAssistantPage', () => {
     vi.clearAllMocks();
   });
 
-  it('renders welcome screen when no messages', () => {
+  // The heading was "Welcome to Your AI Assistant" over "I have real-time
+  // access to your entire Docker infrastructure" — a first-person capability
+  // claim over six read-only tools.
+  it('states the contract instead of welcoming the operator', () => {
     renderPage();
-    expect(screen.getByText('Welcome to Your AI Assistant')).toBeTruthy();
-    expect(screen.getByText(/real-time access/)).toBeTruthy();
+    expect(screen.queryByText(/Welcome to Your AI Assistant/)).toBeNull();
+    expect(screen.queryByText(/real-time access/)).toBeNull();
+    expect(screen.queryByText(/entire Docker infrastructure/)).toBeNull();
+    expect(screen.getByText('Ask about a container, a metric or an anomaly')).toBeTruthy();
+    expect(
+      screen.getByText(/reads containers, metrics, insights, logs and anomalies/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/cannot start, stop or change anything/i)).toBeTruthy();
+  });
+
+  it('titles the page with the navigation manifest label, without a gradient h1', () => {
+    renderPage();
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading.textContent).toBe('Assistant');
+    expect(heading.className).not.toContain('bg-clip-text');
+    expect(heading.className).not.toContain('gradient');
+  });
+
+  // Six suggestions was four plus a pair that existed to fill a third column.
+  it('offers exactly four suggestions', () => {
+    renderPage();
+    const grid = screen.getByTestId('assistant-empty-state');
+    const cards = within(grid).getAllByRole('button');
+    expect(cards).toHaveLength(4);
+    expect(screen.queryByText('Stack overview')).toBeNull();
+    expect(screen.queryByText('Network topology')).toBeNull();
+  });
+
+  // Every second line used to restate its own title ("Container logs" /
+  // "Fetch recent logs for debugging").
+  it('shows the exact prompt each suggestion will send', () => {
+    renderPage();
+    const card = screen.getByRole('button', { name: /Recent restarts/ });
+    expect(card.textContent).toContain(
+      'Which containers restarted in the last hour, and what do their logs say?',
+    );
   });
 
   it('renders model selector with available models', () => {
@@ -232,10 +283,184 @@ describe('LlmAssistantPage', () => {
     } as any);
 
     renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /Running containers/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Busiest container/i }));
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledWith('Show me all running containers and their resource usage', undefined, 'llama3.2');
+    expect(sendMessage).toHaveBeenCalledWith(
+      'Which container is using the most CPU and memory right now?',
+      undefined,
+      'llama3.2',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suggestion generation — the grid is built from live insights so it names the
+// container that is anomalous right now, not a static demo list.
+// ---------------------------------------------------------------------------
+
+describe('suggestionsFromInsights', () => {
+  const insight = (over: Partial<Insight>): Insight => ({
+    id: 'i1',
+    endpoint_id: 1,
+    endpoint_name: 'local',
+    container_id: 'c1',
+    container_name: 'web-api',
+    severity: 'warning',
+    category: 'anomaly',
+    title: 'Memory usage anomaly',
+    description: 'memory z=3.7',
+    suggested_action: null,
+    is_acknowledged: 0,
+    created_at: new Date().toISOString(),
+    ...over,
+  }) as Insight;
+
+  it('returns nothing when there are no insights', () => {
+    expect(suggestionsFromInsights([], 4)).toEqual([]);
+    expect(suggestionsFromInsights(undefined, 4)).toEqual([]);
+  });
+
+  it('names the container and its insight in the prompt', () => {
+    const [s] = suggestionsFromInsights([insight({})], 4);
+    expect(s.label).toBe('web-api');
+    expect(s.prompt).toBe('Why is web-api showing "Memory usage anomaly"? Check its recent metrics and logs.');
+  });
+
+  it('puts critical before warning regardless of array order', () => {
+    const out = suggestionsFromInsights(
+      [
+        insight({ id: 'a', container_name: 'redis', severity: 'warning' }),
+        insight({ id: 'b', container_name: 'postgres', severity: 'critical' }),
+      ],
+      4,
+    );
+    expect(out.map((s) => s.label)).toEqual(['postgres', 'redis']);
+  });
+
+  it('spends at most one slot per container', () => {
+    const out = suggestionsFromInsights(
+      [
+        insight({ id: 'a', container_name: 'redis' }),
+        insight({ id: 'b', container_name: 'redis', title: 'CPU usage anomaly' }),
+      ],
+      4,
+    );
+    expect(out).toHaveLength(1);
+  });
+
+  it('skips acknowledged insights and info-level noise', () => {
+    const out = suggestionsFromInsights(
+      [
+        insight({ id: 'a', container_name: 'redis', is_acknowledged: 1 }),
+        insight({ id: 'b', container_name: 'nginx', severity: 'info' }),
+      ],
+      4,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('skips fleet-wide insights with no container to name', () => {
+    expect(suggestionsFromInsights([insight({ container_name: null })], 4)).toEqual([]);
+  });
+
+  it('honours the cap', () => {
+    const many = ['a', 'b', 'c', 'd', 'e'].map((n) => insight({ id: n, container_name: n }));
+    expect(suggestionsFromInsights(many, 3)).toHaveLength(3);
+  });
+});
+
+describe('buildSuggestions', () => {
+  it('always yields four, live incidents first', () => {
+    const live = [
+      {
+        id: 'i1',
+        endpoint_id: 1,
+        endpoint_name: 'local',
+        container_id: 'c1',
+        container_name: 'web-api',
+        severity: 'critical',
+        category: 'anomaly',
+        title: 'CPU usage anomaly',
+        description: '',
+        suggested_action: null,
+        is_acknowledged: 0,
+        created_at: new Date().toISOString(),
+      } as Insight,
+    ];
+    const out = buildSuggestions(live, false);
+    expect(out).toHaveLength(4);
+    expect(out[0].label).toBe('web-api');
+  });
+
+  it('keeps a kali-mcp entry when the server is connected, still four total', () => {
+    const out = buildSuggestions(undefined, true);
+    expect(out).toHaveLength(4);
+    expect(out.some((s) => s.prompt.includes('kali-mcp'))).toBe(true);
+  });
+
+  it('offers no kali-mcp entry when the server is absent', () => {
+    const out = buildSuggestions(undefined, false);
+    expect(out.some((s) => s.prompt.includes('kali-mcp'))).toBe(false);
+  });
+});
+
+describe('live-state suggestions in the page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useLlmModels).mockReturnValue({
+      data: { models: [{ name: 'llama3.2' }], default: 'llama3.2' },
+    } as any);
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+  });
+
+  it('names the container that is anomalous right now', async () => {
+    mockApiGet.mockResolvedValue({
+      insights: [
+        {
+          id: 'i1',
+          endpoint_id: 1,
+          endpoint_name: 'local',
+          container_id: 'c1',
+          container_name: 'payments-api',
+          severity: 'critical',
+          category: 'anomaly',
+          title: 'Memory usage anomaly',
+          description: '',
+          suggested_action: null,
+          is_acknowledged: 0,
+          created_at: new Date().toISOString(),
+        },
+      ],
+      total: 1,
+    });
+
+    renderPage();
+
+    const card = await screen.findByRole('button', { name: /payments-api/ });
+    expect(card.textContent).toContain(
+      'Why is payments-api showing "Memory usage anomaly"? Check its recent metrics and logs.',
+    );
+    expect(mockApiGet).toHaveBeenCalledWith('/api/monitoring/insights');
+  });
+
+  it('falls back to the baseline four when the insights request fails', async () => {
+    mockApiGet.mockRejectedValue(new Error('offline'));
+
+    renderPage();
+
+    const grid = screen.getByTestId('assistant-empty-state');
+    expect(within(grid).getAllByRole('button')).toHaveLength(4);
+    expect(screen.getByRole('button', { name: /Recent restarts/ })).toBeTruthy();
   });
 });
 
@@ -968,5 +1193,134 @@ describe('Chat send/receive flow (#1050)', () => {
     expect(
       screen.getByText('Error: failed to reach the AI service. Please try again.'),
     ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Design-critique fixes: this was the one page in the product that opted out
+// of the theme system, and it decorated hardest at the moment of least
+// information.
+// ---------------------------------------------------------------------------
+
+describe('Assistant presentation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLlmSocket.connected = true;
+    mockApiGet.mockResolvedValue({ insights: [], total: 0 });
+    vi.mocked(useLlmModels).mockReturnValue({
+      data: { models: [{ name: 'llama3.2' }], default: 'llama3.2' },
+    } as any);
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+    vi.mocked(usePromptProfiles).mockReturnValue({ data: undefined } as any);
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: true,
+      username: 'admin',
+      token: 'test-token',
+      role: 'viewer',
+      login: vi.fn(),
+      loginWithToken: vi.fn(),
+      logout: vi.fn(),
+    });
+  });
+
+  it('uses no blue/purple/emerald gradients in its chrome', () => {
+    const { container } = renderPage();
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/from-blue-\d+/);
+    expect(html).not.toMatch(/to-purple-\d+/);
+    expect(html).not.toMatch(/from-emerald-\d+/);
+  });
+
+  it('gives Send the primary token with no hover scale or coloured shadow', () => {
+    renderPage();
+    const send = screen.getByRole('button', { name: /Send/i });
+    expect(send.className).toContain('bg-primary');
+    expect(send.className).not.toContain('gradient');
+    expect(send.className).not.toContain('hover:scale');
+    expect(send.className).not.toContain('shadow-blue');
+  });
+
+  // Two identical robot glyphs on one empty screen — 48px in the header and
+  // 80px in the hero behind an animate-pulse glow.
+  it('shows one assistant mark on the empty screen, with no pulse glow', () => {
+    const { container } = renderPage();
+    expect(container.querySelectorAll('.lucide-bot')).toHaveLength(1);
+    expect(container.querySelector('.animate-pulse')).toBeNull();
+  });
+
+  // Green means healthy in this palette; it should not also mean "you typed
+  // this". The user's own message gets the quietest treatment available.
+  it('renders the user message on a muted surface, not in status green', () => {
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [{ id: 'u1', role: 'user', content: 'Why is redis restarting?', timestamp: new Date().toISOString() }],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    renderPage();
+    const bubble = screen.getByText('Why is redis restarting?').closest('div');
+    expect(bubble?.className).toContain('bg-muted');
+    expect(bubble?.className).not.toContain('emerald');
+  });
+
+  // The model selector's unconditional min-w-[200px] was clipped off a 390px
+  // viewport by a header row that could not wrap.
+  it('lets the model selector shrink below sm and the header wrap', () => {
+    renderPage();
+    const select = screen.getByRole('combobox');
+    expect(select.className).toContain('min-w-[9rem]');
+    expect(select.className).toContain('sm:min-w-[200px]');
+    expect(select.className).not.toMatch(/(^|\s)min-w-\[200px\]/);
+    expect(screen.getByTestId('page-header').className).toContain('flex-wrap');
+  });
+
+  it('names the cancel affordance the same in both states', () => {
+    renderPage();
+    const input = screen.getByPlaceholderText('Ask about your infrastructure...');
+    fireEvent.change(input, { target: { value: 'ping' } });
+    fireEvent.click(screen.getByRole('button', { name: /Send/i }));
+
+    // Was "Cancel" here and "Stop generating" once the stream started.
+    expect(screen.getByTestId('thinking-indicator').textContent).toContain('Stop generating');
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+  });
+
+  it('drops the only exclamation mark in the app operational copy', () => {
+    vi.mocked(useLlmChat).mockReturnValue({
+      messages: [
+        { id: '1', role: 'assistant', content: '```bash\necho hello\n```', timestamp: new Date().toISOString() },
+      ],
+      isStreaming: false,
+      currentResponse: '',
+      activeToolCalls: [],
+      statusMessage: null,
+      sendMessage: vi.fn(),
+      cancelGeneration: vi.fn(),
+      clearHistory: vi.fn(),
+    } as any);
+
+    // jsdom ships no clipboard implementation.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Copy/i }));
+    expect(writeText).toHaveBeenCalledWith('echo hello');
+    expect(screen.getByText('Copied')).toBeTruthy();
+    expect(screen.queryByText('Copied!')).toBeNull();
   });
 });

--- a/frontend/src/features/ai-intelligence/pages/llm-assistant.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-assistant.tsx
@@ -1,6 +1,8 @@
 import { memo, useState, useRef, useEffect, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { Send, X, Trash2, Bot, User, AlertCircle, Copy, Check, Wrench, CheckCircle2, XCircle, Layers, WifiOff, Loader2 } from 'lucide-react';
+import type { Insight } from '@dashboard/contracts';
 import { ContextBanner, type ContextBannerData } from '@/shared/components/layout/context-banner';
 import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
 import ReactMarkdown, { type Components } from 'react-markdown';
@@ -17,6 +19,9 @@ import { usePromptProfiles, useSwitchProfile } from '@/features/ai-intelligence/
 import { useAuth } from '@/providers/auth-provider';
 import { LlmFeedbackButtons } from '@/shared/components/data-display/llm-feedback-buttons';
 import { ShimmerText } from '@/shared/components/feedback/shimmer-text';
+import { PageHeader } from '@/shared/components/layout/page-header';
+import { api } from '@/shared/lib/api';
+import { STALE_TIMES } from '@/shared/lib/query-constants';
 import { toast } from 'sonner';
 
 const TOOL_DISPLAY_NAMES: Record<string, string> = {
@@ -28,33 +33,96 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   navigate_to: 'Generating link',
 };
 
+/**
+ * A starter prompt. `label` is the short handle; `prompt` is the exact text
+ * that will be sent — and it is what the card's second line shows. The old
+ * shape carried a separate `description` that restated the label ("Container
+ * logs" / "Fetch recent logs for debugging"), so the second line never
+ * changed what the operator would click, and could be truncated on top.
+ */
 interface Suggestion {
   label: string;
-  description: string;
   prompt: string;
 }
 
-const INFRA_SUGGESTIONS: Suggestion[] = [
-  { label: 'Running containers', description: 'List all running containers with status and ports', prompt: 'Show me all running containers and their resource usage' },
-  { label: 'Anomaly detection', description: 'Check for critical insights or anomalies', prompt: 'Are there any critical insights or anomalies across my infrastructure?' },
-  { label: 'Resource metrics', description: 'CPU and memory usage for the busiest container', prompt: 'Which container is using the most CPU and memory right now?' },
-  { label: 'Container logs', description: 'Fetch recent logs for debugging', prompt: 'Show me recent logs for the backend service' },
+/**
+ * The four an operator types at 3am, in the absence of anything anomalous.
+ *
+ * Four, not six: the previous grid was four real suggestions plus a pair
+ * ("Stack overview", "Network topology") that existed to fill the third
+ * column of a `lg:grid-cols-3` whenever the optional kali MCP server was
+ * absent — the array was literally named `FALLBACK_SUGGESTIONS`.
+ */
+const BASELINE_SUGGESTIONS: Suggestion[] = [
+  { label: 'Recent restarts', prompt: 'Which containers restarted in the last hour, and what do their logs say?' },
+  { label: 'Busiest container', prompt: 'Which container is using the most CPU and memory right now?' },
+  { label: 'Open anomalies', prompt: 'List the anomalies detected in the last 24 hours, newest first.' },
+  { label: 'Recent errors', prompt: 'Show the most recent error-level log lines across all containers.' },
 ];
 
-const MCP_SUGGESTIONS: Suggestion[] = [
-  { label: 'Network scan', description: 'Use kali-mcp to discover open ports on a target', prompt: 'Use the kali-mcp to run a quick nmap port scan against the web-platform stack' },
-  { label: 'Security recon', description: 'Use kali-mcp to identify services and OS fingerprints', prompt: 'Use the kali-mcp to run a service version scan with nmap -sV on the web-frontend container' },
-];
+const MCP_SUGGESTION: Suggestion = {
+  label: 'Port scan',
+  prompt: 'Use the kali-mcp to run a quick nmap port scan against the web-platform stack',
+};
 
-const FALLBACK_SUGGESTIONS: Suggestion[] = [
-  { label: 'Stack overview', description: 'Summarize stacks, services, and health', prompt: 'Give me an overview of all my Docker stacks and their health status' },
-  { label: 'Network topology', description: 'Describe container network connections', prompt: 'Describe the network topology and which containers can communicate' },
-];
+const SUGGESTION_COUNT = 4;
+
+/** Insight severities worth interrupting someone about, most urgent first. */
+const ACTIONABLE_SEVERITIES = ['critical', 'warning'] as const;
+
+/**
+ * Turn the fleet's open insights into prompts that name the container which is
+ * misbehaving *now*. One per container, most severe first, so the grid does
+ * not spend two of its four slots on the same workload.
+ */
+export function suggestionsFromInsights(insights: Insight[] | undefined, max: number): Suggestion[] {
+  if (!insights || insights.length === 0) return [];
+  const seen = new Set<string>();
+  const out: Suggestion[] = [];
+
+  for (const severity of ACTIONABLE_SEVERITIES) {
+    for (const insight of insights) {
+      if (out.length >= max) return out;
+      if (insight.severity !== severity) continue;
+      if (insight.is_acknowledged) continue;
+      const container = insight.container_name;
+      if (!container || seen.has(container)) continue;
+      seen.add(container);
+      out.push({
+        label: container,
+        prompt: `Why is ${container} showing "${insight.title}"? Check its recent metrics and logs.`,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Live open insights, sharing `useMonitoring`'s query key so arriving from
+ * Health costs no extra request.
+ */
+function useOpenInsights() {
+  return useQuery<{ insights: Insight[]; total: number }>({
+    queryKey: ['monitoring', 'insights'],
+    queryFn: () => api.get<{ insights: Insight[]; total: number }>('/api/monitoring/insights'),
+    staleTime: STALE_TIMES.SHORT,
+    retry: false,
+  });
+}
+
+export function buildSuggestions(
+  insights: Insight[] | undefined,
+  hasKaliMcp: boolean,
+): Suggestion[] {
+  const live = suggestionsFromInsights(insights, hasKaliMcp ? SUGGESTION_COUNT - 1 : SUGGESTION_COUNT);
+  const tail = hasKaliMcp ? [MCP_SUGGESTION, ...BASELINE_SUGGESTIONS] : BASELINE_SUGGESTIONS;
+  return [...live, ...tail].slice(0, SUGGESTION_COUNT);
+}
 
 function useSuggestions(mcpServers?: import('@/features/ai-intelligence/hooks/use-mcp').McpServer[]): Suggestion[] {
-  const hasKaliMcp = mcpServers?.some(s => s.name.toLowerCase().includes('kali') && s.connected);
-  const mcpPart = hasKaliMcp ? MCP_SUGGESTIONS : FALLBACK_SUGGESTIONS;
-  return [...INFRA_SUGGESTIONS, ...mcpPart];
+  const hasKaliMcp = !!mcpServers?.some(s => s.name.toLowerCase().includes('kali') && s.connected);
+  const { data } = useOpenInsights();
+  return buildSuggestions(data?.insights, hasKaliMcp);
 }
 
 /** State passed via React Router location.state when navigating to this page */
@@ -175,25 +243,32 @@ export default function LlmAssistantPage() {
     setShowClearConfirm(true);
   };
 
+  const selectedUseCase = selectedModel ? getModelUseCase(selectedModel) : null;
+
   return (
     <div className="flex h-[calc(100vh-8rem)] flex-col space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg shadow-blue-500/20">
-            <Bot className="h-6 w-6 text-white" />
-          </div>
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-blue-600 to-purple-600 dark:from-blue-400 dark:to-purple-400 bg-clip-text text-transparent">
-              AI Assistant
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              Your intelligent infrastructure companion
-            </p>
-          </div>
-        </div>
-        <div className="flex flex-col items-end gap-1">
-          <div className="flex items-center gap-3">
+      {/* The one page-header shape. This page used to be the only gradient-
+          filled h1 in the product, titled "AI Assistant" while the sidebar and
+          breadcrumb said "LLM Assistant". The title now matches the navigation
+          manifest, and the subtitle slot carries live state (which model is
+          selected and what it is good at) instead of a tagline. */}
+      <PageHeader
+        title="Assistant"
+        subtitle={
+          selectedUseCase && (
+            <span className="flex items-center gap-2">
+              <span
+                className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-semibold whitespace-nowrap ${selectedUseCase.color}`}
+                style={{ backgroundColor: 'color-mix(in srgb, currentColor 10%, transparent)', borderColor: 'color-mix(in srgb, currentColor 25%, transparent)' }}
+              >
+                {selectedUseCase.label}
+              </span>
+              <span className="text-[11px] text-muted-foreground">{selectedUseCase.description}</span>
+            </span>
+          )
+        }
+        actions={
+          <>
             {/* Profile Selector (admin-only) */}
             {isAdmin && profiles.length > 0 && (
               <div className="flex items-center gap-1.5">
@@ -209,13 +284,14 @@ export default function LlmAssistantPage() {
                 />
               </div>
             )}
-            {/* Model Selector */}
+            {/* Model Selector. `min-w-[200px]` unconditionally pushed this off
+                the right edge of a 390px viewport. */}
             {modelsData && modelsData.models.length > 0 && (
               <ThemedSelect
                 value={selectedModel}
                 onValueChange={(val) => setSelectedModel(val)}
                 disabled={isStreaming || isSending}
-                className="min-w-[200px]"
+                className="min-w-[9rem] sm:min-w-[200px]"
                 options={modelsData.models.map((model) => ({
                   value: model.name,
                   label: model.name,
@@ -225,25 +301,14 @@ export default function LlmAssistantPage() {
             <button
               onClick={handleClear}
               disabled={messages.length === 0}
-            className="inline-flex items-center gap-2 rounded-lg border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm transition-all hover:bg-accent hover:shadow disabled:opacity-50 disabled:cursor-not-allowed"
-          >
+              className="inline-flex items-center gap-2 rounded-lg border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm transition-all hover:bg-accent hover:shadow disabled:opacity-50 disabled:cursor-not-allowed"
+            >
               <Trash2 className="h-4 w-4" />
               Clear History
             </button>
-          </div>
-          {selectedModel && (() => {
-            const useCase = getModelUseCase(selectedModel);
-            return (
-              <div className="flex items-center justify-end gap-2">
-                <span className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-semibold whitespace-nowrap ${useCase.color}`} style={{ backgroundColor: 'color-mix(in srgb, currentColor 10%, transparent)', borderColor: 'color-mix(in srgb, currentColor 25%, transparent)' }}>
-                  {useCase.label}
-                </span>
-                <span className="text-[11px] text-muted-foreground whitespace-nowrap">{useCase.description}</span>
-              </div>
-            );
-          })()}
-        </div>
-      </div>
+          </>
+        }
+      />
 
       {/* Context banner — shown when arriving via "Discuss with AI" from another page */}
       {contextBanner && (
@@ -258,28 +323,33 @@ export default function LlmAssistantPage() {
         <div className="flex h-full flex-col">
           {/* Messages Area */}
           <div className="flex-1 overflow-y-auto p-6 space-y-6">
+            {/* Anchored to the top of the scroll area, not centred in it: with
+                `justify-center` inside `h-[calc(100vh-8rem)]` the heading and
+                the icon sat above the container's top edge on a 390px
+                viewport, so the first visible text was mid-sentence. */}
             {messages.length === 0 && !isStreaming && (
-              <div className="flex flex-col items-center justify-center h-full text-center">
-                <div className="relative">
-                  <div className="absolute inset-0 animate-pulse rounded-full bg-gradient-to-r from-blue-500 to-purple-600 opacity-20 blur-2xl" />
-                  <div className="relative flex h-20 w-20 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg">
-                    <Bot className="h-10 w-10 text-white" />
-                  </div>
+              <div className="flex flex-col items-center text-center" data-testid="assistant-empty-state">
+                <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-primary/10">
+                  <Bot className="h-7 w-7 text-primary" />
                 </div>
-                <h3 className="mt-6 text-xl font-semibold">Welcome to Your AI Assistant</h3>
-                <p className="mt-2 text-sm text-muted-foreground max-w-md">
-                  I have real-time access to your entire Docker infrastructure. Ask me about containers, stacks, resources, or troubleshooting.
+                <h2 className="mt-4 text-lg font-semibold">Ask about a container, a metric or an anomaly</h2>
+                {/* States the contract rather than claiming one. Six tools, all
+                    read-only — not "real-time access to your entire Docker
+                    infrastructure". */}
+                <p className="mt-2 max-w-md text-sm text-muted-foreground">
+                  It reads containers, metrics, insights, logs and anomalies. It cannot start, stop or change anything.
                 </p>
-                <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 w-full max-w-3xl">
+                <div className="mt-6 grid w-full max-w-2xl grid-cols-1 gap-3 sm:grid-cols-2">
                   {suggestions.map((s, i) => (
                     <button
                       key={i}
                       onClick={() => handleSuggestedQuestionClick(s.prompt)}
                       disabled={isStreaming || isSending}
-                      className="rounded-lg border border-border/50 bg-background/50 px-4 py-3 text-sm text-left hover:bg-accent hover:border-border transition-colors disabled:cursor-not-allowed disabled:opacity-50 flex flex-col gap-1"
+                      className="flex flex-col gap-1 rounded-lg border border-border/50 bg-background/50 px-4 py-3 text-left text-sm transition-colors hover:border-border hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <span className="font-medium text-foreground">{s.label}</span>
-                      <span className="text-xs text-muted-foreground line-clamp-2">{s.description}</span>
+                      {/* The prompt itself, so the result is predictable. */}
+                      <span className="text-xs text-muted-foreground">{s.prompt}</span>
                     </button>
                   ))}
                 </div>
@@ -313,9 +383,7 @@ export default function LlmAssistantPage() {
             {isStreaming && activeToolCalls.length > 0 && !currentResponse && (
               <div className="flex gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300">
                 <div className="flex-shrink-0">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg">
-                    <Bot className="h-5 w-5 text-white" />
-                  </div>
+                  <BotAvatar />
                 </div>
                 <div className="flex-1">
                   <div className="rounded-2xl bg-gradient-to-br from-muted/50 to-muted/30 backdrop-blur-sm p-4 shadow-sm border border-border/50">
@@ -329,9 +397,7 @@ export default function LlmAssistantPage() {
             {isStreaming && currentResponse && (
               <div className="flex gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300">
                 <div className="flex-shrink-0">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg">
-                    <Bot className="h-5 w-5 text-white" />
-                  </div>
+                  <BotAvatar />
                 </div>
                 <div className="flex-1 space-y-3">
                   <div className="rounded-2xl bg-gradient-to-br from-muted/50 to-muted/30 backdrop-blur-sm p-4 shadow-sm border border-border/50">
@@ -346,11 +412,7 @@ export default function LlmAssistantPage() {
                       Stop generating
                     </button>
                     <div className="flex items-center gap-2">
-                      <div className="flex gap-1">
-                        <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce [animation-delay:-0.3s]" />
-                        <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce [animation-delay:-0.15s]" />
-                        <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce" />
-                      </div>
+                      <TypingDots />
                       <span className="text-xs text-muted-foreground">Generating response</span>
                     </div>
                   </div>
@@ -382,7 +444,7 @@ export default function LlmAssistantPage() {
               <button
                 type="submit"
                 disabled={!input.trim() || isStreaming || isSending || !isLlmConnected}
-                className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-blue-600 to-purple-600 px-6 py-3 text-sm font-medium text-white shadow-lg shadow-blue-500/25 transition-all hover:shadow-xl hover:shadow-blue-500/30 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+                className="inline-flex items-center gap-2 rounded-xl bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Send className="h-4 w-4" />
                 Send
@@ -405,6 +467,32 @@ export default function LlmAssistantPage() {
   );
 }
 
+/**
+ * The one assistant mark on this page. There used to be two identical robot
+ * glyphs in purple gradient tiles on the same empty screen — 48px in the
+ * header and 80px in the hero, the latter behind an `animate-pulse` blurred
+ * glow — plus four more copies of the same tile inlined through the message
+ * list. Themed, so it follows all 16 themes instead of assuming a dark one.
+ */
+function BotAvatar() {
+  return (
+    <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-primary/20 bg-primary/10">
+      <Bot className="h-5 w-5 text-primary" />
+    </div>
+  );
+}
+
+/** Three-dot typing rhythm, shared by every "still working" affordance here. */
+function TypingDots() {
+  return (
+    <div className="flex gap-1" aria-hidden>
+      <span className="h-1.5 w-1.5 rounded-full bg-primary animate-bounce [animation-delay:-0.3s]" />
+      <span className="h-1.5 w-1.5 rounded-full bg-primary animate-bounce [animation-delay:-0.15s]" />
+      <span className="h-1.5 w-1.5 rounded-full bg-primary animate-bounce" />
+    </div>
+  );
+}
+
 function ThinkingIndicator({ statusMessage, onCancel }: { statusMessage: string | null; onCancel: () => void }) {
   const [elapsed, setElapsed] = useState(0);
 
@@ -419,14 +507,12 @@ function ThinkingIndicator({ statusMessage, onCancel }: { statusMessage: string 
   return (
     <div className="flex gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300" data-testid="thinking-indicator">
       <div className="flex-shrink-0">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg">
-          <Bot className="h-5 w-5 text-white" />
-        </div>
+        <BotAvatar />
       </div>
       <div className="flex-1 space-y-2">
         <div className="rounded-2xl bg-gradient-to-br from-muted/50 to-muted/30 backdrop-blur-sm p-4 shadow-sm border border-border/50">
           <div className="flex items-center gap-3">
-            <Loader2 className="h-4 w-4 text-blue-500 animate-spin" />
+            <Loader2 className="h-4 w-4 text-primary animate-spin" />
             <ShimmerText className="text-[13px]">{displayStatus}</ShimmerText>
             <span className="text-xs text-muted-foreground tabular-nums ml-auto">{elapsed}s</span>
           </div>
@@ -441,7 +527,7 @@ function ThinkingIndicator({ statusMessage, onCancel }: { statusMessage: string 
           className="inline-flex items-center gap-1.5 rounded-lg bg-destructive/10 border border-destructive/20 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/20 transition-colors"
         >
           <X className="h-3 w-3" />
-          Cancel
+          Stop generating
         </button>
       </div>
     </div>
@@ -485,17 +571,13 @@ const MessageBubble = memo(function MessageBubble({ message, userQuery }: Messag
   return (
     <div className={`flex gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300 ${isUser ? 'flex-row-reverse' : ''}`}>
       <div className="flex-shrink-0">
-        <div className={`flex h-10 w-10 items-center justify-center rounded-xl shadow-lg ${
-          isUser
-            ? 'bg-gradient-to-br from-emerald-500 to-teal-600'
-            : 'bg-gradient-to-br from-blue-500 to-purple-600'
-        }`}>
-          {isUser ? (
-            <User className="h-5 w-5 text-white" />
-          ) : (
-            <Bot className="h-5 w-5 text-white" />
-          )}
-        </div>
+        {isUser ? (
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-muted">
+            <User className="h-5 w-5 text-muted-foreground" />
+          </div>
+        ) : (
+          <BotAvatar />
+        )}
       </div>
       <div className={`flex-1 space-y-2 ${isUser ? 'max-w-[80%]' : ''}`}>
         {toolsUsed.length > 0 && (
@@ -513,7 +595,7 @@ const MessageBubble = memo(function MessageBubble({ message, userQuery }: Messag
         )}
         <div className={`rounded-2xl p-4 shadow-sm ${
           isUser
-            ? 'bg-gradient-to-br from-emerald-500 to-teal-600 text-white ml-auto border border-emerald-400/20'
+            ? 'bg-muted/60 text-foreground ml-auto border border-border'
             : 'bg-gradient-to-br from-muted/50 to-muted/30 backdrop-blur-sm border border-border/50'
         }`}>
           {isUser ? (
@@ -548,11 +630,7 @@ function ToolCallIndicator({ events }: { events: ToolCallEvent[] }) {
         <div key={i} className="flex items-center gap-2">
           {event.status === 'executing' ? (
             <>
-              <div className="flex gap-1">
-                <span className="h-1.5 w-1.5 rounded-full bg-purple-500 animate-bounce [animation-delay:-0.3s]" />
-                <span className="h-1.5 w-1.5 rounded-full bg-purple-500 animate-bounce [animation-delay:-0.15s]" />
-                <span className="h-1.5 w-1.5 rounded-full bg-purple-500 animate-bounce" />
-              </div>
+              <TypingDots />
               <Wrench className="h-3.5 w-3.5 text-purple-500" />
               <span className="text-[13px] text-muted-foreground">
                 {event.tools.map(t => TOOL_DISPLAY_NAMES[t] || t).join(', ')}...
@@ -574,11 +652,7 @@ function ToolCallIndicator({ events }: { events: ToolCallEvent[] }) {
       ))}
       {events.length > 0 && events[events.length - 1].status === 'complete' && (
         <div className="flex items-center gap-2 mt-1">
-          <div className="flex gap-1">
-            <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce [animation-delay:-0.3s]" />
-            <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce [animation-delay:-0.15s]" />
-            <span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-bounce" />
-          </div>
+          <TypingDots />
           <span className="text-[13px] text-muted-foreground">Generating response with results...</span>
         </div>
       )}
@@ -636,7 +710,7 @@ const MARKDOWN_COMPONENTS: Components = {
   ol: ({ children }) => <ol className="space-y-0.5 my-2">{children}</ol>,
   li: ({ children }) => <li className="leading-relaxed text-[13px]">{children}</li>,
   blockquote: ({ children }) => (
-    <blockquote className="border-l-4 border-blue-500 bg-blue-500/5 pl-4 py-2 my-2 italic text-[13px]">
+    <blockquote className="border-l-4 border-primary bg-primary/5 pl-4 py-2 my-2 italic text-[13px]">
       {children}
     </blockquote>
   ),
@@ -686,7 +760,7 @@ const MarkdownContent = memo(function MarkdownContent({ content }: { content: st
   const normalizedContent = normalizeMarkdown(content);
 
   return (
-    <div className="prose prose-sm dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-h1:text-lg prose-h2:text-base prose-h3:text-sm prose-p:text-[13px] prose-p:leading-relaxed prose-pre:bg-zinc-900 prose-pre:shadow-lg prose-code:text-blue-600 dark:prose-code:text-blue-400 prose-li:text-[13px] prose-td:text-[13px] prose-th:text-xs">
+    <div className="prose prose-sm dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-h1:text-lg prose-h2:text-base prose-h3:text-sm prose-p:text-[13px] prose-p:leading-relaxed prose-pre:bg-zinc-900 prose-pre:shadow-lg prose-code:text-primary prose-li:text-[13px] prose-td:text-[13px] prose-th:text-xs">
       <ReactMarkdown
         remarkPlugins={REMARK_PLUGINS}
         rehypePlugins={REHYPE_PLUGINS}
@@ -709,6 +783,18 @@ function extractText(node: React.ReactNode): string {
   return '';
 }
 
+/**
+ * Deliberately the one surface on this page that does NOT follow the theme.
+ *
+ * `highlight.js/styles/github-dark.css` is imported globally at the top of
+ * this file and styles `.hljs` itself with a near-black background and token
+ * colours tuned for it (`#79c0ff` on white is ~1.9:1). Swapping this chrome to
+ * `bg-muted` would put a light frame around a block that keeps painting itself
+ * dark from inside — strictly worse than the current, self-consistent dark
+ * code surface. Making it theme-aware means shipping a light/dark pair of
+ * highlight.js stylesheets scoped by theme class in `index.css`, which is a
+ * global-stylesheet change, not a class swap here.
+ */
 function CodeBlock({ plainText, language, children }: { plainText: string; language?: string; children: React.ReactNode }) {
   const [copied, setCopied] = useState(false);
 
@@ -729,7 +815,7 @@ function CodeBlock({ plainText, language, children }: { plainText: string; langu
           {copied ? (
             <>
               <Check className="h-3 w-3" />
-              Copied!
+              Copied
             </>
           ) : (
             <>

--- a/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeAll } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -33,6 +33,12 @@ const mockStats = {
   ],
 };
 
+function isoMinutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60 * 1000).toISOString();
+}
+
+// Timestamps are relative to now: the page narrows the newest-50 traces to the
+// selected range, so fixed calendar dates would fall out of every window.
 const mockTraces = [
   {
     id: 1,
@@ -46,7 +52,7 @@ const mockTraces = [
     status: 'success',
     user_query: 'What containers are using the most memory?',
     response_preview: 'Based on the metrics...',
-    created_at: '2025-01-15 10:30:00',
+    created_at: isoMinutesAgo(10),
   },
   {
     id: 2,
@@ -60,7 +66,7 @@ const mockTraces = [
     status: 'error',
     user_query: 'Show CPU anomalies',
     response_preview: null,
-    created_at: '2025-01-15 10:25:00',
+    created_at: isoMinutesAgo(200),
   },
 ];
 
@@ -71,11 +77,12 @@ vi.mock('@/features/ai-intelligence/hooks/use-llm-observability', () => ({
 }));
 
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: vi.fn().mockReturnValue({ interval: 0, setInterval: vi.fn() }),
+  useAutoRefresh: vi.fn().mockReturnValue({ interval: 0, setRefreshInterval: vi.fn(), setInterval: vi.fn() }),
 }));
 
 import { useLlmTraces, useLlmStats } from '@/features/ai-intelligence/hooks/use-llm-observability';
-import LlmObservabilityPage from './llm-observability';
+import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
+import LlmObservabilityPage, { tracesWithinWindow } from './llm-observability';
 
 function renderPage() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -88,27 +95,57 @@ function renderPage() {
   );
 }
 
+function withStats(stats: unknown) {
+  vi.mocked(useLlmStats).mockReturnValue({
+    data: stats,
+    isLoading: false,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useLlmStats>);
+}
+
+function withTraces(traces: unknown[]) {
+  vi.mocked(useLlmTraces).mockReturnValue({
+    data: traces,
+    isLoading: false,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useLlmTraces>);
+}
+
+// Every test starts from the same hook state — the file previously relied on
+// mockReturnValue leaking between tests in declaration order.
+beforeEach(() => {
+  withStats(null);
+  withTraces([]);
+  vi.mocked(useAutoRefresh).mockReturnValue({
+    interval: 0,
+    setRefreshInterval: vi.fn(),
+    setInterval: vi.fn(),
+  } as unknown as ReturnType<typeof useAutoRefresh>);
+});
+
 describe('LlmObservabilityPage', () => {
-  it('renders the page title and subtitle', () => {
+  it('renders the page title through the shared PageHeader', () => {
     renderPage();
-    expect(screen.getByText('LLM Observability')).toBeTruthy();
-    expect(screen.getByText('Monitor LLM usage and performance')).toBeTruthy();
+    const header = screen.getByTestId('page-header');
+    expect(within(header).getByRole('heading', { level: 1 }).textContent).toBe('LLM Observability');
   });
 
-  it('shows empty state when no traces exist', () => {
+  // "Monitor LLM usage and performance" is the title as a verb phrase: delete
+  // it and the operator loses nothing, so it is gone.
+  it('carries no restated subtitle', () => {
     renderPage();
-    expect(screen.getByText('No LLM traces yet')).toBeTruthy();
-    expect(
-      screen.getByText('LLM interactions will appear here once the assistant is used.')
-    ).toBeTruthy();
+    expect(screen.queryByText('Monitor LLM usage and performance')).toBeNull();
+    expect(screen.queryByTestId('page-header-subtitle')).toBeNull();
+  });
+
+  it('shows a range-scoped empty state when no traces exist', () => {
+    renderPage();
+    expect(screen.getByText('No LLM calls in the last 24h')).toBeTruthy();
+    expect(screen.queryByText('No LLM traces yet')).toBeNull();
   });
 
   it('renders KPI cards with stats data', () => {
-    vi.mocked(useLlmStats).mockReturnValue({
-      data: mockStats,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmStats>);
+    withStats(mockStats);
 
     renderPage();
     expect(screen.getByText('Total Queries')).toBeTruthy();
@@ -118,11 +155,7 @@ describe('LlmObservabilityPage', () => {
   });
 
   it('spaces the KPI cards with a gap-6 grid', () => {
-    vi.mocked(useLlmStats).mockReturnValue({
-      data: mockStats,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmStats>);
+    withStats(mockStats);
 
     const { container } = renderPage();
     // The KPI grid wraps the four metric cards; it must use the wider gap-6
@@ -150,11 +183,7 @@ describe('LlmObservabilityPage', () => {
   });
 
   it('renders model breakdown table with data', () => {
-    vi.mocked(useLlmStats).mockReturnValue({
-      data: mockStats,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmStats>);
+    withStats(mockStats);
 
     renderPage();
     expect(screen.getByText('Model Breakdown')).toBeTruthy();
@@ -165,47 +194,34 @@ describe('LlmObservabilityPage', () => {
   });
 
   it('does not render feedback summary card', () => {
-    vi.mocked(useLlmStats).mockReturnValue({
-      data: mockStats,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmStats>);
+    withStats(mockStats);
 
     renderPage();
     expect(screen.queryByText('Feedback Summary')).toBeNull();
   });
 
-  it('renders when stats payload is missing model breakdown', () => {
-    vi.mocked(useLlmStats).mockReturnValue({
-      data: {
-        totalQueries: 10,
-        totalTokens: 1200,
-        avgLatencyMs: 700,
-        errorRate: 0,
-        avgFeedbackScore: null,
-        feedbackCount: 0,
-      } as unknown as ReturnType<typeof useLlmStats>['data'],
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmStats>);
+  // Was a bare <p>No model data available.</p> — the only one of the page's
+  // three empty states that bypassed the shared primitive.
+  it('uses the shared EmptyState, naming the range, when no model data exists', () => {
+    withStats({
+      totalQueries: 10,
+      totalTokens: 1200,
+      avgLatencyMs: 700,
+      errorRate: 0,
+      avgFeedbackScore: null,
+      feedbackCount: 0,
+    });
 
     renderPage();
     expect(screen.getByText('Model Breakdown')).toBeTruthy();
-    expect(screen.getByText('No model data available.')).toBeTruthy();
+    expect(screen.queryByText('No model data available.')).toBeNull();
+    expect(screen.getByText('No model recorded in the last 24h')).toBeTruthy();
+    expect(screen.getAllByTestId('empty-state-card').length).toBeGreaterThan(0);
   });
 
-
   it('renders traces table with data', () => {
-    vi.mocked(useLlmStats).mockReturnValue({
-      data: mockStats,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmStats>);
-    vi.mocked(useLlmTraces).mockReturnValue({
-      data: mockTraces,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmTraces>);
+    withStats(mockStats);
+    withTraces(mockTraces);
 
     renderPage();
     expect(screen.getByText('What containers are using the most memory?')).toBeTruthy();
@@ -215,16 +231,8 @@ describe('LlmObservabilityPage', () => {
   });
 
   it('renders both shared DataTables when stats and traces have data', () => {
-    vi.mocked(useLlmStats).mockReturnValue({
-      data: mockStats,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmStats>);
-    vi.mocked(useLlmTraces).mockReturnValue({
-      data: mockTraces,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmTraces>);
+    withStats(mockStats);
+    withTraces(mockTraces);
 
     renderPage();
     // Three shared DataTables on this page: Model Breakdown + Recent Traces (this
@@ -236,11 +244,7 @@ describe('LlmObservabilityPage', () => {
   });
 
   it('blurs query column by default and reveals on toggle', () => {
-    vi.mocked(useLlmTraces).mockReturnValue({
-      data: mockTraces,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as ReturnType<typeof useLlmTraces>);
+    withTraces(mockTraces);
 
     renderPage();
     const queryCell = screen.getByText('What containers are using the most memory?');
@@ -271,5 +275,141 @@ describe('LlmObservabilityPage', () => {
     const { container } = renderPage();
     const skeletons = container.querySelectorAll('[role="status"]');
     expect(skeletons.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Design-critique fixes: the range selector drove half the page silently, the
+// refresh dropdown scheduled nothing, and four tiles rendered a confident
+// "Error Rate 0.0%" over zero calls.
+// ---------------------------------------------------------------------------
+
+describe('tracesWithinWindow', () => {
+  it('drops traces older than the window', () => {
+    const rows = [
+      { created_at: isoMinutesAgo(10) },
+      { created_at: isoMinutesAgo(200) },
+    ] as Parameters<typeof tracesWithinWindow>[0];
+    expect(tracesWithinWindow(rows, 1)).toHaveLength(1);
+    expect(tracesWithinWindow(rows, 24)).toHaveLength(2);
+  });
+
+  it('keeps rows whose timestamp cannot be parsed rather than hiding a real call', () => {
+    const rows = [{ created_at: 'not-a-date' }] as Parameters<typeof tracesWithinWindow>[0];
+    expect(tracesWithinWindow(rows, 1)).toHaveLength(1);
+  });
+});
+
+describe('time range drives the whole page', () => {
+  it('narrows the traces table when the range shrinks to 1h', () => {
+    withStats(mockStats);
+    withTraces(mockTraces);
+
+    renderPage();
+    // Both rows visible at the default 24h.
+    expect(screen.getByText('Show CPU anomalies')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: '1h' }));
+
+    // The 200-minute-old trace is outside the 1h window.
+    expect(screen.queryByText('Show CPU anomalies')).toBeNull();
+    expect(screen.getByText('What containers are using the most memory?')).toBeTruthy();
+  });
+
+  it('states the trace cap and the window next to the section heading', () => {
+    withStats(mockStats);
+    withTraces(mockTraces);
+
+    renderPage();
+    expect(screen.getByText('up to 50 newest, last 24h')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: '6h' }));
+    expect(screen.getByText('up to 50 newest, last 6h')).toBeTruthy();
+  });
+
+  it('passes the selected window down to the latency breakdown', () => {
+    withStats(mockStats);
+
+    renderPage();
+    expect(screen.getByText(/per upstream provider, last 24h\./)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: '7d' }));
+    expect(screen.getByText(/per upstream provider, last 7d\./)).toBeTruthy();
+  });
+});
+
+describe('auto-refresh control', () => {
+  it('hands the hook an onTick so the interval actually schedules a fetch', () => {
+    renderPage();
+    const call = vi.mocked(useAutoRefresh).mock.calls[0];
+    expect(call[0]).toBe(30);
+    expect(typeof call[1]?.onTick).toBe('function');
+  });
+
+  it('refetches stats and traces when the tick fires', () => {
+    const refetchStats = vi.fn();
+    const refetchTraces = vi.fn();
+    vi.mocked(useLlmStats).mockReturnValue({
+      data: mockStats,
+      isLoading: false,
+      refetch: refetchStats,
+    } as unknown as ReturnType<typeof useLlmStats>);
+    vi.mocked(useLlmTraces).mockReturnValue({
+      data: mockTraces,
+      isLoading: false,
+      refetch: refetchTraces,
+    } as unknown as ReturnType<typeof useLlmTraces>);
+
+    renderPage();
+    const onTick = vi.mocked(useAutoRefresh).mock.calls[0][1]?.onTick;
+    onTick?.();
+
+    expect(refetchStats).toHaveBeenCalled();
+    expect(refetchTraces).toHaveBeenCalled();
+  });
+});
+
+describe('zero-traffic state', () => {
+  it('collapses the four tiles to one line with a link to the assistant', () => {
+    withStats({
+      totalQueries: 0,
+      totalTokens: 0,
+      avgLatencyMs: 0,
+      errorRate: 0,
+      avgFeedbackScore: null,
+      feedbackCount: 0,
+      modelBreakdown: [],
+    });
+
+    renderPage();
+    // "Error Rate 0.0%" over zero calls is undefined, not 0%.
+    expect(screen.queryByText('Error Rate')).toBeNull();
+    expect(screen.queryByText('0.0%')).toBeNull();
+
+    const line = screen.getByTestId('llm-no-traffic');
+    expect(line.textContent).toContain('No LLM calls in the last 24h');
+    expect(within(line).getByRole('link', { name: 'Assistant' })).toHaveAttribute('href', '/assistant');
+  });
+
+  it('still renders the tiles once there is traffic', () => {
+    withStats(mockStats);
+
+    renderPage();
+    expect(screen.queryByTestId('llm-no-traffic')).toBeNull();
+    expect(screen.getByText('Error Rate')).toBeTruthy();
+  });
+});
+
+describe('error rate tile', () => {
+  it('does not put a downward trend arrow on a rising error rate', () => {
+    withStats({ ...mockStats, errorRate: 0.12 });
+
+    const { container } = renderPage();
+    expect(screen.getByText('12.0%')).toBeTruthy();
+    // The old tile rendered trend="down" — a green/red arrow whose direction
+    // reads as "improving" on the one metric where down is good.
+    expect(screen.queryByText('Above 5%')).toBeNull();
+    expect(container.querySelector('.lucide-trending-down')).toBeNull();
+    expect(screen.getByText(/above the 5% error threshold/i)).toBeTruthy();
   });
 });

--- a/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
@@ -1,12 +1,15 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { type ColumnDef } from '@tanstack/react-table';
-import { LlmLatencyBreakdown } from '@/features/ai-intelligence/components/llm-latency-breakdown';
+import { LlmLatencyBreakdown, formatWindowLabel } from '@/features/ai-intelligence/components/llm-latency-breakdown';
 import { useLlmTraces, useLlmStats, type LlmTrace } from '@/features/ai-intelligence/hooks/use-llm-observability';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { RefreshControls } from '@/shared/components/ui/refresh-controls';
+import { PageHeader } from '@/shared/components/layout/page-header';
+import { DataFreshness } from '@/shared/components/feedback/data-freshness';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
-import { TiltCard } from '@/shared/components/data-display/tilt-card';
 import { DataTable } from '@/shared/components/tables/data-table';
 import { SkeletonKpi, SkeletonList } from '@/shared/components/feedback/skeleton';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
@@ -32,12 +35,25 @@ const TIME_RANGES: { label: string; value: TimeRange }[] = [
   { label: '7d', value: 168 },
 ];
 
+/** Newest `limit` traces the API returned, narrowed to the selected window. */
+export function tracesWithinWindow(traces: LlmTrace[], hours: number): LlmTrace[] {
+  const cutoff = Date.now() - hours * 60 * 60 * 1000;
+  return traces.filter((trace) => {
+    const at = Date.parse(trace.created_at);
+    // An unparseable timestamp is not evidence the row is out of range, so
+    // keep it rather than silently hiding a call that did happen.
+    return Number.isNaN(at) ? true : at >= cutoff;
+  });
+}
+
 function StatusBadge({ status }: { status: string }) {
   const isSuccess = status === 'success';
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+        // `capitalize` because the API's raw lowercase value sits inches from
+        // Title Case column headers and badges everywhere else on the page.
+        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize',
         isSuccess
           ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
           : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
@@ -48,7 +64,17 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-function TracesTable({ traces, isLoading, privacyMode }: { traces: LlmTrace[]; isLoading: boolean; privacyMode: boolean }) {
+function TracesTable({
+  traces,
+  isLoading,
+  privacyMode,
+  windowLabel,
+}: {
+  traces: LlmTrace[];
+  isLoading: boolean;
+  privacyMode: boolean;
+  windowLabel: string;
+}) {
   const columns = useMemo<ColumnDef<LlmTrace, unknown>[]>(() => [
     {
       accessorKey: 'created_at',
@@ -115,8 +141,8 @@ function TracesTable({ traces, isLoading, privacyMode }: { traces: LlmTrace[]; i
     return (
       <EmptyState
         icon={MessageSquare}
-        title="No LLM traces yet"
-        description="LLM interactions will appear here once the assistant is used."
+        title={`No LLM calls in the ${windowLabel}`}
+        description="Every question asked in Assistant is recorded here with its model, token count and latency."
       />
     );
   }
@@ -183,13 +209,46 @@ function ModelBreakdownTable({
   return <DataTable columns={columns} data={modelBreakdown} hideSearch getRowId={(model) => model.model} />;
 }
 
+/** Traces are fetched newest-first with this cap; the window narrows them. */
+const TRACE_LIMIT = 50;
+
 export default function LlmObservabilityPage() {
   const [timeRange, setTimeRange] = useState<TimeRange>(24);
   const [privacyMode, setPrivacyMode] = useState(true);
-  const { interval, setInterval } = useAutoRefresh(30);
+  const queryClient = useQueryClient();
 
-  const { data: stats, isLoading: statsLoading, isPending: statsPending, refetch: refetchStats } = useLlmStats(timeRange);
-  const { data: traces, isLoading: tracesLoading, isPending: tracesPending, refetch: refetchTraces } = useLlmTraces(50);
+  const {
+    data: stats,
+    isLoading: statsLoading,
+    isPending: statsPending,
+    dataUpdatedAt: statsUpdatedAt,
+    refetch: refetchStats,
+  } = useLlmStats(timeRange);
+  const {
+    data: traces,
+    isLoading: tracesLoading,
+    isPending: tracesPending,
+    dataUpdatedAt: tracesUpdatedAt,
+    refetch: refetchTraces,
+  } = useLlmTraces(TRACE_LIMIT);
+
+  const handleRefresh = useCallback(() => {
+    refetchStats();
+    refetchTraces();
+    // The latency panel owns its own per-peer fan-out, so a page refresh has
+    // to reach it explicitly or the "Every 30s" control would be honest about
+    // two of the page's three sections.
+    queryClient.invalidateQueries({ queryKey: ['llm-latency-breakdown'] });
+  }, [refetchStats, refetchTraces, queryClient]);
+
+  // The hook owns the timer. Before `onTick` the dropdown set state and
+  // scheduled nothing, so this page rendered a pulsing "live" dot over a
+  // control that refreshed exactly nothing.
+  const { interval, setRefreshInterval } = useAutoRefresh(30, {
+    onTick: handleRefresh,
+    storageKey: 'llm-observability',
+  });
+
   // Treat both isLoading and isPending-without-data as "loading" to avoid
   // rendering a blank page during SPA navigation before data arrives.
   const showStatsSkeleton = statsLoading || (statsPending && !stats);
@@ -198,59 +257,69 @@ export default function LlmObservabilityPage() {
   const totalModelQueries = modelBreakdown.reduce((sum, model) => sum + model.count, 0);
   const maxModelQueries = modelBreakdown.reduce((max, model) => Math.max(max, model.count), 0);
 
-  const handleRefresh = () => {
-    refetchStats();
-    refetchTraces();
-  };
+  const windowLabel = formatWindowLabel(timeRange);
+
+  // "Recent Traces" was a fixed newest-50 whatever the range selector said.
+  const visibleTraces = useMemo(
+    () => tracesWithinWindow(traces ?? [], timeRange),
+    [traces, timeRange],
+  );
+
+  const lastUpdated = Math.max(statsUpdatedAt ?? 0, tracesUpdatedAt ?? 0) || null;
+  const hasQueries = (stats?.totalQueries ?? 0) > 0;
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">LLM Observability</h1>
-          <p className="text-muted-foreground">
-            Monitor LLM usage and performance
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {/* Time Range Selector */}
-          <div className="flex items-center rounded-md border border-input bg-background">
-            {TIME_RANGES.map((range) => (
-              <button
-                key={range.value}
-                onClick={() => setTimeRange(range.value)}
-                className={cn(
-                  'px-3 py-1.5 text-sm font-medium transition-colors',
-                  timeRange === range.value
-                    ? 'bg-primary text-primary-foreground'
-                    : 'text-muted-foreground hover:text-foreground',
-                  range.value === 1 && 'rounded-l-md',
-                  range.value === 168 && 'rounded-r-md'
-                )}
-              >
-                {range.label}
-              </button>
-            ))}
-          </div>
-          <button
-            onClick={() => setPrivacyMode(!privacyMode)}
-            className={cn(
-              'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
-              privacyMode
-                ? 'border-primary/50 bg-primary/10 text-primary'
-                : 'border-input bg-background text-muted-foreground hover:text-foreground'
-            )}
-            title={privacyMode ? 'Queries are blurred — click to reveal' : 'Queries are visible — click to blur'}
-          >
-            {privacyMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-            Privacy
-          </button>
-          <RefreshControls interval={interval} onIntervalChange={setInterval} onRefresh={handleRefresh} />
-        </div>
-      </div>
+      <PageHeader
+        title="LLM Observability"
+        actions={
+          <>
+            {/* Time Range Selector */}
+            <div className="flex items-center rounded-md border border-input bg-background">
+              {TIME_RANGES.map((range) => (
+                <button
+                  key={range.value}
+                  onClick={() => setTimeRange(range.value)}
+                  aria-pressed={timeRange === range.value}
+                  className={cn(
+                    'px-3 py-1.5 text-sm font-medium transition-colors',
+                    timeRange === range.value
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:text-foreground',
+                    range.value === 1 && 'rounded-l-md',
+                    range.value === 168 && 'rounded-r-md'
+                  )}
+                >
+                  {range.label}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => setPrivacyMode(!privacyMode)}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
+                privacyMode
+                  ? 'border-primary/50 bg-primary/10 text-primary'
+                  : 'border-input bg-background text-muted-foreground hover:text-foreground'
+              )}
+              title={privacyMode ? 'Queries are blurred — click to reveal' : 'Queries are visible — click to blur'}
+            >
+              {privacyMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              Privacy
+            </button>
+            <DataFreshness lastUpdated={lastUpdated} onRefresh={handleRefresh} />
+            <RefreshControls
+              interval={interval}
+              onIntervalChange={setRefreshInterval}
+              onRefresh={handleRefresh}
+            />
+          </>
+        }
+      />
 
-      {/* KPI Cards */}
+      {/* KPI Cards. Four tiles over zero traffic are four zeroes, and an
+          "Error Rate 0.0%" computed from no calls is not 0% — it is undefined.
+          With no queries in the window we say so in one line instead. */}
       {showStatsSkeleton ? (
         <div className="grid gap-6 md:grid-cols-4">
           <SkeletonKpi />
@@ -258,38 +327,46 @@ export default function LlmObservabilityPage() {
           <SkeletonKpi />
           <SkeletonKpi />
         </div>
-      ) : (
+      ) : hasQueries ? (
         <div className="grid gap-6 md:grid-cols-4">
-          <TiltCard>
-            <KpiCard
-              label="Total Queries"
-              value={stats?.totalQueries ?? 0}
-              icon={<MessageSquare className="h-5 w-5" />}
-            />
-          </TiltCard>
-          <TiltCard>
-            <KpiCard
-              label="Total Tokens"
-              value={stats?.totalTokens ?? 0}
-              icon={<Hash className="h-5 w-5" />}
-            />
-          </TiltCard>
-          <TiltCard>
-            <KpiCard
-              label="Avg Latency"
-              value={`${Math.round(stats?.avgLatencyMs ?? 0)}ms`}
-              icon={<Zap className="h-5 w-5" />}
-            />
-          </TiltCard>
-          <TiltCard>
-            <KpiCard
-              label="Error Rate"
-              value={`${((stats?.errorRate ?? 0) * 100).toFixed(1)}%`}
-              icon={<AlertTriangle className="h-5 w-5" />}
-              trend={(stats?.errorRate ?? 0) > 0.05 ? 'down' : undefined}
-              trendValue={(stats?.errorRate ?? 0) > 0.05 ? 'Above 5%' : undefined}
-            />
-          </TiltCard>
+          <KpiCard
+            label="Total Queries"
+            value={stats?.totalQueries ?? 0}
+            icon={<MessageSquare className="h-5 w-5" />}
+          />
+          <KpiCard
+            label="Total Tokens"
+            value={stats?.totalTokens ?? 0}
+            icon={<Hash className="h-5 w-5" />}
+          />
+          <KpiCard
+            label="Avg Latency"
+            value={`${Math.round(stats?.avgLatencyMs ?? 0)}ms`}
+            icon={<Zap className="h-5 w-5" />}
+          />
+          <KpiCard
+            label="Error Rate"
+            value={`${((stats?.errorRate ?? 0) * 100).toFixed(1)}%`}
+            icon={<AlertTriangle className="h-5 w-5" />}
+            // No trend arrow: a down arrow on a rising error rate reads as an
+            // improvement, and there is no direction in this payload anyway.
+            hoverDetail={
+              (stats?.errorRate ?? 0) > 0.05
+                ? `${stats?.totalQueries ?? 0} calls, above the 5% error threshold`
+                : undefined
+            }
+          />
+        </div>
+      ) : (
+        <div
+          data-testid="llm-no-traffic"
+          className="rounded-lg border bg-card p-4 text-sm text-muted-foreground shadow-sm"
+        >
+          No LLM calls in the {windowLabel}. Ask something in{' '}
+          <Link to="/assistant" className="font-medium text-primary underline-offset-4 hover:underline">
+            Assistant
+          </Link>{' '}
+          and its model, tokens and latency land here.
         </div>
       )}
 
@@ -299,7 +376,11 @@ export default function LlmObservabilityPage() {
         <div className="rounded-lg border bg-card p-6 shadow-sm">
           <h2 className="text-lg font-semibold mb-4">Model Breakdown</h2>
           {modelBreakdown.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No model data available.</p>
+            <EmptyState
+              icon={Hash}
+              title={`No model recorded in the ${windowLabel}`}
+              description="Each call is attributed to the model that served it; the split appears once calls are made."
+            />
           ) : (
             <ModelBreakdownTable
               modelBreakdown={modelBreakdown}
@@ -314,18 +395,28 @@ export default function LlmObservabilityPage() {
       {/* LLM Latency Breakdown (#1239) — Network vs Model split per provider */}
       <SpotlightCard>
       <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <LlmLatencyBreakdown />
+        <LlmLatencyBreakdown hours={timeRange} />
       </div>
       </SpotlightCard>
 
       {/* Recent Traces */}
       <SpotlightCard>
       <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <div className="flex items-center gap-2 mb-4">
+        <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1">
           <Activity className="h-5 w-5 text-primary" />
           <h2 className="text-lg font-semibold">Recent Traces</h2>
+          {/* The cap is part of what the operator is looking at, so it is on
+              screen rather than buried in the request. */}
+          <span className="text-xs text-muted-foreground">
+            up to {TRACE_LIMIT} newest, {windowLabel}
+          </span>
         </div>
-        <TracesTable traces={traces ?? []} isLoading={showTracesSkeleton} privacyMode={privacyMode} />
+        <TracesTable
+          traces={visibleTraces}
+          isLoading={showTracesSkeleton}
+          privacyMode={privacyMode}
+          windowLabel={windowLabel}
+        />
       </div>
       </SpotlightCard>
     </div>

--- a/frontend/src/features/containers/components/container-traces-tab.test.tsx
+++ b/frontend/src/features/containers/components/container-traces-tab.test.tsx
@@ -26,7 +26,7 @@ vi.mock('recharts', async (importOriginal) => {
 
 import { useRed } from '@/features/observability/hooks/use-red';
 import { useTraces } from '@/features/observability/hooks/use-traces';
-import { ContainerTracesTab } from './container-traces-tab';
+import { ContainerTracesTab, LATENCY_SERIES } from './container-traces-tab';
 
 const mockUseRed = vi.mocked(useRed);
 const mockUseTraces = vi.mocked(useTraces);
@@ -61,7 +61,7 @@ describe('ContainerTracesTab', () => {
     expect(screen.getByTestId('no-trace-data-callout')).toBeInTheDocument();
   });
 
-  it('renders the four panels when RED data is present', () => {
+  it('renders the three panels when RED data is present', () => {
     mockUseRed.mockReturnValue({
       data: {
         buckets: [
@@ -88,8 +88,11 @@ describe('ContainerTracesTab', () => {
     renderTab();
 
     expect(screen.getByText(/RED summary/i)).toBeInTheDocument();
-    expect(screen.getByText(/Top outgoing calls/i)).toBeInTheDocument();
-    expect(screen.getByText(/Top incoming calls/i)).toBeInTheDocument();
+    expect(screen.getByText(/Slowest calls \(last 1h\)/i)).toBeInTheDocument();
+    // The two direction-labelled panels issued identical queries and rendered
+    // identical rows; one honest panel replaces them.
+    expect(screen.queryByText(/Top outgoing calls/i)).toBeNull();
+    expect(screen.queryByText(/Top incoming calls/i)).toBeNull();
     expect(screen.getByText(/Latency.*timeline|sparkline|over time/i)).toBeInTheDocument();
     // Rate shown
     expect(screen.getByText(/1\.50.*\/s/)).toBeInTheDocument();
@@ -115,20 +118,19 @@ describe('ContainerTracesTab', () => {
     }
   });
 
-  it('fetches outgoing and incoming traces filtered by container name', () => {
+  it('issues one traces query, filtered by container name', () => {
     mockUseRed.mockReturnValue({ data: { buckets: [], truncated: false } } as any);
     mockUseTraces.mockReturnValue({ data: [] } as any);
 
     renderTab('api-2');
 
     const calls = mockUseTraces.mock.calls.map(([opts]) => opts);
-    // Should have both a client (outgoing) and server (incoming) call.
-    const outgoing = calls.find((c) => c?.containerName === 'api-2');
-    expect(outgoing).toBeDefined();
-    expect(calls.length).toBeGreaterThanOrEqual(2);
+    // The second, identical query backed a panel that duplicated the first.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.containerName).toBe('api-2');
   });
 
-  it('renders top outgoing/incoming rows with deep links to /traces?trace=…', () => {
+  it('renders call rows with deep links to /traces?trace=…', () => {
     mockUseRed.mockReturnValue({
       data: {
         buckets: [
@@ -164,5 +166,17 @@ describe('ContainerTracesTab', () => {
 
     const link = screen.getAllByRole('link', { name: /GET \/foo/i })[0];
     expect(link.getAttribute('href')).toMatch(/\/traces\?.*trace=t1/);
+  });
+
+  it('draws the latency series with theme tokens, not hardcoded hex', () => {
+    // Recharts lays out nothing in jsdom (zero-size container), so assert the
+    // shipped series definition the chart renders from.
+    expect(LATENCY_SERIES.map((s) => s.dataKey)).toEqual(['p50', 'p95', 'errorRate']);
+    for (const series of LATENCY_SERIES) {
+      expect(series.stroke).toMatch(/^var\(--color-/);
+    }
+    // p95 must not borrow purple, which is reserved for AI insight.
+    expect(LATENCY_SERIES.find((s) => s.dataKey === 'p95')?.stroke).toBe('var(--color-chart-2)');
+    expect(LATENCY_SERIES.find((s) => s.dataKey === 'errorRate')?.stroke).toBe('var(--color-destructive)');
   });
 });

--- a/frontend/src/features/containers/components/container-traces-tab.tsx
+++ b/frontend/src/features/containers/components/container-traces-tab.tsx
@@ -18,6 +18,20 @@ interface ContainerTracesTabProps {
   endpointId: number;
 }
 
+/**
+ * The latency/error series, as theme tokens.
+ *
+ * These were hardcoded hex (`#3b82f6`, `#8b5cf6`, `#ef4444`), which assumes one
+ * background; the app ships 16 themes, 8 of them light. Purple is reserved for
+ * AI insight, so p95 takes a chart colour rather than violet, and only the
+ * error series keeps a status colour.
+ */
+export const LATENCY_SERIES = [
+  { dataKey: 'p50', yAxisId: 'left', stroke: 'var(--color-chart-1)' },
+  { dataKey: 'p95', yAxisId: 'left', stroke: 'var(--color-chart-2)' },
+  { dataKey: 'errorRate', yAxisId: 'right', stroke: 'var(--color-destructive)' },
+] as const;
+
 // Rounds a Date down to the start of its current minute, then forward
 // `offsetMs` — used to keep RED window edges stable across renders for the
 // React Query cache key.
@@ -30,11 +44,16 @@ function flooredNow(): Date {
 /**
  * Container Detail → "Calls" tab (#1235).
  *
- * Renders four panels for a single container:
+ * Renders three panels for a single container:
  *   1. RED summary (last 1h, bucket=1h, filters.container=name)
- *   2. Top outgoing calls (client kind) — link out to Trace Explorer
- *   3. Top incoming calls (server kind)
- *   4. Latency p50/p95 timeline + error rate (1m bucket, last 60m)
+ *   2. Slowest calls — link out to Trace Explorer
+ *   3. Latency p50/p95 timeline + error rate (1m bucket, last 60m)
+ *
+ * There used to be two call panels, "Top outgoing calls" and "Top incoming
+ * calls", issued as two identical `useTraces` queries — same container, same
+ * window, same limit, no span-kind filter — so they rendered byte-identical
+ * lists under two headings that promised opposite directions. Splitting them
+ * again needs a span `kind` filter on the traces hook and API.
  *
  * Empty state for every panel is the shared NoTraceDataCallout.
  */
@@ -64,18 +83,9 @@ export function ContainerTracesTab({ containerName }: ContainerTracesTabProps) {
     container: containerName,
   });
 
-  // (2) Outgoing (client kind)
-  const { data: outgoing } = useTraces({
-    containerName,
-    from: hourFrom.toISOString(),
-    to: hourTo.toISOString(),
-    limit: 10,
-  });
-  // (3) Incoming (server kind) — use the same /api/traces endpoint without
-  // a kind filter at the hook level since the hook doesn't model it; the
-  // trace explorer page already does best-effort filtering, and this panel
-  // is mostly for navigation, not precise RED counts.
-  const { data: incoming } = useTraces({
+  // (2) Calls touching this container in the window. The traces hook models no
+  // span `kind`, so this is every call, not a direction.
+  const { data: calls } = useTraces({
     containerName,
     from: hourFrom.toISOString(),
     to: hourTo.toISOString(),
@@ -101,8 +111,7 @@ export function ContainerTracesTab({ containerName }: ContainerTracesTabProps) {
 
   const summaryRow = redSummary?.buckets[0]?.rows[0];
   const hasAnyData = (redSummary?.buckets.length ?? 0) > 0
-    || (outgoing?.length ?? 0) > 0
-    || (incoming?.length ?? 0) > 0;
+    || (calls?.length ?? 0) > 0;
 
   if (!hasAnyData) {
     return (
@@ -145,19 +154,13 @@ export function ContainerTracesTab({ containerName }: ContainerTracesTabProps) {
         )}
       </section>
 
-      {/* (2) & (3) Top calls */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <section className="rounded-lg border bg-card p-6 shadow-sm">
-          <h3 className="text-lg font-semibold">Top outgoing calls</h3>
-          <TraceList traces={sortByDuration(outgoing)} emptyText="No outgoing calls observed." />
-        </section>
-        <section className="rounded-lg border bg-card p-6 shadow-sm">
-          <h3 className="text-lg font-semibold">Top incoming calls</h3>
-          <TraceList traces={sortByDuration(incoming)} emptyText="No incoming calls observed." />
-        </section>
-      </div>
+      {/* (2) Slowest calls */}
+      <section className="rounded-lg border bg-card p-6 shadow-sm">
+        <h3 className="text-lg font-semibold">Slowest calls (last 1h)</h3>
+        <TraceList traces={sortByDuration(calls)} emptyText="No calls observed in the last hour." />
+      </section>
 
-      {/* (4) Latency + error timeline */}
+      {/* (3) Latency + error timeline */}
       <section className="rounded-lg border bg-card p-6 shadow-sm">
         <h3 className="text-lg font-semibold">Latency p50/p95 + error rate over time</h3>
         {sparklineData.length === 0 ? (
@@ -171,9 +174,16 @@ export function ContainerTracesTab({ containerName }: ContainerTracesTabProps) {
                 <YAxis yAxisId="left" fontSize={11} label={{ value: 'ms', angle: -90, position: 'insideLeft', fontSize: 11 }} />
                 <YAxis yAxisId="right" orientation="right" fontSize={11} label={{ value: 'err %', angle: 90, position: 'insideRight', fontSize: 11 }} />
                 <Tooltip />
-                <Line yAxisId="left" type="monotone" dataKey="p50" stroke="#3b82f6" dot={false} />
-                <Line yAxisId="left" type="monotone" dataKey="p95" stroke="#8b5cf6" dot={false} />
-                <Line yAxisId="right" type="monotone" dataKey="errorRate" stroke="#ef4444" dot={false} />
+                {LATENCY_SERIES.map((series) => (
+                  <Line
+                    key={series.dataKey}
+                    yAxisId={series.yAxisId}
+                    type="monotone"
+                    dataKey={series.dataKey}
+                    stroke={series.stroke}
+                    dot={false}
+                  />
+                ))}
               </LineChart>
             </ResponsiveContainer>
           </div>

--- a/frontend/src/features/containers/components/container/container-overview.test.tsx
+++ b/frontend/src/features/containers/components/container/container-overview.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ContainerOverview } from './container-overview';
 
 const baseContainer = {
-  id: 'abc123def456',
+  id: 'abc123def456789',
   name: 'api-1',
   image: 'ghcr.io/example/api:latest',
   state: 'running',
@@ -16,52 +17,66 @@ const baseContainer = {
   networks: ['frontend', 'backend'],
 };
 
-describe('ContainerOverview', () => {
-  it('places image, endpoint, and networks cards in the same responsive row grid', () => {
-    render(<ContainerOverview container={baseContainer} />);
-
-    const imageHeading = screen.getByRole('heading', { name: 'Image Information' });
-    const rowGrid = imageHeading.closest('div.grid');
-
-    expect(rowGrid).toHaveClass('grid-cols-1');
-    expect(rowGrid).toHaveClass('lg:grid-cols-3');
-    expect(screen.getByRole('heading', { name: 'Endpoint Information' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Networks' })).toBeInTheDocument();
-  });
-
-  it('renders the port mappings as a DataTable preserving every column and cell value', () => {
+describe('ContainerOverview — Host IP column', () => {
+  it('renders the real per-row bind address instead of a hardcoded 0.0.0.0', () => {
     render(
       <ContainerOverview
         container={{
           ...baseContainer,
           ports: [
-            { private: 8080, public: 80, type: 'tcp' },
-            { private: 53, type: 'udp' },
+            { private: 80, public: 8080, type: 'tcp', ip: '0.0.0.0' },
+            { private: 80, public: 8080, type: 'tcp', ip: '::' },
+            { private: 5432, public: 5432, type: 'tcp', ip: '127.0.0.1' },
           ],
         }}
       />
     );
 
-    expect(screen.getByRole('heading', { name: 'Port Mappings' })).toBeInTheDocument();
-
-    const table = screen.getByTestId('data-table');
-    expect(table).toBeInTheDocument();
-
-    // Headers preserved
+    // Every column survives, and Host IP is now backed by an accessor.
     for (const header of ['Container Port', 'Host Port', 'Type', 'Host IP']) {
       expect(screen.getByRole('columnheader', { name: header })).toBeInTheDocument();
     }
 
-    // First row values
-    expect(screen.getByText('8080')).toBeInTheDocument();
-    expect(screen.getByText('80')).toBeInTheDocument();
-    expect(screen.getByText('tcp')).toBeInTheDocument();
+    // The two bindings Docker publishes for one mapping are now distinguishable
+    // — they used to render as two identical `0.0.0.0` rows.
+    expect(screen.getByText('0.0.0.0')).toBeInTheDocument();
+    expect(screen.getByText('::')).toBeInTheDocument();
+    expect(screen.getByText('127.0.0.1')).toBeInTheDocument();
+  });
 
-    // Missing public port renders the placeholder, and Host IP is constant
-    expect(screen.getByText('53')).toBeInTheDocument();
-    expect(screen.getByText('udp')).toBeInTheDocument();
-    expect(screen.getByText('-')).toBeInTheDocument();
-    expect(screen.getAllByText('0.0.0.0')).toHaveLength(2);
+  it('badges wildcard binds and marks loopback binds, so the exposure is legible', () => {
+    render(
+      <ContainerOverview
+        container={{
+          ...baseContainer,
+          ports: [
+            { private: 80, public: 8080, type: 'tcp', ip: '0.0.0.0' },
+            { private: 5432, public: 5432, type: 'tcp', ip: '127.0.0.1' },
+            { private: 9000, public: 9000, type: 'tcp', ip: '192.168.1.10' },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getAllByText('all interfaces')).toHaveLength(1);
+    expect(screen.getByText('loopback only')).toBeInTheDocument();
+    // A specific routable address needs no badge — the address itself says it.
+    expect(screen.getByText('192.168.1.10')).toBeInTheDocument();
+  });
+
+  it('does not claim 0.0.0.0 when Docker reported no bind address', () => {
+    render(
+      <ContainerOverview
+        container={{
+          ...baseContainer,
+          ports: [{ private: 53, type: 'udp' }],
+        }}
+      />
+    );
+
+    expect(screen.getByText('Not published')).toBeInTheDocument();
+    expect(screen.queryByText('0.0.0.0')).not.toBeInTheDocument();
+    expect(screen.queryByText('all interfaces')).not.toBeInTheDocument();
   });
 
   it('omits the Port Mappings card when there are no ports', () => {
@@ -69,5 +84,171 @@ describe('ContainerOverview', () => {
 
     expect(screen.queryByRole('heading', { name: 'Port Mappings' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
+  });
+});
+
+describe('ContainerOverview — identity strip', () => {
+  it('states the running time once and never alongside Docker raw status string', () => {
+    render(<ContainerOverview container={baseContainer} />);
+
+    expect(screen.getByText('Uptime')).toBeInTheDocument();
+    // The old strip carried `Status: Up 5 minutes` next to `Uptime: 5m`.
+    expect(screen.queryByText('Status')).not.toBeInTheDocument();
+    expect(screen.queryByText('Up 5 minutes')).not.toBeInTheDocument();
+    expect(screen.getByText('Created')).toBeInTheDocument();
+  });
+
+  it('does not report an uptime for a container that is not running', () => {
+    render(
+      <ContainerOverview
+        container={{
+          ...baseContainer,
+          state: 'stopped',
+          status: 'Exited (137) 3 days ago',
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Uptime')).not.toBeInTheDocument();
+    expect(screen.getByText('State')).toBeInTheDocument();
+    // Docker's own line is where the exit code lives, so it is kept for stopped
+    // containers instead of a duration computed from the creation timestamp.
+    expect(screen.getByText('Exited (137) 3 days ago')).toBeInTheDocument();
+  });
+
+  it('promotes the compose project and service into the strip', () => {
+    render(
+      <ContainerOverview
+        container={{
+          ...baseContainer,
+          labels: {
+            'com.docker.compose.project': 'lcm',
+            'com.docker.compose.service': 'web',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Stack')).toBeInTheDocument();
+    expect(screen.getByText('lcm / web')).toBeInTheDocument();
+  });
+
+  it('omits the Stack field when the container is not part of a compose project', () => {
+    render(<ContainerOverview container={baseContainer} />);
+
+    expect(screen.queryByText('Stack')).not.toBeInTheDocument();
+  });
+});
+
+describe('ContainerOverview — Details list', () => {
+  it('replaces the three near-empty cards with one definition list', () => {
+    render(<ContainerOverview container={baseContainer} />);
+
+    expect(screen.queryByRole('heading', { name: 'Image Information' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Endpoint Information' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Networks' })).not.toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: 'Details' })).toBeInTheDocument();
+    const details = within(screen.getByTestId('container-details'));
+    for (const term of ['Image', 'Container ID', 'Endpoint', 'Networks']) {
+      expect(details.getByText(term).tagName).toBe('DT');
+    }
+    expect(screen.getByText('ghcr.io/example/api:latest')).toBeInTheDocument();
+    expect(screen.getByText('abc123def456789')).toBeInTheDocument();
+    expect(screen.getByText('· ID 1')).toBeInTheDocument();
+    expect(screen.getByText('frontend')).toBeInTheDocument();
+    expect(screen.getByText('backend')).toBeInTheDocument();
+  });
+
+  it('shows the per-network IP and says so plainly when nothing is attached', () => {
+    const { unmount } = render(
+      <ContainerOverview
+        container={{
+          ...baseContainer,
+          networks: ['frontend'],
+          networkIPs: { frontend: '172.18.0.4' },
+        }}
+      />
+    );
+    expect(screen.getByText('172.18.0.4')).toBeInTheDocument();
+    unmount();
+
+    render(<ContainerOverview container={{ ...baseContainer, networks: [] }} />);
+    expect(screen.getByText('None attached')).toBeInTheDocument();
+  });
+});
+
+describe('ContainerOverview — Labels', () => {
+  const manyLabels: Record<string, string> = {
+    'z.last': 'z',
+    'a.first': 'a',
+    'com.docker.compose.project': 'lcm',
+    'com.docker.compose.service': 'web',
+    'b.two': '2',
+    'c.three': '3',
+    'd.four': '4',
+    'e.five': '5',
+    'f.six': '6',
+    'g.seven': '7',
+  };
+
+  it('sorts labels and collapses everything past the first eight', async () => {
+    const user = userEvent.setup();
+    render(<ContainerOverview container={{ ...baseContainer, labels: manyLabels }} />);
+
+    expect(screen.getByRole('heading', { name: 'Labels (10)' })).toBeInTheDocument();
+
+    const list = screen.getByTestId('container-labels');
+    const keys = within(list)
+      .getAllByTestId('label-key')
+      .map((el) => el.textContent);
+    expect(keys).toHaveLength(8);
+    expect(keys.slice(0, 3)).toEqual(['a.first', 'b.two', 'c.three']);
+    expect(screen.queryByText('z.last')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show all 10' }));
+    expect(screen.getByText('z.last')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show fewer' })).toBeInTheDocument();
+  });
+
+  it('hides value-less labels and says how many it hid', () => {
+    render(
+      <ContainerOverview
+        container={{
+          ...baseContainer,
+          labels: {
+            'com.docker.dhi.flavor': '',
+            'com.docker.dhi.shell': '',
+            'org.opencontainers.image.title': 'api',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Labels (3)' })).toBeInTheDocument();
+    expect(screen.queryByText('com.docker.dhi.flavor')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('2 labels are set with no value and are not shown.')
+    ).toBeInTheDocument();
+  });
+
+  it('explains the redaction instead of rendering a bare [REDACTED] token', () => {
+    render(
+      <ContainerOverview
+        container={{
+          ...baseContainer,
+          labels: { 'com.docker.compose.project.config_files': '[REDACTED]' },
+        }}
+      />
+    );
+
+    expect(screen.queryByText('[REDACTED]')).not.toBeInTheDocument();
+    expect(screen.getByText('— host path hidden —')).toBeInTheDocument();
+  });
+
+  it('omits the Labels card entirely when there are no labels', () => {
+    render(<ContainerOverview container={baseContainer} />);
+
+    expect(screen.queryByTestId('container-labels')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/containers/components/container/container-overview.tsx
+++ b/frontend/src/features/containers/components/container/container-overview.tsx
@@ -15,22 +15,15 @@ import { type Container } from '@/features/containers/hooks/use-containers';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { DataTable } from '@/shared/components/tables/data-table';
 import { formatDate } from '@/shared/lib/utils';
+import {
+  UNSPECIFIED_BIND_ADDRESSES,
+  isLoopbackBind,
+  type PortMapping,
+} from '@/features/containers/lib/port-bindings';
 
 /**
- * A published port mapping as the API actually sends it.
- *
- * `Container['ports']` in `use-containers.ts` does not declare `ip` yet, but the
- * response contract (`ContainerPortSchema` in `@dashboard/contracts`) does and
- * the normalizer emits it, so the field is present at runtime. Widening here
- * keeps the real value renderable without editing the shared hook; drop the
- * intersection once `Container['ports']` carries `ip` itself.
+ * The token the backend substitutes for a label value that looked like a host path.
  */
-type PortMapping = Container['ports'][number] & { ip?: string };
-
-/** Host bind addresses that mean "every interface on this host". */
-const UNSPECIFIED_BIND_ADDRESSES = new Set(['0.0.0.0', '::', '[::]']);
-
-/** The token the backend substitutes for a label value that looked like a host path. */
 const REDACTED_TOKEN = '[REDACTED]';
 
 const COMPOSE_PROJECT_LABEL = 'com.docker.compose.project';
@@ -38,10 +31,6 @@ const COMPOSE_SERVICE_LABEL = 'com.docker.compose.service';
 
 /** Labels shown before "Show all N" is pressed. */
 const COLLAPSED_LABEL_COUNT = 8;
-
-function isLoopbackBind(ip: string): boolean {
-  return ip === '::1' || ip === '[::1]' || ip.startsWith('127.');
-}
 
 function formatUptime(createdTimestamp: number): string {
   const now = Date.now();

--- a/frontend/src/features/containers/components/container/container-overview.tsx
+++ b/frontend/src/features/containers/components/container/container-overview.tsx
@@ -1,12 +1,47 @@
-import { useMemo } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { type ColumnDef } from '@tanstack/react-table';
-import { Box, Server, HardDrive, Clock, Activity, RotateCw, Network, Tag } from 'lucide-react';
+import {
+  Box,
+  Info,
+  HardDrive,
+  Clock,
+  Activity,
+  CalendarClock,
+  Layers,
+  Network,
+  Tag,
+} from 'lucide-react';
 import { type Container } from '@/features/containers/hooks/use-containers';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { DataTable } from '@/shared/components/tables/data-table';
 import { formatDate } from '@/shared/lib/utils';
 
-type PortMapping = Container['ports'][number];
+/**
+ * A published port mapping as the API actually sends it.
+ *
+ * `Container['ports']` in `use-containers.ts` does not declare `ip` yet, but the
+ * response contract (`ContainerPortSchema` in `@dashboard/contracts`) does and
+ * the normalizer emits it, so the field is present at runtime. Widening here
+ * keeps the real value renderable without editing the shared hook; drop the
+ * intersection once `Container['ports']` carries `ip` itself.
+ */
+type PortMapping = Container['ports'][number] & { ip?: string };
+
+/** Host bind addresses that mean "every interface on this host". */
+const UNSPECIFIED_BIND_ADDRESSES = new Set(['0.0.0.0', '::', '[::]']);
+
+/** The token the backend substitutes for a label value that looked like a host path. */
+const REDACTED_TOKEN = '[REDACTED]';
+
+const COMPOSE_PROJECT_LABEL = 'com.docker.compose.project';
+const COMPOSE_SERVICE_LABEL = 'com.docker.compose.service';
+
+/** Labels shown before "Show all N" is pressed. */
+const COLLAPSED_LABEL_COUNT = 8;
+
+function isLoopbackBind(ip: string): boolean {
+  return ip === '::1' || ip === '[::1]' || ip.startsWith('127.');
+}
 
 function formatUptime(createdTimestamp: number): string {
   const now = Date.now();
@@ -36,16 +71,41 @@ function getHealthStatus(container: Container): string {
   return 'unknown';
 }
 
+/**
+ * The running-time field.
+ *
+ * The strip used to carry `Uptime 10h 7m` *and* `Status Up 10 hours` — one fact
+ * at two precisions — and it computed "uptime" from the creation timestamp even
+ * for an exited container, so a container stopped a week ago reported a growing
+ * uptime. Running containers now get the computed duration; everything else
+ * gets Docker's own state line, which is where the exit code lives.
+ */
+function runningTimeField(container: Container): { label: string; value: string } {
+  if (container.state === 'running') {
+    return { label: 'Uptime', value: formatUptime(container.created) };
+  }
+  return { label: 'State', value: container.status || container.state };
+}
+
 function MetadataItem({ icon: Icon, label, value }: { icon: React.ElementType; label: string; value: string | number }) {
   return (
     <div className="flex items-center gap-3">
       <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted">
         <Icon className="h-4 w-4 text-muted-foreground" />
       </div>
-      <div>
+      <div className="min-w-0">
         <p className="text-xs text-muted-foreground">{label}</p>
-        <p className="text-sm font-medium">{value}</p>
+        <p className="truncate text-sm font-medium">{value}</p>
       </div>
+    </div>
+  );
+}
+
+function DetailRow({ term, children }: { term: string; children: ReactNode }) {
+  return (
+    <div className="grid gap-1 py-3 sm:grid-cols-[9rem_minmax(0,1fr)] sm:gap-4">
+      <dt className="text-xs text-muted-foreground sm:text-sm">{term}</dt>
+      <dd className="min-w-0 text-sm">{children}</dd>
     </div>
   );
 }
@@ -55,10 +115,33 @@ interface ContainerOverviewProps {
 }
 
 export function ContainerOverview({ container }: ContainerOverviewProps) {
-  const ports = container.ports || [];
+  const ports: PortMapping[] = container.ports || [];
   const networks = container.networks || [];
   const labels = container.labels || {};
-  const labelEntries = Object.entries(labels);
+
+  const [showAllLabels, setShowAllLabels] = useState(false);
+
+  const composeProject = labels[COMPOSE_PROJECT_LABEL];
+  const composeService = labels[COMPOSE_SERVICE_LABEL];
+  const stackValue = composeProject
+    ? composeService
+      ? `${composeProject} / ${composeService}`
+      : composeProject
+    : undefined;
+
+  const { totalLabels, namedLabels, emptyLabelCount } = useMemo(() => {
+    const entries = Object.entries(labels);
+    const named = entries
+      .filter(([, value]) => (value ?? '').trim() !== '')
+      .sort(([a], [b]) => a.localeCompare(b));
+    return {
+      totalLabels: entries.length,
+      namedLabels: named,
+      emptyLabelCount: entries.length - named.length,
+    };
+  }, [labels]);
+
+  const visibleLabels = showAllLabels ? namedLabels : namedLabels.slice(0, COLLAPSED_LABEL_COUNT);
 
   const portColumns = useMemo<ColumnDef<PortMapping, unknown>[]>(
     () => [
@@ -78,10 +161,37 @@ export function ContainerOverview({ container }: ContainerOverviewProps) {
         cell: ({ getValue }) => <span className="uppercase">{getValue<string>()}</span>,
       },
       {
-        id: 'hostIp',
+        // Docker's real host bind address. This column used to render the
+        // literal string "0.0.0.0" for every row, which asserted the least safe
+        // answer with confidence and collapsed the separate IPv4 and IPv6
+        // bindings of one mapping into two identical rows.
+        accessorKey: 'ip',
         header: 'Host IP',
-        enableSorting: false,
-        cell: () => <span className="font-mono">0.0.0.0</span>,
+        cell: ({ row }) => {
+          const ip = row.original.ip;
+          if (!ip) {
+            return (
+              <span
+                className="text-muted-foreground"
+                title="Exposed by the image but not published to a host interface"
+              >
+                Not published
+              </span>
+            );
+          }
+          return (
+            <span className="flex items-center gap-2">
+              <span className="font-mono">{ip}</span>
+              {UNSPECIFIED_BIND_ADDRESSES.has(ip) ? (
+                <span className="rounded px-1.5 py-0.5 text-xs font-medium text-amber-700 bg-amber-500/10 dark:text-amber-400">
+                  all interfaces
+                </span>
+              ) : isLoopbackBind(ip) ? (
+                <span className="text-xs text-muted-foreground">loopback only</span>
+              ) : null}
+            </span>
+          );
+        },
       },
     ],
     []
@@ -109,92 +219,71 @@ export function ContainerOverview({ container }: ContainerOverviewProps) {
           />
         </div>
 
-        <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
-          <MetadataItem
-            icon={Server}
-            label="Endpoint"
-            value={container.endpointName}
-          />
+        <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
           <MetadataItem
             icon={HardDrive}
             label="Image"
             value={container.image.split(':')[0].split('/').pop() || container.image}
           />
           <MetadataItem
-            icon={Clock}
-            label="Uptime"
-            value={formatUptime(container.created)}
+            icon={container.state === 'running' ? Clock : Activity}
+            {...runningTimeField(container)}
           />
           <MetadataItem
-            icon={Activity}
-            label="Status"
-            value={container.status}
-          />
-          <MetadataItem
-            icon={RotateCw}
+            icon={CalendarClock}
             label="Created"
             value={formatDate(new Date(container.created * 1000))}
           />
+          {stackValue && (
+            <MetadataItem icon={Layers} label="Stack" value={stackValue} />
+          )}
         </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        {/* Image Information Card */}
-        <div className="rounded-lg border bg-card p-6 shadow-sm">
-          <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-            <HardDrive className="h-5 w-5" />
-            Image Information
-          </h3>
-          <div className="space-y-2">
-            <div>
-              <p className="text-xs text-muted-foreground">Full Image</p>
-              <p className="text-sm font-mono">{container.image}</p>
-            </div>
-          </div>
-        </div>
-
-        {/* Endpoint Information Card */}
-        <div className="rounded-lg border bg-card p-6 shadow-sm">
-          <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-            <Server className="h-5 w-5" />
-            Endpoint Information
-          </h3>
-          <div className="space-y-2">
-            <div>
-              <p className="text-xs text-muted-foreground">Name</p>
-              <p className="text-sm font-medium">{container.endpointName}</p>
-            </div>
-            <div>
-              <p className="text-xs text-muted-foreground">ID</p>
-              <p className="text-sm font-mono">{container.endpointId}</p>
-            </div>
-          </div>
-        </div>
-
-        {/* Networks Card */}
-        {networks.length > 0 && (
-          <div className="rounded-lg border bg-card p-6 shadow-sm">
-            <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-              <Network className="h-5 w-5" />
-              Networks
-            </h3>
-            <div className="flex flex-wrap gap-2">
-              {networks.map((network) => (
-                <span
-                  key={network}
-                  className="inline-flex items-center rounded-md bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
-                >
-                  {network}
-                  {container.networkIPs?.[network] && (
-                    <span className="ml-1.5 font-mono text-xs opacity-75">
-                      ({container.networkIPs[network]})
-                    </span>
-                  )}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
+      {/*
+        One definition list, not three near-empty cards. Image Information held a
+        single field, Endpoint Information held two (one of them repeated from the
+        strip above and the page subline), and Networks held one chip — roughly
+        450px of card chrome around five lines of text.
+      */}
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <h3 className="text-lg font-semibold mb-2 flex items-center gap-2">
+          <Info className="h-5 w-5" />
+          Details
+        </h3>
+        <dl className="divide-y divide-border" data-testid="container-details">
+          <DetailRow term="Image">
+            <span className="font-mono break-all">{container.image}</span>
+          </DetailRow>
+          <DetailRow term="Container ID">
+            <span className="font-mono break-all">{container.id}</span>
+          </DetailRow>
+          <DetailRow term="Endpoint">
+            <span className="font-medium">{container.endpointName}</span>
+            <span className="text-muted-foreground"> · ID {container.endpointId}</span>
+          </DetailRow>
+          <DetailRow term="Networks">
+            {networks.length === 0 ? (
+              <span className="text-muted-foreground">None attached</span>
+            ) : (
+              <span className="flex flex-wrap gap-2">
+                {networks.map((network) => (
+                  <span
+                    key={network}
+                    className="inline-flex items-center rounded-md border border-border bg-muted/50 px-2 py-0.5 text-sm font-medium"
+                  >
+                    {network}
+                    {container.networkIPs?.[network] && (
+                      <span className="ml-1.5 font-mono text-xs text-muted-foreground">
+                        {container.networkIPs[network]}
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </span>
+            )}
+          </DetailRow>
+        </dl>
       </div>
 
       {/* Port Mappings Card */}
@@ -209,20 +298,47 @@ export function ContainerOverview({ container }: ContainerOverviewProps) {
       )}
 
       {/* Labels Card */}
-      {labelEntries.length > 0 && (
+      {totalLabels > 0 && (
         <div className="rounded-lg border bg-card p-6 shadow-sm">
           <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
             <Tag className="h-5 w-5" />
-            Labels ({labelEntries.length})
+            Labels ({totalLabels})
           </h3>
-          <div className="space-y-2 max-h-[400px] overflow-y-auto">
-            {labelEntries.map(([key, value]) => (
+          <div
+            className={`space-y-2 ${showAllLabels ? 'max-h-[400px] overflow-y-auto scrollbar-themed' : ''}`}
+            data-testid="container-labels"
+          >
+            {visibleLabels.map(([key, value]) => (
               <div key={key} className="flex flex-col gap-1 p-2 rounded bg-muted/50">
-                <p className="text-xs font-mono text-muted-foreground break-all">{key}</p>
-                <p className="text-sm font-mono break-all">{value}</p>
+                <p data-testid="label-key" className="text-xs font-mono text-muted-foreground break-all">{key}</p>
+                {value === REDACTED_TOKEN ? (
+                  <p
+                    className="text-sm italic text-muted-foreground"
+                    title="Filesystem paths in container labels are stripped before they reach the browser."
+                  >
+                    — host path hidden —
+                  </p>
+                ) : (
+                  <p className="text-sm font-mono break-all">{value}</p>
+                )}
               </div>
             ))}
           </div>
+          {namedLabels.length > COLLAPSED_LABEL_COUNT && (
+            <button
+              type="button"
+              onClick={() => setShowAllLabels((prev) => !prev)}
+              className="mt-3 text-sm font-medium text-primary hover:underline"
+            >
+              {showAllLabels ? 'Show fewer' : `Show all ${namedLabels.length}`}
+            </button>
+          )}
+          {emptyLabelCount > 0 && (
+            <p className="mt-3 text-xs text-muted-foreground">
+              {emptyLabelCount} {emptyLabelCount === 1 ? 'label is' : 'labels are'} set with no
+              value and {emptyLabelCount === 1 ? 'is' : 'are'} not shown.
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.test.tsx
@@ -133,6 +133,32 @@ describe('FleetSearch', () => {
     expect(screen.getByRole('button', { name: 'status:up' })).toBeInTheDocument();
   });
 
+  it('renders example chips below the field, not overlaid on it', () => {
+    renderSearch({ examples: ['name:prod', 'status:up'] });
+
+    const input = screen.getByRole('textbox');
+    const group = screen.getByRole('group', { name: /example searches/i });
+
+    // The chip strip used to be absolutely positioned inside the input's own
+    // relative wrapper. It must now be a sibling block after the field row.
+    expect(group.className).not.toMatch(/absolute/);
+    expect(group.contains(input)).toBe(false);
+    expect(input.parentElement?.contains(group)).toBe(false);
+  });
+
+  it('keeps the placeholder visible while example chips are shown', () => {
+    renderSearch({
+      placeholder: 'Search endpoints... (name:prod status:up)',
+      examples: ['name:prod', 'status:up'],
+    });
+
+    // `placeholder:text-transparent` was the suppression that turned the field
+    // into a blank slab — the syntax hint has to stay readable.
+    const input = screen.getByRole('textbox');
+    expect(input.className).not.toContain('placeholder:text-transparent');
+    expect(screen.getByPlaceholderText('Search endpoints... (name:prod status:up)')).toBeInTheDocument();
+  });
+
   it('hides example chips once a query is typed', () => {
     renderSearch({ examples: ['name:prod'] });
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'x' } });

--- a/frontend/src/features/containers/components/fleet/fleet-search.tsx
+++ b/frontend/src/features/containers/components/fleet/fleet-search.tsx
@@ -99,78 +99,71 @@ export function FleetSearch({
   const showExamples = !query && !!examples && examples.length > 0;
 
   return (
-    <div className="flex items-center gap-3">
-      <div className="relative flex-1">
-        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
-          <Search className="h-4 w-4 text-muted-foreground" />
-        </div>
-        <input
-          ref={inputRef}
-          type="text"
-          value={query}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder}
-          className={cn(
-            'w-full rounded-xl border bg-card/80 py-3 pl-11 pr-9 text-[16px] sm:text-sm backdrop-blur-sm',
-            'placeholder:text-muted-foreground/50',
-            'focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50',
-            'transition-all duration-200',
-            // While example chips overlay the empty field, hide the placeholder
-            // text (kept in the DOM for a11y/tests) so the two don't collide.
-            showExamples && 'placeholder:text-transparent',
-          )}
-          aria-label={label}
-        />
-        {showExamples && (
-          // Chips stay mounted while the field is empty (including while it is
-          // focused) so they remain keyboard-reachable, mirroring WorkloadSmartSearch.
-          <div
-            role="group"
-            aria-label="Example searches"
-            onClick={(e) => {
-              // A click on the empty strip (not a chip) focuses the input.
-              if (e.target === e.currentTarget) {
-                inputRef.current?.focus();
-              }
-            }}
-            className="absolute inset-y-0 left-11 right-3 flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-          >
-            {examples.map((ex, i) => (
-              <button
-                key={ex}
-                type="button"
-                onClick={() => handleExampleClick(ex)}
-                className={cn(
-                  'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-border/60 bg-card/80 px-2 py-0.5 text-xs font-medium',
-                  'text-muted-foreground backdrop-blur-sm transition-colors duration-200',
-                  'hover:bg-primary/10 hover:text-primary hover:border-primary/30',
-                  // Right-align the chip row: ml-auto on the first chip absorbs
-                  // free space so chips sit right when they fit, and collapse to
-                  // a left-aligned scrollable row when they overflow.
-                  i === 0 && 'ml-auto',
-                )}
-              >
-                {ex}
-              </button>
-            ))}
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
+            <Search className="h-4 w-4 text-muted-foreground" />
           </div>
-        )}
-        {query && (
-          <button
-            type="button"
-            onClick={handleClear}
-            className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
-            aria-label="Clear search"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            className={cn(
+              'w-full rounded-xl border bg-card/80 py-3 pl-11 pr-9 text-[16px] sm:text-sm backdrop-blur-sm',
+              'placeholder:text-muted-foreground/50',
+              'focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50',
+              'transition-all duration-200',
+            )}
+            aria-label={label}
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={handleClear}
+              className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+              aria-label="Clear search"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+        {isFiltered && showCount && (
+          <span className="shrink-0 text-sm text-muted-foreground" data-testid="fleet-search-count">
+            {filteredCount} of {totalCount}
+          </span>
         )}
       </div>
-      {isFiltered && showCount && (
-        <span className="shrink-0 text-sm text-muted-foreground" data-testid="fleet-search-count">
-          {filteredCount} of {totalCount}
-        </span>
+      {showExamples && (
+        // Chips sit *below* the field, not overlaid on it. Overlaying meant the
+        // placeholder had to be made transparent to avoid a collision, so the
+        // field rendered as a blank slab with pills floating in it and the one
+        // string explaining the query syntax was invisible. They stay mounted
+        // while the field is empty (including while focused) so they remain
+        // keyboard-reachable, mirroring WorkloadSmartSearch.
+        <div
+          role="group"
+          aria-label="Example searches"
+          className="flex flex-wrap items-center gap-1.5 pl-1"
+        >
+          {examples.map((ex) => (
+            <button
+              key={ex}
+              type="button"
+              onClick={() => handleExampleClick(ex)}
+              className={cn(
+                'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-border/60 bg-card/80 px-2 py-0.5 text-xs font-medium',
+                'text-muted-foreground backdrop-blur-sm transition-colors duration-200',
+                'hover:bg-primary/10 hover:text-primary hover:border-primary/30',
+              )}
+            >
+              {ex}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/features/containers/components/network/container-node.test.tsx
+++ b/frontend/src/features/containers/components/network/container-node.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { stripGroupPrefix, ContainerNode } from './container-node';
+
+// @xyflow/react's Handle needs a ReactFlow provider; the node's label logic
+// does not, so stub the handle at the boundary.
+vi.mock('@xyflow/react', () => ({
+  Handle: () => null,
+  Position: { Top: 'top', Right: 'right', Bottom: 'bottom', Left: 'left' },
+}));
+
+describe('stripGroupPrefix', () => {
+  it('drops the compose project prefix the group box already shows', () => {
+    expect(stripGroupPrefix('container-insights-backend', 'container-insights')).toBe(
+      'backend',
+    );
+    expect(stripGroupPrefix('container-insights-redis', 'container-insights')).toBe(
+      'redis',
+    );
+  });
+
+  it('distinguishes siblings that previously all truncated to the same string', () => {
+    const group = 'container-insights';
+    const names = [
+      'container-insights-backend',
+      'container-insights-frontend',
+      'container-insights-redis',
+    ];
+    const stripped = names.map((n) => stripGroupPrefix(n, group));
+    expect(new Set(stripped).size).toBe(3);
+    // Every label now fits the 160px cap comfortably at text-xs (~22 chars).
+    expect(stripped.every((s) => s.length <= 22)).toBe(true);
+  });
+
+  it('handles underscore-separated project names', () => {
+    expect(stripGroupPrefix('docker_postgres', 'docker')).toBe('postgres');
+  });
+
+  it('leaves the label alone with no group, a non-matching group, or an exact match', () => {
+    expect(stripGroupPrefix('standalone-thing')).toBe('standalone-thing');
+    expect(stripGroupPrefix('other-app-web', 'container-insights')).toBe('other-app-web');
+    expect(stripGroupPrefix('container-insights', 'container-insights')).toBe(
+      'container-insights',
+    );
+  });
+
+  it('never strips the label down to nothing', () => {
+    expect(stripGroupPrefix('proj-', 'proj')).toBe('proj-');
+  });
+});
+
+describe('ContainerNode', () => {
+  const data = {
+    label: 'container-insights-backend',
+    groupLabel: 'container-insights',
+    state: 'running',
+    image: 'ghcr.io/example/backend:1.2.3',
+    usedHandles: [],
+  };
+
+  function renderNode(overrides: Record<string, unknown> = {}) {
+    // NodeProps carries a large xyflow surface the component never reads.
+    return render(<ContainerNode {...({ data: { ...data, ...overrides } } as never)} />);
+  }
+
+  it('renders the de-prefixed name, not the shared prefix', () => {
+    renderNode();
+    expect(screen.getByText('backend')).toBeInTheDocument();
+    expect(screen.queryByText('container-insights-backend')).not.toBeInTheDocument();
+  });
+
+  it('does not render a letter badge derived from the name', () => {
+    const { container } = renderNode();
+    // The circle used to show `label.charAt(0)`, which is constant inside a
+    // compose project: six green circles all reading "C".
+    expect(container.textContent).not.toMatch(/^C/);
+    expect(container.textContent).toBe('backend');
+  });
+
+  it('moves the full name and image onto the hover title instead of a second line', () => {
+    const { container } = renderNode();
+    expect(screen.queryByText('ghcr.io/example/backend:1.2.3')).not.toBeInTheDocument();
+    expect((container.firstChild as HTMLElement).title).toBe(
+      'container-insights-backend (running) — ghcr.io/example/backend:1.2.3',
+    );
+  });
+
+  it('widens the label past the compose-prefix width', () => {
+    const { container } = renderNode();
+    const labelEl = container.querySelector('.truncate') as HTMLElement;
+    expect(labelEl.className).toContain('max-w-[160px]');
+    expect(labelEl.className).not.toContain('max-w-[100px]');
+  });
+
+  it('uses a neutral selection ring rather than a status hue', () => {
+    const { container } = renderNode({ selected: true });
+    const circle = container.querySelector('.rounded-full') as HTMLElement;
+    expect(circle.className).toContain('ring-foreground/70');
+    expect(circle.className).not.toContain('ring-cyan-300');
+  });
+});

--- a/frontend/src/features/containers/components/network/container-node.tsx
+++ b/frontend/src/features/containers/components/network/container-node.tsx
@@ -1,4 +1,5 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { Box } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { shouldShowHandle, type HandleDirection } from './handle-visibility';
 
@@ -9,35 +10,72 @@ const stateColors: Record<string, string> = {
   unknown: 'bg-gray-500 border-gray-600',
 };
 
+/**
+ * Drop the compose project's own name from a child node's label.
+ *
+ * Inside a stack group box titled `container-insights`, every child is called
+ * `container-insights-<something>`. The label had `max-w-[100px] truncate`,
+ * which fits ~14 characters at `text-xs` — and the prefix alone is 19 — so six
+ * different containers all rendered as `container-insig…` and the operator
+ * could not tell backend from frontend from redis. The group box already shows
+ * the project name, so repeating it in every child is pure noise.
+ *
+ * Only a real prefix followed by a separator is stripped, and never the whole
+ * label: a container named exactly after its project keeps its name.
+ */
+export function stripGroupPrefix(label: string, groupLabel?: string): string {
+  if (!groupLabel || groupLabel === label) return label;
+  for (const separator of ['-', '_']) {
+    const prefix = `${groupLabel}${separator}`;
+    if (label.startsWith(prefix) && label.length > prefix.length) {
+      return label.slice(prefix.length);
+    }
+  }
+  return label;
+}
+
 export function ContainerNode({ data }: NodeProps) {
   const state = (data as any).state || 'unknown';
   const label = (data as any).label || 'Unknown';
   const image = (data as any).image || '';
+  const groupLabel = (data as any).groupLabel as string | undefined;
   const selected = Boolean((data as any).selected);
   const related = Boolean((data as any).related);
   const usedHandles = (data as any).usedHandles as HandleDirection[] | undefined;
 
+  const displayLabel = stripGroupPrefix(label, groupLabel);
+  // The full name and the image go on the hover title. The image line used to
+  // occupy its own row and truncated as badly as the name did.
+  const title = image ? `${label} (${state}) — ${image}` : `${label} (${state})`;
+
   return (
-    <div className="flex flex-col items-center gap-1">
+    <div className="flex flex-col items-center gap-1" title={title}>
       {shouldShowHandle(usedHandles, 'top') && <Handle id="top" type="source" position={Position.Top} className="!bg-gray-400" />}
       {shouldShowHandle(usedHandles, 'right') && <Handle id="right" type="source" position={Position.Right} className="!bg-gray-400" />}
       <div
         className={cn(
-          'h-10 w-10 rounded-full border-2 flex items-center justify-center text-white text-xs font-bold transition-all duration-200',
-          selected && 'ring-2 ring-cyan-300 ring-offset-2 ring-offset-background scale-110',
-          !selected && related && 'ring-1 ring-emerald-300/70 ring-offset-1 ring-offset-background',
+          'h-10 w-10 rounded-full border-2 flex items-center justify-center text-white transition-all duration-200',
+          // Selection chrome is a neutral ring, not a status hue — cyan on a
+          // green/red/amber state swatch read as a sixth state.
+          selected && 'ring-2 ring-foreground/70 ring-offset-2 ring-offset-background scale-110',
+          !selected && related && 'ring-1 ring-foreground/40 ring-offset-1 ring-offset-background',
           !selected && !related && 'opacity-80',
           stateColors[state] || stateColors.unknown
         )}
-        title={`${label} (${state})`}
+        aria-hidden="true"
       >
-        {label.charAt(0).toUpperCase()}
+        {/*
+          This used to be `label.charAt(0).toUpperCase()` — the first letter of
+          the container name, which inside a compose project is constant by
+          construction: six green circles all reading "C". It looked like a type
+          code and encoded nothing. The circle is the state swatch; the glyph
+          says "container", which is what actually distinguishes it from the
+          diamond network nodes.
+        */}
+        <Box className="h-4 w-4" />
       </div>
-      <div className="text-xs font-medium max-w-[100px] truncate text-center">
-        {label}
-      </div>
-      <div className="text-[10px] text-muted-foreground max-w-[100px] truncate">
-        {image}
+      <div className="text-xs font-medium max-w-[160px] truncate text-center">
+        {displayLabel}
       </div>
       {shouldShowHandle(usedHandles, 'bottom') && <Handle id="bottom" type="source" position={Position.Bottom} className="!bg-gray-400" />}
       {shouldShowHandle(usedHandles, 'left') && <Handle id="left" type="source" position={Position.Left} className="!bg-gray-400" />}

--- a/frontend/src/features/containers/components/network/topology-graph-rpc.test.ts
+++ b/frontend/src/features/containers/components/network/topology-graph-rpc.test.ts
@@ -3,6 +3,8 @@ import {
   getRpcEdgeColor,
   getRpcEdgeWidth,
   capAndSortRpcEdges,
+  matchRpcEdgesToContainers,
+  formatEdgeRateLabel,
   type RpcEdgeInput,
 } from './topology-graph';
 
@@ -84,5 +86,97 @@ describe('capAndSortRpcEdges', () => {
     expect(result).toHaveLength(1);
     expect(result[0].source).toBe('a');
     expect(result[0].target).toBe('b');
+  });
+});
+
+describe('matchRpcEdgesToContainers', () => {
+  const make = (source: string, target: string, callCount: number): RpcEdgeInput => ({
+    source,
+    target,
+    callCount,
+  });
+  const containers = [
+    { name: 'container-insights-backend' },
+    { name: 'container-insights-redis' },
+  ];
+
+  it('matches edges whose endpoints both name a container on canvas', () => {
+    const result = matchRpcEdgesToContainers(
+      [make('container-insights-backend', 'container-insights-redis', 42)],
+      containers,
+    );
+    expect(result.matched).toHaveLength(1);
+    expect(result.unmatched).toHaveLength(0);
+    expect(result.unmatchedServices).toEqual([]);
+  });
+
+  // The shipped bug: Beyla reports `api-gateway`, no container is called that,
+  // every edge hit `continue`, and the graph was dimmed for a layer that drew
+  // nothing while the checkbox still read "Observed traffic (3)".
+  it('reports the misses instead of silently dropping them', () => {
+    const result = matchRpcEdgesToContainers(
+      [
+        make('api-gateway', 'api-gateway-db', 100),
+        make('api-gateway', 'container-insights-redis', 50),
+      ],
+      containers,
+    );
+    expect(result.matched).toEqual([]);
+    expect(result.unmatched).toHaveLength(2);
+    expect(result.unmatchedServices).toEqual(['api-gateway', 'api-gateway-db']);
+  });
+
+  it('splits a mixed set and keeps the matched half drawable', () => {
+    const result = matchRpcEdgesToContainers(
+      [
+        make('container-insights-backend', 'container-insights-redis', 10),
+        make('api-gateway', 'container-insights-redis', 99),
+      ],
+      containers,
+    );
+    expect(result.matched.map((e) => e.source)).toEqual(['container-insights-backend']);
+    expect(result.unmatched.map((e) => e.source)).toEqual(['api-gateway']);
+    expect(result.unmatchedServices).toEqual(['api-gateway']);
+  });
+
+  it('drops self-edges and honours the cap, like the raw sorter', () => {
+    const result = matchRpcEdgesToContainers(
+      [make('container-insights-redis', 'container-insights-redis', 1000)],
+      containers,
+    );
+    expect(result.matched).toEqual([]);
+    expect(result.unmatched).toEqual([]);
+  });
+
+  it('returns an empty result for no observed edges', () => {
+    const result = matchRpcEdgesToContainers([], containers);
+    expect(result.matched).toEqual([]);
+    expect(result.unmatched).toEqual([]);
+    expect(result.unmatchedServices).toEqual([]);
+  });
+});
+
+describe('formatEdgeRateLabel', () => {
+  // Thirteen edges all labelled `↓0B/s ↑0B/s` were the highest-contrast
+  // repeated element on the canvas and carried no information.
+  it('emits nothing when both directions are idle', () => {
+    expect(formatEdgeRateLabel({ rxBytesPerSec: 0, txBytesPerSec: 0 })).toBeUndefined();
+  });
+
+  it('emits nothing when there is no rate at all', () => {
+    expect(formatEdgeRateLabel(undefined)).toBeUndefined();
+  });
+
+  it('labels an edge as soon as either direction carries traffic', () => {
+    expect(formatEdgeRateLabel({ rxBytesPerSec: 2048, txBytesPerSec: 0 })).toBe(
+      '↓2.0KB/s ↑0B/s',
+    );
+    expect(formatEdgeRateLabel({ rxBytesPerSec: 0, txBytesPerSec: 1 })).toBe(
+      '↓0B/s ↑1B/s',
+    );
+  });
+
+  it('ignores a nonsensical negative sum', () => {
+    expect(formatEdgeRateLabel({ rxBytesPerSec: -5, txBytesPerSec: 5 })).toBeUndefined();
   });
 });

--- a/frontend/src/features/containers/components/network/topology-graph.tsx
+++ b/frontend/src/features/containers/components/network/topology-graph.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ReactFlow,
   Background,
@@ -107,6 +107,64 @@ export function capAndSortRpcEdges(edges: RpcEdgeInput[]): RpcEdgeInput[] {
     .slice()
     .sort((a, b) => b.callCount - a.callCount)
     .slice(0, RPC_EDGE_CAP);
+}
+
+export interface RpcMatchResult {
+  /** Edges whose source *and* target both resolve to a container on canvas. */
+  matched: RpcEdgeInput[];
+  /** Edges that will not be drawn because a name did not resolve. */
+  unmatched: RpcEdgeInput[];
+  /** Distinct span service names with no container of that name, sorted. */
+  unmatchedServices: string[];
+}
+
+/**
+ * Resolve observed RPC edges against the containers on canvas.
+ *
+ * The overlay matches span service names to `container.name` exactly, which is
+ * a real constraint — Beyla reports `api-gateway` while the container is called
+ * `container-insights-backend`. Previously that mismatch was silent: every edge
+ * hit `continue`, drawing nothing, while the checkbox still read "Observed
+ * traffic (3)" and the structural graph was dimmed to 0.2 to make room for a
+ * layer that never appeared. Returning the misses lets the caller say so.
+ */
+export function matchRpcEdgesToContainers(
+  edges: RpcEdgeInput[],
+  containers: Pick<ContainerData, 'name'>[],
+): RpcMatchResult {
+  const names = new Set(containers.map((c) => c.name));
+  const matched: RpcEdgeInput[] = [];
+  const unmatched: RpcEdgeInput[] = [];
+  const unmatchedServices = new Set<string>();
+
+  for (const edge of capAndSortRpcEdges(edges)) {
+    const hasSource = names.has(edge.source);
+    const hasTarget = names.has(edge.target);
+    if (hasSource && hasTarget) {
+      matched.push(edge);
+      continue;
+    }
+    unmatched.push(edge);
+    if (!hasSource) unmatchedServices.add(edge.source);
+    if (!hasTarget) unmatchedServices.add(edge.target);
+  }
+
+  return { matched, unmatched, unmatchedServices: [...unmatchedServices].sort() };
+}
+
+/**
+ * The `↓… ↑…` chip for a container↔network edge, or `undefined` when there is
+ * nothing to say.
+ *
+ * This used to emit a label whenever a rate *object* existed, without checking
+ * that the rate was non-zero — so an idle fleet drew thirteen identical
+ * `↓0B/s ↑0B/s` chips, the highest-contrast repeated element on the canvas,
+ * carrying exactly zero information.
+ */
+export function formatEdgeRateLabel(rate: NetworkRate | undefined): string | undefined {
+  if (!rate) return undefined;
+  if (rate.rxBytesPerSec + rate.txBytesPerSec <= 0) return undefined;
+  return `↓${formatRate(rate.rxBytesPerSec)} ↑${formatRate(rate.txBytesPerSec)}`;
 }
 
 // --- End RPC overlay helpers ---
@@ -273,9 +331,11 @@ const nodeTypes = {
   'stack-group': StackGroupNode,
 };
 
-// Node dimensions for elkjs layout
-const CONTAINER_W = 140;
-const CONTAINER_H = 90;
+// Node dimensions for elkjs layout. Container nodes reserve the 160px their
+// label is now allowed to occupy (it was clipped at 100px, which is narrower
+// than a compose prefix), plus room for the ring on the selected node.
+const CONTAINER_W = 176;
+const CONTAINER_H = 80;
 const NETWORK_W = 140;
 const NETWORK_H = 90;
 
@@ -419,6 +479,17 @@ export function TopologyGraph({
 }: TopologyGraphProps) {
   const potatoMode = useUiStore((state) => state.potatoMode);
   const relatedSet = useMemo(() => new Set(relatedNodeIds ?? []), [relatedNodeIds]);
+  const [showMiniMap, setShowMiniMap] = useState(false);
+
+  // Resolve the overlay before anything decides to de-emphasise the graph for
+  // it. Dimming to 0.2 for a layer that draws nothing is strictly a loss.
+  const rpcMatch = useMemo(
+    () => matchRpcEdgesToContainers(observedEdges ?? [], containers),
+    [observedEdges, containers],
+  );
+  const overlayActive = showObservedTraffic && rpcMatch.matched.length > 0;
+  const overlayMatchedNothing =
+    showObservedTraffic && rpcMatch.matched.length === 0 && rpcMatch.unmatched.length > 0;
 
   // Phase 1: Categorize stacks, classify inline/external networks, sort everything
   const { blueprints, externalNets } = useMemo(() => {
@@ -540,6 +611,9 @@ export function TopologyGraph({
           extent: 'parent' as const,
           data: {
             label: container.name,
+            // The group box already displays the compose project; the node
+            // strips it from its own label so siblings stay distinguishable.
+            groupLabel: bp.stackName,
             state: container.state,
             image: container.image,
             selected: childId === selectedNodeId,
@@ -587,11 +661,10 @@ export function TopologyGraph({
           : { sourceHandle: 'bottom' as HandleDirection, targetHandle: 'top' as HandleDirection };
 
         const edgeStyle = getEdgeStyle(container.id, container.state, networkRates);
-        const rate = networkRates?.[container.id];
-        const edgeLabel = rate ? `↓${formatRate(rate.rxBytesPerSec)} ↑${formatRate(rate.txBytesPerSec)}` : undefined;
-        // Fade structural edges when the RPC overlay is on so observed
-        // traffic reads as the primary signal.
-        const structuralOpacity = showObservedTraffic ? 0.2 : 0.7;
+        const edgeLabel = formatEdgeRateLabel(networkRates?.[container.id]);
+        // Fade structural edges when the RPC overlay actually draws something,
+        // so observed traffic reads as the primary signal.
+        const structuralOpacity = overlayActive ? 0.2 : 0.7;
         edges.push({
           id: `e-${container.id}-${net.id}`,
           source: sourceId,
@@ -599,15 +672,22 @@ export function TopologyGraph({
           sourceHandle: handles.sourceHandle,
           targetHandle: handles.targetHandle,
           type: 'smoothstep',
-          animated: !potatoMode && !showObservedTraffic && container.state === 'running',
+          animated: !potatoMode && !overlayActive && container.state === 'running',
           style: {
             stroke: edgeStyle.stroke,
             strokeWidth: edgeStyle.strokeWidth,
             opacity: structuralOpacity,
           },
           label: edgeLabel,
-          labelStyle: { fontSize: 10, fill: 'var(--color-muted-foreground)' },
-          labelBgStyle: { fill: 'var(--color-card)', opacity: 0.9 },
+          // The label has to fade with its own stroke. It did not, so a 0.2
+          // line carried a full-opacity chip and the layer meant to recede
+          // became the loudest thing on the canvas.
+          labelStyle: {
+            fontSize: 10,
+            fill: 'var(--color-muted-foreground)',
+            opacity: structuralOpacity,
+          },
+          labelBgStyle: { fill: 'var(--color-card)', opacity: 0.9 * structuralOpacity },
           labelBgPadding: [4, 2],
           labelBgBorderRadius: 4,
         });
@@ -616,12 +696,11 @@ export function TopologyGraph({
 
     // Observed RPC overlay edges (#1233). Service names from spans are
     // matched to container nodes by `container.name`.
-    if (showObservedTraffic && observedEdges && observedEdges.length > 0) {
+    if (showObservedTraffic && rpcMatch.matched.length > 0) {
       const containerByName = new Map<string, ContainerData>();
       for (const c of containers) containerByName.set(c.name, c);
 
-      const capped = capAndSortRpcEdges(observedEdges);
-      for (const rpc of capped) {
+      for (const rpc of rpcMatch.matched) {
         const src = containerByName.get(rpc.source);
         const tgt = containerByName.get(rpc.target);
         if (!src || !tgt) continue;
@@ -673,7 +752,7 @@ export function TopologyGraph({
     }
 
     return { nodes, edges };
-  }, [blueprints, externalNets, layoutPositions, containers, networks, networkRates, relatedSet, selectedNodeId, potatoMode, showObservedTraffic, observedEdges]);
+  }, [blueprints, externalNets, layoutPositions, containers, networks, networkRates, relatedSet, selectedNodeId, potatoMode, showObservedTraffic, overlayActive, rpcMatch]);
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
@@ -703,6 +782,43 @@ export function TopologyGraph({
   return (
     <div className="h-full rounded-lg border relative">
       <TopologyLegend />
+
+      {/*
+        Say when the overlay resolved nothing. Silently dimming the structural
+        graph for an empty layer left the operator staring at a faded canvas
+        with a checkbox claiming three observed edges.
+      */}
+      {overlayMatchedNothing && (
+        <div
+          role="status"
+          className="absolute left-1/2 top-3 z-10 max-w-[min(32rem,90%)] -translate-x-1/2 rounded-md border border-amber-500/40 bg-card/95 px-3 py-2 text-xs shadow-sm backdrop-blur-sm"
+        >
+          <span className="font-medium text-amber-700 dark:text-amber-400">
+            {rpcMatch.unmatched.length} observed{' '}
+            {rpcMatch.unmatched.length === 1 ? 'edge' : 'edges'} could not be matched to
+            containers.
+          </span>{' '}
+          <span className="text-muted-foreground">
+            Traces name {rpcMatch.unmatchedServices.slice(0, 3).join(', ')}
+            {rpcMatch.unmatchedServices.length > 3
+              ? ` and ${rpcMatch.unmatchedServices.length - 3} more`
+              : ''}
+            ; no container on this endpoint carries{' '}
+            {rpcMatch.unmatchedServices.length === 1 ? 'that name' : 'those names'}. Set
+            OTEL_SERVICE_NAME to the container name to link them.
+          </span>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setShowMiniMap((v) => !v)}
+        aria-pressed={showMiniMap}
+        className="absolute bottom-4 right-4 z-10 rounded-md border bg-card/95 px-2.5 py-1.5 text-xs font-medium text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-accent hover:text-foreground"
+      >
+        {showMiniMap ? 'Hide minimap' : 'Minimap'}
+      </button>
+
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -720,7 +836,12 @@ export function TopologyGraph({
       >
         <Background />
         <Controls />
-        <MiniMap />
+        {/*
+          Off by default: it floats over the canvas bottom-right and covered the
+          bridge/none/host column, and `fitView` already shows the whole graph
+          on a fleet this size.
+        */}
+        {showMiniMap && <MiniMap className="!bottom-14" pannable zoomable />}
       </ReactFlow>
     </div>
   );

--- a/frontend/src/features/containers/components/network/topology-legend.test.tsx
+++ b/frontend/src/features/containers/components/network/topology-legend.test.tsx
@@ -21,14 +21,39 @@ describe('TopologyLegend', () => {
     expect(wrapper.className).not.toContain('bottom-14');
   });
 
-  it('hides legend entries by default', () => {
+  // The legend used to open closed, so the only thing it documented — Edge
+  // Load — was invisible unless you went looking, and every edge on an idle
+  // fleet reads 0 B/s anyway.
+  it('is open by default', () => {
     render(<TopologyLegend />);
-    expect(screen.queryByText('Edge Load')).toBeNull();
+    expect(screen.getByText('Edge Load')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /legend/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
   });
 
-  it('shows all 5 color tiers when opened', () => {
+  it('documents node shape and container state before edge load', () => {
+    const { container } = render(<TopologyLegend />);
+
+    const headings = Array.from(container.querySelectorAll('p.font-semibold')).map(
+      (el) => el.textContent,
+    );
+    expect(headings).toEqual(['Node', 'Container State', 'Edge Load']);
+
+    // Circle vs diamond — never explained before, and the first thing a
+    // first-time viewer needs.
+    expect(screen.getByText('Container')).toBeTruthy();
+    expect(screen.getByText('Network')).toBeTruthy();
+    // Node state colours.
+    expect(screen.getByText('Running')).toBeTruthy();
+    expect(screen.getByText('Stopped')).toBeTruthy();
+    expect(screen.getByText('Paused')).toBeTruthy();
+    expect(screen.getByText('Unknown')).toBeTruthy();
+  });
+
+  it('shows all 5 edge-load color tiers', () => {
     render(<TopologyLegend />);
-    fireEvent.click(screen.getByRole('button', { name: /legend/i }));
 
     expect(screen.getByText('Edge Load')).toBeTruthy();
     expect(screen.getByText('No data / Idle')).toBeTruthy();
@@ -42,10 +67,13 @@ describe('TopologyLegend', () => {
     render(<TopologyLegend />);
     const btn = screen.getByRole('button', { name: /legend/i });
 
-    fireEvent.click(btn); // open
     expect(screen.getByText('Edge Load')).toBeTruthy();
 
     fireEvent.click(btn); // close
     expect(screen.queryByText('Edge Load')).toBeNull();
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(btn); // re-open
+    expect(screen.getByText('Edge Load')).toBeTruthy();
   });
 });

--- a/frontend/src/features/containers/components/network/topology-legend.tsx
+++ b/frontend/src/features/containers/components/network/topology-legend.tsx
@@ -1,6 +1,24 @@
 import { useState } from 'react';
 import { Info, ChevronDown } from 'lucide-react';
 
+/**
+ * Node shapes. This is the first thing that needs explaining and the legend
+ * never mentioned it: a circle is a container, a diamond is a network.
+ */
+const SHAPE_ENTRIES = [
+  { shape: 'circle', label: 'Container' },
+  { shape: 'diamond', label: 'Network' },
+] as const;
+
+/** Container state, read from the fill of the circle. */
+const STATE_ENTRIES = [
+  { color: '#10b981', label: 'Running' },
+  { color: '#f59e0b', label: 'Paused' },
+  { color: '#ef4444', label: 'Stopped' },
+  { color: '#6b7280', label: 'Unknown' },
+] as const;
+
+/** Edge colour, read from throughput on the container ↔ network link. */
 const LEGEND_ENTRIES = [
   { color: '#6b7280', label: 'No data / Idle' },
   { color: '#10b981', label: 'Low (< 10 KB/s)' },
@@ -9,18 +27,59 @@ const LEGEND_ENTRIES = [
   { color: '#ef4444', label: 'Very High (>= 1 MB/s)' },
 ] as const;
 
+/**
+ * Legend for the topology canvas.
+ *
+ * It used to open closed and document only Edge Load — the one dimension that
+ * is constant on an idle fleet, where every edge reads 0 B/s — while never
+ * explaining the circle/diamond distinction or the node state colours, which
+ * are the two things a first-time viewer actually needs. Node shape and state
+ * now come first, edge load last, and the panel opens by default.
+ */
 export function TopologyLegend() {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
 
   return (
     <div className="absolute bottom-4 left-16 z-10">
       {open && (
-        <div className="mb-2 rounded-lg border bg-card/95 backdrop-blur-sm p-3 shadow-lg">
-          <p className="text-xs font-semibold text-foreground mb-2">Edge Load</p>
+        <div className="mb-2 max-h-[60vh] overflow-y-auto rounded-lg border bg-card/95 backdrop-blur-sm p-3 shadow-lg">
+          <p className="text-xs font-semibold text-foreground mb-2">Node</p>
+          <div className="space-y-1.5">
+            {SHAPE_ENTRIES.map((entry) => (
+              <div key={entry.shape} className="flex items-center gap-2">
+                <span
+                  aria-hidden="true"
+                  className={
+                    entry.shape === 'circle'
+                      ? 'inline-block h-3 w-3 rounded-full border border-foreground/40 bg-muted-foreground/40'
+                      : 'inline-block h-3 w-3 rotate-45 border border-foreground/40 bg-muted-foreground/40'
+                  }
+                />
+                <span className="text-xs text-muted-foreground">{entry.label}</span>
+              </div>
+            ))}
+          </div>
+
+          <p className="mt-3 text-xs font-semibold text-foreground mb-2">Container State</p>
+          <div className="space-y-1.5">
+            {STATE_ENTRIES.map((entry) => (
+              <div key={entry.label} className="flex items-center gap-2">
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-3 w-3 rounded-full"
+                  style={{ backgroundColor: entry.color }}
+                />
+                <span className="text-xs text-muted-foreground">{entry.label}</span>
+              </div>
+            ))}
+          </div>
+
+          <p className="mt-3 text-xs font-semibold text-foreground mb-2">Edge Load</p>
           <div className="space-y-1.5">
             {LEGEND_ENTRIES.map((entry) => (
               <div key={entry.color} className="flex items-center gap-2">
                 <span
+                  aria-hidden="true"
                   className="inline-block h-2.5 w-6 rounded-sm"
                   style={{ backgroundColor: entry.color }}
                 />
@@ -32,11 +91,13 @@ export function TopologyLegend() {
       )}
       <button
         onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
         className="inline-flex items-center gap-1.5 rounded-md border bg-card/95 backdrop-blur-sm px-2.5 py-1.5 text-xs font-medium text-muted-foreground shadow-sm transition-colors hover:text-foreground hover:bg-accent"
       >
-        <Info className="h-3.5 w-3.5" />
+        <Info className="h-3.5 w-3.5" aria-hidden="true" />
         Legend
         <ChevronDown
+          aria-hidden="true"
           className={`h-3 w-3 transition-transform ${open ? 'rotate-180' : ''}`}
         />
       </button>

--- a/frontend/src/features/containers/hooks/use-containers.ts
+++ b/frontend/src/features/containers/hooks/use-containers.ts
@@ -14,6 +14,12 @@ export interface Container {
     private: number;
     public?: number;
     type: string;
+    /**
+     * Docker's host-side bind address (`0.0.0.0`, `127.0.0.1`, `::`, …).
+     * Declared by `ContainerPortSchema` in `@dashboard/contracts` and emitted by
+     * the normalizer. Undefined when the port is exposed but not published.
+     */
+    ip?: string;
   }>;
   created: number;
   labels: Record<string, string>;

--- a/frontend/src/features/containers/lib/port-bindings.test.ts
+++ b/frontend/src/features/containers/lib/port-bindings.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  UNSPECIFIED_BIND_ADDRESSES,
+  isLoopbackBind,
+  isPubliclyBound,
+  formatPortMapping,
+} from './port-bindings';
+
+describe('isLoopbackBind', () => {
+  it('recognises IPv4 and IPv6 loopback', () => {
+    expect(isLoopbackBind('127.0.0.1')).toBe(true);
+    expect(isLoopbackBind('127.1.2.3')).toBe(true);
+    expect(isLoopbackBind('::1')).toBe(true);
+    expect(isLoopbackBind('[::1]')).toBe(true);
+  });
+
+  it('does not treat a routable address as loopback', () => {
+    expect(isLoopbackBind('0.0.0.0')).toBe(false);
+    expect(isLoopbackBind('192.168.1.10')).toBe(false);
+    // The near-miss that a naive `startsWith('127')` would get wrong.
+    expect(isLoopbackBind('12.7.0.1')).toBe(false);
+  });
+});
+
+describe('isPubliclyBound', () => {
+  it('flags the addresses that mean every interface', () => {
+    for (const ip of UNSPECIFIED_BIND_ADDRESSES) expect(isPubliclyBound(ip)).toBe(true);
+  });
+
+  it('does not flag loopback or an absent bind address', () => {
+    expect(isPubliclyBound('127.0.0.1')).toBe(false);
+    expect(isPubliclyBound(undefined)).toBe(false);
+  });
+});
+
+describe('formatPortMapping', () => {
+  it('includes the bind address so a loopback publish is not shown as world-facing', () => {
+    expect(formatPortMapping({ private: 5432, public: 5432, type: 'tcp', ip: '127.0.0.1' }))
+      .toBe('127.0.0.1:5432 → 5432/tcp');
+    expect(formatPortMapping({ private: 80, public: 8080, type: 'tcp', ip: '0.0.0.0' }))
+      .toBe('0.0.0.0:8080 → 80/tcp');
+  });
+
+  it('keeps the two bindings of a dual-stack publish distinguishable', () => {
+    // Docker emits these as separate entries. Dropping the IP rendered them as
+    // two identical lines, which reads as a rendering bug.
+    const v4 = formatPortMapping({ private: 80, public: 8080, type: 'tcp', ip: '0.0.0.0' });
+    const v6 = formatPortMapping({ private: 80, public: 8080, type: 'tcp', ip: '::' });
+    expect(v4).not.toBe(v6);
+  });
+
+  it('brackets an IPv6 literal, as docker ps does', () => {
+    // `::` + `:8080` would otherwise render `:::8080` — ambiguous, and unlike
+    // anything the operator sees in `docker ps`.
+    expect(formatPortMapping({ private: 80, public: 8080, type: 'tcp', ip: '::' }))
+      .toBe('[::]:8080 → 80/tcp');
+    expect(formatPortMapping({ private: 80, public: 8080, type: 'tcp', ip: '::1' }))
+      .toBe('[::1]:8080 → 80/tcp');
+    // Already-bracketed input is not double-bracketed.
+    expect(formatPortMapping({ private: 80, public: 8080, type: 'tcp', ip: '[::]' }))
+      .toBe('[::]:8080 → 80/tcp');
+    // IPv4 is untouched.
+    expect(formatPortMapping({ private: 80, public: 8080, type: 'tcp', ip: '0.0.0.0' }))
+      .toBe('0.0.0.0:8080 → 80/tcp');
+  });
+
+  it('renders an exposed but unpublished port as the target alone', () => {
+    expect(formatPortMapping({ private: 9000, type: 'tcp' })).toBe('9000/tcp');
+  });
+
+  it('falls back to the host port when Docker reported no bind address', () => {
+    expect(formatPortMapping({ private: 80, public: 8080, type: 'tcp' })).toBe('8080 → 80/tcp');
+  });
+});

--- a/frontend/src/features/containers/lib/port-bindings.ts
+++ b/frontend/src/features/containers/lib/port-bindings.ts
@@ -1,0 +1,54 @@
+import type { Container } from '@/features/containers/hooks/use-containers';
+
+/**
+ * Reading Docker's host-side bind address.
+ *
+ * Whether a port is published on `127.0.0.1` or `0.0.0.0` is the most
+ * security-relevant fact about it, and it is also the only thing separating the
+ * IPv4 and IPv6 bindings Docker emits for the same mapping — without it they
+ * render as two identical rows and the table looks broken.
+ *
+ * These live here rather than beside one renderer because two surfaces show
+ * ports (the container detail table and the topology side panel) and a second
+ * copy of "which addresses mean every interface" is a copy that drifts.
+ */
+
+export type PortMapping = Container['ports'][number];
+
+/** Host bind addresses that mean "every interface on this host". */
+export const UNSPECIFIED_BIND_ADDRESSES = new Set(['0.0.0.0', '::', '[::]']);
+
+export function isLoopbackBind(ip: string): boolean {
+  return ip === '::1' || ip === '[::1]' || ip.startsWith('127.');
+}
+
+/** True when the mapping is reachable from outside the host. */
+export function isPubliclyBound(ip: string | undefined): boolean {
+  return !!ip && UNSPECIFIED_BIND_ADDRESSES.has(ip);
+}
+
+/**
+ * One-line rendering of a mapping for compact surfaces, e.g.
+ * `127.0.0.1:5432 → 5432/tcp`.
+ *
+ * The bind address is included whenever the port is published, so a
+ * loopback-only publish is never displayed identically to a world-facing one,
+ * and the two bindings of a dual-stack publish stay distinguishable.
+ */
+/**
+ * Bracket an IPv6 literal before appending a port.
+ *
+ * Without this, `::` + `:8080` renders as `:::8080`, which is ambiguous and
+ * matches nothing an operator has seen elsewhere — Docker's own `docker ps`
+ * prints `[::]:8080->80/tcp`.
+ */
+function formatHostAddress(ip: string): string {
+  return ip.includes(':') && !ip.startsWith('[') ? `[${ip}]` : ip;
+}
+
+export function formatPortMapping(port: PortMapping): string {
+  const target = `${port.private}/${port.type}`;
+  if (port.public === undefined) return target;
+  const host = port.ip ? `${formatHostAddress(port.ip)}:${port.public}` : String(port.public);
+  return `${host} → ${target}`;
+}

--- a/frontend/src/features/containers/lib/workload-search-filter.test.ts
+++ b/frontend/src/features/containers/lib/workload-search-filter.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { parseSearchQuery, filterContainers } from './workload-search-filter';
+import {
+  parseSearchQuery,
+  filterContainers,
+  deriveSearchChips,
+  SEARCH_FIELDS,
+} from './workload-search-filter';
 import type { Container } from '@/features/containers/hooks/use-containers';
 
 function makeContainer(overrides: Partial<Container> = {}): Container {
@@ -162,5 +167,74 @@ describe('filterContainers', () => {
   it('partial match on free text', () => {
     const result = filterContainers(containers, 'post', knownStackNames);
     expect(result.map((c) => c.id)).toEqual(['c2']);
+  });
+});
+
+describe('SEARCH_FIELDS', () => {
+  it('every advertised field prefix is parsed as a field, not free text', () => {
+    for (const field of SEARCH_FIELDS) {
+      expect(parseSearchQuery(`${field}:value`)).toEqual([{ field, value: 'value' }]);
+    }
+  });
+});
+
+describe('deriveSearchChips', () => {
+  const knownStackNames = ['proxy', 'db', 'traefik'];
+  const fleet = [
+    makeContainer({ id: 'c1', name: 'nginx-proxy-1', image: 'nginx:1.25', state: 'running', endpointName: 'prod', labels: { 'com.docker.compose.project': 'proxy' } }),
+    makeContainer({ id: 'c2', name: 'postgres-db-1', image: 'postgres:15', state: 'running', endpointName: 'prod', labels: { 'com.docker.compose.project': 'db' } }),
+    makeContainer({ id: 'c3', name: 'redis-cache-1', image: 'redis:alpine', state: 'exited', endpointName: 'staging', labels: {} }),
+    makeContainer({ id: 'c4', name: 'traefik-proxy-1', image: 'traefik:v3', state: 'running', endpointName: 'staging', labels: { 'com.docker.compose.project': 'traefik' } }),
+  ];
+
+  it('returns no chips for an empty fleet', () => {
+    expect(deriveSearchChips([], knownStackNames)).toEqual([]);
+  });
+
+  it('every derived chip matches at least one container and narrows the list', () => {
+    const chips = deriveSearchChips(fleet, knownStackNames);
+    expect(chips.length).toBeGreaterThan(0);
+    for (const chip of chips) {
+      const matched = filterContainers(fleet, chip, knownStackNames);
+      expect(matched.length).toBeGreaterThan(0);
+      expect(matched.length).toBeLessThan(fleet.length);
+    }
+  });
+
+  it('suggests the rarest state, not the majority one', () => {
+    // 3 running / 1 exited — "state:running" would return almost everything.
+    expect(deriveSearchChips(fleet, knownStackNames)).toContain('state:exited');
+  });
+
+  it('omits the state chip when every container shares one state', () => {
+    const allRunning = fleet.map((c) => ({ ...c, state: 'running' }));
+    const chips = deriveSearchChips(allRunning, knownStackNames);
+    expect(chips.some((c) => c.startsWith('state:'))).toBe(false);
+  });
+
+  it('omits the endpoint chip when every container is on the same endpoint', () => {
+    const oneEndpoint = fleet.map((c) => ({ ...c, endpointName: 'docker-dev-1' }));
+    const chips = deriveSearchChips(oneEndpoint, knownStackNames);
+    expect(chips.some((c) => c.startsWith('endpoint:'))).toBe(false);
+  });
+
+  it('suggests an image by its base name, so the registry path and tag do not break the match', () => {
+    const containers = [
+      makeContainer({ id: 'a', name: 'lcm-web', image: 'registry.example.com/lcm/lcm-web:dev-local', labels: {} }),
+      makeContainer({ id: 'b', name: 'lcm-api', image: 'postgres:16', labels: {} }),
+    ];
+    const chips = deriveSearchChips(containers, []);
+    const imageChip = chips.find((c) => c.startsWith('image:'));
+    expect(imageChip).toBeDefined();
+    expect(filterContainers(containers, imageChip!, []).length).toBe(1);
+  });
+
+  it('never suggests a value containing whitespace (it would parse as two tokens)', () => {
+    const containers = [
+      makeContainer({ id: 'a', endpointName: 'prod cluster', labels: {} }),
+      makeContainer({ id: 'b', endpointName: 'staging', labels: {} }),
+    ];
+    const chips = deriveSearchChips(containers, []);
+    expect(chips.some((c) => c.includes('prod cluster'))).toBe(false);
   });
 });

--- a/frontend/src/features/containers/lib/workload-search-filter.ts
+++ b/frontend/src/features/containers/lib/workload-search-filter.ts
@@ -1,14 +1,32 @@
 import type { Container } from '@/features/containers/hooks/use-containers';
 import { resolveContainerStackName } from '@/features/containers/lib/container-stack-grouping';
 
+/**
+ * Every field prefix `parseSearchQuery` understands, in the order the UI lists
+ * them. Exported so the search bar's syntax hint is generated from the parser
+ * rather than retyped next to it — `label:` was supported here and named in no
+ * hint and no chip, so the one filter that finds a Docker Hardened image by its
+ * `com.docker.dhi.name` label was undiscoverable.
+ */
+export const SEARCH_FIELDS = [
+  'name',
+  'image',
+  'state',
+  'status',
+  'stack',
+  'endpoint',
+  'port',
+  'label',
+] as const;
+
 export interface SearchToken {
-  field?: 'name' | 'image' | 'state' | 'status' | 'stack' | 'endpoint' | 'port' | 'label';
+  field?: (typeof SEARCH_FIELDS)[number];
   value: string;
 }
 
 type FieldName = NonNullable<SearchToken['field']>;
 
-const FIELD_NAMES = new Set<FieldName>(['name', 'image', 'state', 'status', 'stack', 'endpoint', 'port', 'label']);
+const FIELD_NAMES = new Set<FieldName>(SEARCH_FIELDS);
 
 function isFieldName(s: string): s is FieldName {
   return FIELD_NAMES.has(s as FieldName);
@@ -83,4 +101,90 @@ export function filterContainers(
   return containers.filter((container) =>
     tokens.every((token) => matchesToken(container, token, knownStackNames)),
   );
+}
+
+/** `registry.example.com/team/api-service:1.4.2` → `api-service`. */
+function imageBaseName(image: string): string {
+  const lastSlash = image.lastIndexOf('/');
+  const tail = lastSlash >= 0 ? image.slice(lastSlash + 1) : image;
+  const at = tail.indexOf('@');
+  const withoutDigest = at > 0 ? tail.slice(0, at) : tail;
+  const colon = withoutDigest.lastIndexOf(':');
+  return colon > 0 ? withoutDigest.slice(0, colon) : withoutDigest;
+}
+
+function tally(values: Array<string | null | undefined>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    // A value containing whitespace cannot round-trip through the query
+    // parser (which splits on whitespace), so it can never be a chip.
+    if (!value || /\s/.test(value)) continue;
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * The most common value that still *narrows* the list. A value present on every
+ * row is skipped: a chip that returns all rows is a chip that does nothing.
+ */
+function mostCommonNarrowing(counts: Map<string, number>, total: number): string | undefined {
+  let best: string | undefined;
+  let bestCount = 0;
+  for (const [value, count] of [...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    if (count >= total) continue;
+    if (count > bestCount) {
+      best = value;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/**
+ * Suggested filter chips, derived from the containers actually loaded.
+ *
+ * Every chip is built from a value read off a real container, so each one is
+ * guaranteed to match at least one row and to narrow the list. The chips this
+ * replaced were module-level literals (`image:nginx`, `stack:traefik`,
+ * `endpoint:prod`) — working controls pointed at infrastructure that did not
+ * exist, so clicking one emptied the table.
+ *
+ * Returns `[]` for an empty fleet: nothing to suggest, so show no chips.
+ */
+export function deriveSearchChips(
+  containers: Container[],
+  knownStackNames: string[],
+): string[] {
+  const total = containers.length;
+  if (total === 0) return [];
+
+  const chips: string[] = [];
+
+  // State only when the fleet is mixed. On an all-running fleet `state:running`
+  // returns every row unchanged; the rarest state is the one worth a click.
+  const states = tally(containers.map((c) => c.state));
+  if (states.size > 1) {
+    const rarest = [...states.entries()].sort(
+      (a, b) => a[1] - b[1] || a[0].localeCompare(b[0]),
+    )[0];
+    chips.push(`state:${rarest[0]}`);
+  }
+
+  const stack = mostCommonNarrowing(
+    tally(containers.map((c) => resolveContainerStackName(c, knownStackNames))),
+    total,
+  );
+  if (stack) chips.push(`stack:${stack}`);
+
+  const endpoint = mostCommonNarrowing(tally(containers.map((c) => c.endpointName)), total);
+  if (endpoint) chips.push(`endpoint:${endpoint}`);
+
+  const image = mostCommonNarrowing(
+    tally(containers.map((c) => imageBaseName(c.image))),
+    total,
+  );
+  if (image) chips.push(`image:${image}`);
+
+  return chips;
 }

--- a/frontend/src/features/containers/pages/__tests__/fleet-overview-cards.test.tsx
+++ b/frontend/src/features/containers/pages/__tests__/fleet-overview-cards.test.tsx
@@ -19,7 +19,12 @@ vi.mock('@/features/containers/hooks/use-stacks', () => ({
 }));
 
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn() }),
+  useAutoRefresh: () => ({
+    interval: 30,
+    setRefreshInterval: vi.fn(),
+    setInterval: vi.fn(),
+    enabled: true,
+  }),
 }));
 
 vi.mock('@/shared/lib/api', () => ({
@@ -158,12 +163,45 @@ describe('EndpointCard — compact 3-row layout', () => {
     // Stats row: total containers and running count
     expect(screen.getByText('5')).toBeInTheDocument();
     expect(screen.getByText(/3 running/)).toBeInTheDocument();
-    // Stacks count
+    // Stacks count — no discovered compose projects on this endpoint
     expect(screen.getByText('2 stacks')).toBeInTheDocument();
-    // CPU
-    expect(screen.getByText(/4 CPU/)).toBeInTheDocument();
-    // Memory
-    expect(screen.getByText('8.0 GB')).toBeInTheDocument();
+    // Capacity carries its unit; "10 CPU / 7.8 GB" named no quantity.
+    expect(screen.getByText('4 CPU cores')).toBeInTheDocument();
+    expect(screen.getByText('8.0 GB memory')).toBeInTheDocument();
+  });
+
+  it('separates Portainer-managed stacks from discovered compose projects', () => {
+    // The reported contradiction: the card said "0 stacks" for an endpoint
+    // whose Stack Overview tab listed five.
+    mockEndpoints([makeEndpoint({ id: 3, name: 'docker-dev-1', stackCount: 0 })]);
+    mockStacks([
+      makeStack({ id: -1, name: 'a', source: 'compose-label', endpointId: 3 }),
+      makeStack({ id: -2, name: 'b', source: 'compose-label', endpointId: 3 }),
+      makeStack({ id: -3, name: 'c', source: 'compose-label', endpointId: 3 }),
+    ]);
+
+    renderPage();
+
+    expect(screen.getByText('0 managed · 3 discovered')).toBeInTheDocument();
+    expect(screen.queryByText('0 stacks')).not.toBeInTheDocument();
+  });
+
+  it('offers the "View stacks" link for discovered-only endpoints', () => {
+    // Gated on stackCount alone, this link vanished exactly when the endpoint
+    // had compose projects but no Portainer-managed stack.
+    mockEndpoints([makeEndpoint({ id: 3, name: 'docker-dev-1', stackCount: 0 })]);
+    mockStacks([
+      makeStack({ id: -1, name: 'a', source: 'compose-label', endpointId: 3 }),
+      makeStack({ id: -2, name: 'b', source: 'compose-label', endpointId: 3 }),
+    ]);
+
+    renderPage();
+
+    const link = screen.getByTestId('view-stacks-link');
+    expect(link).toHaveTextContent('View 2 stacks');
+
+    fireEvent.click(link);
+    expect(screen.getByTestId('clear-stack-filter')).toBeInTheDocument();
   });
 
   it('renders Edge Agent badge on row 2 for edge endpoint', () => {
@@ -328,7 +366,7 @@ describe('StackCard — compact 3-row layout', () => {
     expect(screen.getByText('3 env vars')).toBeInTheDocument();
   });
 
-  it('shows Discovered badge instead of ID for inferred stacks', () => {
+  it('shows Discovered badge instead of ID for inferred stacks in a mixed list', () => {
     mockEndpoints([makeEndpoint({ id: 1, name: 'local-env' })]);
     mockStacks([
       makeStack({
@@ -339,14 +377,29 @@ describe('StackCard — compact 3-row layout', () => {
         envCount: 0,
         endpointId: 1,
       }),
+      makeStack({ id: 9, name: 'managed-app', source: 'portainer', envCount: 1, endpointId: 1 }),
     ]);
 
     renderPage({ initialRoute: '/infrastructure?tab=stacks' });
 
     expect(screen.getByText('compose-app')).toBeInTheDocument();
-    expect(screen.getByText('Discovered')).toBeInTheDocument();
+    expect(screen.getAllByText('Discovered')).toHaveLength(1);
     // Should show containers instead of env vars for inferred stacks
     expect(screen.getByText('3 containers')).toBeInTheDocument();
+  });
+
+  it('drops the Discovered badge when the whole list is inferred', () => {
+    mockEndpoints([makeEndpoint({ id: 1, name: 'local-env' })]);
+    mockStacks([
+      makeStack({ id: -1, name: 'compose-app', source: 'compose-label', containerCount: 3, envCount: 0, endpointId: 1 }),
+      makeStack({ id: -2, name: 'compose-two', source: 'compose-label', containerCount: 1, envCount: 0, endpointId: 1 }),
+    ]);
+
+    renderPage({ initialRoute: '/infrastructure?tab=stacks' });
+
+    expect(screen.queryByText('Discovered')).not.toBeInTheDocument();
+    // Singular form for a one-container project (#'1 containers' regression).
+    expect(screen.getByText('1 container')).toBeInTheDocument();
   });
 
   it('does not show Discovered badge for portainer stacks', () => {

--- a/frontend/src/features/containers/pages/container-detail.test.tsx
+++ b/frontend/src/features/containers/pages/container-detail.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 const mockSetSearchParams = vi.fn();
@@ -6,32 +6,40 @@ const mockNavigate = vi.fn();
 const mockRefetch = vi.fn();
 const mockForceRefresh = vi.fn();
 
+const state = vi.hoisted(() => ({
+  search: 'tab=metrics',
+  isLoading: false,
+}));
+
 vi.mock('react-router-dom', () => ({
-  useParams: () => ({ endpointId: '1', containerId: 'c1' }),
-  useSearchParams: () => [new URLSearchParams('tab=metrics'), mockSetSearchParams],
+  useParams: () => ({ endpointId: '1', containerId: 'c1abcdef01234567' }),
+  useSearchParams: () => [new URLSearchParams(state.search), mockSetSearchParams],
   useNavigate: () => mockNavigate,
 }));
 
 vi.mock('@/features/containers/hooks/use-container-detail', () => ({
   useContainerDetail: () => ({
-    data: {
-      id: 'c1',
-      name: 'api',
-      image: 'nginx:latest',
-      state: 'running',
-      status: 'Up 5m',
-      endpointId: 1,
-      endpointName: 'local',
-      ports: [],
-      created: 1700000000,
-      labels: {},
-      networks: ['frontend'],
-    },
-    isLoading: false,
+    data: state.isLoading
+      ? undefined
+      : {
+          id: 'c1abcdef01234567',
+          name: 'api',
+          image: 'nginx:latest',
+          state: 'running',
+          status: 'Up 5m',
+          endpointId: 1,
+          endpointName: 'local',
+          ports: [],
+          created: 1700000000,
+          labels: {},
+          networks: ['frontend'],
+        },
+    isLoading: state.isLoading,
     isError: false,
     error: null,
     refetch: mockRefetch,
     isFetching: false,
+    dataUpdatedAt: Date.now(),
   }),
 }));
 
@@ -46,10 +54,6 @@ vi.mock('@/shared/components/ui/favorite-button', () => ({
   FavoriteButton: () => <button type="button">Favorite</button>,
 }));
 
-vi.mock('@/shared/components/ui/refresh-button', () => ({
-  RefreshButton: () => <button type="button" data-testid="refresh-button">Refresh</button>,
-}));
-
 vi.mock('@/features/containers/components/container/container-overview', () => ({
   ContainerOverview: () => <div>Overview</div>,
 }));
@@ -60,6 +64,10 @@ vi.mock('@/features/containers/components/container/container-logs-viewer', () =
 
 vi.mock('@/features/containers/components/container/container-metrics-viewer', () => ({
   ContainerMetricsViewer: () => <div>Metrics</div>,
+}));
+
+vi.mock('@/features/containers/components/container-traces-tab', () => ({
+  ContainerTracesTab: () => <div>Traces panel</div>,
 }));
 
 vi.mock('@/features/containers/hooks/use-endpoints', () => ({
@@ -73,22 +81,89 @@ vi.mock('@/features/containers/hooks/use-endpoints', () => ({
 
 import ContainerDetailPage from './container-detail';
 
-describe('ContainerDetailPage', () => {
-  it('renders metrics time selector to the left of refresh in header controls', () => {
+beforeEach(() => {
+  state.search = 'tab=metrics';
+  state.isLoading = false;
+  localStorage.clear();
+  mockRefetch.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ContainerDetailPage header controls', () => {
+  it('renders metrics time selector, then freshness, then the refresh controls', () => {
     render(<ContainerDetailPage />);
 
     const controls = screen.getByTestId('metrics-header-controls');
     const timeRangeControl = screen.getByTestId('metrics-time-range-control');
-    const refreshButton = screen.getByTestId('refresh-button');
 
     expect(controls.firstElementChild).toBe(timeRangeControl);
-    expect(controls.lastElementChild).toBe(refreshButton);
     expect(screen.getByTestId('time-range-selector')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '15 min' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '30 min' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '1 hour' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '6 hours' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '24 hours' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '7 days' })).toBeInTheDocument();
+    for (const label of ['15 min', '30 min', '1 hour', '6 hours', '24 hours', '7 days']) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    }
+    // The page used to offer a manual Refresh button only — the one screen in
+    // the drill-down cluster that never updated itself.
+    expect(screen.getByLabelText('Auto-refresh interval')).toBeInTheDocument();
+    expect(screen.getByText(/^Updated /)).toBeInTheDocument();
+  });
+
+  it('refetches on the auto-refresh tick', () => {
+    vi.useFakeTimers();
+    render(<ContainerDetailPage />);
+
+    expect(mockRefetch).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(30_000);
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(30_000);
+    expect(mockRefetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps its own refresh cadence rather than sharing the fleet-wide key', () => {
+    render(<ContainerDetailPage />);
+
+    expect(localStorage.getItem('ai-portainer-auto-refresh:container-detail')).not.toBeNull();
+    expect(localStorage.getItem('ai-portainer-auto-refresh')).toBeNull();
+  });
+});
+
+describe('ContainerDetailPage tabs', () => {
+  it('names the trace tab Traces, matching the rest of the product', () => {
+    render(<ContainerDetailPage />);
+
+    expect(screen.getByRole('tab', { name: 'Traces' })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Calls' })).not.toBeInTheDocument();
+  });
+
+  it('still resolves the old ?tab=calls links to the Traces tab', () => {
+    state.search = 'tab=calls';
+    render(<ContainerDetailPage />);
+
+    expect(screen.getByRole('tab', { name: 'Traces' })).toHaveAttribute(
+      'data-state',
+      'active'
+    );
+    expect(screen.getByText('Traces panel')).toBeInTheDocument();
+  });
+});
+
+describe('ContainerDetailPage loading state', () => {
+  it('uses the shared PageHeader and drops the generic subtitle prose', () => {
+    state.isLoading = true;
+    render(<ContainerDetailPage />);
+
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveTextContent('Container Details');
+    expect(screen.getByTestId('page-header')).toBeInTheDocument();
+    expect(
+      screen.queryByText('View detailed information about a container')
+    ).not.toBeInTheDocument();
+    // The subtitle carries the ids already known from the URL.
+    expect(screen.getByTestId('page-header-subtitle')).toHaveTextContent(
+      'c1abcdef0123 • endpoint 1'
+    );
   });
 });

--- a/frontend/src/features/containers/pages/container-detail.test.tsx
+++ b/frontend/src/features/containers/pages/container-detail.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 const mockSetSearchParams = vi.fn();
 const mockNavigate = vi.fn();
@@ -124,7 +124,20 @@ describe('ContainerDetailPage header controls', () => {
   it('keeps its own refresh cadence rather than sharing the fleet-wide key', () => {
     render(<ContainerDetailPage />);
 
-    expect(localStorage.getItem('ai-portainer-auto-refresh:container-detail')).not.toBeNull();
+    // Merely opening the page records nothing: a default the user never chose
+    // is not a preference, and writing one here to the shared key is how
+    // visiting one page used to change every other page's cadence.
+    expect(localStorage.getItem('ai-portainer-auto-refresh:container-detail')).toBeNull();
+    expect(localStorage.getItem('ai-portainer-auto-refresh')).toBeNull();
+
+    // Choosing a cadence does record it — against this page's own key only.
+    fireEvent.change(screen.getByLabelText('Auto-refresh interval'), {
+      target: { value: '60' },
+    });
+
+    const stored = localStorage.getItem('ai-portainer-auto-refresh:container-detail');
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).interval).toBe(60);
     expect(localStorage.getItem('ai-portainer-auto-refresh')).toBeNull();
   });
 });

--- a/frontend/src/features/containers/pages/container-detail.tsx
+++ b/frontend/src/features/containers/pages/container-detail.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
-import { AlertTriangle, ArrowLeft, Info, ScrollText, Activity, Clock, Wifi, PhoneCall } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, Info, ScrollText, Activity, Clock, Wifi, GitBranch } from 'lucide-react';
 import * as Tabs from '@radix-ui/react-tabs';
 import { useContainerDetail } from '@/features/containers/hooks/use-container-detail';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
-import { RefreshButton } from '@/shared/components/ui/refresh-button';
+import { PageHeader } from '@/shared/components/layout/page-header';
+import { RefreshControls } from '@/shared/components/ui/refresh-controls';
+import { DataFreshness } from '@/shared/components/feedback/data-freshness';
+import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { useForceRefresh } from '@/shared/hooks/use-force-refresh';
 import { FavoriteButton } from '@/shared/components/ui/favorite-button';
 import { ContainerOverview } from '@/features/containers/components/container/container-overview';
@@ -30,7 +33,10 @@ export default function ContainerDetailPage() {
 
   // Parse URL params
   const parsedEndpointId = endpointId ? Number(endpointId) : undefined;
-  const activeTab = searchParams.get('tab') || 'overview';
+  const requestedTab = searchParams.get('tab') || 'overview';
+  // `calls` was this tab's original value; the tab is now labelled Traces to
+  // match the rest of the product, so old bookmarks keep resolving.
+  const activeTab = requestedTab === 'calls' ? 'traces' : requestedTab;
 
   // Fetch container details
   const {
@@ -39,9 +45,18 @@ export default function ContainerDetailPage() {
     isError,
     error,
     refetch,
-    isFetching
+    isFetching,
+    dataUpdatedAt,
   } = useContainerDetail(parsedEndpointId!, containerId!);
   const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', refetch);
+
+  // This was the only page in the drill-down cluster with no auto-refresh — the
+  // one screen you sit on while watching a container recover. Its own storage
+  // key so the cadence here is not inherited from whatever a list page last set.
+  const { interval, setRefreshInterval } = useAutoRefresh(30, {
+    onTick: () => refetch(),
+    storageKey: 'container-detail',
+  });
 
   // Look up endpoint for Edge staleness banner
   const { data: endpoints } = useEndpoints();
@@ -54,16 +69,30 @@ export default function ContainerDetailPage() {
     setSearchParams({ tab: value });
   };
 
+  /*
+   * The identity header below is bespoke on purpose (h1 = container name, back
+   * arrow and favourite star inline with it, subline = short id · endpoint) and
+   * `PageHeader` has no leading-element slot, so the loaded branch keeps it.
+   * The pre-load branches had no identity to show and hand-rolled the same
+   * generic title three times; they share one `PageHeader` instead. The subtitle
+   * carries the ids we already know from the URL rather than restating the title.
+   */
+  const fallbackHeader = (
+    <PageHeader
+      title="Container Details"
+      subtitle={
+        containerId && parsedEndpointId
+          ? `${containerId.slice(0, 12)} • endpoint ${parsedEndpointId}`
+          : undefined
+      }
+    />
+  );
+
   // Error state - invalid params
   if (!parsedEndpointId || !containerId) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Container Details</h1>
-          <p className="text-muted-foreground">
-            View detailed information about a container
-          </p>
-        </div>
+        {fallbackHeader}
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
           <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
           <p className="mt-4 font-medium text-destructive">Invalid URL parameters</p>
@@ -79,12 +108,7 @@ export default function ContainerDetailPage() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Container Details</h1>
-          <p className="text-muted-foreground">
-            View detailed information about a container
-          </p>
-        </div>
+        {fallbackHeader}
         <SkeletonChart size="lg" className="h-[600px]" />
       </div>
     );
@@ -94,12 +118,7 @@ export default function ContainerDetailPage() {
   if (isError || !container) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Container Details</h1>
-          <p className="text-muted-foreground">
-            View detailed information about a container
-          </p>
-        </div>
+        {fallbackHeader}
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
           <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
           <p className="mt-4 font-medium text-destructive">Container not found</p>
@@ -120,26 +139,26 @@ export default function ContainerDetailPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-4">
           <button
             onClick={() => navigate('/workloads')}
-            className="flex h-8 w-8 items-center justify-center rounded-md border border-input bg-background hover:bg-accent"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-input bg-background hover:bg-accent"
             title="Back to Workload Explorer"
           >
             <ArrowLeft className="h-4 w-4" />
           </button>
-          <div>
+          <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <h1 className="text-3xl font-bold tracking-tight">{container.name}</h1>
+              <h1 className="truncate text-xl font-bold tracking-tight sm:text-3xl">{container.name}</h1>
               <FavoriteButton endpointId={parsedEndpointId} containerId={containerId} />
             </div>
-            <p className="text-muted-foreground">
+            <p className="truncate text-sm text-muted-foreground">
               {container.id.slice(0, 12)} • {container.endpointName}
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2" data-testid="metrics-header-controls">
+        <div className="flex flex-wrap items-center gap-2" data-testid="metrics-header-controls">
           {activeTab === 'metrics' && container.state === 'running' && (
             <div className="flex items-center gap-2" data-testid="metrics-time-range-control">
               <Clock className="h-4 w-4 text-muted-foreground" />
@@ -161,7 +180,14 @@ export default function ContainerDetailPage() {
               </div>
             </div>
           )}
-          <RefreshButton onClick={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
+          <DataFreshness lastUpdated={dataUpdatedAt ?? null} onRefresh={() => refetch()} />
+          <RefreshControls
+            interval={interval}
+            onIntervalChange={setRefreshInterval}
+            onRefresh={() => refetch()}
+            onForceRefresh={forceRefresh}
+            isLoading={isFetching || isForceRefreshing}
+          />
         </div>
       </div>
 
@@ -225,11 +251,11 @@ export default function ContainerDetailPage() {
             Metrics
           </Tabs.Trigger>
           <Tabs.Trigger
-            value="calls"
+            value="traces"
             className="flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors hover:text-primary data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary"
           >
-            <PhoneCall className="h-4 w-4" />
-            Calls
+            <GitBranch className="h-4 w-4" />
+            Traces
           </Tabs.Trigger>
         </Tabs.List>
 
@@ -245,7 +271,7 @@ export default function ContainerDetailPage() {
           />
         </Tabs.Content>
 
-        <Tabs.Content value="calls" className="focus:outline-none">
+        <Tabs.Content value="traces" className="focus:outline-none">
           <ContainerTracesTab
             containerName={container.name}
             endpointId={container.endpointId}

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import InfrastructurePage from './fleet-overview';
@@ -25,8 +25,15 @@ vi.mock('@/features/kubernetes/hooks/use-kubernetes', () => ({
   useK8sNamespaces: vi.fn(() => ({ data: [] })),
 }));
 
+const mockUseAutoRefresh = vi.fn(() => ({
+  interval: 30,
+  setRefreshInterval: vi.fn(),
+  setInterval: vi.fn(),
+  enabled: true,
+}));
+
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn() }),
+  useAutoRefresh: (...args: unknown[]) => mockUseAutoRefresh(...(args as [])),
 }));
 
 vi.mock('@/shared/lib/api', () => ({
@@ -141,6 +148,107 @@ describe('InfrastructurePage — page structure', () => {
     renderPage();
     expect(screen.getByTestId('tab-fleet')).toBeInTheDocument();
     expect(screen.getByTestId('tab-stacks')).toBeInTheDocument();
+  });
+
+  it('renders the heading through the shared PageHeader', () => {
+    renderPage();
+    const header = screen.getByTestId('page-header');
+    expect(header).toBeInTheDocument();
+    expect(within(header).getByRole('heading', { level: 1, name: 'Infrastructure' })).toBeInTheDocument();
+  });
+});
+
+describe('InfrastructurePage — auto-refresh actually refreshes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({ pageViewModes: {} });
+  });
+
+  it('passes onTick to useAutoRefresh and refetches both queries when it fires', () => {
+    const refetchEndpoints = vi.fn();
+    const refetchStacks = vi.fn();
+    mockEndpoints([makeEndpoint()], { refetch: refetchEndpoints });
+    mockStacks([makeStack()], { refetch: refetchStacks });
+
+    renderPage();
+
+    // The dropdown used to write a localStorage preference and schedule
+    // nothing, while RefreshControls rendered a pulsing live dot.
+    const options = mockUseAutoRefresh.mock.calls.at(-1)?.[1] as
+      | { onTick?: () => void }
+      | undefined;
+    expect(typeof options?.onTick).toBe('function');
+
+    options!.onTick!();
+
+    expect(refetchEndpoints).toHaveBeenCalled();
+    expect(refetchStacks).toHaveBeenCalled();
+  });
+
+  it('stamps the header with how old the endpoint data is', () => {
+    mockEndpoints([makeEndpoint()], { dataUpdatedAt: Date.now() - 12_000 });
+    mockStacks([makeStack()]);
+
+    renderPage();
+
+    expect(screen.getByText(/^Updated /)).toBeInTheDocument();
+  });
+});
+
+describe('InfrastructurePage — table rows are real links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({ pageViewModes: {} });
+  });
+
+  function anchorNamed(name: string): HTMLElement | undefined {
+    return screen.getAllByRole('link', { name }).find((el) => el.tagName === 'A');
+  }
+
+  it('renders endpoint rows with an anchor to the endpoint workloads', () => {
+    useUiStore.setState({ pageViewModes: { fleet: 'table' } });
+    mockEndpoints([makeEndpoint({ id: 7, name: 'click-env' })]);
+    mockStacks([]);
+
+    renderPage();
+
+    const anchor = anchorNamed('Containers on click-env');
+    expect(anchor).toBeDefined();
+    expect(anchor).toHaveAttribute('href', '/workloads?endpoint=7');
+  });
+
+  it('renders stack rows with an anchor to the stack workloads', () => {
+    useUiStore.setState({ pageViewModes: { stacks: 'table' } });
+    mockEndpoints([makeEndpoint({ id: 1, name: 'local' })]);
+    mockStacks([makeStack({ id: 4, name: 'my stack', endpointId: 1 })]);
+
+    renderPageWithInitialParams('/infrastructure?tab=stacks');
+
+    const anchor = anchorNamed('Containers in my stack');
+    expect(anchor).toBeDefined();
+    expect(anchor).toHaveAttribute('href', '/workloads?endpoint=1&stack=my%20stack');
+  });
+});
+
+describe('InfrastructurePage — view-mode toggle is chrome, not signal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({ pageViewModes: {} });
+    mockEndpoints([makeEndpoint()]);
+    mockStacks([makeStack()]);
+  });
+
+  it('marks the selected segment with a neutral surface, not the primary accent', () => {
+    renderPage();
+
+    const grid = screen.getByTestId('fleet-view-grid');
+    const table = screen.getByTestId('fleet-view-table');
+
+    expect(grid).toHaveAttribute('aria-pressed', 'true');
+    expect(table).toHaveAttribute('aria-pressed', 'false');
+    // A layout preference must not out-shout the Up/Down status pills.
+    expect(grid.className).toContain('bg-muted');
+    expect(grid.className).not.toMatch(/bg-(primary|accent)\b/);
   });
 });
 
@@ -500,15 +608,55 @@ describe('InfrastructurePage — stack section', () => {
     mockEndpoints([makeEndpoint({ id: 1, name: 'local' })]);
   });
 
-  it('renders stack cards with Discovered badge for compose-label stacks', () => {
+  it('renders the Discovered badge only on the inferred rows of a mixed list', () => {
     mockStacks([
       makeStack({ id: -12345, name: 'my-compose-app', source: 'compose-label', containerCount: 3, envCount: 0 }),
+      makeStack({ id: 7, name: 'portainer-stack', source: 'portainer', envCount: 2 }),
     ]);
 
     renderPageWithInitialParams('/infrastructure?tab=stacks');
 
     expect(screen.getByText('my-compose-app')).toBeInTheDocument();
-    expect(screen.getByText('Discovered')).toBeInTheDocument();
+    expect(screen.getAllByText('Discovered')).toHaveLength(1);
+  });
+
+  it('omits the Discovered badge when every stack was discovered', () => {
+    // A badge on every row distinguishes nothing — the endpoint card carries
+    // the "N discovered" fact instead.
+    mockStacks([
+      makeStack({ id: -1, name: 'compose-a', source: 'compose-label', containerCount: 3, envCount: 0 }),
+      makeStack({ id: -2, name: 'compose-b', source: 'compose-label', containerCount: 1, envCount: 0 }),
+    ]);
+
+    renderPageWithInitialParams('/infrastructure?tab=stacks');
+
+    expect(screen.getByText('compose-a')).toBeInTheDocument();
+    expect(screen.queryByText('Discovered')).not.toBeInTheDocument();
+  });
+
+  it('renders the Discovered badge in a neutral, non-AI colour', () => {
+    mockStacks([
+      makeStack({ id: -1, name: 'compose-a', source: 'compose-label', containerCount: 3, envCount: 0 }),
+      makeStack({ id: 7, name: 'portainer-stack', source: 'portainer', envCount: 2 }),
+    ]);
+
+    renderPageWithInitialParams('/infrastructure?tab=stacks');
+
+    // Purple is reserved for AI insight; reading a compose label is not one.
+    const badge = screen.getByText('Discovered').closest('span');
+    expect(badge?.className).not.toMatch(/purple/);
+    expect(badge?.className).toContain('bg-muted');
+  });
+
+  it('uses singular "container" for a one-container discovered stack', () => {
+    mockStacks([
+      makeStack({ id: -1, name: 'solo', source: 'compose-label', containerCount: 1, envCount: 0 }),
+    ]);
+
+    renderPageWithInitialParams('/infrastructure?tab=stacks');
+
+    expect(screen.getByText('1 container')).toBeInTheDocument();
+    expect(screen.queryByText('1 containers')).not.toBeInTheDocument();
   });
 
   it('renders Portainer stacks with standard ID label', () => {
@@ -1175,12 +1323,58 @@ describe('Infrastructure smart search — Fleet tab', () => {
     mockStacks([]);
   });
 
-  it('renders endpoint example chips inside the search bar', () => {
-    mockEndpoints([makeEndpoint({ id: 1, name: 'prod-1' }), makeEndpoint({ id: 2, name: 'prod-2', status: 'down' })]);
+  it('derives the endpoint example chips from the loaded endpoints', () => {
+    mockEndpoints([
+      makeEndpoint({ id: 1, name: 'docker-dev-1', url: 'tcp://10.0.0.1:9001' }),
+      makeEndpoint({ id: 2, name: 'docker-dev-2', url: 'tcp://10.0.0.2:9001' }),
+    ]);
     renderPage();
-    expect(screen.getByRole('button', { name: 'name:prod' })).toBeInTheDocument();
+
+    // Seeded from the first endpoint's name and URL, not a hardcoded "prod".
+    expect(screen.getByRole('button', { name: 'name:docker' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'status:up' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'type:edge' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'url:10.0.0.1' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'name:prod' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'type:edge' })).not.toBeInTheDocument();
+  });
+
+  it('every endpoint chip matches at least one row when clicked', async () => {
+    mockEndpoints([
+      makeEndpoint({ id: 1, name: 'docker-dev-1', url: 'tcp://10.0.0.1:9001' }),
+      makeEndpoint({ id: 2, name: 'other-host', url: 'tcp://10.0.0.2:9001', status: 'down' }),
+    ]);
+    renderPage();
+
+    // The whole point of deriving chips: `name:prod` and `type:edge` returned
+    // zero rows in a fleet that has neither.
+    const chipLabels = screen
+      .getAllByRole('button')
+      .map((b) => b.textContent ?? '')
+      .filter((t) => /^(name|status|url):/.test(t));
+    expect(chipLabels.length).toBeGreaterThan(0);
+
+    for (const label of chipLabels) {
+      // Re-query each round: clicking a chip unmounts the whole chip group.
+      fireEvent.click(screen.getByRole('button', { name: label }));
+      await waitFor(() => {
+        expect(screen.getByTestId('fleet-filtered-count')).not.toHaveTextContent(/^0 of/);
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+      });
+    }
+  });
+
+  it('prefers a status chip that is actually present in the fleet', () => {
+    mockEndpoints([
+      makeEndpoint({ id: 1, name: 'a-host', status: 'down' }),
+      makeEndpoint({ id: 2, name: 'b-host', status: 'down' }),
+    ]);
+    renderPage();
+
+    expect(screen.getByRole('button', { name: 'status:down' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'status:up' })).not.toBeInTheDocument();
   });
 
   it('seeds the endpoint search from the URL (endpointSearch param)', () => {
@@ -1199,11 +1393,31 @@ describe('Infrastructure smart search — Stacks tab', () => {
     mockStacks([makeStack({ id: 1, name: 'traefik' }), makeStack({ id: 2, name: 'grafana' })]);
   });
 
-  it('renders stack example chips inside the search bar', () => {
+  it('derives the stack example chips from the loaded stacks', () => {
     renderPageWithInitialParams('/infrastructure?tab=stacks');
+
+    // First stack in this fixture is literally named "traefik", so the chip is
+    // real here — what matters is that it came from the data.
     expect(screen.getByRole('button', { name: 'name:traefik' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'status:active' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'endpoint:prod' })).toBeInTheDocument();
+    // Only one endpoint owns stacks, so an `endpoint:` chip would teach nothing.
+    expect(screen.queryByRole('button', { name: 'endpoint:prod' })).not.toBeInTheDocument();
+  });
+
+  it('offers an endpoint chip only when more than one endpoint owns stacks', () => {
+    mockEndpoints([
+      makeEndpoint({ id: 1, name: 'docker-dev-1' }),
+      makeEndpoint({ id: 2, name: 'docker-dev-2' }),
+    ]);
+    mockStacks([
+      makeStack({ id: 1, name: 'web-app', endpointId: 1 }),
+      makeStack({ id: 2, name: 'db', endpointId: 2 }),
+    ]);
+
+    renderPageWithInitialParams('/infrastructure?tab=stacks');
+
+    expect(screen.getByRole('button', { name: 'name:web' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'endpoint:docker' })).toBeInTheDocument();
   });
 
   it('shows the smart search bar and no DataTable search in Stacks table view', () => {

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -15,6 +15,8 @@ import { DataTable } from '@/shared/components/tables/data-table';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { RefreshControls } from '@/shared/components/ui/refresh-controls';
 import { RefreshButton } from '@/shared/components/ui/refresh-button';
+import { DataFreshness } from '@/shared/components/feedback/data-freshness';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { SkeletonText, SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
@@ -91,17 +93,73 @@ function formatDate(timestamp?: number): string {
   return new Date(timestamp * 1000).toLocaleDateString();
 }
 
+/**
+ * Reading a `com.docker.compose.project` label off a container is not
+ * inference, so this badge is deliberately neutral: purple is reserved for AI
+ * insight (DESIGN.md, CLAUDE.md). It is also only rendered when the list
+ * contains at least one *non*-discovered stack — a badge on every row
+ * distinguishes nothing.
+ */
 function DiscoveredBadge() {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
+    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
       <Search className="h-3 w-3" />
       Discovered
     </span>
   );
 }
 
-function EndpointCard({ endpoint, onClick, onViewStacks }: { endpoint: Endpoint; onClick: () => void; onViewStacks?: () => void }) {
+/**
+ * The two stack populations this page has to keep straight.
+ *
+ * `managed` is Portainer's own count (`endpoint.stackCount`); `discovered` are
+ * compose projects inferred from container labels. Both used to be printed as
+ * "stacks", so the Fleet tab could say `0 stacks` for an endpoint whose Stack
+ * Overview tab listed five, and the "View N stacks" link was gated on the
+ * managed count alone — unreachable exactly when the discovered ones existed.
+ */
+interface EndpointStackSummary {
+  managed: number;
+  discovered: number;
+  /** How many rows the Stack Overview tab will actually show for this endpoint. */
+  listed: number;
+}
+
+/**
+ * First alphanumeric segment of a name — `docker-dev-1` → `docker`. Used to
+ * seed a search chip that demonstrates substring matching against real data
+ * rather than pinning the whole name (which only ever matches one row).
+ */
+function firstNameSegment(name: string | undefined): string | null {
+  if (!name) return null;
+  const segment = name.split(/[^A-Za-z0-9]+/).find(Boolean);
+  return segment ?? null;
+}
+
+/** Hostname of an endpoint URL, for a `url:` chip that resolves to real rows. */
+function firstUrlHost(url: string | undefined): string | null {
+  if (!url) return null;
+  const withoutScheme = url.replace(/^[a-z0-9+.-]+:\/\//i, '');
+  const host = withoutScheme.split(/[/:]/).find(Boolean);
+  return host ?? null;
+}
+
+function formatContainerCount(count: number): string {
+  return `${count} container${count !== 1 ? 's' : ''}`;
+}
+
+function formatStackSummary(summary: EndpointStackSummary): string {
+  if (summary.discovered > 0) {
+    return `${summary.managed} managed · ${summary.discovered} discovered`;
+  }
+  return `${summary.managed} stack${summary.managed !== 1 ? 's' : ''}`;
+}
+
+function EndpointCard({ endpoint, stacks, onClick, onViewStacks }: { endpoint: Endpoint; stacks: EndpointStackSummary; onClick: () => void; onViewStacks?: () => void }) {
   const memoryGB = (endpoint.totalMemory / (1024 * 1024 * 1024)).toFixed(1);
+  // Promise the number the Stack Overview tab will show; fall back to the
+  // managed count while the stacks query has not resolved for this endpoint.
+  const linkCount = stacks.listed > 0 ? stacks.listed : stacks.managed;
 
   // Non-interactive container: nesting the "View stacks" button inside a
   // card-level <button> is invalid HTML (#1547). The endpoint name is the
@@ -151,9 +209,9 @@ function EndpointCard({ endpoint, onClick, onViewStacks }: { endpoint: Endpoint;
           {endpoint.totalContainers}
           <span className="ml-1">({endpoint.containersRunning} running)</span>
         </span>
-        <span>{endpoint.stackCount} stacks</span>
-        <span>{endpoint.totalCpu} CPU</span>
-        <span>{memoryGB} GB</span>
+        <span>{formatStackSummary(stacks)}</span>
+        <span>{endpoint.totalCpu} CPU cores</span>
+        <span>{memoryGB} GB memory</span>
       </div>
 
       {/* Edge metadata (compact) — matches table Check-in + Snapshot columns */}
@@ -168,15 +226,16 @@ function EndpointCard({ endpoint, onClick, onViewStacks }: { endpoint: Endpoint;
         </div>
       )}
 
-      {/* View stacks link — positioned above the stretched name-button overlay */}
-      {onViewStacks && endpoint.stackCount > 0 && (
+      {/* View stacks link — positioned above the stretched name-button overlay.
+          Gated on the union of both populations, not on the managed count. */}
+      {onViewStacks && linkCount > 0 && (
         <button
           type="button"
           onClick={(e) => { e.stopPropagation(); onViewStacks(); }}
           className="relative mt-2 inline-flex items-center gap-1 text-xs text-primary hover:underline"
           data-testid="view-stacks-link"
         >
-          View {endpoint.stackCount} stack{endpoint.stackCount !== 1 ? 's' : ''}
+          View {linkCount} stack{linkCount !== 1 ? 's' : ''}
           <ArrowRight className="h-3 w-3" />
         </button>
       )}
@@ -184,7 +243,7 @@ function EndpointCard({ endpoint, onClick, onViewStacks }: { endpoint: Endpoint;
   );
 }
 
-function StackCard({ stack, onClick }: { stack: StackWithEndpoint; onClick: () => void }) {
+function StackCard({ stack, showDiscoveredBadge, onClick }: { stack: StackWithEndpoint; showDiscoveredBadge: boolean; onClick: () => void }) {
   const isInferred = stack.source === 'compose-label';
 
   return (
@@ -195,7 +254,9 @@ function StackCard({ stack, onClick }: { stack: StackWithEndpoint; onClick: () =
       {/* Row 1: Name + ID/Discovered — matches table Name column */}
       <div className="flex items-center justify-between gap-2">
         <h3 className="truncate font-medium">{stack.name}</h3>
-        {isInferred ? <DiscoveredBadge /> : <span className="shrink-0 text-xs text-muted-foreground">(ID: {stack.id})</span>}
+        {isInferred
+          ? (showDiscoveredBadge ? <DiscoveredBadge /> : null)
+          : <span className="shrink-0 text-xs text-muted-foreground">(ID: {stack.id})</span>}
       </div>
 
       {/* Row 2: Stack type + Status badge — matches table Type + Status columns */}
@@ -212,7 +273,7 @@ function StackCard({ stack, onClick }: { stack: StackWithEndpoint; onClick: () =
           {stack.endpointName}
           <span className="ml-1">(ID: {stack.endpointId})</span>
         </span>
-        <span>{isInferred ? `${stack.containerCount ?? 0} containers` : `${stack.envCount} env vars`}</span>
+        <span>{isInferred ? formatContainerCount(stack.containerCount ?? 0) : `${stack.envCount} env vars`}</span>
       </div>
     </button>
   );
@@ -333,6 +394,7 @@ export default function InfrastructurePage() {
     error: endpointErrorObj,
     refetch: refetchEndpoints,
     isFetching: endpointsFetching,
+    dataUpdatedAt: endpointsUpdatedAt,
   } = useEndpoints();
 
   const {
@@ -383,9 +445,6 @@ export default function InfrastructurePage() {
   const isLoading = endpointsLoading || stacksLoading;
   const isFetching = endpointsFetching || stacksFetching;
 
-  // Shared auto-refresh preference
-  const { interval, setInterval } = useAutoRefresh(30);
-
   // Cross-section filter: "View stacks" link sets stackEndpoint filter AND switches to stacks tab
   const handleViewStacks = useCallback((endpointId: number) => {
     const params: Record<string, string> = { tab: 'stacks', stackEndpoint: String(endpointId) };
@@ -422,6 +481,11 @@ export default function InfrastructurePage() {
     void refetchEndpoints();
     void refetchStacks();
   }, [refetchEndpoints, refetchStacks]);
+
+  // Shared auto-refresh preference. `onTick` is the point of the control: the
+  // dropdown used to write a localStorage preference, render a pulsing live
+  // dot, and schedule nothing at all.
+  const { interval, setRefreshInterval } = useAutoRefresh(30, { onTick: handleRefresh });
 
   // Auto-switch fleet to table view when > 100 endpoints (only if user hasn't chosen)
   useEffect(() => {
@@ -474,6 +538,71 @@ export default function InfrastructurePage() {
       endpointName: endpoints.find(ep => ep.id === stack.endpointId)?.name || `Endpoint ${stack.endpointId}`,
     }));
   }, [stacks, endpoints]);
+
+  // Per-endpoint stack populations, keyed by endpoint id. `managed` comes from
+  // Portainer (endpoint.stackCount); everything here is derived from the stacks
+  // the Stack Overview tab will actually list.
+  const stackCountsByEndpoint = useMemo(() => {
+    const map = new Map<number, { discovered: number; listed: number }>();
+    for (const stack of stacksWithEndpoints) {
+      const entry = map.get(stack.endpointId) ?? { discovered: 0, listed: 0 };
+      entry.listed += 1;
+      if (stack.source === 'compose-label') entry.discovered += 1;
+      map.set(stack.endpointId, entry);
+    }
+    return map;
+  }, [stacksWithEndpoints]);
+
+  const getStackSummary = useCallback((endpoint: Endpoint): EndpointStackSummary => {
+    const entry = stackCountsByEndpoint.get(endpoint.id);
+    return {
+      managed: endpoint.stackCount,
+      discovered: entry?.discovered ?? 0,
+      listed: entry?.listed ?? 0,
+    };
+  }, [stackCountsByEndpoint]);
+
+  // The "Discovered" badge only earns its space when it separates one row from
+  // another. If every listed stack was inferred it labels a constant.
+  const showDiscoveredBadge = useMemo(
+    () =>
+      stacksWithEndpoints.some((s) => s.source === 'compose-label') &&
+      stacksWithEndpoints.some((s) => s.source !== 'compose-label'),
+    [stacksWithEndpoints],
+  );
+
+  // Search example chips, derived from what is actually loaded. They used to be
+  // the hardcoded `name:prod`, `status:up`, `type:edge` / `name:traefik`,
+  // `status:active`, `endpoint:prod` — none of which match anything in a fleet
+  // that has no `prod`, no `traefik` and no Edge endpoint, so clicking one
+  // emptied the list.
+  const endpointSearchExamples = useMemo(() => {
+    const list = endpoints ?? [];
+    if (list.length === 0) return [];
+    const chips: string[] = [];
+    const nameSeed = firstNameSegment(list[0].name);
+    if (nameSeed) chips.push(`name:${nameSeed}`);
+    if (list.some((ep) => ep.status === 'down')) chips.push('status:down');
+    else if (list.some((ep) => ep.status === 'up')) chips.push('status:up');
+    const host = firstUrlHost(list[0].url);
+    if (host) chips.push(`url:${host}`);
+    return chips;
+  }, [endpoints]);
+
+  const stackSearchExamples = useMemo(() => {
+    if (stacksWithEndpoints.length === 0) return [];
+    const chips: string[] = [];
+    const nameSeed = firstNameSegment(stacksWithEndpoints[0].name);
+    if (nameSeed) chips.push(`name:${nameSeed}`);
+    if (stacksWithEndpoints.some((s) => s.status === 'inactive')) chips.push('status:inactive');
+    else if (stacksWithEndpoints.some((s) => s.status === 'active')) chips.push('status:active');
+    const endpointIds = new Set(stacksWithEndpoints.map((s) => s.endpointId));
+    if (endpointIds.size > 1) {
+      const endpointSeed = firstNameSegment(stacksWithEndpoints[0].endpointName);
+      if (endpointSeed) chips.push(`endpoint:${endpointSeed}`);
+    }
+    return chips;
+  }, [stacksWithEndpoints]);
 
   // Slim status-KPI pills for the search rows (counts from the unfiltered lists,
   // matching the old summary-bar semantics). Clicking a pill toggles the same
@@ -697,6 +826,7 @@ export default function InfrastructurePage() {
     {
       accessorKey: 'stackCount',
       header: 'Stacks',
+      cell: ({ row }) => formatStackSummary(getStackSummary(row.original)),
     },
     {
       accessorKey: 'totalCpu',
@@ -750,7 +880,7 @@ export default function InfrastructurePage() {
         <span className="text-xs text-muted-foreground">{getValue<string>()}</span>
       ),
     },
-  ], []);
+  ], [getStackSummary]);
 
   const stackColumns: ColumnDef<StackWithEndpoint, unknown>[] = useMemo(() => [
     {
@@ -760,7 +890,7 @@ export default function InfrastructurePage() {
         <div className="flex items-center gap-2">
           <span className="font-medium">{row.original.name}</span>
           {row.original.source === 'compose-label'
-            ? <DiscoveredBadge />
+            ? (showDiscoveredBadge ? <DiscoveredBadge /> : null)
             : <span className="text-xs text-muted-foreground">(ID: {row.original.id})</span>
           }
         </div>
@@ -790,7 +920,7 @@ export default function InfrastructurePage() {
       id: 'envOrContainers',
       header: 'Details',
       cell: ({ row }) => row.original.source === 'compose-label'
-        ? `${row.original.containerCount ?? 0} containers`
+        ? formatContainerCount(row.original.containerCount ?? 0)
         : `${row.original.envCount} env vars`,
     },
     {
@@ -803,7 +933,7 @@ export default function InfrastructurePage() {
       header: 'Updated',
       cell: ({ getValue }) => formatDate(getValue<number>()),
     },
-  ], []);
+  ], [showDiscoveredBadge]);
 
   // ── Kubernetes column definitions ───────────────────────────────────────────
   const k8sPodColumns: ColumnDef<K8sPod, unknown>[] = useMemo(() => [
@@ -925,23 +1055,22 @@ export default function InfrastructurePage() {
   return (
     <div className="space-y-6">
       {/* Page header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Infrastructure</h1>
-          <p className="text-muted-foreground">
-            Endpoints and compose stacks across your fleet
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <RefreshControls
-            interval={interval}
-            onIntervalChange={setInterval}
-            onRefresh={handleRefresh}
-            onForceRefresh={forceRefresh}
-            isLoading={isFetching || isForceRefreshing}
-          />
-        </div>
-      </div>
+      <PageHeader
+        title="Infrastructure"
+        subtitle="Endpoints and compose stacks across your fleet"
+        actions={
+          <>
+            <DataFreshness lastUpdated={endpointsUpdatedAt || null} onRefresh={handleRefresh} />
+            <RefreshControls
+              interval={interval}
+              onIntervalChange={setRefreshInterval}
+              onRefresh={handleRefresh}
+              onForceRefresh={forceRefresh}
+              isLoading={isFetching || isForceRefreshing}
+            />
+          </>
+        }
+      />
 
       {/* Error state */}
       {hasError && (
@@ -997,9 +1126,9 @@ export default function InfrastructurePage() {
                       onSearch={handleEndpointSearch}
                       totalCount={endpoints.length}
                       filteredCount={filteredEndpoints.length}
-                      placeholder="Search endpoints... (name:prod status:up type:edge)"
+                      placeholder="Search endpoints by name, status, type, or URL"
                       label="Search endpoints"
-                      examples={['name:prod', 'status:up', 'type:edge']}
+                      examples={endpointSearchExamples}
                       // Focus the search when the Fleet tab first mounts; gate with ref
                       // so re-mounting (tab switch) does not re-steal focus.
                       autoFocus={!fleetSearchAutoFocusedRef.current}
@@ -1011,13 +1140,18 @@ export default function InfrastructurePage() {
                   <StatusKpi pills={endpointStatusKpiPills} ariaLabel="Endpoint status" />
                 </>
               )}
+              {/* Layout preference, not signal: a neutral segmented control.
+                  Filled with the primary accent it was the loudest element on
+                  the page, louder than the Up/Down status pills. */}
               <div className="flex items-center rounded-lg border p-1">
                 <button
                   onClick={() => setFleetViewMode('grid')}
+                  aria-pressed={fleetViewMode === 'grid'}
+                  data-testid="fleet-view-grid"
                   className={cn(
                     'inline-flex items-center justify-center rounded-md p-2 transition-colors',
                     fleetViewMode === 'grid'
-                      ? 'bg-accent text-accent-foreground'
+                      ? 'bg-muted text-foreground'
                       : 'text-muted-foreground hover:text-foreground'
                   )}
                   title="Grid view"
@@ -1026,10 +1160,12 @@ export default function InfrastructurePage() {
                 </button>
                 <button
                   onClick={() => setFleetViewMode('table')}
+                  aria-pressed={fleetViewMode === 'table'}
+                  data-testid="fleet-view-table"
                   className={cn(
                     'inline-flex items-center justify-center rounded-md p-2 transition-colors',
                     fleetViewMode === 'table'
-                      ? 'bg-accent text-accent-foreground'
+                      ? 'bg-muted text-foreground'
                       : 'text-muted-foreground hover:text-foreground'
                   )}
                   title="Table view"
@@ -1108,6 +1244,7 @@ export default function InfrastructurePage() {
                   <EndpointCard
                     key={endpoint.id}
                     endpoint={endpoint}
+                    stacks={getStackSummary(endpoint)}
                     onClick={() => handleEndpointClick(endpoint.id)}
                     onViewStacks={() => handleViewStacks(endpoint.id)}
                   />
@@ -1151,6 +1288,8 @@ export default function InfrastructurePage() {
               hideSearch
               autoFit
               onRowClick={(row) => handleEndpointClick(row.id)}
+              rowHref={(row) => `/workloads?endpoint=${row.id}`}
+              rowLabel={(row) => `Containers on ${row.name}`}
             />
           </div>
           </SpotlightCard>
@@ -1186,9 +1325,9 @@ export default function InfrastructurePage() {
                     onSearch={handleStackSearch}
                     totalCount={dropdownFilteredStacks.length}
                     filteredCount={filteredStacks.length}
-                    placeholder="Search stacks... (name:traefik status:active endpoint:prod)"
+                    placeholder="Search stacks by name, status, or endpoint"
                     label="Search stacks"
-                    examples={['name:traefik', 'status:active', 'endpoint:prod']}
+                    examples={stackSearchExamples}
                     initialValue={stackSearchQuery}
                     showCount={false}
                   />
@@ -1202,10 +1341,12 @@ export default function InfrastructurePage() {
               <div className="flex items-center rounded-lg border p-1">
                 <button
                   onClick={() => setStacksViewMode('grid')}
+                  aria-pressed={stacksViewMode === 'grid'}
+                  data-testid="stacks-view-grid"
                   className={cn(
                     'inline-flex items-center justify-center rounded-md p-2 transition-colors',
                     stacksViewMode === 'grid'
-                      ? 'bg-accent text-accent-foreground'
+                      ? 'bg-muted text-foreground'
                       : 'text-muted-foreground hover:text-foreground'
                   )}
                   title="Grid view"
@@ -1214,10 +1355,12 @@ export default function InfrastructurePage() {
                 </button>
                 <button
                   onClick={() => setStacksViewMode('table')}
+                  aria-pressed={stacksViewMode === 'table'}
+                  data-testid="stacks-view-table"
                   className={cn(
                     'inline-flex items-center justify-center rounded-md p-2 transition-colors',
                     stacksViewMode === 'table'
-                      ? 'bg-accent text-accent-foreground'
+                      ? 'bg-muted text-foreground'
                       : 'text-muted-foreground hover:text-foreground'
                   )}
                   title="Table view"
@@ -1315,6 +1458,7 @@ export default function InfrastructurePage() {
               <StackCard
                 key={stack.id}
                 stack={stack}
+                showDiscoveredBadge={showDiscoveredBadge}
                 onClick={() => handleStackClick(stack)}
               />
             ))}
@@ -1328,6 +1472,8 @@ export default function InfrastructurePage() {
               hideSearch
               autoFit
               onRowClick={handleStackClick}
+              rowHref={(stack) => `/workloads?endpoint=${stack.endpointId}&stack=${encodeURIComponent(stack.name)}`}
+              rowLabel={(stack) => `Containers in ${stack.name}`}
             />
           </div>
           </SpotlightCard>

--- a/frontend/src/features/containers/pages/image-footprint.test.tsx
+++ b/frontend/src/features/containers/pages/image-footprint.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 
 vi.mock('react-dom', async () => {
   const actual = await vi.importActual('react-dom');
@@ -112,10 +112,11 @@ vi.mock('@/shared/components/data-display/spotlight-card', () => ({
 }));
 
 vi.mock('@/shared/components/data-display/kpi-card', () => ({
-  KpiCard: ({ label, value }: any) => (
+  KpiCard: ({ label, value, trendValue }: any) => (
     <div data-testid="kpi-card">
       <span>{label}</span>
       <span>{value}</span>
+      {trendValue && <span>{trendValue}</span>}
     </div>
   ),
 }));
@@ -179,9 +180,44 @@ describe('ImageFootprintPage', () => {
   it('renders charts and page header', () => {
     render(<ImageFootprintPage />);
 
-    expect(screen.getByText('Image Footprint')).toBeInTheDocument();
+    // h1 matches the navigation manifest's short label ("Images"), not the
+    // longer sidebar-era title the page used to carry.
+    expect(screen.getByRole('heading', { level: 1, name: 'Images' })).toBeInTheDocument();
+    expect(screen.getByTestId('page-header')).toBeInTheDocument();
     expect(screen.getByTestId('image-treemap')).toBeInTheDocument();
     expect(screen.getByTestId('image-sunburst')).toBeInTheDocument();
+  });
+
+  it('drops the subtitle that promised layer composition', () => {
+    render(<ImageFootprintPage />);
+
+    expect(screen.queryByTestId('page-header-subtitle')).not.toBeInTheDocument();
+    expect(screen.queryByText(/layer composition/i)).not.toBeInTheDocument();
+  });
+
+  it('does not restate the charts’ own titles in explanatory sentences', () => {
+    render(<ImageFootprintPage />);
+
+    expect(screen.queryByText(/Larger boxes indicate larger images/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Shows total image size grouped by container registry/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the same page header in the error branch', () => {
+    mockUseImages.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isPending: false,
+      isError: true,
+      error: new Error('boom'),
+      refetch: mockRefetch,
+      isFetching: false,
+    });
+
+    render(<ImageFootprintPage />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Images' })).toBeInTheDocument();
   });
 
   it('wraps the page in MotionPage', () => {
@@ -259,15 +295,41 @@ describe('ImageFootprintPage', () => {
   });
 
   describe('staleness summary', () => {
+    // Three images on this page: one up to date, one stale, one never checked.
+    const pageImages = [
+      { ...defaultImageData[0], id: 'img-1', name: 'nginx' },
+      { ...defaultImageData[0], id: 'img-2', name: 'redis', size: 40_000_000 },
+      { ...defaultImageData[0], id: 'img-3', name: 'busybox', size: 5_000_000 },
+    ];
+
+    // The API-wide summary deliberately disagrees with the page's image list —
+    // 57 checked rows above a 3-row table was the reported bug.
     const stalenessData = {
-      summary: { total: 12, upToDate: 9, stale: 3 },
-      records: [],
+      summary: { total: 57, upToDate: 7, stale: 4, unchecked: 46 },
+      records: [
+        { image_name: 'nginx', is_stale: 0, last_checked_at: '2026-01-01T00:00:00.000Z' },
+        { image_name: 'redis', is_stale: 1, last_checked_at: '2026-01-01T00:00:00.000Z' },
+        // A record for an image that is not on this page — must not be counted.
+        { image_name: 'ghost', is_stale: 1, last_checked_at: '2026-01-01T00:00:00.000Z' },
+      ],
     };
 
-    it('renders the three KPI cards inside a single grid container when staleness data is available', () => {
+    function renderWithStaleness() {
+      mockUseImages.mockReturnValue({
+        data: pageImages,
+        isLoading: false,
+        isPending: false,
+        isError: false,
+        error: null,
+        refetch: mockRefetch,
+        isFetching: false,
+      });
       mockUseImageStaleness.mockReturnValue({ data: stalenessData });
+      return render(<ImageFootprintPage />);
+    }
 
-      const { container } = render(<ImageFootprintPage />);
+    it('renders the three KPI cards inside a single grid container when staleness data is available', () => {
+      const { container } = renderWithStaleness();
 
       // The Staleness Summary grid is identified by a stable class hook so the
       // test does not depend on Tailwind utility ordering.
@@ -277,24 +339,83 @@ describe('ImageFootprintPage', () => {
       // All three KPI cards must be children (transitively) of the same grid
       // container — overlap regressions happen when a card escapes the grid
       // track or is rendered outside its expected parent.
+      // Scoped to the grid: "Up to Date" also appears as a row status badge in
+      // the table below, which is precisely the reconciliation this page owes.
       const labels = ['Checked', 'Up to Date', 'Stale'];
-      const cardsInsideGrid = labels.map((label) => {
-        const node = screen.getByText(label);
-        expect(grid!.contains(node)).toBe(true);
-        return node;
-      });
+      const cardsInsideGrid = labels.map((label) => within(grid as HTMLElement).getByText(label));
       expect(cardsInsideGrid).toHaveLength(3);
+    });
 
-      // KPI values render from the summary payload.
-      expect(screen.getByText('12')).toBeInTheDocument();
-      expect(screen.getByText('9')).toBeInTheDocument();
-      expect(screen.getByText('3')).toBeInTheDocument();
+    it('scopes the tile counts to the images the table shows, not the whole staleness table', () => {
+      renderWithStaleness();
+
+      const checked = screen.getByTestId('staleness-tile-checked');
+      const upToDate = screen.getByTestId('staleness-tile-upToDate');
+      const stale = screen.getByTestId('staleness-tile-stale');
+
+      // 3 images on this page, 2 of them have a staleness record.
+      expect(checked).toHaveTextContent('2');
+      expect(checked).toHaveTextContent('of 3 images');
+      expect(upToDate).toHaveTextContent('1');
+      expect(stale).toHaveTextContent('1');
+
+      // None of the API-wide numbers may leak through.
+      expect(checked).not.toHaveTextContent('57');
+      expect(upToDate).not.toHaveTextContent('7');
+      expect(stale).not.toHaveTextContent('4');
+    });
+
+    it('the Stale tile filters the table down to the stale rows', () => {
+      renderWithStaleness();
+
+      // All three rows before filtering.
+      expect(screen.getByText('nginx')).toBeInTheDocument();
+      expect(screen.getByText('redis')).toBeInTheDocument();
+      expect(screen.getByText('busybox')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('staleness-tile-stale'));
+
+      expect(screen.getByText('redis')).toBeInTheDocument();
+      expect(screen.queryByText('nginx')).not.toBeInTheDocument();
+      expect(screen.queryByText('busybox')).not.toBeInTheDocument();
+      expect(screen.getByTestId('image-status-filter')).toHaveTextContent('1 of 3 images');
+    });
+
+    it('clicking the active tile again clears the filter', () => {
+      renderWithStaleness();
+
+      fireEvent.click(screen.getByTestId('staleness-tile-stale'));
+      expect(screen.queryByText('nginx')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('staleness-tile-stale'));
+      expect(screen.getByText('nginx')).toBeInTheDocument();
+      expect(screen.queryByTestId('image-status-filter')).not.toBeInTheDocument();
+    });
+
+    it('"Show all images" clears the filter', () => {
+      renderWithStaleness();
+
+      fireEvent.click(screen.getByTestId('staleness-tile-upToDate'));
+      expect(screen.queryByText('redis')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show all images' }));
+      expect(screen.getByText('redis')).toBeInTheDocument();
+    });
+
+    it('exposes each tile as a keyboard-operable toggle', () => {
+      renderWithStaleness();
+
+      const stale = screen.getByTestId('staleness-tile-stale');
+      expect(stale).toHaveAttribute('role', 'button');
+      expect(stale).toHaveAttribute('tabindex', '0');
+      expect(stale).toHaveAttribute('aria-pressed', 'false');
+
+      fireEvent.keyDown(stale, { key: 'Enter' });
+      expect(screen.getByTestId('staleness-tile-stale')).toHaveAttribute('aria-pressed', 'true');
     });
 
     it('uses a generous gap so transformed cards stay clear of their neighbours', () => {
-      mockUseImageStaleness.mockReturnValue({ data: stalenessData });
-
-      const { container } = render(<ImageFootprintPage />);
+      const { container } = renderWithStaleness();
 
       const grid = container.querySelector('.staleness-summary-grid');
       expect(grid).not.toBeNull();
@@ -317,6 +438,23 @@ describe('ImageFootprintPage', () => {
     it('does not render the staleness grid when summary.total is zero', () => {
       mockUseImageStaleness.mockReturnValue({
         data: { summary: { total: 0, upToDate: 0, stale: 0 }, records: [] },
+      });
+
+      const { container } = render(<ImageFootprintPage />);
+
+      expect(container.querySelector('.staleness-summary-grid')).toBeNull();
+    });
+
+    it('does not render the staleness grid when none of this page’s images were checked', () => {
+      // The staleness table has rows, but none of them are for an image the
+      // table below is showing — the tiles would be unresolvable to any row.
+      mockUseImageStaleness.mockReturnValue({
+        data: {
+          summary: { total: 57, upToDate: 7, stale: 4, unchecked: 46 },
+          records: [
+            { image_name: 'ghost', is_stale: 1, last_checked_at: '2026-01-01T00:00:00.000Z' },
+          ],
+        },
       });
 
       const { container } = render(<ImageFootprintPage />);

--- a/frontend/src/features/containers/pages/image-footprint.tsx
+++ b/frontend/src/features/containers/pages/image-footprint.tsx
@@ -11,23 +11,42 @@ import { useImageStaleness } from '@/features/containers/hooks/use-image-stalene
 import { ImageTreemap } from '@/shared/components/charts/image-treemap';
 import { ImageSunburst } from '@/shared/components/charts/image-sunburst';
 import { RefreshControls } from '@/shared/components/ui/refresh-controls';
+import { DataFreshness } from '@/shared/components/feedback/data-freshness';
 import { useForceRefresh } from '@/shared/hooks/use-force-refresh';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { DataTable } from '@/shared/components/tables/data-table';
 import { KpiCard } from '@/shared/components/data-display/kpi-card';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { MotionPage, MotionReveal, MotionStagger } from '@/shared/components/layout/motion-page';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { TiltCard } from '@/shared/components/data-display/tilt-card';
 import { spring } from '@/shared/lib/motion-tokens';
 import { formatBytes, truncate } from '@/shared/lib/utils';
 
+/**
+ * Which slice of the image list the table is showing. The staleness tiles are
+ * the only way to reach the stale rows, so they double as the filter — a
+ * "Stale 4" an operator cannot resolve to four image names is worse than no
+ * tile at all.
+ */
+type ImageStatusFilter = 'all' | 'checked' | 'upToDate' | 'stale';
+
+const STATUS_FILTER_LABELS: Record<Exclude<ImageStatusFilter, 'all'>, string> = {
+  checked: 'Checked',
+  upToDate: 'Up to date',
+  stale: 'Update available',
+};
+
 export default function ImageFootprintPage() {
   const [selectedEndpoint, setSelectedEndpoint] = useState<number | undefined>(undefined);
   const [selectedImage, setSelectedImage] = useState<DockerImage | null>(null);
+  const [statusFilter, setStatusFilter] = useState<ImageStatusFilter>('all');
 
   const { data: endpoints } = useEndpoints();
-  const { interval, setInterval, enabled } = useAutoRefresh(60);
-  const { data: images, isLoading, isPending, isError, error, refetch, isFetching } = useImages(
+  const { interval, setRefreshInterval, enabled } = useAutoRefresh(60);
+  // Auto-refresh is armed through react-query's own `refetchInterval` rather
+  // than the hook's `onTick`, so the dropdown really does schedule a fetch.
+  const { data: images, isLoading, isPending, isError, error, refetch, isFetching, dataUpdatedAt } = useImages(
     selectedEndpoint,
     { refetchInterval: enabled && interval > 0 ? interval * 1000 : false },
   );
@@ -85,10 +104,53 @@ export default function ImageFootprintPage() {
       }));
   }, [images]);
 
+  /**
+   * Staleness counts for *the images on this page*, not for every row the
+   * staleness table has ever recorded.
+   *
+   * The tiles used to read `stalenessData.summary` while the header and the
+   * table read the per-endpoint image list, so the page could claim
+   * "Checked 57" above a 14-row table in which every row said "Up to Date",
+   * and the 4 stale images appeared nowhere. Scoping the counts to `images`
+   * makes the three numbers reconcile with the table by construction.
+   */
+  const staleness = useMemo(() => {
+    if (!images) return null;
+    let stale = 0;
+    let upToDate = 0;
+    for (const img of images) {
+      const rec = stalenessMap.get(img.name);
+      if (!rec) continue;
+      if (rec.isStale) stale += 1;
+      else upToDate += 1;
+    }
+    return {
+      total: images.length,
+      checked: stale + upToDate,
+      stale,
+      upToDate,
+      unchecked: images.length - stale - upToDate,
+    };
+  }, [images, stalenessMap]);
+
   const sortedImages = useMemo(() => {
     if (!images) return [];
     return [...images].sort((a, b) => b.size - a.size);
   }, [images]);
+
+  const visibleImages = useMemo(() => {
+    if (statusFilter === 'all') return sortedImages;
+    return sortedImages.filter((img) => {
+      const rec = stalenessMap.get(img.name);
+      if (!rec) return false;
+      if (statusFilter === 'checked') return true;
+      return statusFilter === 'stale' ? rec.isStale : !rec.isStale;
+    });
+  }, [sortedImages, stalenessMap, statusFilter]);
+
+  const toggleStatusFilter = useCallback((next: Exclude<ImageStatusFilter, 'all'>) => {
+    setStatusFilter((prev) => (prev === next ? 'all' : next));
+  }, []);
 
   const imageColumns: ColumnDef<DockerImage, any>[] = useMemo(() => [
     {
@@ -182,12 +244,7 @@ export default function ImageFootprintPage() {
   if (isError) {
     return (
       <MotionPage>
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Image Footprint</h1>
-          <p className="text-muted-foreground">
-            Analyze Docker image sizes and layer composition
-          </p>
-        </div>
+        <PageHeader title="Images" />
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
           <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
           <p className="mt-4 font-medium text-destructive">Failed to load images</p>
@@ -207,18 +264,17 @@ export default function ImageFootprintPage() {
 
   return (
     <MotionPage>
-      {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Image Footprint</h1>
-          <p className="text-muted-foreground">
-            Analyze Docker image sizes and layer composition
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <RefreshControls interval={interval} onIntervalChange={setInterval} onRefresh={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
-        </div>
-      </div>
+      {/* Header — the old subtitle promised "layer composition", which this
+          page never shows; the live totals sit in the stat row below. */}
+      <PageHeader
+        title="Images"
+        actions={
+          <>
+            <DataFreshness lastUpdated={dataUpdatedAt || null} onRefresh={() => refetch()} />
+            <RefreshControls interval={interval} onIntervalChange={setRefreshInterval} onRefresh={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
+          </>
+        }
+      />
 
       {/* Filters and Summary */}
       <div className="flex flex-wrap items-center gap-4">
@@ -258,46 +314,42 @@ export default function ImageFootprintPage() {
         )}
       </div>
 
-      {/* Staleness Summary */}
-      {stalenessData && stalenessData.summary.total > 0 && (
+      {/* Staleness Summary — every tile filters the table below it. */}
+      {staleness && staleness.checked > 0 && (
         <MotionStagger
           className="staleness-summary-grid grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3"
           stagger={0.05}
         >
-          <MotionReveal className="h-full">
-            <TiltCard intensity="subtle">
-              <KpiCard
-                label="Checked"
-                value={stalenessData.summary.total}
-                icon={<Layers className="h-5 w-5" />}
-                disableHoverLift
-              />
-            </TiltCard>
-          </MotionReveal>
-          <MotionReveal className="h-full">
-            <TiltCard intensity="subtle">
-              <KpiCard
-                label="Up to Date"
-                value={stalenessData.summary.upToDate}
-                icon={<CheckCircle2 className="h-5 w-5" />}
-                trend="up"
-                trendValue={`of ${stalenessData.summary.total} checked`}
-                disableHoverLift
-              />
-            </TiltCard>
-          </MotionReveal>
-          <MotionReveal className="h-full">
-            <TiltCard intensity="subtle">
-              <KpiCard
-                label="Stale"
-                value={stalenessData.summary.stale}
-                icon={<AlertTriangle className="h-5 w-5" />}
-                trend={stalenessData.summary.stale > 0 ? 'down' : 'neutral'}
-                trendValue={stalenessData.summary.stale > 0 ? `${stalenessData.summary.stale} outdated` : 'none'}
-                disableHoverLift
-              />
-            </TiltCard>
-          </MotionReveal>
+          <StalenessTile
+            filter="checked"
+            active={statusFilter === 'checked'}
+            onToggle={toggleStatusFilter}
+            label="Checked"
+            value={staleness.checked}
+            icon={<Layers className="h-5 w-5" />}
+            trend="neutral"
+            trendValue={`of ${staleness.total} image${staleness.total !== 1 ? 's' : ''}`}
+          />
+          <StalenessTile
+            filter="upToDate"
+            active={statusFilter === 'upToDate'}
+            onToggle={toggleStatusFilter}
+            label="Up to Date"
+            value={staleness.upToDate}
+            icon={<CheckCircle2 className="h-5 w-5" />}
+            trend="up"
+            trendValue={`of ${staleness.checked} checked`}
+          />
+          <StalenessTile
+            filter="stale"
+            active={statusFilter === 'stale'}
+            onToggle={toggleStatusFilter}
+            label="Stale"
+            value={staleness.stale}
+            icon={<AlertTriangle className="h-5 w-5" />}
+            trend={staleness.stale > 0 ? 'down' : 'neutral'}
+            trendValue={staleness.stale > 0 ? 'update available' : 'none'}
+          />
         </MotionStagger>
       )}
 
@@ -312,13 +364,12 @@ export default function ImageFootprintPage() {
           {/* Treemap */}
           <MotionReveal>
             <SpotlightCard>
-              <div className="rounded-lg border bg-card p-6 shadow-sm">
+              {/* The only non-obvious fact — that a box opens the image — is a
+                  hover affordance, not a paragraph restating the title. */}
+              <div className="rounded-lg border bg-card p-6 shadow-sm" title="Select an image for its tags, digest and registry">
                 <h3 className="mb-4 text-sm font-medium text-muted-foreground">
                   Image Size Distribution
                 </h3>
-                <p className="mb-4 text-xs text-muted-foreground">
-                  Visualizes relative image sizes. Larger boxes indicate larger images. Click an image to view details.
-                </p>
                 <ImageTreemap
                   data={treemapData}
                   onCellClick={(name) => {
@@ -339,9 +390,6 @@ export default function ImageFootprintPage() {
                 <h3 className="mb-4 text-sm font-medium text-muted-foreground">
                   Registry Distribution
                 </h3>
-                <p className="mb-4 text-xs text-muted-foreground">
-                  Shows total image size grouped by container registry.
-                </p>
                 <ImageSunburst data={sunburstData} />
               </div>
             </SpotlightCard>
@@ -366,9 +414,27 @@ export default function ImageFootprintPage() {
         <MotionReveal>
           <SpotlightCard>
             <div className="rounded-lg border bg-card p-6 shadow-sm">
+              {statusFilter !== 'all' && (
+                <div
+                  className="mb-3 flex flex-wrap items-center gap-2 text-sm text-muted-foreground"
+                  data-testid="image-status-filter"
+                >
+                  <span>
+                    {visibleImages.length} of {images.length} image
+                    {images.length !== 1 ? 's' : ''} · {STATUS_FILTER_LABELS[statusFilter]}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setStatusFilter('all')}
+                    className="underline-offset-4 hover:text-foreground hover:underline"
+                  >
+                    Show all images
+                  </button>
+                </div>
+              )}
               <DataTable
                 columns={imageColumns}
-                data={sortedImages}
+                data={visibleImages}
                 searchKey="name"
                 searchPlaceholder="Search images by name..."
                 pageSize={15}
@@ -389,6 +455,76 @@ export default function ImageFootprintPage() {
         )}
       </AnimatePresence>
     </MotionPage>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Staleness tile                                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * A staleness KPI that is also the filter for the rows behind it.
+ *
+ * `role="button"` on a wrapper rather than a real `<button>`: `KpiCard` renders
+ * block-level content, and a `<div>` inside a `<button>` is invalid HTML — the
+ * same trap `EndpointCard` documents (#1547). This mirrors the pattern already
+ * used by `endpoint-health-octagons` and the treemap cells.
+ */
+function StalenessTile({
+  filter,
+  active,
+  onToggle,
+  label,
+  value,
+  icon,
+  trend,
+  trendValue,
+}: {
+  filter: Exclude<ImageStatusFilter, 'all'>;
+  active: boolean;
+  onToggle: (filter: Exclude<ImageStatusFilter, 'all'>) => void;
+  label: string;
+  value: number;
+  icon: React.ReactNode;
+  trend: 'up' | 'down' | 'neutral';
+  trendValue: string;
+}) {
+  const activate = () => onToggle(filter);
+
+  return (
+    <MotionReveal className="h-full">
+      <div
+        role="button"
+        tabIndex={0}
+        aria-pressed={active}
+        aria-label={
+          active
+            ? `${label}: ${value}. Showing only these images — activate to show all`
+            : `${label}: ${value}. Activate to show only these images`
+        }
+        data-testid={`staleness-tile-${filter}`}
+        onClick={activate}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            activate();
+          }
+        }}
+        className="h-full cursor-pointer rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <TiltCard intensity="subtle">
+          <KpiCard
+            label={label}
+            value={value}
+            icon={icon}
+            trend={trend}
+            trendValue={trendValue}
+            className={active ? 'border-primary/50 ring-1 ring-primary/30' : undefined}
+            disableHoverLift
+          />
+        </TiltCard>
+      </div>
+    </MotionReveal>
   );
 }
 

--- a/frontend/src/features/containers/pages/network-topology.test.tsx
+++ b/frontend/src/features/containers/pages/network-topology.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import NetworkTopologyPage, { resolveNetworkMembers } from './network-topology';
@@ -42,17 +42,25 @@ vi.mock('@/features/containers/components/network/topology-graph', () => ({
     networks,
     showObservedTraffic,
     observedEdges,
+    onNodeClick,
   }: {
     containers: Array<{ id: string; name: string }>;
     networks: Array<{ id: string; name: string }>;
     showObservedTraffic?: boolean;
     observedEdges?: Array<{ source: string; target: string; callCount: number }>;
+    onNodeClick?: (nodeId: string) => void;
   }) => (
     <div data-testid="topology-graph">
       <span data-testid="topology-container-count">{containers.length}</span>
       <span data-testid="topology-network-count">{networks.length}</span>
       <span data-testid="topology-show-observed">{String(Boolean(showObservedTraffic))}</span>
       <span data-testid="topology-observed-count">{observedEdges?.length ?? 0}</span>
+      {/* Stand-in for clicking a node, so the detail side panel is reachable. */}
+      {containers.map((c) => (
+        <button key={c.id} onClick={() => onNodeClick?.(`container-${c.id}`)}>
+          select {c.name}
+        </button>
+      ))}
     </div>
   ),
 }));
@@ -341,6 +349,46 @@ describe('NetworkTopologyPage', () => {
 
       renderPage();
       expect(screen.getByTestId('topology-observed-count')).toHaveTextContent('2');
+    });
+  });
+
+  describe('container detail panel — ports', () => {
+    function selectContainerWithPorts(ports: unknown[]) {
+      // Both hooks must be stubbed here. `clearMocks` resets call history but
+      // NOT return values, so stubbing only `useContainers` left this test
+      // passing on whatever `useNetworks` value a previously-run test happened
+      // to leave behind — and failing when run alone.
+      setHooks({ containers: [makeContainer({ ports })], networks: [makeNetwork()] });
+      renderPage();
+      fireEvent.click(screen.getByRole('button', { name: 'select web' }));
+    }
+
+    it('shows the host bind address, so a loopback publish is not read as world-facing', () => {
+      selectContainerWithPorts([
+        { private: 5432, public: 5432, type: 'tcp', ip: '127.0.0.1' },
+      ]);
+
+      expect(screen.getByText('127.0.0.1:5432 → 5432/tcp')).toBeInTheDocument();
+    });
+
+    it('keeps the IPv4 and IPv6 bindings of one publish distinguishable', () => {
+      // Docker emits these as two entries. Without the bind address the panel
+      // printed the same line twice, which reads as a rendering fault.
+      selectContainerWithPorts([
+        { private: 80, public: 8080, type: 'tcp', ip: '0.0.0.0' },
+        { private: 80, public: 8080, type: 'tcp', ip: '::' },
+      ]);
+
+      expect(screen.getByText('0.0.0.0:8080 → 80/tcp')).toBeInTheDocument();
+      expect(screen.getByText('[::]:8080 → 80/tcp')).toBeInTheDocument();
+      expect(screen.getAllByText('all interfaces')).toHaveLength(2);
+    });
+
+    it('marks an exposed but unpublished port without inventing a bind address', () => {
+      selectContainerWithPorts([{ private: 9000, type: 'tcp' }]);
+
+      expect(screen.getByText('9000/tcp')).toBeInTheDocument();
+      expect(screen.queryByText('all interfaces')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/features/containers/pages/network-topology.test.tsx
+++ b/frontend/src/features/containers/pages/network-topology.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
-import NetworkTopologyPage from './network-topology';
+import NetworkTopologyPage, { resolveNetworkMembers } from './network-topology';
 import { useUiStore } from '@/stores/ui-store';
 
 // Mock data hooks at the boundary
@@ -26,8 +26,12 @@ vi.mock('@/features/observability/hooks/use-service-map', () => ({
   useServiceMap: vi.fn(),
 }));
 
+const autoRefreshCalls: Array<[number, { onTick?: () => void } | undefined]> = [];
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn() }),
+  useAutoRefresh: (defaultInterval: number, opts?: { onTick?: () => void }) => {
+    autoRefreshCalls.push([defaultInterval, opts]);
+    return { interval: 30, setRefreshInterval: vi.fn(), setInterval: vi.fn() };
+  },
 }));
 
 // Stub TopologyGraph — it depends on @xyflow/react which is heavy in jsdom and
@@ -167,17 +171,22 @@ describe('NetworkTopologyPage', () => {
     mockUseServiceMap.mockReturnValue({ data: undefined } as any);
   });
 
-  it('renders the page heading and description', () => {
+  it('renders one h1 matching the navigation label, with the fleet fact as subtitle', () => {
     setHooks({ containers: [makeContainer()], networks: [makeNetwork()] });
 
     renderPage();
 
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveTextContent('Topology');
+
+    // The old subtitle was three synonyms for "graph"; the counts are the fact.
     expect(
-      screen.getByRole('heading', { name: 'Network Topology' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('Interactive network graph visualization'),
-    ).toBeInTheDocument();
+      screen.queryByText('Interactive network graph visualization'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('page-header-subtitle')).toHaveTextContent(
+      '1 container across 1 network',
+    );
   });
 
   it('renders the topology graph with container and network counts', () => {
@@ -206,6 +215,18 @@ describe('NetworkTopologyPage', () => {
 
     expect(screen.getByText(/2 containers/)).toBeInTheDocument();
     expect(screen.getByText(/2 networks/)).toBeInTheDocument();
+    // ...and only once — it used to sit in the filter row as well.
+    expect(screen.getAllByText(/2 containers across 2 networks/)).toHaveLength(1);
+  });
+
+  it('wires the refresh interval to an actual tick', () => {
+    setHooks({ containers: [makeContainer()], networks: [makeNetwork()] });
+
+    renderPage();
+
+    // The hook owns the timer; the page must hand it something to call.
+    const opts = autoRefreshCalls.at(-1)?.[1];
+    expect(typeof opts?.onTick).toBe('function');
   });
 
   it('shows the loading skeleton while data is loading', () => {
@@ -321,5 +342,34 @@ describe('NetworkTopologyPage', () => {
       renderPage();
       expect(screen.getByTestId('topology-observed-count')).toHaveTextContent('2');
     });
+  });
+});
+
+describe('resolveNetworkMembers', () => {
+  const fleet = [
+    { id: 'aaaaaaaaaaaa1111', name: 'container-insights-backend' },
+    { id: 'bbbbbbbbbbbb2222', name: 'container-insights-redis' },
+  ];
+
+  it('names each connected container instead of showing a raw hex id', () => {
+    expect(resolveNetworkMembers(['aaaaaaaaaaaa1111'], fleet)).toEqual([
+      {
+        id: 'aaaaaaaaaaaa1111',
+        shortId: 'aaaaaaaaaaaa',
+        name: 'container-insights-backend',
+      },
+    ]);
+  });
+
+  it('keeps the short id and invents no name when the container is not in scope', () => {
+    const [member] = resolveNetworkMembers(['ffffffffffff9999'], fleet);
+    expect(member.name).toBeNull();
+    expect(member.shortId).toBe('ffffffffffff');
+  });
+
+  it('preserves order and handles an empty fleet', () => {
+    const members = resolveNetworkMembers(['bbbbbbbbbbbb2222', 'aaaaaaaaaaaa1111'], []);
+    expect(members.map((m) => m.shortId)).toEqual(['bbbbbbbbbbbb', 'aaaaaaaaaaaa']);
+    expect(members.every((m) => m.name === null)).toBe(true);
   });
 });

--- a/frontend/src/features/containers/pages/network-topology.tsx
+++ b/frontend/src/features/containers/pages/network-topology.tsx
@@ -13,8 +13,12 @@ import { RefreshControls } from '@/shared/components/ui/refresh-controls';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
+import { PageHeader } from '@/shared/components/layout/page-header';
+import { findDestination } from '@/features/core/lib/navigation-manifest';
 import { formatDate } from '@/shared/lib/utils';
 import { useUiStore } from '@/stores/ui-store';
+
+const PAGE_TITLE = findDestination('/topology')?.label ?? 'Topology';
 
 // Memoised 24h window — recomputed at most once per render. Stable across
 // renders within the same minute so React Query can dedupe.
@@ -54,7 +58,6 @@ export default function NetworkTopologyPage() {
   const { data: containers, isLoading: containersLoading, isPending: containersPending, isError: containersError, refetch: refetchContainers, isFetching: containersFetching } = useContainers(selectedEndpoint !== undefined ? { endpointId: selectedEndpoint } : undefined);
   const { data: networks, isLoading: networksLoading, isPending: networksPending, isError: networksError, refetch: refetchNetworks, isFetching: networksFetching } = useNetworks(selectedEndpoint);
   const { data: networkRatesData } = useNetworkRates(selectedEndpoint);
-  const { interval, setInterval } = useAutoRefresh(30);
 
   // RPC overlay (#1233): fetch last-24h service map, default-on if there's
   // anything to show, user can toggle from the header.
@@ -118,11 +121,25 @@ export default function NetworkTopologyPage() {
     refetchNetworks();
   };
 
+  // The hook owns the timer — the dropdown used to schedule nothing at all.
+  const { interval, setRefreshInterval } = useAutoRefresh(30, {
+    storageKey: 'topology',
+    onTick: handleRefresh,
+  });
+
   // Treat both isLoading and isPending-without-data as "loading" to avoid
   // rendering a blank page during SPA navigation before data arrives.
   const isLoading = containersLoading || networksLoading || (containersPending && !containers) || (networksPending && !networks);
   const isError = containersError || networksError;
   const isFetching = containersFetching || networksFetching;
+
+  // The subtitle used to read "Interactive network graph visualization" —
+  // three synonyms for "graph", none of which the operator cannot already see.
+  // The counts are the fact worth carrying.
+  const fleetSummary =
+    containers && networks
+      ? `${containers.length} container${containers.length !== 1 ? 's' : ''} across ${networks.length} network${networks.length !== 1 ? 's' : ''}`
+      : undefined;
 
   const handleNodeClick = (nodeId: string) => {
     // Determine if it's a container or network node
@@ -143,39 +160,43 @@ export default function NetworkTopologyPage() {
 
   return (
     <div className="flex flex-col h-[calc(100vh-8rem)]">
-      {/* Header */}
-      <div className="flex items-center justify-between shrink-0">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Network Topology</h1>
-          <p className="text-muted-foreground">
-            Interactive network graph visualization
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={showObservedTraffic}
-              onChange={(e) => {
-                setOverlayUserToggled(true);
-                setShowObservedTraffic(e.target.checked);
-              }}
-              disabled={!hasObservedTraffic}
-              aria-label="Toggle observed traffic overlay"
-              className="h-4 w-4 rounded border-input"
+      <PageHeader
+        className="shrink-0"
+        title={PAGE_TITLE}
+        subtitle={fleetSummary}
+        hideSubtitleOnMobile={false}
+        actions={
+          <>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={showObservedTraffic}
+                onChange={(e) => {
+                  setOverlayUserToggled(true);
+                  setShowObservedTraffic(e.target.checked);
+                }}
+                disabled={!hasObservedTraffic}
+                aria-label="Toggle observed traffic overlay"
+                className="h-4 w-4 rounded border-input"
+              />
+              <span className={hasObservedTraffic ? '' : 'text-muted-foreground'}>
+                Observed traffic
+                {hasObservedTraffic && (
+                  <span className="ml-1 text-xs text-muted-foreground">
+                    ({observedEdges.length})
+                  </span>
+                )}
+              </span>
+            </label>
+            <RefreshControls
+              interval={interval}
+              onIntervalChange={setRefreshInterval}
+              onRefresh={handleRefresh}
+              isLoading={isFetching}
             />
-            <span className={hasObservedTraffic ? '' : 'text-muted-foreground'}>
-              Observed traffic
-              {hasObservedTraffic && (
-                <span className="ml-1 text-xs text-muted-foreground">
-                  ({observedEdges.length})
-                </span>
-              )}
-            </span>
-          </label>
-          <RefreshControls interval={interval} onIntervalChange={setInterval} onRefresh={handleRefresh} isLoading={isFetching} />
-        </div>
-      </div>
+          </>
+        }
+      />
 
       {/* Endpoint Filter */}
       <div className="flex items-center gap-4 flex-wrap shrink-0 mt-4">
@@ -197,11 +218,6 @@ export default function NetworkTopologyPage() {
           />
         </div>
 
-        {containers && networks && (
-          <span className="text-sm text-muted-foreground">
-            {containers.length} container{containers.length !== 1 ? 's' : ''} · {networks.length} network{networks.length !== 1 ? 's' : ''}
-          </span>
-        )}
       </div>
 
       {/* Graph Container — fills remaining height */}
@@ -254,7 +270,7 @@ export default function NetworkTopologyPage() {
                 {selectedNode.type === 'container' ? (
                   <ContainerDetails container={selectedNode.data} />
                 ) : (
-                  <NetworkDetails network={selectedNode.data} />
+                  <NetworkDetails network={selectedNode.data} containers={containers ?? []} />
                 )}
               </div>
             )}
@@ -345,7 +361,35 @@ function ContainerDetails({ container }: { container: Container }) {
   );
 }
 
-function NetworkDetails({ network }: { network: Network }) {
+/**
+ * Resolve a network's member container IDs to names.
+ *
+ * The panel listed raw 12-character hex IDs while the rest of the app names
+ * containers — and the page already holds the full `containers` array. An ID
+ * with no match (a container on another endpoint, or one removed since the
+ * network was read) keeps its short ID rather than inventing a name.
+ */
+export function resolveNetworkMembers(
+  containerIds: string[],
+  containers: Pick<Container, 'id' | 'name'>[],
+): { id: string; shortId: string; name: string | null }[] {
+  const nameById = new Map(containers.map((c) => [c.id, c.name]));
+  return containerIds.map((id) => ({
+    id,
+    shortId: id.slice(0, 12),
+    name: nameById.get(id) ?? null,
+  }));
+}
+
+function NetworkDetails({
+  network,
+  containers,
+}: {
+  network: Network;
+  containers: Pick<Container, 'id' | 'name'>[];
+}) {
+  const members = resolveNetworkMembers(network.containers, containers);
+
   return (
     <div className="space-y-4">
       <div>
@@ -389,11 +433,18 @@ function NetworkDetails({ network }: { network: Network }) {
       <div>
         <label className="text-xs font-medium text-muted-foreground">Connected Containers</label>
         <div className="mt-1">
-          {network.containers.length > 0 ? (
+          {members.length > 0 ? (
             <div className="space-y-1">
-              {network.containers.map((containerId) => (
-                <div key={containerId} className="text-sm px-2 py-1 rounded bg-muted font-mono">
-                  {containerId.slice(0, 12)}
+              {members.map((member) => (
+                <div key={member.id} className="text-sm px-2 py-1 rounded bg-muted">
+                  <span className={member.name ? '' : 'font-mono'}>
+                    {member.name ?? member.shortId}
+                  </span>
+                  {member.name && (
+                    <span className="ml-1.5 font-mono text-xs text-muted-foreground">
+                      {member.shortId}
+                    </span>
+                  )}
                 </div>
               ))}
             </div>

--- a/frontend/src/features/containers/pages/network-topology.tsx
+++ b/frontend/src/features/containers/pages/network-topology.tsx
@@ -16,6 +16,7 @@ import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { PageHeader } from '@/shared/components/layout/page-header';
 import { findDestination } from '@/features/core/lib/navigation-manifest';
 import { formatDate } from '@/shared/lib/utils';
+import { formatPortMapping, isPubliclyBound } from '@/features/containers/lib/port-bindings';
 import { useUiStore } from '@/stores/ui-store';
 
 const PAGE_TITLE = findDestination('/topology')?.label ?? 'Topology';
@@ -330,9 +331,20 @@ function ContainerDetails({ container }: { container: Container }) {
         <div>
           <label className="text-xs font-medium text-muted-foreground">Ports</label>
           <div className="mt-1 space-y-1">
+            {/*
+              The bind address is part of the mapping, not decoration. Without
+              it the IPv4 and IPv6 bindings Docker publishes for one port render
+              as two identical lines, and a loopback-only publish is
+              indistinguishable from a world-facing one.
+            */}
             {container.ports.map((port, i) => (
               <div key={i} className="text-sm font-mono">
-                {port.public ? `${port.public} → ` : ''}{port.private}/{port.type}
+                {formatPortMapping(port)}
+                {isPubliclyBound(port.ip) && (
+                  <span className="ml-2 font-sans text-xs text-amber-600 dark:text-amber-400">
+                    all interfaces
+                  </span>
+                )}
               </div>
             ))}
           </div>

--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -11,6 +11,9 @@ let mockQueryString = 'endpoint=1&stack=workers';
 vi.mock('react-router-dom', () => ({
   useSearchParams: () => [new URLSearchParams(mockQueryString), mockSetSearchParams],
   useNavigate: () => mockNavigate,
+  Link: ({ to, children, ...rest }: { to: string; children?: ReactNode }) => (
+    <a href={to} {...rest}>{children}</a>
+  ),
 }));
 
 vi.mock('@/shared/lib/csv-export', () => ({
@@ -87,11 +90,17 @@ vi.mock('@/features/containers/hooks/use-containers', () => ({
   useContainers: (...args: unknown[]) => mockUseContainers(...args),
 }));
 
+let mockAutoRefreshOptions: { onTick?: () => void } | undefined;
+
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: () => ({
-    interval: 30,
-    setInterval: vi.fn(),
-  }),
+  useAutoRefresh: (_interval?: number, opts?: { onTick?: () => void }) => {
+    mockAutoRefreshOptions = opts;
+    return {
+      interval: 30,
+      setRefreshInterval: vi.fn(),
+      setInterval: vi.fn(),
+    };
+  },
 }));
 
 vi.mock('@/shared/hooks/use-force-refresh', () => ({
@@ -113,6 +122,8 @@ vi.mock('@/shared/components/ui/themed-select', () => ({
 
 let mockOnSelectionChange: ((rows: Array<{ id: string; name: string; endpointId: number }>) => void) | undefined;
 let mockColumns: any[] | undefined;
+let mockRowHref: ((row: any) => string) | undefined;
+let mockRowLabel: ((row: any) => string) | undefined;
 
 vi.mock('@/shared/components/tables/data-table', () => ({
   DataTable: ({
@@ -125,6 +136,8 @@ vi.mock('@/shared/components/tables/data-table', () => ({
     onRowClick,
     autoFit,
     minTableWidth,
+    rowHref,
+    rowLabel,
   }: {
     columns?: any[];
     data: Array<{ name: string }>;
@@ -135,9 +148,13 @@ vi.mock('@/shared/components/tables/data-table', () => ({
     onRowClick?: (row: { id: string; name: string; endpointId: number }) => void;
     autoFit?: boolean;
     minTableWidth?: number;
+    rowHref?: (row: any) => string;
+    rowLabel?: (row: any) => string;
   }) => {
     mockOnSelectionChange = onSelectionChange;
     mockColumns = columns;
+    mockRowHref = rowHref;
+    mockRowLabel = rowLabel;
     return (
       <div
         data-testid="workloads-table"
@@ -242,6 +259,7 @@ vi.mock('@/shared/components/forms/workload-smart-search', () => ({
   },
 }));
 
+import { findDestination } from '@/features/core/lib/navigation-manifest';
 import WorkloadExplorerPage from './workload-explorer';
 
 describe('WorkloadExplorerPage', () => {
@@ -669,30 +687,13 @@ describe('WorkloadExplorerPage', () => {
     expect(params.get('state')).toBe('running');
   });
 
-  it('clicking the Group cell filters by the container group, preserving other filters', () => {
+  it('still offers group filtering via the Group dropdown after the Group column was dropped', () => {
     mockQueryString = 'endpoint=1&state=running';
     render(<WorkloadExplorerPage />);
-
-    const groupColumn = mockColumns?.find((col: { id?: string }) => col.id === 'group');
-    expect(groupColumn).toBeDefined();
-
-    const workloadContainer = {
-      id: 'c-workers',
-      name: 'workers-api-1',
-      image: 'workers:latest',
-      labels: { 'com.docker.compose.project': 'workers' },
-    };
-    const cellResult = groupColumn.cell({ row: { original: workloadContainer } });
-    const { container } = render(cellResult);
-    const groupButton = container.querySelector('button');
-    expect(groupButton).not.toBeNull();
-    fireEvent.click(groupButton!);
-
-    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
-    const params = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
-    expect(params.get('group')).toBe('workload');
-    expect(params.get('endpoint')).toBe('1');
-    expect(params.get('state')).toBe('running');
+    // The column went away; the filter did not.
+    expect(screen.getByTestId('group-select')).toBeInTheDocument();
+    expect(screen.getAllByText('System').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Workload').length).toBeGreaterThanOrEqual(1);
   });
 
   it('clicking the Image cell filters by image, preserving other filters', () => {
@@ -1076,18 +1077,28 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
     return typeof col?.header === 'string' ? col.header : undefined;
   }
 
-  it('renders columns in order Name, Stackname, State, Endpoint, Imagename, Group (no Actions column)', () => {
+  it('renders columns in order Name, Favourite, Stack, State, Endpoint, Image (no Actions column)', () => {
     render(<WorkloadExplorerPage />);
     const ids = mockColumns?.map((c) => c.id ?? c.accessorKey);
-    expect(ids).toEqual(['name', 'stack', 'state', 'endpointName', 'image', 'group']);
+    // The favourite star has its own column so the Name cell can be wrapped in
+    // the row anchor — an <a> may not contain a <button>.
+    expect(ids).toEqual(['name', 'favorite', 'stack', 'state', 'endpointName', 'image']);
   });
 
-  it('renames the stack and image headers to Stackname and Imagename', () => {
+  it('labels the stack and image columns Stack and Image, matching the filter dropdowns', () => {
     render(<WorkloadExplorerPage />);
     const stack = mockColumns?.find((c) => c.id === 'stack');
     const image = mockColumns?.find((c) => c.accessorKey === 'image');
-    expect(columnHeader(stack)).toBe('Stackname');
-    expect(columnHeader(image)).toBe('Imagename');
+    // "Stackname"/"Imagename" were data keys typed as labels, while the
+    // dropdowns directly above them said Stack and Endpoint.
+    expect(columnHeader(stack)).toBe('Stack');
+    expect(columnHeader(image)).toBe('Image');
+  });
+
+  it('drops the Group column, which drew an identical unlabelled icon on every row', () => {
+    render(<WorkloadExplorerPage />);
+    const ids = new Set(mockColumns?.map((c) => c.id ?? c.accessorKey));
+    expect(ids.has('group')).toBe(false);
   });
 
   it('omits the rate, errorRate, p95Ms, and age columns', () => {
@@ -1127,7 +1138,7 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
     );
   });
 
-  it('Name cell tag button is single-line (whitespace-nowrap)', () => {
+  it('Name cell tag is single-line and contains no interactive element', () => {
     render(<WorkloadExplorerPage />);
     const nameCol = mockColumns?.find((c) => c.accessorKey === 'name');
     expect(nameCol).toBeDefined();
@@ -1136,11 +1147,44 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
       getValue: () => 'workers-api-1',
     });
     const { container } = render(cellResult);
-    // The name tag button is the one that links to the container detail page
-    // (the FavoriteButton mock is a separate <button>). Find it by its bg class.
-    const tagButton = container.querySelector('button.bg-primary\\/10');
-    expect(tagButton).not.toBeNull();
-    expect(tagButton?.className).toContain('whitespace-nowrap');
+    const tag = container.querySelector('span.bg-primary\\/10');
+    expect(tag).not.toBeNull();
+    expect(tag?.className).toContain('whitespace-nowrap');
+    // DataTable wraps this cell in the row's <a href>; a nested button would
+    // be invalid HTML and would swallow the link.
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('marks only system containers with an inline System chip in the Name cell', () => {
+    render(<WorkloadExplorerPage />);
+    const nameCol = mockColumns?.find((c) => c.accessorKey === 'name');
+
+    // beyla (grafana/beyla) is classified as a system container.
+    const { container: sys } = render(
+      nameCol.cell({
+        row: { original: defaultContainersMock.data[1] },
+        getValue: () => 'beyla',
+      }),
+    );
+    expect(sys.textContent).toContain('System');
+
+    // A plain workload carries no chip — the column has variance now.
+    const { container: workload } = render(
+      nameCol.cell({
+        row: { original: defaultContainersMock.data[0] },
+        getValue: () => 'workers-api-1',
+      }),
+    );
+    expect(workload.textContent).not.toContain('System');
+  });
+
+  it('renders the favourite star in its own column with an accessible header', () => {
+    render(<WorkloadExplorerPage />);
+    const favCol = mockColumns?.find((c) => c.id === 'favorite');
+    expect(favCol).toBeDefined();
+    const { container } = render(favCol.header());
+    expect(container.querySelector('.sr-only')?.textContent).toBe('Favourite');
   });
 
   it('Stackname cell renders the stack tag with whitespace-nowrap', () => {
@@ -1156,25 +1200,211 @@ describe('WorkloadExplorerPage — columns (#1288)', () => {
     expect(tagButton?.className).toContain('whitespace-nowrap');
   });
 
-  it('renders the Group cell as a labelled, clickable icon (System=Cog, Workload=Box)', () => {
+  it('uses theme tokens, not raw palette colours, for the Stack and Endpoint cells', () => {
     render(<WorkloadExplorerPage />);
-    const groupCol = mockColumns?.find((c) => c.id === 'group');
-    expect(groupCol).toBeDefined();
+    const stackCol = mockColumns?.find((c) => c.id === 'stack');
+    const endpointCol = mockColumns?.find((c) => c.accessorKey === 'endpointName');
 
-    // System container (beyla → grafana/beyla image)
-    const systemCell = groupCol.cell({ row: { original: defaultContainersMock.data[1] } });
-    const { container: sysC } = render(systemCell);
-    const sysWrap = sysC.querySelector('button[aria-label="Filter by System"]');
-    expect(sysWrap).not.toBeNull();
-    expect(sysWrap?.querySelector('svg.lucide-cog')).toBeInTheDocument();
-    expect(sysWrap?.className).toContain('bg-amber-100');
+    const { container: stackC } = render(
+      stackCol.cell({ row: { original: defaultContainersMock.data[0] }, getValue: () => undefined }),
+    );
+    const stackBtn = stackC.querySelector('button');
+    // purple is reserved for AI insight; the app ships 8 light themes, so a
+    // hardcoded purple-100/purple-900 pair fails on most of them.
+    expect(stackBtn?.className).not.toMatch(/purple/);
 
-    // Workload container (workers-api-1)
-    const workloadCell = groupCol.cell({ row: { original: defaultContainersMock.data[0] } });
-    const { container: wlC } = render(workloadCell);
-    const wlWrap = wlC.querySelector('button[aria-label="Filter by Workload"]');
-    expect(wlWrap).not.toBeNull();
-    expect(wlWrap?.querySelector('svg.lucide-box')).toBeInTheDocument();
-    expect(wlWrap?.className).toContain('bg-slate-100');
+    const { container: epC } = render(
+      endpointCol.cell({ row: { original: { endpointId: 1, endpointName: 'local' } } }),
+    );
+    const epBtn = epC.querySelector('button');
+    // The saturated blue pill was the highest-chroma element on the page and
+    // repeated one value on every row.
+    expect(epBtn?.className).not.toMatch(/blue/);
+    expect(epBtn?.className).toContain('text-muted-foreground');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Design-critique remediation: header, auto-refresh, row links, mobile cards
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('WorkloadExplorerPage — page header', () => {
+  beforeEach(() => {
+    mockQueryString = 'endpoint=1';
+    mockSetSearchParams.mockReset();
+    mockNavigate.mockReset();
+    mockUseContainers.mockReturnValue(defaultContainersMock);
+  });
+
+  it('renders exactly one h1, titled with the nav manifest label', () => {
+    render(<WorkloadExplorerPage />);
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    // The sidebar says "Workloads"; the page used to say "Workload Explorer".
+    expect(headings[0]).toHaveTextContent(findDestination('/workloads')!.label);
+    expect(headings[0]).toHaveTextContent('Workloads');
+    expect(screen.getByTestId('page-header')).toBeInTheDocument();
+  });
+
+  it('replaces the "Browse and manage containers" subtitle with live counts', () => {
+    render(<WorkloadExplorerPage />);
+    // Observer-first: nothing on this page manages anything.
+    expect(screen.queryByText(/browse and manage containers/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('page-header-subtitle')).toHaveTextContent(
+      '3 containers across 1 endpoint',
+    );
+  });
+
+  it('singularises the subtitle for a single container', () => {
+    mockQueryString = 'endpoint=1&stack=workers';
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByTestId('page-header-subtitle')).toHaveTextContent(
+      '1 container across 1 endpoint',
+    );
+  });
+
+  it('keeps the subtitle visible on mobile, since it carries state the title does not', () => {
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByTestId('page-header-subtitle').className).not.toContain('hidden');
+  });
+
+  it('renders the same h1 while the containers query is still loading', () => {
+    mockUseContainers.mockReturnValue({ ...defaultContainersMock, isLoading: true, data: undefined });
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Workloads');
+    // No fabricated "0 containers" count before the data has arrived.
+    expect(screen.queryByTestId('page-header-subtitle')).not.toBeInTheDocument();
+  });
+
+  it('renders the h1 on the error branch too', () => {
+    mockUseContainers.mockReturnValue({
+      ...defaultContainersMock,
+      isError: true,
+      error: new Error('boom'),
+      data: undefined,
+    });
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Workloads');
+    expect(screen.getByText('Failed to load containers')).toBeInTheDocument();
+  });
+});
+
+describe('WorkloadExplorerPage — auto-refresh actually refreshes', () => {
+  beforeEach(() => {
+    mockQueryString = 'endpoint=1';
+    mockSetSearchParams.mockReset();
+    mockNavigate.mockReset();
+    mockAutoRefreshOptions = undefined;
+  });
+
+  it('passes onTick to useAutoRefresh, and the tick refetches', () => {
+    const refetch = vi.fn();
+    mockUseContainers.mockReturnValue({ ...defaultContainersMock, refetch });
+    render(<WorkloadExplorerPage />);
+
+    // Before this, the interval dropdown wrote a localStorage preference and
+    // scheduled no fetch, while the control rendered a pulsing "live" dot.
+    expect(mockAutoRefreshOptions?.onTick).toBeTypeOf('function');
+    expect(refetch).not.toHaveBeenCalled();
+
+    act(() => {
+      mockAutoRefreshOptions!.onTick!();
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a data-freshness stamp once the query reports an update time', () => {
+    mockUseContainers.mockReturnValue({
+      ...defaultContainersMock,
+      dataUpdatedAt: Date.now() - 3000,
+    });
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByText(/^Updated /)).toBeInTheDocument();
+  });
+
+  it('shows no freshness stamp when the query has never resolved', () => {
+    mockUseContainers.mockReturnValue({ ...defaultContainersMock, dataUpdatedAt: 0 });
+    render(<WorkloadExplorerPage />);
+    expect(screen.queryByText(/^Updated /)).not.toBeInTheDocument();
+  });
+});
+
+describe('WorkloadExplorerPage — rows are real links', () => {
+  beforeEach(() => {
+    mockQueryString = 'endpoint=1';
+    mockRowHref = undefined;
+    mockRowLabel = undefined;
+    mockUseContainers.mockReturnValue(defaultContainersMock);
+  });
+
+  it('passes rowHref so cmd-click, middle-click and "copy link address" work', () => {
+    render(<WorkloadExplorerPage />);
+    expect(mockRowHref).toBeTypeOf('function');
+    expect(mockRowHref!(defaultContainersMock.data[0])).toBe('/containers/1/c-workers');
+  });
+
+  it('passes a rowLabel naming the destination, so AT hears more than "row"', () => {
+    render(<WorkloadExplorerPage />);
+    expect(mockRowLabel!(defaultContainersMock.data[0])).toBe('Open container workers-api-1');
+  });
+
+  it('keeps the whole-row click handler alongside the anchor', () => {
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByTestId('workloads-table')).toHaveAttribute('data-has-row-click', 'true');
+  });
+});
+
+describe('WorkloadExplorerPage — mobile card list', () => {
+  beforeEach(() => {
+    mockQueryString = 'endpoint=1';
+    mockUseContainers.mockReturnValue(defaultContainersMock);
+  });
+
+  it('renders one card per visible container, each a real link', () => {
+    render(<WorkloadExplorerPage />);
+    const list = screen.getByTestId('workload-card-list');
+    const links = list.querySelectorAll('a');
+    expect(links).toHaveLength(3);
+    expect(links[0].getAttribute('href')).toBe('/containers/1/c-workers');
+  });
+
+  it('shows the state on every card — the question a phone is opened to answer', () => {
+    render(<WorkloadExplorerPage />);
+    const list = screen.getByTestId('workload-card-list');
+    // StatusBadge is stubbed as the bare state string.
+    expect(list.textContent).toContain('workers-api-1');
+    expect(list.textContent).toContain('running');
+  });
+
+  it('shows stack and image on the second line', () => {
+    render(<WorkloadExplorerPage />);
+    const list = screen.getByTestId('workload-card-list');
+    expect(list.textContent).toContain('workers · workers:latest');
+    // A container with no stack says so rather than rendering a bare dot, and
+    // the image drops its registry path to fit a phone-width card.
+    expect(list.textContent).toContain('No stack · beyla:latest');
+  });
+
+  it('hides the table below md and the cards from md up', () => {
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByTestId('workload-card-list').parentElement?.className).toContain('md:hidden');
+    expect(screen.getByTestId('workloads-table').parentElement?.className).toContain('hidden');
+    expect(screen.getByTestId('workloads-table').parentElement?.className).toContain('md:block');
+  });
+
+  it('mirrors the search-filtered rows, not the unfiltered list', () => {
+    render(<WorkloadExplorerPage />);
+    act(() => {
+      mockOnFiltered?.([defaultContainersMock.data[0]]);
+    });
+    expect(screen.getByTestId('workload-card-list').querySelectorAll('a')).toHaveLength(1);
+  });
+
+  it('states plainly when nothing matches', () => {
+    mockQueryString = 'endpoint=1&state=stopped';
+    render(<WorkloadExplorerPage />);
+    expect(screen.getByTestId('workload-card-list').textContent).toContain(
+      'No containers match these filters.',
+    );
   });
 });

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState, useEffect, useCallback } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { type ColumnDef, type RowSelectionState } from '@tanstack/react-table';
 import { AnimatePresence, m, useReducedMotion } from 'framer-motion';
-import { AlertTriangle, Box, Boxes, Cog, Download, GitCompareArrows, X } from 'lucide-react';
+import { AlertTriangle, Boxes, Download, GitCompareArrows, X } from 'lucide-react';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { useContainers, type Container } from '@/features/containers/hooks/use-containers';
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
@@ -15,6 +15,8 @@ import { useForceRefresh } from '@/shared/hooks/use-force-refresh';
 import { FavoriteButton } from '@/shared/components/ui/favorite-button';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
+import { DataFreshness } from '@/shared/components/feedback/data-freshness';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { resolveContainerStackName } from '@/features/containers/lib/container-stack-grouping';
 import { exportToCsv } from '@/shared/lib/csv-export';
 import { getContainerGroup, getContainerGroupLabel, type ContainerGroup } from '@/features/containers/lib/system-container-grouping';
@@ -26,6 +28,8 @@ import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import { ContainerComparisonView } from '@/features/containers/components/container-comparison-view';
 
 const MAX_COMPARE = 4;
+/** Cards rendered per batch below `md`, where there is no table pagination. */
+const MOBILE_PAGE_SIZE = 25;
 
 export default function WorkloadExplorerPage() {
   const navigate = useNavigate();
@@ -110,10 +114,25 @@ export default function WorkloadExplorerPage() {
 
   const { data: endpoints } = useEndpoints();
   const { data: stacks } = useStacks();
-  const { data: containers, isLoading, isError, error, refetch, isFetching } = useContainers(selectedEndpoint !== undefined ? { endpointId: selectedEndpoint } : undefined);
+  const {
+    data: containers,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetching,
+    dataUpdatedAt,
+  } = useContainers(selectedEndpoint !== undefined ? { endpointId: selectedEndpoint } : undefined);
 
   const { forceRefresh, isForceRefreshing } = useForceRefresh('containers', refetch);
-  const { interval, setInterval } = useAutoRefresh(30);
+  // The hook owns the timer: without `onTick` the dropdown wrote a preference,
+  // scheduled no fetch, and the refresh control still rendered a pulsing live
+  // dot. The `Updated Ns ago` stamp below is the second signal.
+  const { interval, setRefreshInterval } = useAutoRefresh(30, {
+    onTick: () => {
+      void refetch();
+    },
+  });
 
   const knownStackNames = useMemo(() => {
     if (!stacks) return [];
@@ -219,6 +238,22 @@ export default function WorkloadExplorerPage() {
     setSearchFilteredContainers(undefined);
   }, [selectedEndpoint, selectedStack, selectedGroup, selectedState, selectedImage]);
 
+  /** The rows actually on screen — table body, card list and subtitle share it. */
+  const visibleContainers = searchFilteredContainers ?? filteredContainers;
+
+  // Live state, not a capability claim. The page it replaced said "Browse and
+  // manage containers across all endpoints" on an observer-first product that
+  // manages nothing here.
+  const subtitle = useMemo(() => {
+    if (isLoading) return undefined;
+    const containerCount = visibleContainers.length;
+    const endpointCount = new Set(visibleContainers.map((c) => c.endpointId)).size;
+    return `${containerCount} container${containerCount === 1 ? '' : 's'} across ${endpointCount} endpoint${endpointCount === 1 ? '' : 's'}`;
+  }, [visibleContainers, isLoading]);
+
+  const [mobileLimit, setMobileLimit] = useState(MOBILE_PAGE_SIZE);
+  const mobileRows = visibleContainers.slice(0, mobileLimit);
+
   const exportRows = useMemo<Record<string, unknown>[]>(() => {
     if (!filteredContainers) return [];
     return filteredContainers.map((container) => ({
@@ -312,29 +347,43 @@ export default function WorkloadExplorerPage() {
   const columns: ColumnDef<Container, any>[] = useMemo(() => [
     {
       accessorKey: 'name',
+      // The whole cell is wrapped in the row's `<a href>` by DataTable
+      // (`rowHref` below), so nothing in here may be a button — an anchor
+      // cannot contain interactive content. The favourite star therefore moved
+      // to its own column.
       header: 'Name',
       size: 280,
       cell: ({ row, getValue }) => {
-        const container = row.original;
+        const isSystem = getContainerGroup(row.original) === 'system';
         return (
-          <div className="flex items-center gap-1">
-            <FavoriteButton size="sm" endpointId={container.endpointId} containerId={container.id} />
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                navigate(`/containers/${container.endpointId}/${container.id}`);
-              }}
-              className="inline-flex items-center whitespace-nowrap rounded-lg bg-primary/10 px-3 py-1 text-sm font-medium text-primary transition-all duration-200 hover:bg-primary/20 hover:shadow-sm hover:ring-1 hover:ring-primary/20"
-            >
+          <span className="flex items-center gap-2">
+            <span className="inline-flex items-center whitespace-nowrap rounded-lg bg-primary/10 px-3 py-1 text-sm font-medium text-primary transition-all duration-200 group-hover/row:bg-primary/20">
               {truncate(getValue<string>(), 45)}
-            </button>
-          </div>
+            </span>
+            {/* Replaces the Group column, which rendered an identical unlabelled
+                icon on every row. Only system containers carry a mark now, so
+                the column has variance instead of being decoration. */}
+            {isSystem && (
+              <span className="whitespace-nowrap rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                System
+              </span>
+            )}
+          </span>
         );
       },
     },
     {
+      id: 'favorite',
+      header: () => <span className="sr-only">Favourite</span>,
+      size: 44,
+      enableSorting: false,
+      cell: ({ row }) => (
+        <FavoriteButton size="sm" endpointId={row.original.endpointId} containerId={row.original.id} />
+      ),
+    },
+    {
       id: 'stack',
-      header: 'Stackname',
+      header: 'Stack',
       size: 160,
       cell: ({ row }) => {
         const stackName = resolveContainerStackName(row.original, knownStackNames);
@@ -347,7 +396,7 @@ export default function WorkloadExplorerPage() {
               e.stopPropagation();
               setSelectedStack(stackName);
             }}
-            className="inline-flex items-center whitespace-nowrap rounded-md bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-800 transition-colors hover:bg-purple-200 hover:ring-1 hover:ring-purple-300 dark:bg-purple-900/30 dark:text-purple-300 dark:hover:bg-purple-900/50"
+            className="inline-flex items-center whitespace-nowrap rounded-md bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground transition-colors hover:bg-accent hover:ring-1 hover:ring-border"
             title={`Filter by stack: ${stackName}`}
           >
             {truncate(stackName, 25)}
@@ -387,7 +436,10 @@ export default function WorkloadExplorerPage() {
               e.stopPropagation();
               setSelectedEndpoint(container.endpointId);
             }}
-            className="inline-flex items-center whitespace-nowrap rounded-md bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 transition-colors hover:bg-blue-200 hover:ring-1 hover:ring-blue-300 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+            // Plain text at rest. As a saturated pill this was the highest-chroma
+            // element on the page while repeating one value on every row — the
+            // most dominant column had zero variance.
+            className="inline-flex items-center whitespace-nowrap rounded-md px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground hover:ring-1 hover:ring-border"
             title={`Filter by endpoint: ${container.endpointName}`}
           >
             {container.endpointName}
@@ -397,7 +449,7 @@ export default function WorkloadExplorerPage() {
     },
     {
       accessorKey: 'image',
-      header: 'Imagename',
+      header: 'Image',
       cell: ({ getValue }) => {
         const full = getValue<string>();
         return (
@@ -415,46 +467,12 @@ export default function WorkloadExplorerPage() {
         );
       },
     },
-    {
-      id: 'group',
-      header: 'Group',
-      size: 72,
-      cell: ({ row }) => {
-        const container = row.original;
-        const label = getContainerGroupLabel(container);
-        const isSystem = label === 'System';
-        const Icon = isSystem ? Cog : Box;
-        return (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setSelectedGroup(getContainerGroup(container));
-            }}
-            title={`Filter by group: ${label}`}
-            aria-label={`Filter by ${label}`}
-            className={
-              isSystem
-                ? 'inline-flex items-center justify-center rounded-md bg-amber-100 p-1 text-amber-900 transition-colors hover:bg-amber-200 hover:ring-1 hover:ring-amber-300 dark:bg-amber-900/30 dark:text-amber-300 dark:hover:bg-amber-900/50'
-                : 'inline-flex items-center justify-center rounded-md bg-slate-100 p-1 text-slate-700 transition-colors hover:bg-slate-200 hover:ring-1 hover:ring-slate-300 dark:bg-slate-900/30 dark:text-slate-300 dark:hover:bg-slate-900/50'
-            }
-          >
-            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
-        );
-      },
-    },
-  ], [navigate, knownStackNames, selectedEndpoint, selectedStack, selectedGroup, selectedState, selectedImage]);
+  ], [knownStackNames, selectedEndpoint, selectedStack, selectedGroup, selectedState, selectedImage]);
 
   if (isError) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Workload Explorer</h1>
-          <p className="text-muted-foreground">
-            Browse and manage containers across all endpoints
-          </p>
-        </div>
+        <PageHeader title="Workloads" />
         <EmptyState
           variant="error"
           icon={AlertTriangle}
@@ -473,64 +491,54 @@ export default function WorkloadExplorerPage() {
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          {compareMode ? (
-            <>
-              <div className="flex items-center gap-3">
+      {/* Header — the page's single h1, rendered in the loading branch too. */}
+      <PageHeader
+        title={
+          compareMode
+            ? `Comparing ${compareContainerIds.length} container${compareContainerIds.length === 1 ? '' : 's'}`
+            : 'Workloads'
+        }
+        subtitle={compareMode ? undefined : subtitle}
+        hideSubtitleOnMobile={false}
+        actions={
+          <>
+            {compareMode ? (
+              <button
+                type="button"
+                onClick={exitCompareMode}
+                className="inline-flex h-10 items-center gap-1 rounded-full border border-input bg-background px-4 text-sm font-medium hover:bg-accent"
+              >
+                ← Back to list
+              </button>
+            ) : (
+              <>
                 <button
                   type="button"
-                  onClick={exitCompareMode}
-                  className="inline-flex items-center gap-1 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent"
+                  onClick={handleCompare}
+                  disabled={selectedContainers.length < 2}
+                  title={selectedContainers.length < 2 ? 'Select 2 or more containers to compare' : `Compare ${selectedContainers.length} selected containers`}
+                  className="inline-flex h-10 items-center gap-2 rounded-full border border-input bg-background px-4 text-sm font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
                 >
-                  ← Back to list
+                  <GitCompareArrows className="h-4 w-4" />
+                  {selectedContainers.length < 2 ? 'Compare' : `Compare ${selectedContainers.length}`}
                 </button>
-                <h1 className="text-3xl font-bold tracking-tight">
-                  Comparing {compareContainerIds.length} container{compareContainerIds.length === 1 ? '' : 's'}
-                </h1>
-              </div>
-              <p className="mt-1 text-muted-foreground">
-                Compare metrics, configuration, and status across selected containers
-              </p>
-            </>
-          ) : (
-            <>
-              <h1 className="text-3xl font-bold tracking-tight">Workload Explorer</h1>
-              <p className="text-muted-foreground">
-                Browse and manage containers across all endpoints
-              </p>
-            </>
-          )}
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          {!compareMode && (
-            <>
-              <button
-                type="button"
-                onClick={handleCompare}
-                disabled={selectedContainers.length < 2}
-                title={selectedContainers.length < 2 ? 'Select 2 or more containers to compare' : `Compare ${selectedContainers.length} selected containers`}
-                className="inline-flex h-10 items-center gap-2 rounded-full border border-input bg-background px-4 text-sm font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
-              >
-                <GitCompareArrows className="h-4 w-4" />
-                {selectedContainers.length < 2 ? 'Compare' : `Compare ${selectedContainers.length}`}
-              </button>
-              <button
-                type="button"
-                onClick={handleExportCsv}
-                disabled={!exportRows.length}
-                title={!exportRows.length ? 'Nothing to export' : 'Export the current view as CSV'}
-                className="inline-flex h-10 items-center gap-2 rounded-full border border-input bg-background px-4 text-sm font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
-              >
-                <Download className="h-4 w-4" />
-                Export CSV
-              </button>
-            </>
-          )}
-          <RefreshControls interval={interval} onIntervalChange={setInterval} onRefresh={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
-        </div>
-      </div>
+                <button
+                  type="button"
+                  onClick={handleExportCsv}
+                  disabled={!exportRows.length}
+                  title={!exportRows.length ? 'Nothing to export' : 'Export the current view as CSV'}
+                  className="inline-flex h-10 items-center gap-2 rounded-full border border-input bg-background px-4 text-sm font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
+                >
+                  <Download className="h-4 w-4" />
+                  Export CSV
+                </button>
+                <DataFreshness lastUpdated={dataUpdatedAt ?? null} onRefresh={() => refetch()} />
+              </>
+            )}
+            <RefreshControls interval={interval} onIntervalChange={setRefreshInterval} onRefresh={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
+          </>
+        }
+      />
 
       {compareMode ? (
         // ── Compare mode body ──
@@ -548,8 +556,8 @@ export default function WorkloadExplorerPage() {
                 ? 'No containers to compare'
                 : 'Compare needs at least 2 containers';
               const body = compared.length === 0
-                ? 'Pick at least 2 containers from Workload Explorer to compare them.'
-                : 'Add another container from Workload Explorer to compare.';
+                ? 'Pick at least 2 containers from Workloads to compare them.'
+                : 'Add another container from Workloads to compare.';
               return (
                 <>
                   <EmptyState
@@ -714,19 +722,66 @@ export default function WorkloadExplorerPage() {
                 </div>
               )}
 
-              <DataTable
-                columns={columns}
-                data={searchFilteredContainers ?? filteredContainers}
-                hideSearch
-                autoFit
-                minTableWidth={770}
-                enableRowSelection
-                maxSelection={MAX_COMPARE}
-                onSelectionChange={handleSelectionChange}
-                getRowId={(row) => `${row.endpointId}:${row.id}`}
-                selectedRowIds={controlledRowIds}
-                onRowClick={(row) => navigate(`/containers/${row.endpointId}/${row.id}`)}
-              />
+              {/* Below md the table pushed State, Endpoint, Image and Stack
+                  off-canvas with no scroll affordance, leaving a phone able to
+                  read only the container name. Two-line cards instead. */}
+              <div className="md:hidden">
+                <ul data-testid="workload-card-list" className="space-y-2">
+                  {mobileRows.length === 0 ? (
+                    <li className="rounded-lg border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
+                      No containers match these filters.
+                    </li>
+                  ) : (
+                    mobileRows.map((container) => {
+                      const stackName = resolveContainerStackName(container, knownStackNames);
+                      return (
+                        <li key={`${container.endpointId}:${container.id}`}>
+                          <Link
+                            to={`/containers/${container.endpointId}/${container.id}`}
+                            className="flex items-center justify-between gap-3 rounded-lg border bg-card/60 p-3 transition-colors hover:bg-muted/40"
+                          >
+                            <span className="min-w-0 flex-1">
+                              <span className="block truncate text-sm font-medium">{container.name}</span>
+                              <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                                {stackName ?? 'No stack'} · {getImageShortName(container.image)}
+                              </span>
+                            </span>
+                            <StatusBadge status={container.state} />
+                          </Link>
+                        </li>
+                      );
+                    })
+                  )}
+                </ul>
+                {visibleContainers.length > mobileRows.length && (
+                  <button
+                    type="button"
+                    onClick={() => setMobileLimit((limit) => limit + MOBILE_PAGE_SIZE)}
+                    className="mt-2 w-full rounded-lg border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+                  >
+                    Show {Math.min(MOBILE_PAGE_SIZE, visibleContainers.length - mobileRows.length)} more
+                    {' '}({visibleContainers.length - mobileRows.length} remaining)
+                  </button>
+                )}
+              </div>
+
+              <div className="hidden md:block">
+                <DataTable
+                  columns={columns}
+                  data={visibleContainers}
+                  hideSearch
+                  autoFit
+                  minTableWidth={770}
+                  enableRowSelection
+                  maxSelection={MAX_COMPARE}
+                  onSelectionChange={handleSelectionChange}
+                  getRowId={(row) => `${row.endpointId}:${row.id}`}
+                  selectedRowIds={controlledRowIds}
+                  onRowClick={(row) => navigate(`/containers/${row.endpointId}/${row.id}`)}
+                  rowHref={(row) => `/containers/${row.endpointId}/${row.id}`}
+                  rowLabel={(row) => `Open container ${row.name}`}
+                />
+              </div>
             </div>
             </SpotlightCard>
           ) : null}

--- a/frontend/src/features/core/components/layout/app-layout.test.tsx
+++ b/frontend/src/features/core/components/layout/app-layout.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -7,7 +8,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // --- carries data-testid="sidebar"; the stub mirrors that so the test asserts
 // --- AppLayout still renders the sidebar slot when a page throws.
 vi.mock('@/features/core/components/layout/sidebar', () => ({
-  Sidebar: () => <div data-testid="sidebar" />,
+  Sidebar: ({ forceRail }: { forceRail?: boolean }) => (
+    <div data-testid="sidebar" data-force-rail={forceRail ? 'true' : 'false'} />
+  ),
 }));
 vi.mock('@/features/core/components/layout/header', () => ({
   Header: () => <div data-testid="header" />,
@@ -70,21 +73,22 @@ vi.mock('framer-motion', async (importOriginal) => {
   return { ...actual, useReducedMotion: () => true };
 });
 
-import { AppLayout } from './app-layout';
+import { AppLayout, NAV_CHORDS } from './app-layout';
 import { RouteErrorBoundary } from '@/shared/components/feedback/route-error-boundary';
+import { navDestinations, breadcrumbLabelForPath } from '@/features/core/lib/navigation-manifest';
 
 function Boom(): never {
   throw new Error('page exploded');
 }
 
-function renderAt() {
+function renderAt(child: ReactNode = <Boom />) {
   const router = createMemoryRouter(
     [
       {
         path: '/',
         element: <AppLayout />,
         errorElement: <RouteErrorBoundary />, // mirrors router.tsx
-        children: [{ index: true, element: <Boom /> }],
+        children: [{ index: true, element: child }],
       },
     ],
     { initialEntries: ['/'] },
@@ -107,5 +111,79 @@ describe('AppLayout shell resilience', () => {
     expect(screen.getByTestId('sidebar')).toBeInTheDocument();
     expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
     spy.mockRestore();
+  });
+});
+
+describe('g-chord navigation', () => {
+  it('only jumps to paths that exist in the route manifest', () => {
+    const manifestPaths = navDestinations.map((d) => d.path);
+    for (const [keys, path] of NAV_CHORDS) {
+      expect(manifestPaths, `chord ${keys} points at an unknown path`).toContain(path);
+    }
+  });
+
+  it('assigns each chord a unique key sequence', () => {
+    const keys = NAV_CHORDS.map(([k]) => k);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('names destinations exactly as the sidebar does', () => {
+    for (const [, path] of NAV_CHORDS) {
+      expect(breadcrumbLabelForPath(path)).toBeTruthy();
+    }
+    // The overlay used to say "Go to Trace Explorer" while the nav said Traces.
+    expect(breadcrumbLabelForPath('/traces')).toBe('Traces');
+    expect(breadcrumbLabelForPath('/assistant')).toBe('Assistant');
+  });
+});
+
+describe('AppLayout tablet rail', () => {
+  function stubMatchMedia(matches: (query: string) => boolean) {
+    const original = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: (query: string) => ({
+        matches: matches(query),
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+    return () => {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: original,
+      });
+    };
+  }
+
+  it('gives the content the full sidebar width above 1024px', () => {
+    const restore = stubMatchMedia(() => false);
+    try {
+      renderAt(<div>page</div>);
+      expect(screen.getByTestId('sidebar')).toHaveAttribute('data-force-rail', 'false');
+      expect(screen.getByTestId('app-content').className).toContain('md:ml-[calc(256px+2rem)]');
+    } finally {
+      restore();
+    }
+  });
+
+  it('collapses to the 64px icon rail between 768px and 1023px', () => {
+    const restore = stubMatchMedia((q) => q.includes('1023px'));
+    try {
+      renderAt(<div>page</div>);
+      expect(screen.getByTestId('sidebar')).toHaveAttribute('data-force-rail', 'true');
+      const content = screen.getByTestId('app-content');
+      expect(content.className).toContain('md:ml-[calc(64px+2rem)]');
+      expect(content.className).not.toContain('md:ml-[calc(256px+2rem)]');
+    } finally {
+      restore();
+    }
   });
 });

--- a/frontend/src/features/core/components/layout/app-layout.tsx
+++ b/frontend/src/features/core/components/layout/app-layout.tsx
@@ -17,7 +17,10 @@ import { useKeyChord } from '@/shared/hooks/use-key-chord';
 import type { ChordBinding } from '@/shared/hooks/use-key-chord';
 import { AnimatePresence, m, useReducedMotion } from 'framer-motion';
 import { ErrorBoundary } from '@/shared/components/feedback/error-boundary';
-import { breadcrumbLabelForPath } from '@/features/core/lib/navigation-manifest';
+import {
+  breadcrumbLabelForPath,
+  NAV_CHORDS,
+} from '@/features/core/lib/navigation-manifest';
 
 /**
  * Catches render errors thrown by the active page so one failing route
@@ -46,22 +49,16 @@ function getRouteDepth(pathname: string): number {
   return pathname.split('/').filter(Boolean).length;
 }
 
-/** `g`-chord key assignments, paired with the manifest path they jump to. */
-export const NAV_CHORDS: ReadonlyArray<readonly [string, string]> = [
-  ['gh', '/'],
-  ['gw', '/workloads'],
-  ['gf', '/infrastructure'],
-  ['gl', '/health'],
-  ['gi', '/images'],
-  ['gn', '/topology'],
-  ['gm', '/metrics'],
-  ['gr', '/remediation'],
-  ['ge', '/traces'],
-  ['gx', '/assistant'],
-  ['go', '/edge-logs'],
-  ['gv', '/logs'],
-  ['gs', '/settings'],
-];
+/**
+ * `g`-chord key assignments, re-exported for existing importers.
+ *
+ * The definition lives in the navigation manifest alongside the destinations it
+ * points at. It was briefly declared here, which created a cycle: the keyboard
+ * shortcuts overlay needs the chords to label itself, and this module imports
+ * that overlay — so `NAV_CHORDS` read as `undefined` at module-init time
+ * whenever the graph was entered through the router.
+ */
+export { NAV_CHORDS };
 
 /**
  * True between 768px and 1023px. At 820px the full 256px sidebar spent ~37%

--- a/frontend/src/features/core/components/layout/app-layout.tsx
+++ b/frontend/src/features/core/components/layout/app-layout.tsx
@@ -17,6 +17,7 @@ import { useKeyChord } from '@/shared/hooks/use-key-chord';
 import type { ChordBinding } from '@/shared/hooks/use-key-chord';
 import { AnimatePresence, m, useReducedMotion } from 'framer-motion';
 import { ErrorBoundary } from '@/shared/components/feedback/error-boundary';
+import { breadcrumbLabelForPath } from '@/features/core/lib/navigation-manifest';
 
 /**
  * Catches render errors thrown by the active page so one failing route
@@ -45,6 +46,44 @@ function getRouteDepth(pathname: string): number {
   return pathname.split('/').filter(Boolean).length;
 }
 
+/** `g`-chord key assignments, paired with the manifest path they jump to. */
+export const NAV_CHORDS: ReadonlyArray<readonly [string, string]> = [
+  ['gh', '/'],
+  ['gw', '/workloads'],
+  ['gf', '/infrastructure'],
+  ['gl', '/health'],
+  ['gi', '/images'],
+  ['gn', '/topology'],
+  ['gm', '/metrics'],
+  ['gr', '/remediation'],
+  ['ge', '/traces'],
+  ['gx', '/assistant'],
+  ['go', '/edge-logs'],
+  ['gv', '/logs'],
+  ['gs', '/settings'],
+];
+
+/**
+ * True between 768px and 1023px. At 820px the full 256px sidebar spent ~37%
+ * of the viewport on navigation, which is why the workloads table showed two
+ * columns there. The 64px icon rail (with its tooltips) already existed;
+ * this just switches to it automatically and gives 192px back.
+ */
+export function useTabletRail(): boolean {
+  const [isRail, setIsRail] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia('(min-width: 768px) and (max-width: 1023px)');
+    const update = () => setIsRail(mql.matches);
+    update();
+    mql.addEventListener?.('change', update);
+    return () => mql.removeEventListener?.('change', update);
+  }, []);
+
+  return isRail;
+}
+
 export function AppLayout() {
   const { isAuthenticated } = useAuth();
   const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
@@ -63,6 +102,8 @@ export function AppLayout() {
   const reducedMotion = useReducedMotion();
   const disableVisualMotion = reducedMotion || potatoMode;
   const [direction, setDirection] = useState(1);
+  const tabletRail = useTabletRail();
+  const railMode = sidebarCollapsed || tabletRail;
   const previousDepthRef = useRef(getRouteDepth(location.pathname));
   const { hasPlayed, markPlayed } = useEntrancePlayed();
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
@@ -85,23 +126,16 @@ export function AppLayout() {
     };
   }, [disableVisualMotion, hasPlayed, markPlayed]);
 
-  // Vim-style g+key chord navigation
+  // Vim-style g+key chord navigation. Only the key assignment lives here —
+  // the destination's name comes from the route manifest, so the overlay can
+  // never disagree with the sidebar about what a page is called.
   const chordBindings: ChordBinding[] = useMemo(
-    () => [
-      { keys: 'gh', action: () => navigate('/'), label: 'Go to Home' },
-      { keys: 'gw', action: () => navigate('/workloads'), label: 'Go to Workloads' },
-      { keys: 'gf', action: () => navigate('/infrastructure'), label: 'Go to Infrastructure' },
-      { keys: 'gl', action: () => navigate('/health'), label: 'Go to Health & Monitoring' },
-      { keys: 'gi', action: () => navigate('/images'), label: 'Go to Images' },
-      { keys: 'gn', action: () => navigate('/topology'), label: 'Go to Network Topology' },
-      { keys: 'gm', action: () => navigate('/metrics'), label: 'Go to Metrics' },
-      { keys: 'gr', action: () => navigate('/remediation'), label: 'Go to Remediation' },
-      { keys: 'ge', action: () => navigate('/traces'), label: 'Go to Trace Explorer' },
-      { keys: 'gx', action: () => navigate('/assistant'), label: 'Go to LLM Assistant' },
-      { keys: 'go', action: () => navigate('/edge-logs'), label: 'Go to Edge Logs' },
-      { keys: 'gv', action: () => navigate('/logs'), label: 'Go to Log Viewer' },
-      { keys: 'gs', action: () => navigate('/settings'), label: 'Go to Settings' },
-    ],
+    () =>
+      NAV_CHORDS.map(([keys, path]) => ({
+        keys,
+        action: () => navigate(path),
+        label: `Go to ${breadcrumbLabelForPath(path) ?? path}`,
+      })),
     [navigate],
   );
 
@@ -216,13 +250,14 @@ export function AppLayout() {
             : { duration: 0 }
         }
       >
-        <Sidebar />
+        <Sidebar forceRail={tabletRail} />
       </m.div>
       <div
+        data-testid="app-content"
         className={cn(
           'relative z-10 flex flex-1 flex-col overflow-hidden',
           !disableVisualMotion && 'transition-all duration-300',
-          sidebarCollapsed ? 'md:ml-[calc(64px+2rem)]' : 'md:ml-[calc(256px+2rem)]',
+          railMode ? 'md:ml-[calc(64px+2rem)]' : 'md:ml-[calc(256px+2rem)]',
         )}
       >
         {/* Header — drops in from top */}

--- a/frontend/src/features/core/components/layout/command-palette.test.tsx
+++ b/frontend/src/features/core/components/layout/command-palette.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CommandPalette, pages } from './command-palette';
+
+const PLACEHOLDER = 'Search containers, images, logs and pages';
 import { useUiStore } from '@/stores/ui-store';
 import { useSearchStore } from '@/stores/search-store';
 import { SearchProvider } from '@/providers/search-provider';
@@ -101,14 +103,14 @@ describe('CommandPalette (Spotlight Style)', () => {
     expect(screen.getByLabelText('Filter by Containers')).toBeInTheDocument();
 
     // Typing state
-    const input = screen.getByPlaceholderText('Search or Ask Neural AI...');
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: 'web' } });
     expect(screen.getByLabelText('Filter by Containers')).toBeInTheDocument();
   });
 
   it('toggles category on click and filters results', () => {
     renderPalette();
-    const input = screen.getByPlaceholderText('Search or Ask Neural AI...');
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: 'web' } });
 
     // With 'all' category, containers should be visible
@@ -120,7 +122,7 @@ describe('CommandPalette (Spotlight Style)', () => {
     expect(settingsBtn).toHaveAttribute('aria-pressed', 'true');
 
     // Container results should be hidden when settings filter is active
-    expect(screen.queryByText('Infrastructure Units')).not.toBeInTheDocument();
+    expect(screen.queryByText('Containers', { selector: '[cmdk-group-heading]' })).not.toBeInTheDocument();
   });
 
   it('deselects category on second click (returns to all)', () => {
@@ -139,34 +141,34 @@ describe('CommandPalette (Spotlight Style)', () => {
   it('renders recent interactions when query is empty', () => {
     useSearchStore.setState({ recent: [{ term: 'postgres', lastUsed: Date.now() }] });
     renderPalette();
-    expect(screen.getByText('Recent Neural Interactions')).toBeInTheDocument();
+    expect(screen.getByText('Recent')).toBeInTheDocument();
     expect(screen.getByText('postgres')).toBeInTheDocument();
   });
 
   it('renders container results when searching', () => {
     renderPalette();
-    const input = screen.getByPlaceholderText('Search or Ask Neural AI...');
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: 'web' } });
-    expect(screen.getByText('Infrastructure Units')).toBeInTheDocument();
+    expect(screen.getByText('Containers', { selector: '[cmdk-group-heading]' })).toBeInTheDocument();
     expect(screen.getByText('web-frontend')).toBeInTheDocument();
   });
 
-  it('shows Neural Run button for natural language queries', () => {
+  it('shows the Ask AI button for natural language queries', () => {
     renderPalette();
-    const input = screen.getByPlaceholderText('Search or Ask Neural AI...');
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: 'what containers are running' } });
-    expect(screen.getByText('Neural Run')).toBeInTheDocument();
+    expect(screen.getByText('Ask AI')).toBeInTheDocument();
   });
 
-  it('does not show Neural Run button for simple searches', () => {
+  it('does not show the Ask AI button for simple searches', () => {
     renderPalette();
-    const input = screen.getByPlaceholderText('Search or Ask Neural AI...');
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: 'nginx' } });
-    expect(screen.queryByText('Neural Run')).toBeNull();
+    expect(screen.queryByText('Ask AI')).toBeNull();
   });
 
   it('orders the Intelligence pages directly after Monitoring and before Diagnostics, mirroring the sidebar', () => {
-    const order = pages.map((p) => p.to);
+    const order = pages.map((p) => p.path);
     const metrics = order.indexOf('/metrics'); // last Monitoring view
     const assistant = order.indexOf('/assistant'); // Intelligence
     const llmObservability = order.indexOf('/llm-observability'); // Intelligence
@@ -181,28 +183,84 @@ describe('CommandPalette (Spotlight Style)', () => {
 
   it('does not include deprecated backups page in static page entries', () => {
     renderPalette();
-    const input = screen.getByPlaceholderText('Search or Ask Neural AI...');
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: 'se' } });
     expect(screen.queryByText('Backups')).not.toBeInTheDocument();
     expect(screen.getAllByText('Settings').length).toBeGreaterThan(0);
   });
 
+
+  it('names things the way the sidebar names them', () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
+    // 'server' matches the mocked endpoints as well as the mocked containers.
+    fireEvent.change(input, { target: { value: 'server' } });
+
+    const headings = Array.from(
+      document.querySelectorAll('[cmdk-group-heading]'),
+    ).map((el) => el.textContent);
+
+    expect(headings).toContain('Containers');
+    expect(headings).toContain('Endpoints');
+    expect(headings).toContain('Pages');
+    expect(headings).toContain('Logs');
+    for (const invented of [
+      'Infrastructure Units',
+      'Nodes',
+      'Neural Navigation',
+      'Binary Blueprints',
+      'Neural Log Stream',
+    ]) {
+      expect(headings).not.toContain(invented);
+    }
+  });
+
+  it('carries no "Neural" vocabulary anywhere in the rendered palette', () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
+    fireEvent.change(input, { target: { value: 'what containers are running' } });
+    expect(document.body.textContent).not.toMatch(/neural/i);
+  });
+
+  it('drops the tautological footer credit from the shortcut bar', () => {
+    renderPalette();
+    expect(screen.queryByText(/powered by/i)).toBeNull();
+    expect(screen.queryByText(/AI Intelligence/i)).toBeNull();
+  });
+
+  it('labels the shortcut bar with plain verbs', () => {
+    renderPalette();
+    expect(screen.getByText('Navigate')).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.queryByText('Traverse')).toBeNull();
+    expect(screen.queryByText('Execute')).toBeNull();
+  });
+
+  it('offers the destinations the hand-maintained list used to omit', () => {
+    const paths = pages.map((p) => p.path);
+    expect(paths).toContain('/logs');
+    expect(paths).toContain('/packet-capture');
+    expect(paths).toContain('/ebpf-coverage');
+    expect(paths).toContain('/reports');
+    expect(paths).toContain('/security/vulnerabilities');
+  });
+
   it('starts compact and expands when typing', () => {
     renderPalette();
-    const dialog = screen.getByPlaceholderText('Search or Ask Neural AI...').closest('[class*="z-[101]"]');
+    const dialog = screen.getByPlaceholderText(PLACEHOLDER).closest('[class*="z-[101]"]');
     // Dialog should exist and have the base classes
     expect(dialog?.className).toContain('z-[101]');
     expect(dialog?.className).toContain('w-full');
 
     // Verify typing updates the query state
-    const input = screen.getByPlaceholderText('Search or Ask Neural AI...');
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: 'test' } });
     expect((input as HTMLInputElement).value).toBe('test');
   });
 
   it('respects prefers-reduced-motion via CSS utility classes', () => {
     renderPalette();
-    const dialog = screen.getByPlaceholderText('Search or Ask Neural AI...').closest('[class*="z-[101]"]');
+    const dialog = screen.getByPlaceholderText(PLACEHOLDER).closest('[class*="z-[101]"]');
     expect(dialog).toBeInTheDocument();
     expect(dialog?.className).toContain('z-[101]');
   });

--- a/frontend/src/features/core/components/layout/command-palette.tsx
+++ b/frontend/src/features/core/components/layout/command-palette.tsx
@@ -2,20 +2,9 @@ import { useEffect, useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Command } from 'cmdk';
 import {
-  LayoutDashboard,
-  Boxes,
-  HeartPulse,
-  PackageOpen,
-  Network,
   Brain,
-  BarChart3,
   Shield,
-  GitBranch,
-  MessageSquare,
   Activity,
-  FileSearch,
-  Webhook,
-  Users,
   Settings,
   Settings2,
   Bot,
@@ -24,6 +13,7 @@ import {
   Palette,
   Server,
   Package,
+  Boxes,
   Layers,
   ScrollText,
   Clock,
@@ -40,32 +30,16 @@ import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
 import { useStacks } from '@/features/containers/hooks/use-stacks';
 import { useSearch } from '@/providers/search-provider';
 import { useNlQuery, type NlQueryResult } from '@/features/ai-intelligence/hooks/use-nl-query';
+import { palettePages, type NavDestination } from '@/features/core/lib/navigation-manifest';
 import { Search } from 'lucide-react';
 
-interface PageEntry {
-  label: string;
-  to: string;
-  icon: React.ComponentType<{ className?: string }>;
-}
-
-export const pages: PageEntry[] = [
-  { label: 'Home', to: '/', icon: LayoutDashboard },
-  { label: 'Workload Explorer', to: '/workloads', icon: Boxes },
-  { label: 'Infrastructure', to: '/infrastructure', icon: Server },
-  { label: 'Health & Monitoring', to: '/health', icon: HeartPulse },
-  { label: 'Image Footprint', to: '/images', icon: PackageOpen },
-  { label: 'Network Topology', to: '/topology', icon: Network },
-  { label: 'Metrics Dashboard', to: '/metrics', icon: BarChart3 },
-  { label: 'LLM Assistant', to: '/assistant', icon: MessageSquare },
-  { label: 'LLM Observability', to: '/llm-observability', icon: Activity },
-  { label: 'Trace Explorer', to: '/traces', icon: GitBranch },
-  { label: 'Remediation', to: '/remediation', icon: Shield },
-  { label: 'Security Audit', to: '/security/audit', icon: Shield },
-  { label: 'Edge Agent Logs', to: '/edge-logs', icon: FileSearch },
-  { label: 'Settings', to: '/settings', icon: Settings },
-  { label: 'Webhooks', to: '/webhooks', icon: Webhook },
-  { label: 'Users', to: '/users', icon: Users },
-];
+/**
+ * The palette's page list is the route manifest — it used to be a
+ * hand-maintained 16-entry copy of a 21-route list and was missing the Log
+ * Viewer, Packet Capture, Reports, eBPF Coverage and Vulnerabilities, i.e.
+ * most of what an on-call engineer reaches for under time pressure.
+ */
+export const pages: readonly NavDestination[] = palettePages;
 
 interface SettingsEntry {
   label: string;
@@ -165,7 +139,7 @@ export function CommandPalette() {
       onError: () => {
         setAiResult({
           action: 'error',
-          text: 'Neural services are currently unreachable.',
+          text: 'The AI service is unreachable.',
         });
       },
     });
@@ -200,9 +174,9 @@ export function CommandPalette() {
   const filteredPages = activeCategory === 'all'
     ? pages
     : activeCategory === 'containers'
-      ? pages.filter((p) => p.to === '/workloads' || p.to === '/health' || p.to === '/infrastructure' || p.to === '/images')
+      ? pages.filter((p) => p.path === '/workloads' || p.path === '/health' || p.path === '/infrastructure' || p.path === '/images')
       : activeCategory === 'settings'
-        ? pages.filter((p) => p.to === '/settings' || p.to === '/users' || p.to === '/webhooks')
+        ? pages.filter((p) => p.path === '/settings' || p.path === '/users' || p.path === '/webhooks')
         : pages;
 
   const filteredSettings = activeCategory === 'all' || activeCategory === 'settings' ? settingsEntries : [];
@@ -259,14 +233,14 @@ export function CommandPalette() {
 
                 {/* Input */}
                 <Command.Input
-                  placeholder={hoveredCategory ? `Filter by ${hoveredCategory}...` : 'Search or Ask Neural AI...'}
+                  placeholder={hoveredCategory ? `Filter by ${hoveredCategory}...` : 'Search containers, images, logs and pages'}
                   className="!h-full !flex-1 !border-0 !bg-transparent !text-base !font-medium !tracking-tight !text-foreground !shadow-none !ring-0 !outline-none placeholder:!text-muted-foreground/50 focus:!ring-0 focus:!border-0 focus:!outline-none focus:!shadow-none"
                   value={query}
                   onValueChange={(v) => { setQuery(v); setAiResult(null); }}
                   autoFocus
                 />
 
-                {/* Neural Run Button */}
+                {/* Ask AI — hands the query to the LLM instead of matching it */}
                 {isNl && query.trim().length >= 5 && (
                   <button
                     onClick={handleAiQuery}
@@ -278,7 +252,7 @@ export function CommandPalette() {
                     ) : (
                       <Sparkles className="h-3.5 w-3.5" />
                     )}
-                    <span>Neural Run</span>
+                    <span>Ask AI</span>
                   </button>
                 )}
 
@@ -333,8 +307,7 @@ export function CommandPalette() {
                         <Sparkles className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 text-primary" />
                       </div>
                       <div className="flex flex-col gap-1">
-                        <span className="text-lg font-bold tracking-tight text-primary">Neural processing...</span>
-                        <span className="text-xs font-medium text-primary/40 uppercase tracking-widest">Analyzing infrastructure graph</span>
+                        <span className="text-lg font-bold tracking-tight text-primary">Thinking…</span>
                       </div>
                     </div>
                   </div>
@@ -368,7 +341,7 @@ export function CommandPalette() {
                           <p className="text-[14px] font-medium text-primary/60">{aiResult.page}</p>
                         </div>
                         <div className="rounded-full bg-muted/50 px-5 py-2 text-[11px] font-black uppercase tracking-[0.2em] text-muted-foreground group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
-                          Execute
+                          Open
                         </div>
                       </button>
                     )}
@@ -386,7 +359,7 @@ export function CommandPalette() {
                     {/* 2. Containers - Essential infrastructure */}
                     {containers.length > 0 && (
                       <Command.Group
-                        heading="Infrastructure Units"
+                        heading="Containers"
                         className="px-2 pb-4 [&_[cmdk-group-heading]]:px-6 [&_[cmdk-group-heading]]:py-4 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-black [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.25em] [&_[cmdk-group-heading]]:text-muted-foreground/30"
                       >
                         {containers.map((container) => (
@@ -419,7 +392,7 @@ export function CommandPalette() {
                     {/* Nodes / Endpoints */}
                     {filteredEndpoints.length > 0 && (
                       <Command.Group
-                        heading="Nodes"
+                        heading="Endpoints"
                         className="px-2 pb-4 [&_[cmdk-group-heading]]:px-6 [&_[cmdk-group-heading]]:py-4 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-black [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.25em] [&_[cmdk-group-heading]]:text-muted-foreground/30"
                       >
                         {filteredEndpoints.map((ep) => (
@@ -449,15 +422,15 @@ export function CommandPalette() {
                     {/* 3. Navigation - Core pages (filtered by category) */}
                     {filteredPages.length > 0 && (
                       <Command.Group
-                        heading="Neural Navigation"
+                        heading="Pages"
                         className="px-2 pb-4 [&_[cmdk-group-heading]]:px-6 [&_[cmdk-group-heading]]:py-4 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-black [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.25em] [&_[cmdk-group-heading]]:text-muted-foreground/30"
                       >
                         <div className="grid grid-cols-2 gap-2">
                           {filteredPages.map((page) => (
                             <Command.Item
-                              key={page.to}
+                              key={page.path}
                               value={page.label}
-                              onSelect={() => navigateTo(page.to)}
+                              onSelect={() => navigateTo(page.path)}
                               className={cn(
                                 'flex cursor-pointer items-center gap-4 rounded-[16px] px-5 py-4 text-[15px] transition-all',
                                 'text-foreground/60 aria-selected:bg-muted/60 aria-selected:text-foreground'
@@ -536,7 +509,7 @@ export function CommandPalette() {
                     {/* 5. Images - Assets */}
                     {images.length > 0 && (
                       <Command.Group
-                        heading="Binary Blueprints"
+                        heading="Images"
                         className="px-2 pb-4 [&_[cmdk-group-heading]]:px-6 [&_[cmdk-group-heading]]:py-4 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-black [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.25em] [&_[cmdk-group-heading]]:text-muted-foreground/30"
                       >
                         {images.map((image) => (
@@ -571,7 +544,7 @@ export function CommandPalette() {
                 {/* 6. Recent History */}
                 {hasRecent && (
                   <Command.Group
-                    heading="Recent Neural Interactions"
+                    heading="Recent"
                     className="px-2 pb-4 [&_[cmdk-group-heading]]:px-6 [&_[cmdk-group-heading]]:py-4 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-black [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.25em] [&_[cmdk-group-heading]]:text-muted-foreground/30"
                   >
                     {recent.map((item) => (
@@ -599,7 +572,7 @@ export function CommandPalette() {
                     {/* 7. Logs - High volume data */}
                     {logs.length > 0 && (
                       <Command.Group
-                        heading="Neural Log Stream"
+                        heading="Logs"
                         className="px-2 pb-4 [&_[cmdk-group-heading]]:px-6 [&_[cmdk-group-heading]]:py-4 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-black [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.25em] [&_[cmdk-group-heading]]:text-muted-foreground/30"
                       >
                         {logs.map((logItem) => (
@@ -635,7 +608,7 @@ export function CommandPalette() {
                       <AlertCircle className="h-12 w-12 text-muted-foreground/20" />
                     </div>
                     <p className="text-xl font-bold text-foreground/60 tracking-tight">No results for "{query}"</p>
-                    <p className="mt-2 text-sm font-medium text-muted-foreground/40 uppercase tracking-[0.15em]">Refine search or try Neural Run</p>
+                    <p className="mt-2 text-sm font-medium text-muted-foreground/40">Try a shorter term, or press Enter to ask the AI.</p>
                   </Command.Empty>
                 )}
               </Command.List>
@@ -645,16 +618,12 @@ export function CommandPalette() {
                 <div className="flex items-center gap-5">
                   <span className="flex items-center gap-1.5 text-[10px] font-black uppercase tracking-[0.15em] text-muted-foreground/30">
                     <kbd className="rounded-[5px] bg-muted/30 px-1.5 py-0.5 font-mono text-muted-foreground/50 border border-border/20 shadow-inner">↑↓</kbd>
-                    <span>Traverse</span>
+                    <span>Navigate</span>
                   </span>
                   <span className="flex items-center gap-1.5 text-[10px] font-black uppercase tracking-[0.15em] text-muted-foreground/30">
                     <kbd className="rounded-[5px] bg-muted/30 px-1.5 py-0.5 font-mono text-muted-foreground/50 border border-border/20 shadow-inner">↵</kbd>
-                    <span>Execute</span>
+                    <span>Open</span>
                   </span>
-                </div>
-                <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.15em] text-muted-foreground/30">
-                  <span className="text-[9px] opacity-50">Powered by</span>
-                  <span className="text-primary/60 tracking-[0.3em]">AI Intelligence</span>
                 </div>
               </div>
             </Command>

--- a/frontend/src/features/core/components/layout/header.test.tsx
+++ b/frontend/src/features/core/components/layout/header.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { Header } from './header';
+import { Header, prefersCommandKey } from './header';
 import { useHeaderContextStore } from '@/stores/header-context-store';
 
 vi.mock('@/providers/auth-provider', () => ({
@@ -28,6 +28,7 @@ vi.mock('@/stores/theme-store', () => ({
   useThemeStore: mockThemeStore.useThemeStore,
 }));
 
+const setPotatoMode = vi.fn();
 vi.mock('@/stores/ui-store', () => ({
   useUiStore: (selector: (s: {
     setCommandPaletteOpen: (open: boolean) => void;
@@ -37,7 +38,7 @@ vi.mock('@/stores/ui-store', () => ({
     selector({
       setCommandPaletteOpen: vi.fn(),
       potatoMode: false,
-      setPotatoMode: vi.fn(),
+      setPotatoMode,
     }),
 }));
 
@@ -45,10 +46,24 @@ vi.mock('@/shared/components/ui/connection-orb', () => ({
   ConnectionOrb: () => <div data-testid="connection-orb" />,
 }));
 
+const mockContainerDetail = vi.hoisted(() => ({ data: undefined as { name: string } | undefined }));
+vi.mock('@/features/containers/hooks/use-container-detail', () => ({
+  useContainerDetail: () => mockContainerDetail,
+}));
+
+function renderAt(path = '/') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Header />
+    </MemoryRouter>
+  );
+}
+
 describe('Header', () => {
   beforeEach(() => {
     vi.stubEnv('VITE_GIT_COMMIT', 'abc1234');
     vi.stubEnv('DEV', 'true');
+    mockContainerDetail.data = undefined;
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ commit: 'def5678' }),
@@ -62,11 +77,7 @@ describe('Header', () => {
   });
 
   it('renders commit hash in the top header', async () => {
-    render(
-      <MemoryRouter>
-        <Header />
-      </MemoryRouter>
-    );
+    renderAt();
 
     expect(await screen.findByText('DEV def5678')).toBeInTheDocument();
     expect(screen.getByLabelText('Build DEV def5678')).toBeInTheDocument();
@@ -80,24 +91,17 @@ describe('Header', () => {
       json: async () => null,
     } as Response);
 
-    render(
-      <MemoryRouter>
-        <Header />
-      </MemoryRouter>
-    );
+    renderAt();
 
     expect(await screen.findByText(/(DEV|BUILD) build-202602/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Build (DEV|BUILD) build-202602/i)).toBeInTheDocument();
   });
 
-  it('renders potato mode toggle in header actions', async () => {
-    render(
-      <MemoryRouter>
-        <Header />
-      </MemoryRouter>
-    );
-
-    expect(await screen.findByRole('switch', { name: /potato mode off/i })).toBeInTheDocument();
+  it('hides the build badge below md so it cannot wrap to two lines on a phone', async () => {
+    renderAt();
+    const badge = await screen.findByLabelText('Build DEV def5678');
+    expect(badge.className).toContain('hidden');
+    expect(badge.className).toContain('md:inline-flex');
   });
 
   it('renders explicit build number identifiers', async () => {
@@ -108,11 +112,7 @@ describe('Header', () => {
       json: async () => null,
     } as Response);
 
-    render(
-      <MemoryRouter>
-        <Header />
-      </MemoryRouter>
-    );
+    renderAt();
 
     expect(await screen.findByText(/(DEV|BUILD) 20260213.7/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Build (DEV|BUILD) 20260213.7/i)).toBeInTheDocument();
@@ -120,21 +120,105 @@ describe('Header', () => {
 
   it('renders the metrics container name when set', () => {
     useHeaderContextStore.setState({ metricsContainerName: 'nginx-proxy' });
-    render(
-      <MemoryRouter>
-        <Header />
-      </MemoryRouter>
-    );
+    renderAt();
     expect(screen.getByTestId('header-context-name')).toHaveTextContent('nginx-proxy');
   });
 
   it('renders no container name when unset', () => {
     useHeaderContextStore.setState({ metricsContainerName: null });
-    render(
-      <MemoryRouter>
-        <Header />
-      </MemoryRouter>
-    );
+    renderAt();
     expect(screen.queryByTestId('header-context-name')).toBeNull();
+  });
+
+  // --- Breadcrumb ---------------------------------------------------------
+
+  it('calls / "Home" — the same word as the sidebar and the page h1', () => {
+    renderAt('/');
+    const crumbs = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    expect(crumbs).toHaveTextContent('Home');
+    expect(crumbs).not.toHaveTextContent('Dashboard');
+  });
+
+  it.each([
+    ['/llm-observability', 'LLM Observability'],
+    ['/ebpf-coverage', 'eBPF Coverage'],
+    ['/packet-capture', 'Packet Capture'],
+    ['/logs', 'Log Viewer'],
+    ['/security/vulnerabilities', 'Vulnerabilities'],
+    ['/reports', 'Reports'],
+  ])('labels %s as %s instead of "Dashboard / Dashboard"', (path, label) => {
+    renderAt(path);
+    const crumbs = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    expect(crumbs).toHaveTextContent(`Home/${label}`);
+    expect(crumbs.textContent).not.toContain('Dashboard');
+  });
+
+  it('says so when the URL does not resolve, rather than naming another page', () => {
+    renderAt('/no-such-page');
+    expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toHaveTextContent(
+      'Page not found',
+    );
+  });
+
+  it('names the container on the container detail route', () => {
+    mockContainerDetail.data = { name: 'lcm-web' };
+    renderAt('/containers/1/abc123def456');
+    expect(screen.getByTestId('header-container-name')).toHaveTextContent('lcm-web');
+    expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).not.toHaveTextContent(
+      'Container Details',
+    );
+  });
+
+  it('falls back to the short container id before the name loads', () => {
+    mockContainerDetail.data = undefined;
+    renderAt('/containers/1/abc123def456');
+    expect(screen.getByTestId('header-container-name')).toHaveTextContent('abc123def456');
+  });
+
+  it('lets the breadcrumb shrink so the right-hand cluster stays on screen', () => {
+    renderAt('/workloads');
+    expect(screen.getByRole('navigation', { name: 'Breadcrumb' }).className).toContain('min-w-0');
+  });
+
+  // --- Search trigger -----------------------------------------------------
+
+  it('shows one keyboard hint for search, not two', () => {
+    renderAt();
+    const search = screen.getByRole('button', { name: 'Search' });
+    expect(search.querySelectorAll('kbd')).toHaveLength(1);
+    expect(search.textContent).not.toContain('/');
+  });
+
+  it('detects an Apple keyboard without the deprecated navigator.platform', () => {
+    expect(
+      prefersCommandKey({ platform: '', userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' } as Navigator),
+    ).toBe(true);
+    expect(
+      prefersCommandKey({
+        userAgentData: { platform: 'macOS' },
+        platform: '',
+        userAgent: '',
+      } as unknown as Navigator),
+    ).toBe(true);
+    expect(
+      prefersCommandKey({ platform: 'Win32', userAgent: 'Mozilla/5.0 (Windows NT 10.0)' } as Navigator),
+    ).toBe(false);
+  });
+
+  // --- Potato mode --------------------------------------------------------
+
+  it('keeps potato mode as a labelled switch in the user menu', async () => {
+    renderAt();
+    expect(screen.queryByRole('switch', { name: /potato mode/i })).toBeNull();
+
+    fireEvent.click(screen.getByTestId('user-menu-trigger'));
+
+    const toggle = await screen.findByRole('switch', { name: /potato mode off/i });
+    expect(toggle).toBeInTheDocument();
+    // Visible text label, not a bare emoji.
+    expect(toggle).toHaveTextContent('Potato mode');
+
+    fireEvent.click(toggle);
+    expect(setPotatoMode).toHaveBeenCalledWith(true);
   });
 });

--- a/frontend/src/features/core/components/layout/header.tsx
+++ b/frontend/src/features/core/components/layout/header.tsx
@@ -1,29 +1,53 @@
 import { useLocation, Link } from 'react-router-dom';
-import { Sun, Moon, Search, LogOut, User, Keyboard } from 'lucide-react';
+import { Sun, Moon, Search, LogOut, User } from 'lucide-react';
 import { useAuth } from '@/providers/auth-provider';
 import { useThemeStore } from '@/stores/theme-store';
 import { useUiStore } from '@/stores/ui-store';
 import { useHeaderContextStore } from '@/stores/header-context-store';
 import { cn } from '@/shared/lib/utils';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo, type ReactNode } from 'react';
 import { ConnectionOrb } from '@/shared/components/ui/connection-orb';
+import { breadcrumbLabelForPath } from '@/features/core/lib/navigation-manifest';
+import { useContainerDetail } from '@/features/containers/hooks/use-container-detail';
 
-const routeLabels: Record<string, string> = {
-  '/': 'Home',
-  '/workloads': 'Workload Explorer',
-  '/infrastructure': 'Infrastructure',
-  '/health': 'Health & Monitoring',
-  '/images': 'Image Footprint',
-  '/topology': 'Network Topology',
-  '/metrics': 'Metrics Dashboard',
-  '/remediation': 'Remediation',
-  '/traces': 'Trace Explorer',
-  '/assistant': 'LLM Assistant',
-  '/security/audit': 'Security Audit',
-  '/edge-logs': 'Edge Agent Logs',
-  '/settings': 'Settings',
-};
+interface Crumb {
+  key: string;
+  label: string;
+  /** Set on every crumb except the last one, which is the current page. */
+  path?: string;
+  /** Rendered instead of `label` when the crumb resolves live data. */
+  node?: ReactNode;
+}
 
+/**
+ * `navigator.platform` is deprecated and returns `""` in some hardened
+ * browsers, which silently rendered `Ctrl+K` to Mac users. Check the modern
+ * `userAgentData.platform` first and fall back through the legacy fields.
+ */
+export function prefersCommandKey(nav: Navigator = navigator): boolean {
+  const withData = nav as Navigator & { userAgentData?: { platform?: string } };
+  const haystack = [
+    withData.userAgentData?.platform ?? '',
+    nav.platform ?? '',
+    nav.userAgent ?? '',
+  ].join(' ');
+  return /mac|iphone|ipad|ipod/i.test(haystack);
+}
+
+/**
+ * Names the container rather than the route template. The breadcrumb used to
+ * read the hardcoded "Container Details" while the page's own h1 showed the
+ * container name. Shares the containers query with the page below it, so this
+ * costs no extra request.
+ */
+function ContainerCrumb({ endpointId, containerId }: { endpointId: number; containerId: string }) {
+  const { data } = useContainerDetail(endpointId, containerId);
+  return (
+    <span className="truncate font-medium text-foreground" data-testid="header-container-name">
+      {data?.name ?? containerId.slice(0, 12)}
+    </span>
+  );
+}
 
 export function Header() {
   const location = useLocation();
@@ -51,24 +75,43 @@ export function Header() {
   );
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
+  const isMacKeyboard = useMemo(() => prefersCommandKey(), []);
 
   // Check if the current route is a container detail page
   const containerDetailMatch = location.pathname.match(/^\/containers\/(\d+)\/([a-f0-9]+)$/);
 
-  const currentLabel = routeLabels[location.pathname] || 'Dashboard';
-  let breadcrumbs = [
-    { label: 'Dashboard', path: '/' },
-    ...(location.pathname !== '/'
-      ? [{ label: currentLabel, path: location.pathname }]
-      : []),
-  ];
+  // Every label comes from the one route manifest — the header used to keep
+  // its own 13-entry copy of a 20-route list, so 7 routes fell through to the
+  // literal "Dashboard" and rendered "Dashboard / Dashboard".
+  const currentLabel = breadcrumbLabelForPath(location.pathname);
 
-  // Handle dynamic container detail breadcrumbs
+  let breadcrumbs: Crumb[];
   if (containerDetailMatch) {
     breadcrumbs = [
-      { label: 'Dashboard', path: '/' },
-      { label: 'Workload Explorer', path: '/workloads' },
-      { label: 'Container Details', path: location.pathname },
+      { key: '/', label: 'Home', path: '/' },
+      { key: '/workloads', label: 'Workloads', path: '/workloads' },
+      {
+        key: location.pathname,
+        label: 'Container',
+        node: (
+          <ContainerCrumb
+            endpointId={Number(containerDetailMatch[1])}
+            containerId={containerDetailMatch[2]}
+          />
+        ),
+      },
+    ];
+  } else {
+    breadcrumbs = [
+      { key: '/', label: 'Home', path: '/' },
+      ...(location.pathname !== '/'
+        ? [{
+          key: location.pathname,
+          // A genuinely unknown path is the 404 route; say so rather than
+          // naming some other page.
+          label: currentLabel ?? 'Page not found',
+        }]
+        : []),
     ];
   }
 
@@ -114,23 +157,29 @@ export function Header() {
     <header
       data-testid="header"
       data-animated-bg={hasAnimatedBg || undefined}
-      className="relative z-40 mx-2 mt-2 flex h-12 shrink-0 items-center justify-between rounded-2xl bg-sidebar-background/80 backdrop-blur-xl shadow-lg ring-1 ring-black/5 dark:ring-white/10 px-2 md:mx-4 md:mt-4 md:px-4"
+      className="relative z-40 mx-2 mt-2 flex h-12 shrink-0 items-center justify-between gap-2 rounded-2xl bg-sidebar-background/80 backdrop-blur-xl shadow-lg ring-1 ring-black/5 dark:ring-white/10 px-2 md:mx-4 md:mt-4 md:px-4"
     >
-      {/* Breadcrumbs */}
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
+      {/* Breadcrumbs — must be able to shrink, or at ~820px it pushes the
+          right-hand cluster (including the only route to Log out) off-screen. */}
+      <nav
+        aria-label="Breadcrumb"
+        className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden text-sm"
+      >
         {breadcrumbs.map((crumb, index) => (
-          <span key={crumb.path} className="flex items-center gap-1.5">
+          <span key={crumb.key} className="flex min-w-0 items-center gap-1.5">
             {index > 0 && (
               <span className="text-muted-foreground">/</span>
             )}
             {index === breadcrumbs.length - 1 ? (
-              <span className="font-medium text-foreground">
-                {crumb.label}
-              </span>
+              crumb.node ?? (
+                <span className="truncate font-medium text-foreground">
+                  {crumb.label}
+                </span>
+              )
             ) : (
               <Link
-                to={crumb.path}
-                className="text-muted-foreground transition-colors hover:text-foreground"
+                to={crumb.path ?? '/'}
+                className="truncate text-muted-foreground transition-colors hover:text-foreground"
               >
                 {crumb.label}
               </Link>
@@ -138,16 +187,16 @@ export function Header() {
           </span>
         ))}
         {metricsContainerName && (
-          <span className="flex items-center gap-1.5">
+          <span className="flex min-w-0 items-center gap-1.5">
             <span className="text-muted-foreground">/</span>
-            <span className="font-medium text-foreground" data-testid="header-context-name">
+            <span className="truncate font-medium text-foreground" data-testid="header-context-name">
               {metricsContainerName}
             </span>
           </span>
         )}
         {(appBuildRef || buildChannel) && (
           <span
-            className="ml-2 inline-flex items-center rounded-full border border-border/60 bg-muted/60 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+            className="ml-2 hidden shrink-0 items-center rounded-full border border-border/60 bg-muted/60 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground md:inline-flex"
             aria-label={`Build ${buildBadge}`}
             title={`Build ${buildBadge}`}
           >
@@ -157,37 +206,18 @@ export function Header() {
       </nav>
 
       {/* Right-side actions */}
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         {/* Command palette trigger */}
         <button
+          type="button"
           onClick={() => setCommandPaletteOpen(true)}
+          aria-label="Search"
           className="flex items-center gap-2 rounded-xl bg-muted/50 px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted"
         >
           <Search className="h-4 w-4" />
-          <span className="hidden sm:inline">Search...</span>
           <kbd className="pointer-events-none hidden select-none rounded-md bg-background/80 px-1.5 py-0.5 font-mono text-xs sm:inline-block">
-            {navigator.platform.includes('Mac') ? '⌘' : 'Ctrl+'}K
+            {isMacKeyboard ? '⌘' : 'Ctrl+'}K
           </kbd>
-          <kbd className="pointer-events-none hidden select-none rounded-md bg-background/80 px-1.5 py-0.5 font-mono text-xs sm:inline-block">
-            /
-          </kbd>
-        </button>
-
-        <button
-          type="button"
-          role="switch"
-          aria-checked={Boolean(potatoMode)}
-          aria-label={`Potato mode ${potatoMode ? 'on' : 'off'}`}
-          title="Toggle Potato Mode"
-          onClick={() => setPotatoMode(Boolean(!potatoMode))}
-          className={cn(
-            'inline-flex h-8 w-8 items-center justify-center rounded-full border text-xs font-medium',
-            potatoMode
-              ? 'border-primary bg-primary/10 text-primary'
-              : 'border-border bg-muted text-muted-foreground'
-          )}
-        >
-          <span aria-hidden="true">🥔</span>
         </button>
 
         {/* Theme toggle — pill switch between two configured themes */}
@@ -237,10 +267,41 @@ export function Header() {
           </button>
 
           {userMenuOpen && (
-            <div className="absolute right-0 top-full z-50 mt-1 w-48 rounded-md border border-border bg-popover p-1 shadow-lg">
+            <div className="absolute right-0 top-full z-50 mt-1 w-60 rounded-md border border-border bg-popover p-1 shadow-lg">
               <div className="px-2 py-1.5 text-sm text-muted-foreground">
                 Signed in as <span className="font-medium text-foreground">{username}</span>
               </div>
+              <div className="my-1 h-px bg-border" />
+              {/* Potato mode: a real performance switch, previously an
+                  unlabelled emoji in the header cluster. */}
+              <button
+                type="button"
+                role="switch"
+                aria-checked={Boolean(potatoMode)}
+                aria-label={`Potato mode ${potatoMode ? 'on' : 'off'}`}
+                data-testid="potato-mode-toggle"
+                onClick={() => setPotatoMode(Boolean(!potatoMode))}
+                className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent"
+              >
+                <span aria-hidden="true" className="leading-5">🥔</span>
+                <span className="flex flex-col">
+                  <span className="font-medium text-foreground">Potato mode</span>
+                  <span className="text-xs text-muted-foreground">
+                    Stops all animation and the gradient background.
+                  </span>
+                </span>
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'ml-auto shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium',
+                    potatoMode
+                      ? 'bg-primary/10 text-primary'
+                      : 'bg-muted text-muted-foreground'
+                  )}
+                >
+                  {potatoMode ? 'On' : 'Off'}
+                </span>
+              </button>
               <div className="my-1 h-px bg-border" />
               <button
                 data-testid="logout-button"

--- a/frontend/src/features/core/components/layout/mobile-bottom-nav.test.tsx
+++ b/frontend/src/features/core/components/layout/mobile-bottom-nav.test.tsx
@@ -1,17 +1,25 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MobileBottomNav } from './mobile-bottom-nav';
+import {
+  mobilePrimaryDestinations,
+  mobileDrawerDestinations,
+} from '@/features/core/lib/navigation-manifest';
 
-vi.mock('@/shared/lib/utils', () => ({
-  cn: (...classes: (string | boolean | undefined)[]) => classes.filter(Boolean).join(' '),
+vi.mock('@/features/security/hooks/use-harbor-vulnerabilities', () => ({
+  useHarborEnabled: () => ({ data: { enabled: true } }),
 }));
 
 function renderNav(initialRoute = '/') {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <MemoryRouter initialEntries={[initialRoute]}>
-      <MobileBottomNav />
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <MobileBottomNav />
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
@@ -31,7 +39,7 @@ describe('MobileBottomNav', () => {
 
   it('opens drawer when More is clicked', () => {
     renderNav();
-    const moreButton = screen.getByLabelText('More pages');
+    const moreButton = screen.getByLabelText('More pages', { selector: 'button' });
     fireEvent.click(moreButton);
     expect(screen.getByText('More Pages')).toBeTruthy();
     expect(screen.getByText(/Infrastructure/)).toBeTruthy();
@@ -40,12 +48,11 @@ describe('MobileBottomNav', () => {
 
   it('closes drawer when Close button is clicked', () => {
     renderNav();
-    fireEvent.click(screen.getByLabelText('More pages'));
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
     expect(screen.getByText('More Pages')).toBeTruthy();
 
-    fireEvent.click(screen.getByLabelText('Close menu'));
-    // Drawer should still be in DOM but translated off-screen
-    // The "More Pages" text is inside the translated div
+    fireEvent.click(screen.getByLabelText('Close more pages'));
+    expect(screen.queryByText('More Pages')).toBeNull();
   });
 
   it('has correct navigation role and label', () => {
@@ -56,10 +63,97 @@ describe('MobileBottomNav', () => {
 
   it('shows secondary nav items in the drawer grid', () => {
     renderNav();
-    fireEvent.click(screen.getByLabelText('More pages'));
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
     expect(screen.getByText(/Infrastructure/)).toBeTruthy();
     expect(screen.getByText(/Remediation/)).toBeTruthy();
     expect(screen.getByText(/Traces/)).toBeTruthy();
     expect(screen.getByText(/Assistant/)).toBeTruthy();
+  });
+
+  // --- Coverage: every destination must be reachable from a phone ----------
+
+  it('reaches every manifest destination from the bar or the drawer', () => {
+    renderNav();
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
+
+    const hrefs = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
+    const expected = [
+      ...mobilePrimaryDestinations,
+      ...mobileDrawerDestinations({ harborEnabled: true }),
+    ];
+    for (const destination of expected) {
+      expect(hrefs, `${destination.path} unreachable on mobile`).toContain(destination.path);
+    }
+  });
+
+  it('exposes the destinations the curated list used to drop', () => {
+    renderNav();
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
+    const hrefs = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
+    for (const path of [
+      '/logs',
+      '/security/audit',
+      '/security/vulnerabilities',
+      '/reports',
+      '/llm-observability',
+      '/ebpf-coverage',
+    ]) {
+      expect(hrefs).toContain(path);
+    }
+  });
+
+  // --- Drawer accessibility ------------------------------------------------
+
+  it('is a modal dialog, not an anonymous div', () => {
+    renderNav();
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
+    const dialog = screen.getByRole('dialog', { name: 'More pages' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('closes on Escape', () => {
+    renderNav();
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
+    expect(screen.getByRole('dialog')).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('gives the scrim a keyboard-reachable control instead of a bare div onClick', () => {
+    renderNav();
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
+    const scrim = screen.getByTestId('mobile-drawer-scrim');
+    expect(scrim.tagName).toBe('BUTTON');
+    fireEvent.click(scrim);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('moves focus into the drawer on open and back to the opener on close', () => {
+    renderNav();
+    const opener = screen.getByLabelText('More pages', { selector: 'button' });
+    fireEvent.click(opener);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.contains(document.activeElement)).toBe(true);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('reports drawer state on the More button', () => {
+    renderNav();
+    const opener = screen.getByLabelText('More pages', { selector: 'button' });
+    expect(opener).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(opener);
+    expect(opener).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  // --- Label legibility ----------------------------------------------------
+
+  it('raises bottom-bar labels above the 10px floor', () => {
+    renderNav();
+    const home = screen.getByText('Home').closest('a');
+    expect(home?.className).not.toContain('text-[10px]');
+    expect(home?.className).toContain('text-xs');
   });
 });

--- a/frontend/src/features/core/components/layout/mobile-bottom-nav.tsx
+++ b/frontend/src/features/core/components/layout/mobile-bottom-nav.tsx
@@ -1,58 +1,25 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
-import {
-  LayoutDashboard,
-  Boxes,
-  HeartPulse,
-  MoreHorizontal,
-  X,
-  Server,
-  PackageOpen,
-  Network,
-  BarChart3,
-  Shield,
-  GitBranch,
-  MessageSquare,
-  FileSearch,
-  Radio,
-  Settings,
-} from 'lucide-react';
+import { MoreHorizontal, X } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
+import { useHarborEnabled } from '@/features/security/hooks/use-harbor-vulnerabilities';
+import {
+  mobilePrimaryDestinations,
+  mobileDrawerDestinations,
+  mobileLabel,
+  type NavDestination,
+} from '@/features/core/lib/navigation-manifest';
 
-interface MobileNavItem {
-  label: string;
-  to: string;
-  icon: React.ComponentType<{ className?: string }>;
-}
-
-const primaryNav: MobileNavItem[] = [
-  { label: 'Home', to: '/', icon: LayoutDashboard },
-  { label: 'Workloads', to: '/workloads', icon: Boxes },
-  { label: 'Health', to: '/health', icon: HeartPulse },
-  { label: 'Metrics', to: '/metrics', icon: BarChart3 },
-];
-
-const secondaryNav: MobileNavItem[] = [
-  { label: 'Infrastructure', to: '/infrastructure', icon: Server },
-  { label: 'Images', to: '/images', icon: PackageOpen },
-  { label: 'Topology', to: '/topology', icon: Network },
-  { label: 'Traces', to: '/traces', icon: GitBranch },
-  { label: 'Assistant', to: '/assistant', icon: MessageSquare },
-  { label: 'Remediation', to: '/remediation', icon: Shield },
-  { label: 'Edge Logs', to: '/edge-logs', icon: FileSearch },
-  { label: 'Packet Capture', to: '/packet-capture', icon: Radio },
-  { label: 'Settings', to: '/settings', icon: Settings },
-];
-
-function NavButton({ item, onClick }: { item: MobileNavItem; onClick?: () => void }) {
+function NavButton({ item, onClick }: { item: NavDestination; onClick?: () => void }) {
   return (
     <NavLink
-      to={item.to}
-      end={item.to === '/'}
+      to={item.path}
+      end={item.path === '/'}
       onClick={onClick}
       className={({ isActive }) =>
         cn(
-          'flex flex-col items-center gap-0.5 px-2 py-2 text-[10px] font-medium transition-colors min-w-[56px]',
+          // 10px was below the legible floor for a control label.
+          'flex flex-col items-center gap-0.5 px-2 py-2 text-xs font-medium transition-colors min-w-[56px]',
           isActive
             ? 'text-primary'
             : 'text-muted-foreground',
@@ -60,71 +27,127 @@ function NavButton({ item, onClick }: { item: MobileNavItem; onClick?: () => voi
       }
     >
       <item.icon className="h-5 w-5" />
-      <span className="truncate">{item.label}</span>
+      <span className="truncate">{mobileLabel(item)}</span>
     </NavLink>
   );
 }
 
+const FOCUSABLE = 'a[href], button:not([disabled])';
+
 export function MobileBottomNav() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const location = useLocation();
+  const { data: harborEnabled } = useHarborEnabled();
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const openerRef = useRef<HTMLButtonElement>(null);
 
-  // Check if current route is in secondary nav
-  const isSecondaryActive = secondaryNav.some((item) => item.to === location.pathname);
+  const primaryNav = mobilePrimaryDestinations;
+  // Derived from the manifest, not curated. The hand-written list left the
+  // whole Security group and the Log Viewer unreachable from a phone.
+  const secondaryNav = mobileDrawerDestinations({
+    harborEnabled: harborEnabled?.enabled === true,
+  });
+
+  const isSecondaryActive = secondaryNav.some((item) => item.path === location.pathname);
+
+  const closeDrawer = useCallback(() => {
+    setDrawerOpen(false);
+    openerRef.current?.focus();
+  }, []);
+
+  // Escape + focus trap: without them a keyboard or switch user could open
+  // the drawer and had no way to close it.
+  useEffect(() => {
+    if (!drawerOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeDrawer();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const root = drawerRef.current;
+      if (!root) return;
+      const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE));
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (event.shiftKey && (active === first || !root.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    drawerRef.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [drawerOpen, closeDrawer]);
 
   return (
     <>
-      {/* More Drawer overlay */}
+      {/* More Drawer scrim — a real button so it is reachable without a mouse */}
       {drawerOpen && (
-        <div
+        <button
+          type="button"
+          data-testid="mobile-drawer-scrim"
+          aria-label="Close menu"
           className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"
-          onClick={() => setDrawerOpen(false)}
+          onClick={closeDrawer}
         />
       )}
 
       {/* More Drawer */}
-      <div
-        className={cn(
-          'fixed inset-x-0 bottom-0 z-50 transform transition-transform duration-300 ease-out md:hidden',
-          drawerOpen ? 'translate-y-0' : 'translate-y-full',
-        )}
-      >
-        <div className="rounded-t-2xl bg-background/95 backdrop-blur-xl shadow-2xl ring-1 ring-black/5 dark:ring-white/10">
-          {/* Drawer handle */}
-          <div className="flex items-center justify-between px-4 py-3 border-b">
-            <span className="text-sm font-semibold">More Pages</span>
-            <button
-              onClick={() => setDrawerOpen(false)}
-              className="rounded-md p-1 hover:bg-muted"
-              aria-label="Close menu"
-            >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
-
-          {/* Secondary nav grid */}
-          <div className="grid grid-cols-4 gap-1 p-3 max-h-[60vh] overflow-y-auto">
-            {secondaryNav.map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                onClick={() => setDrawerOpen(false)}
-                className={({ isActive }) =>
-                  cn(
-                    'flex flex-col items-center gap-1 rounded-xl p-3 text-xs font-medium transition-colors',
-                    isActive
-                      ? 'bg-primary/10 text-primary'
-                      : 'text-muted-foreground hover:bg-muted',
-                  )
-                }
+      {drawerOpen && (
+        <div
+          ref={drawerRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="More pages"
+          className="fixed inset-x-0 bottom-0 z-50 md:hidden"
+        >
+          <div className="rounded-t-2xl bg-background/95 backdrop-blur-xl shadow-2xl ring-1 ring-black/5 dark:ring-white/10">
+            {/* Drawer handle */}
+            <div className="flex items-center justify-between px-4 py-3 border-b">
+              <span className="text-sm font-semibold">More Pages</span>
+              <button
+                type="button"
+                onClick={closeDrawer}
+                className="rounded-md p-1 hover:bg-muted"
+                aria-label="Close more pages"
               >
-                <item.icon className="h-6 w-6" />
-                <span className="text-center leading-tight">{item.label}</span>
-              </NavLink>
-            ))}
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            {/* Secondary nav grid */}
+            <div className="grid grid-cols-4 gap-1 p-3 max-h-[60vh] overflow-y-auto">
+              {secondaryNav.map((item) => (
+                <NavLink
+                  key={item.path}
+                  to={item.path}
+                  onClick={() => setDrawerOpen(false)}
+                  className={({ isActive }) =>
+                    cn(
+                      'flex flex-col items-center gap-1 rounded-xl p-3 text-xs font-medium transition-colors',
+                      isActive
+                        ? 'bg-primary/10 text-primary'
+                        : 'text-muted-foreground hover:bg-muted',
+                    )
+                  }
+                >
+                  <item.icon className="h-6 w-6" />
+                  <span className="text-center leading-tight">{item.label}</span>
+                </NavLink>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       {/* Bottom Navigation Bar */}
       <nav
@@ -133,12 +156,15 @@ export function MobileBottomNav() {
         aria-label="Mobile navigation"
       >
         {primaryNav.map((item) => (
-          <NavButton key={item.to} item={item} />
+          <NavButton key={item.path} item={item} />
         ))}
         <button
-          onClick={() => setDrawerOpen(!drawerOpen)}
+          type="button"
+          ref={openerRef}
+          onClick={() => setDrawerOpen((open) => !open)}
+          aria-expanded={drawerOpen}
           className={cn(
-            'flex flex-col items-center gap-0.5 px-2 py-2 text-[10px] font-medium transition-colors min-w-[56px]',
+            'flex flex-col items-center gap-0.5 px-2 py-2 text-xs font-medium transition-colors min-w-[56px]',
             isSecondaryActive || drawerOpen
               ? 'text-primary'
               : 'text-muted-foreground',

--- a/frontend/src/features/core/components/layout/mobile-nav.test.tsx
+++ b/frontend/src/features/core/components/layout/mobile-nav.test.tsx
@@ -1,17 +1,25 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MobileBottomNav } from './mobile-bottom-nav';
 
 vi.mock('@/shared/lib/utils', () => ({
   cn: (...classes: (string | boolean | undefined)[]) => classes.filter(Boolean).join(' '),
 }));
 
+vi.mock('@/features/security/hooks/use-harbor-vulnerabilities', () => ({
+  useHarborEnabled: () => ({ data: { enabled: true } }),
+}));
+
 function renderNav(initialRoute = '/') {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <MemoryRouter initialEntries={[initialRoute]}>
-      <MobileBottomNav />
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <MobileBottomNav />
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
@@ -33,7 +41,7 @@ describe('MobileBottomNav - Mobile Optimization', () => {
 
   it('More button opens secondary navigation drawer', () => {
     renderNav();
-    fireEvent.click(screen.getByLabelText('More pages'));
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
     expect(screen.getByText('More Pages')).toBeTruthy();
     expect(screen.getByText('Settings')).toBeTruthy();
     expect(screen.getByText('Infrastructure')).toBeTruthy();
@@ -41,7 +49,7 @@ describe('MobileBottomNav - Mobile Optimization', () => {
 
   it('secondary nav items in drawer have adequate touch targets', () => {
     renderNav();
-    fireEvent.click(screen.getByLabelText('More pages'));
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
     const settingsLink = screen.getAllByText('Settings')[0].closest('a');
     // Drawer items use p-3 (12px padding) + icon (24px) + text = well above 48px
     expect(settingsLink?.className).toContain('p-3');
@@ -49,10 +57,10 @@ describe('MobileBottomNav - Mobile Optimization', () => {
 
   it('drawer closes on close button click', () => {
     renderNav();
-    fireEvent.click(screen.getByLabelText('More pages'));
+    fireEvent.click(screen.getByLabelText('More pages', { selector: 'button' }));
     expect(screen.getByText('More Pages')).toBeTruthy();
-    fireEvent.click(screen.getByLabelText('Close menu'));
-    // Drawer transitions off-screen (translate-y-full) — still in DOM but hidden
+    fireEvent.click(screen.getByLabelText('Close more pages'));
+    expect(screen.queryByText('More Pages')).toBeNull();
   });
 
   it('has mobile navigation aria label', () => {

--- a/frontend/src/features/core/components/layout/sidebar.test.tsx
+++ b/frontend/src/features/core/components/layout/sidebar.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Sidebar } from './sidebar';
 import { useUiStore } from '@/stores/ui-store';
+import { navDestinations } from '@/features/core/lib/navigation-manifest';
 
 vi.mock('@/features/operations/hooks/use-remediation', () => ({
   useRemediationActions: vi.fn(),
@@ -13,14 +14,14 @@ import { useRemediationActions } from '@/features/operations/hooks/use-remediati
 
 const mockUseRemediationActions = vi.mocked(useRemediationActions);
 
-function renderSidebar() {
+function renderSidebar(props: { forceRail?: boolean } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
-        <Sidebar />
+        <Sidebar {...props} />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -32,7 +33,7 @@ function renderSidebar() {
  * child of <nav>; the title is the header button's first span, items are <li>s.
  */
 function getNavGroups() {
-  const nav = screen.getByRole('navigation');
+  const nav = screen.getByRole('navigation', { name: 'Primary' });
   const groupDivs = Array.from(nav.children).filter((el) =>
     el.classList.contains('mb-2'),
   ) as HTMLElement[];
@@ -134,7 +135,6 @@ describe('Sidebar', () => {
       'Operations',
     ]);
     // Old grab-bag groups are gone.
-    expect(screen.queryByText('Containers')).not.toBeInTheDocument();
     expect(screen.queryByText('Backups')).not.toBeInTheDocument();
     expect(screen.getByText(/Settings/i)).toBeInTheDocument();
   });
@@ -168,7 +168,7 @@ describe('Sidebar', () => {
     const diagnostics = getNavGroups().find((g) => g.title === 'Diagnostics');
     const items = diagnostics?.items ?? [];
     const logViewer = items.indexOf('Log Viewer');
-    const edgeLogs = items.indexOf('Edge Agent Logs');
+    const edgeLogs = items.indexOf('Edge Logs');
     expect(logViewer).toBeGreaterThanOrEqual(0);
     expect(edgeLogs).toBeGreaterThanOrEqual(0);
     expect(Math.abs(logViewer - edgeLogs)).toBe(1);
@@ -189,7 +189,7 @@ describe('Sidebar', () => {
     renderSidebar();
 
     // Settings remains reachable...
-    expect(screen.getByRole('button', { name: /Settings/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Settings/i })).toBeInTheDocument();
     // ...but is no longer an item inside any of the titled groups.
     for (const group of getNavGroups()) {
       expect(group.items).not.toContain('Settings');
@@ -218,5 +218,120 @@ describe('Sidebar', () => {
     const badge = screen.getByTestId('sidebar-badge');
     expect(badge).toBeInTheDocument();
     expect(badge).toHaveTextContent('1');
+  });
+
+  // --- Navigation is made of real links -----------------------------------
+
+  it('renders every destination as an anchor with an href, not a button', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+
+    renderSidebar();
+
+    const expected = navDestinations.filter(
+      (d) => !d.paletteOnly && d.featureGate === undefined,
+    );
+    for (const destination of expected) {
+      const link = screen.getByRole('link', { name: new RegExp(`^${destination.label}$`, 'i') });
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', destination.path);
+    }
+    // Middle-click / Cmd-click need an href; nothing in the nav list is a button.
+    const navList = screen.getByRole('navigation', { name: 'Primary' });
+    expect(navList.querySelectorAll('li button')).toHaveLength(0);
+  });
+
+  it('routes Home client-side like every other destination (no full page reload)', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+    const assign = vi.fn();
+    const original = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...original, assign },
+    });
+
+    try {
+      renderSidebar();
+      const home = screen.getByRole('link', { name: /^Home$/i });
+      expect(home).toHaveAttribute('href', '/');
+      home.click();
+      expect(assign).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: original });
+    }
+  });
+
+  it('marks the active destination with aria-current', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+    renderSidebar();
+    expect(screen.getByRole('link', { name: /^Home$/i })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: /^Reports$/i })).not.toHaveAttribute('aria-current');
+  });
+
+  it('names the nav and exposes group expansion state to assistive tech', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+    renderSidebar();
+    expect(screen.getByRole('navigation', { name: 'Primary' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Overview' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  // --- Scroll affordance ---------------------------------------------------
+
+  it('shows no scroll cue when the nav fits', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+    renderSidebar();
+    expect(screen.queryByTestId('scroll-gradient')).toBeNull();
+  });
+
+  it('draws a scroll cue that is visible on light themes when groups fall below the fold', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+    const scrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    const clientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get: () => 300,
+    });
+
+    try {
+      renderSidebar();
+      const cue = screen.getByTestId('scroll-gradient');
+      // A hard rule at the cut line, plus a fade at real opacity — the old
+      // 8px `from-sidebar-background/40` fade was invisible on light themes.
+      expect(cue.className).toContain('border-b');
+      expect(cue.className).toContain('border-sidebar-border');
+      expect(cue.className).toContain('from-sidebar-background');
+      expect(cue.className).not.toContain('from-sidebar-background/40');
+    } finally {
+      if (scrollHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', scrollHeight);
+      }
+      if (clientHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientHeight);
+      }
+    }
+  });
+
+  // --- Tablet rail --------------------------------------------------------
+
+  it('collapses to the 64px icon rail when the viewport forces it', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+    renderSidebar({ forceRail: true });
+
+    expect(screen.getByTestId('sidebar').className).toContain('w-16');
+    expect(screen.getByTestId('sidebar').className).not.toContain('w-64');
+    // The manual toggle would be a no-op at this width.
+    expect(screen.queryByLabelText(/sidebar$/i)).toBeNull();
+  });
+
+  it('keeps the full width when the viewport allows it', () => {
+    mockUseRemediationActions.mockReturnValue({ data: [] } as any);
+    renderSidebar();
+    expect(screen.getByTestId('sidebar').className).toContain('w-64');
   });
 });

--- a/frontend/src/features/core/components/layout/sidebar.tsx
+++ b/frontend/src/features/core/components/layout/sidebar.tsx
@@ -1,27 +1,6 @@
 import { useRef, useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import {
-  LayoutDashboard,
-  Boxes,
-  Server,
-  HeartPulse,
-  PackageOpen,
-  Network,
-  BarChart3,
-  Shield,
-  ShieldAlert,
-  GitBranch,
-  MessageSquare,
-  Activity,
-  FileBarChart,
-  ScrollText,
-  FileSearch,
-  Radio,
-  Bug,
-  Settings,
-  ChevronRight,
-  ChevronDown,
-} from 'lucide-react';
+import { useLocation, Link } from 'react-router-dom';
+import { ChevronRight, ChevronDown } from 'lucide-react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { SidebarLogo } from '@/shared/components/icons/sidebar-logo';
 import { useUiStore } from '@/stores/ui-store';
@@ -30,80 +9,12 @@ import { useRemediationActions } from '@/features/operations/hooks/use-remediati
 import { useHarborEnabled } from '@/features/security/hooks/use-harbor-vulnerabilities';
 import { usePrefetch } from '@/shared/hooks/use-prefetch';
 import { cn } from '@/shared/lib/utils';
+import {
+  sidebarNavigation,
+  pinnedNavDestinations,
+  type NavDestination,
+} from '@/features/core/lib/navigation-manifest';
 import { m, AnimatePresence, useReducedMotion } from 'framer-motion';
-
-interface NavItem {
-  label: string;
-  to: string;
-  icon: React.ComponentType<{ className?: string }>;
-  badge?: number;
-  /** When true, the item is hidden from the sidebar. */
-  hidden?: boolean;
-}
-
-interface NavGroup {
-  title: string;
-  items: NavItem[];
-}
-
-// Grouped by operator intent: what's running -> is it healthy -> ask the AI ->
-// why -> security posture -> act. Remediation is the one mutating
-// workflow and lives alone under Operations to keep the observer-first
-// separation between looking and acting. Settings is pinned separately
-// (see `settingsItem`), out of the themed groups.
-const navigation: NavGroup[] = [
-  {
-    title: 'Overview',
-    items: [
-      { label: 'Home', to: '/', icon: LayoutDashboard },
-      { label: 'Workload Explorer', to: '/workloads', icon: Boxes },
-      { label: 'Infrastructure', to: '/infrastructure', icon: Server },
-      { label: 'Image Footprint', to: '/images', icon: PackageOpen },
-    ],
-  },
-  {
-    title: 'Monitoring',
-    items: [
-      { label: 'Health & Monitoring', to: '/health', icon: HeartPulse },
-      { label: 'Metrics Dashboard', to: '/metrics', icon: BarChart3 },
-    ],
-  },
-  {
-    title: 'Intelligence',
-    items: [
-      { label: 'LLM Assistant', to: '/assistant', icon: MessageSquare },
-      { label: 'LLM Observability', to: '/llm-observability', icon: Activity },
-    ],
-  },
-  {
-    title: 'Diagnostics',
-    items: [
-      { label: 'Trace Explorer', to: '/traces', icon: GitBranch },
-      { label: 'eBPF Coverage', to: '/ebpf-coverage', icon: Bug },
-      { label: 'Network Topology', to: '/topology', icon: Network },
-      { label: 'Packet Capture', to: '/packet-capture', icon: Radio },
-      { label: 'Log Viewer', to: '/logs', icon: ScrollText },
-      { label: 'Edge Agent Logs', to: '/edge-logs', icon: FileSearch },
-    ],
-  },
-  {
-    title: 'Security',
-    items: [
-      { label: 'Security Audit', to: '/security/audit', icon: Shield },
-      { label: 'Vulnerabilities', to: '/security/vulnerabilities', icon: ShieldAlert },
-    ],
-  },
-  {
-    title: 'Operations',
-    items: [
-      { label: 'Remediation', to: '/remediation', icon: Shield },
-      { label: 'Reports', to: '/reports', icon: FileBarChart },
-    ],
-  },
-];
-
-// Pinned at the foot of the sidebar, separated from the themed groups.
-const settingsItem: NavItem = { label: 'Settings', to: '/settings', icon: Settings };
 
 function AnimatedBadge({ count }: { count: number }) {
   const prevCountRef = useRef(count);
@@ -138,7 +49,14 @@ function AnimatedBadge({ count }: { count: number }) {
   );
 }
 
-function ScrollGradient({ navRef }: { navRef: React.RefObject<HTMLElement | null> }) {
+/**
+ * Scroll affordance for the nav. The previous cue was an 8px
+ * `from-sidebar-background/40` fade — invisible on the eight light themes,
+ * which meant two whole groups could sit below the fold at 1440x900 with
+ * nothing on screen saying so. This uses a full-opacity fade, a hard rule at
+ * the cut line and a chevron, so the cue survives every theme.
+ */
+function ScrollCue({ navRef }: { navRef: React.RefObject<HTMLElement | null> }) {
   const [showBottom, setShowBottom] = useState(false);
 
   useEffect(() => {
@@ -166,33 +84,38 @@ function ScrollGradient({ navRef }: { navRef: React.RefObject<HTMLElement | null
 
   return (
     <div
-      className="pointer-events-none absolute bottom-12 left-0 right-0 h-8 bg-gradient-to-t from-sidebar-background/40 to-transparent"
+      className="pointer-events-none sticky bottom-0 left-0 right-0 -mt-10 flex h-10 items-end justify-center border-b border-sidebar-border bg-gradient-to-t from-sidebar-background via-sidebar-background/85 to-transparent"
       aria-hidden="true"
       data-testid="scroll-gradient"
-    />
+    >
+      <ChevronDown className="mb-0.5 h-3.5 w-3.5 text-muted-foreground" />
+    </div>
   );
 }
 
-function NavLink({
+function NavItemLink({
   item,
   isActive,
   collapsed,
   reducedMotion,
   pendingCount,
   onPrefetch,
-  onNavigate,
 }: {
-  item: NavItem;
+  item: NavDestination;
   isActive: boolean;
   collapsed: boolean;
   reducedMotion: boolean | null;
   pendingCount: number;
   onPrefetch?: () => void;
-  onNavigate: () => void;
 }) {
+  // A real anchor, not a <button>: middle-click, Cmd-click to a new tab and
+  // the hover status-bar preview are the core power-user navigation gestures
+  // and none of them exist without an href.
   const link = (
-    <button
-      type="button"
+    <Link
+      to={item.path}
+      state={{ source: 'sidebar-nav' }}
+      aria-current={isActive ? 'page' : undefined}
       className={cn(
         'relative flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm font-medium transition-colors duration-200',
         isActive
@@ -202,7 +125,6 @@ function NavLink({
       )}
       onMouseEnter={onPrefetch}
       onFocus={onPrefetch}
-      onClick={onNavigate}
     >
       <>
         {isActive && (
@@ -242,16 +164,14 @@ function NavLink({
               }
             >
               <span className="truncate">{item.label}</span>
-              {item.to === '/remediation' ? (
+              {item.path === '/remediation' ? (
                 <AnimatedBadge count={pendingCount} />
-              ) : item.badge != null && item.badge > 0 ? (
-                <AnimatedBadge count={item.badge} />
               ) : null}
             </m.span>
           )}
         </AnimatePresence>
       </>
-    </button>
+    </Link>
   );
 
   return (
@@ -277,8 +197,12 @@ function NavLink({
   );
 }
 
-export function Sidebar() {
-  const navigate = useNavigate();
+/**
+ * @param forceRail Collapse to the 64px icon rail regardless of the stored
+ * preference. AppLayout sets this between 768px and 1023px, where a 256px
+ * sidebar costs a third of the viewport.
+ */
+export function Sidebar({ forceRail = false }: { forceRail?: boolean } = {}) {
   const location = useLocation();
   const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
@@ -293,6 +217,8 @@ export function Sidebar() {
   const navRef = useRef<HTMLElement>(null);
   const hasAnimatedBg = dashboardBackground !== 'none';
   const { prefetchContainers, prefetchEndpoints, prefetchDashboard, prefetchImages, prefetchStacks } = usePrefetch();
+
+  const collapsed = sidebarCollapsed || forceRail;
 
   // Wrap prefetch in requestIdleCallback to avoid blocking hover interactions
   const idlePrefetch = (fn: (() => void) | undefined) => {
@@ -314,27 +240,10 @@ export function Sidebar() {
     '/images': idlePrefetch(prefetchImages),
   };
 
-  // Compute effective nav — hide items that are feature-gated
-  const effectiveNavigation = navigation.map((group) => ({
-    ...group,
-    items: group.items.filter((item) => {
-      if (item.to === '/security/vulnerabilities') {
-        return harborEnabled?.enabled === true;
-      }
-      return !item.hidden;
-    }),
-  }));
+  const navigation = sidebarNavigation({ harborEnabled: harborEnabled?.enabled === true });
 
   const isItemActive = (to: string) =>
     to === '/' ? location.pathname === '/' : location.pathname.startsWith(to);
-
-  const handleNavigate = (to: string) => {
-    if (to === '/') {
-      window.location.assign('/');
-      return;
-    }
-    navigate(to, { state: { source: 'sidebar-nav', ts: Date.now() } });
-  };
 
   return (
     <TooltipPrimitive.Provider delayDuration={200}>
@@ -344,7 +253,7 @@ export function Sidebar() {
         className={cn(
           'fixed left-4 top-4 bottom-4 z-30 flex flex-col rounded-2xl bg-sidebar-background/80 backdrop-blur-xl shadow-lg ring-1 ring-black/5 dark:ring-white/10',
           !potatoMode && 'transition-[width,background-color] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
-          sidebarCollapsed ? 'w-16' : 'w-64'
+          collapsed ? 'w-16' : 'w-64'
         )}
       >
         {/* Brand */}
@@ -362,7 +271,7 @@ export function Sidebar() {
               <SidebarLogo />
             </m.div>
             <AnimatePresence>
-              {!sidebarCollapsed && (
+              {!collapsed && (
                 <m.div
                   className="flex flex-col"
                   initial={reducedMotion ? false : { opacity: 0, x: -8 }}
@@ -385,18 +294,20 @@ export function Sidebar() {
         </div>
 
         {/* Navigation */}
-        <nav ref={navRef} className="relative flex-1 overflow-y-auto py-4">
-          {effectiveNavigation.map((group, groupIndex) => {
-            const isGroupCollapsed = collapsedGroups[group.title] && !sidebarCollapsed;
+        <nav ref={navRef} aria-label="Primary" className="relative flex-1 overflow-y-auto py-4">
+          {navigation.map((group, groupIndex) => {
+            const isGroupCollapsed = collapsedGroups[group.title] && !collapsed;
             return (
               <div key={group.title} className="mb-2">
-                {sidebarCollapsed ? (
+                {collapsed ? (
                   groupIndex > 0 ? (
                     <div className="mx-3 my-2 h-px bg-border/50" role="separator" />
                   ) : null
                 ) : (
                   <button
+                    type="button"
                     onClick={() => toggleGroup(group.title)}
+                    aria-expanded={!isGroupCollapsed}
                     className="mb-1 flex w-full items-center justify-between border-b border-border/20 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
                   >
                     <span>{group.title}</span>
@@ -420,15 +331,14 @@ export function Sidebar() {
                 >
                   <ul className="space-y-0.5 overflow-hidden px-2">
                     {group.items.map((item) => (
-                      <NavLink
-                        key={item.to}
+                      <NavItemLink
+                        key={item.path}
                         item={item}
-                        isActive={isItemActive(item.to)}
-                        collapsed={sidebarCollapsed}
+                        isActive={isItemActive(item.path)}
+                        collapsed={collapsed}
                         reducedMotion={reducedMotion}
                         pendingCount={pendingCount}
-                        onPrefetch={prefetchMap[item.to]}
-                        onNavigate={() => handleNavigate(item.to)}
+                        onPrefetch={prefetchMap[item.path]}
                       />
                     ))}
                   </ul>
@@ -436,42 +346,47 @@ export function Sidebar() {
               </div>
             );
           })}
-          <ScrollGradient navRef={navRef} />
+          <ScrollCue navRef={navRef} />
         </nav>
 
         {/* Settings — pinned at the foot, separated from the themed groups */}
         <div className="border-t border-border/30 px-2 pt-2">
           <ul className="space-y-0.5">
-            <NavLink
-              item={settingsItem}
-              isActive={isItemActive(settingsItem.to)}
-              collapsed={sidebarCollapsed}
-              reducedMotion={reducedMotion}
-              pendingCount={pendingCount}
-              onNavigate={() => handleNavigate(settingsItem.to)}
-            />
+            {pinnedNavDestinations.map((item) => (
+              <NavItemLink
+                key={item.path}
+                item={item}
+                isActive={isItemActive(item.path)}
+                collapsed={collapsed}
+                reducedMotion={reducedMotion}
+                pendingCount={pendingCount}
+              />
+            ))}
           </ul>
         </div>
 
-        {/* Collapse toggle */}
-        <div className="p-2">
-          <button
-            onClick={toggleSidebar}
-            className="flex w-full items-center justify-center rounded-md p-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-            aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          >
-            <m.span
-              animate={{ rotate: sidebarCollapsed ? 0 : 180 }}
-              transition={
-                reducedMotion
-                  ? { duration: 0 }
-                  : { type: 'spring', stiffness: 300, damping: 25 }
-              }
+        {/* Collapse toggle — hidden when the viewport forces the rail */}
+        {!forceRail && (
+          <div className="p-2">
+            <button
+              type="button"
+              onClick={toggleSidebar}
+              className="flex w-full items-center justify-center rounded-md p-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
             >
-              <ChevronRight className="h-4 w-4" />
-            </m.span>
-          </button>
-        </div>
+              <m.span
+                animate={{ rotate: collapsed ? 0 : 180 }}
+                transition={
+                  reducedMotion
+                    ? { duration: 0 }
+                    : { type: 'spring', stiffness: 300, damping: 25 }
+                }
+              >
+                <ChevronRight className="h-4 w-4" />
+              </m.span>
+            </button>
+          </div>
+        )}
       </aside>
     </TooltipPrimitive.Provider>
   );

--- a/frontend/src/features/core/components/layout/sidebar.tsx
+++ b/frontend/src/features/core/components/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   type NavDestination,
 } from '@/features/core/lib/navigation-manifest';
 import { m, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { PRODUCT_NAME } from '@/shared/lib/product';
 
 function AnimatedBadge({ count }: { count: number }) {
   const prevCountRef = useRef(count);
@@ -284,9 +285,8 @@ export function Sidebar({ forceRail = false }: { forceRail?: boolean } = {}) {
                   }
                 >
                   <span className="truncate text-sm font-semibold text-sidebar-foreground">
-                    Docker Insights
+                    {PRODUCT_NAME}
                   </span>
-                  <span className="text-[10px] text-muted-foreground">powered by AI</span>
                 </m.div>
               )}
             </AnimatePresence>

--- a/frontend/src/features/core/components/settings/setting-row.test.tsx
+++ b/frontend/src/features/core/components/settings/setting-row.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import {
+  DEFAULT_SETTINGS,
+  GUARDED_SETTING_KEYS,
+  SETTING_BY_KEY,
+  SettingRow,
+  SettingsSavedKeysProvider,
+  isGuardedSetting,
+  searchSettings,
+  settingConsequence,
+  settingDomId,
+  settingRisk,
+  shrinksRetentionWindow,
+} from './shared';
+
+function rowFor(key: string, overrides: Partial<Parameters<typeof SettingRow>[0]> = {}) {
+  return (
+    <SettingRow
+      setting={SETTING_BY_KEY[key]}
+      value={SETTING_BY_KEY[key].defaultValue}
+      onChange={vi.fn()}
+      hasChanges={false}
+      {...overrides}
+    />
+  );
+}
+
+describe('setting risk descriptors', () => {
+  it('marks the OIDC plaintext toggle as security-risk with a consequence', () => {
+    const setting = SETTING_BY_KEY['oidc.allow_insecure_transport'];
+    expect(settingRisk(setting)).toBe('security');
+    expect(settingConsequence(setting)).toMatch(/unencrypted/i);
+  });
+
+  it('marks the public status page as security-risk', () => {
+    expect(settingRisk(SETTING_BY_KEY['status.page.enabled'])).toBe('security');
+    expect(settingConsequence(SETTING_BY_KEY['status.page.enabled'])).toMatch(/no sign-in/i);
+  });
+
+  it('marks every retention window as destructive with a consequence', () => {
+    for (const setting of DEFAULT_SETTINGS.metricsRetention) {
+      expect(settingRisk(setting)).toBe('destructive');
+      expect(settingConsequence(setting)).toMatch(/deletes/i);
+    }
+    expect(settingRisk(SETTING_BY_KEY['portainer_backup.max_count'])).toBe('destructive');
+    expect(settingRisk(SETTING_BY_KEY['monitoring.metric_retention_days'])).toBe('destructive');
+  });
+
+  it('leaves ordinary knobs unmarked so the marking still means something', () => {
+    expect(settingRisk(SETTING_BY_KEY['cache.image_ttl'])).toBeUndefined();
+    expect(settingRisk(SETTING_BY_KEY['monitoring.polling_interval'])).toBeUndefined();
+    expect(settingRisk(SETTING_BY_KEY['status.page.title'])).toBeUndefined();
+    // The guarded set must stay a minority of the ~107 keys.
+    expect(GUARDED_SETTING_KEYS.size).toBeLessThan(Object.keys(SETTING_BY_KEY).length / 2);
+  });
+
+  it('guards every authentication key', () => {
+    for (const setting of DEFAULT_SETTINGS.authentication) {
+      expect(isGuardedSetting(setting.key)).toBe(true);
+    }
+  });
+
+  it('does not weaken any default value', () => {
+    expect(SETTING_BY_KEY['oidc.allow_insecure_transport'].defaultValue).toBe('false');
+    expect(SETTING_BY_KEY['status.page.enabled'].defaultValue).toBe('false');
+    expect(SETTING_BY_KEY['oidc.allow_unmapped_viewer'].defaultValue).toBe('false');
+    expect(SETTING_BY_KEY['harbor.verify_ssl'].defaultValue).toBe('true');
+    expect(SETTING_BY_KEY['elasticsearch.verify_ssl'].defaultValue).toBe('true');
+  });
+});
+
+describe('shrinksRetentionWindow', () => {
+  it('is true only when a destructive window is lowered', () => {
+    expect(shrinksRetentionWindow('infrastructure.metrics_raw_retention_days', '3', '30')).toBe(true);
+    expect(shrinksRetentionWindow('infrastructure.metrics_raw_retention_days', '60', '30')).toBe(false);
+    expect(shrinksRetentionWindow('infrastructure.metrics_raw_retention_days', '30', '30')).toBe(false);
+  });
+
+  it('ignores non-destructive keys and unparseable values', () => {
+    expect(shrinksRetentionWindow('cache.image_ttl', '30', '600')).toBe(false);
+    expect(shrinksRetentionWindow('infrastructure.metrics_raw_retention_days', '', '30')).toBe(false);
+  });
+});
+
+describe('SettingRow', () => {
+  it('gives a security setting its own chrome and states the consequence', () => {
+    render(rowFor('oidc.allow_insecure_transport'));
+
+    const row = screen.getByTestId('setting-row-oidc.allow_insecure_transport');
+    expect(row).toHaveAttribute('data-risk', 'security');
+    expect(within(row).getByText('Security')).toBeInTheDocument();
+    expect(row).toHaveTextContent(/Anyone on the network path can capture and replay them/i);
+  });
+
+  it('gives a retention setting the destructive marker', () => {
+    render(rowFor('infrastructure.metrics_raw_retention_days'));
+
+    const row = screen.getByTestId('setting-row-infrastructure.metrics_raw_retention_days');
+    expect(row).toHaveAttribute('data-risk', 'destructive');
+    expect(within(row).getByText('Deletes data')).toBeInTheDocument();
+  });
+
+  it('leaves an ordinary setting unmarked', () => {
+    render(rowFor('cache.image_ttl'));
+
+    const row = screen.getByTestId('setting-row-cache.image_ttl');
+    expect(row).not.toHaveAttribute('data-risk');
+    expect(within(row).queryByText('Security')).not.toBeInTheDocument();
+    expect(within(row).queryByText('Deletes data')).not.toBeInTheDocument();
+  });
+
+  it('labels its number input so it is reachable by name', () => {
+    render(rowFor('cache.image_ttl'));
+
+    const input = screen.getByLabelText('Image Cache TTL');
+    expect(input).toHaveAttribute('id', settingDomId('cache.image_ttl'));
+    expect(input).toHaveAttribute('type', 'number');
+    expect(input).toHaveAccessibleDescription(/Time to cache image list/i);
+  });
+
+  it('exposes a boolean setting as a named switch', () => {
+    const onChange = vi.fn();
+    render(rowFor('status.page.enabled', { onChange }));
+
+    const toggle = screen.getByRole('switch', { name: 'Enable Status Page' });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith('true');
+  });
+
+  it('gives the password reveal button an accessible name', () => {
+    render(rowFor('oidc.client_secret'));
+
+    expect(screen.getByRole('button', { name: 'Show Client Secret' })).toBeInTheDocument();
+  });
+
+  it('confirms at the row when the key has just been saved', () => {
+    render(
+      <SettingsSavedKeysProvider savedKeys={new Set(['cache.image_ttl'])}>
+        {rowFor('cache.image_ttl')}
+      </SettingsSavedKeysProvider>,
+    );
+
+    expect(screen.getByTestId('setting-saved-cache.image_ttl')).toHaveTextContent('Saved');
+  });
+
+  it('says "Unsaved" rather than "Modified" on a guarded key, because nothing will commit on its own', () => {
+    render(rowFor('oidc.client_id', { value: 'changed', hasChanges: true }));
+
+    const row = screen.getByTestId('setting-row-oidc.client_id');
+    expect(within(row).getByText('Unsaved')).toBeInTheDocument();
+    expect(within(row).queryByText('Modified')).not.toBeInTheDocument();
+  });
+});
+
+describe('searchSettings', () => {
+  it('finds a key by a word from its label and ranks label matches first', () => {
+    const results = searchSettings('retention');
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].label).toMatch(/retention/i);
+    expect(results.map((r) => r.key)).toContain('infrastructure.metrics_raw_retention_days');
+  });
+
+  it('finds a key by its dotted key and by its description', () => {
+    expect(searchSettings('oidc.client_secret').map((r) => r.key)).toContain('oidc.client_secret');
+    expect(searchSettings('BotFather').map((r) => r.key)).toContain('notifications.telegram_bot_token');
+  });
+
+  it('reports the category so the caller can route to the right tab', () => {
+    const match = searchSettings('polling interval')[0];
+    expect(match.key).toBe('monitoring.polling_interval');
+    expect(match.category).toBe('monitoring');
+  });
+
+  it('carries the risk class through, and stays quiet below two characters', () => {
+    expect(searchSettings('status page')[0].risk).toBeDefined();
+    expect(searchSettings('a')).toEqual([]);
+    expect(searchSettings('  ')).toEqual([]);
+  });
+});

--- a/frontend/src/features/core/components/settings/shared.tsx
+++ b/frontend/src/features/core/components/settings/shared.tsx
@@ -1,14 +1,27 @@
-import { useState } from 'react';
+import { createContext, useContext, useState } from 'react';
 import { Eye, EyeOff, RefreshCw } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
 export const REDACTED_SECRET = '••••••••';
 
+/**
+ * Blast radius of a setting, for the settings that have one.
+ *
+ * Most of the 107 keys are recoverable: get a cache TTL wrong and you pay a
+ * cache miss. These two classes are not, so they are rendered with their own
+ * chrome and — critically — excluded from auto-save. Nothing here changes what
+ * a setting *does*; it only changes how much friction stands in front of it.
+ *
+ * - `security`    — changes who can reach the dashboard, or how credentials travel.
+ * - `destructive` — *lowering* the value permanently deletes stored data.
+ */
+export type SettingRisk = 'security' | 'destructive';
+
 // Default settings definitions
 export const DEFAULT_SETTINGS = {
   monitoring: [
     { key: 'monitoring.polling_interval', label: 'Polling Interval', description: 'How often to fetch container metrics (seconds)', type: 'number', defaultValue: '30', min: 5, max: 300 },
-    { key: 'monitoring.metric_retention_days', label: 'Metric Retention', description: 'How long to keep historical metrics (days)', type: 'number', defaultValue: '7', min: 1, max: 90 },
+    { key: 'monitoring.metric_retention_days', label: 'Metric Retention', description: 'How long to keep historical metrics (days)', type: 'number', defaultValue: '7', min: 1, max: 90, risk: 'destructive', consequence: 'Lowering this deletes stored metrics older than the new window. Deleted history does not come back if you raise it again.' },
     { key: 'monitoring.enabled', label: 'Enable Monitoring', description: 'Enable background container monitoring', type: 'boolean', defaultValue: 'true' },
     { key: 'monitoring.scheduler_interval_minutes', label: 'Scheduler Interval', description: 'How often the monitoring scheduler runs (minutes). Changes apply without restart.', type: 'number', defaultValue: '5', min: 1, max: 60 },
   ],
@@ -48,18 +61,18 @@ export const DEFAULT_SETTINGS = {
     { key: 'llm.max_tokens', label: 'Max Tokens', description: 'Maximum tokens in LLM response', type: 'number', defaultValue: '20000', min: 256, max: 128000 },
   ],
   authentication: [
-    { key: 'oidc.enabled', label: 'Enable OIDC/SSO', description: 'Enable OpenID Connect single sign-on authentication', type: 'boolean', defaultValue: 'false' },
-    { key: 'oidc.issuer_url', label: 'Issuer URL', description: 'OIDC provider issuer URL (e.g., https://auth.example.com/realms/master)', type: 'string', defaultValue: '' },
-    { key: 'oidc.client_id', label: 'Client ID', description: 'OIDC client identifier registered with your provider', type: 'string', defaultValue: '' },
-    { key: 'oidc.client_secret', label: 'Client Secret', description: 'OIDC client secret for server-side authentication', type: 'password', defaultValue: '' },
-    { key: 'oidc.redirect_uri', label: 'Redirect URI', description: 'Callback URL registered with your IdP. Leave blank to inherit from DASHBOARD_EXTERNAL_URL — when that env var is set, it takes precedence and the value here is ignored.', type: 'string', defaultValue: '' },
-    { key: 'oidc.scopes', label: 'Scopes', description: 'Space-separated OIDC scopes to request', type: 'string', defaultValue: 'openid profile email' },
-    { key: 'oidc.local_auth_enabled', label: 'Keep Local Auth Enabled', description: 'Allow username/password login alongside SSO', type: 'boolean', defaultValue: 'true' },
-    { key: 'oidc.groups_claim', label: 'Groups Claim', description: 'ID token claim name containing group membership. Supports dot-notation for nested claims (e.g., realm_access.roles)', type: 'string', defaultValue: 'groups' },
-    { key: 'oidc.group_role_mappings', label: 'Group-to-Role Mappings', description: 'JSON mapping of IdP group names to dashboard roles. Use * as a wildcard fallback.', type: 'string', defaultValue: '{}' },
-    { key: 'oidc.allow_unmapped_viewer', label: 'Grant viewer role to all IDP users', description: 'When on, IDP users whose groups match no mapping keep access — new users get viewer, existing users keep their current role. When off, only users in a defined group (or any user, if a * wildcard mapping is set) can sign in; everyone else is denied. Local auth is unaffected.', type: 'boolean', defaultValue: 'false' },
-    { key: 'oidc.auto_provision', label: 'Auto-Provision OIDC Users', description: 'Automatically create user records for new OIDC-authenticated users', type: 'boolean', defaultValue: 'true' },
-    { key: 'oidc.allow_insecure_transport', label: 'Allow Insecure Transport (HTTP)', description: '⚠ Permit plain-HTTP OIDC discovery and token exchange. Auth codes and tokens travel unencrypted — enable ONLY for local development against an HTTP-only IdP. Never enable in production.', type: 'boolean', defaultValue: 'false' },
+    { key: 'oidc.enabled', label: 'Enable OIDC/SSO', description: 'Enable OpenID Connect single sign-on authentication', type: 'boolean', defaultValue: 'false', risk: 'security', consequence: 'Switches the sign-in path for every user. A misconfigured provider locks out everyone who has no local password.' },
+    { key: 'oidc.issuer_url', label: 'Issuer URL', description: 'OIDC provider issuer URL (e.g., https://auth.example.com/realms/master)', type: 'string', defaultValue: '', risk: 'security', consequence: 'A wrong issuer fails discovery, and every SSO login fails until it is corrected and the backend restarts.' },
+    { key: 'oidc.client_id', label: 'Client ID', description: 'OIDC client identifier registered with your provider', type: 'string', defaultValue: '', risk: 'security', consequence: 'Must match the client registered with your IdP, or every SSO login is rejected at the provider.' },
+    { key: 'oidc.client_secret', label: 'Client Secret', description: 'OIDC client secret for server-side authentication', type: 'password', defaultValue: '', risk: 'security', consequence: 'A wrong value fails every login. A leaked value lets someone else impersonate this dashboard to your IdP.' },
+    { key: 'oidc.redirect_uri', label: 'Redirect URI', description: 'Callback URL registered with your IdP. Leave blank to inherit from DASHBOARD_EXTERNAL_URL — when that env var is set, it takes precedence and the value here is ignored.', type: 'string', defaultValue: '', risk: 'security', consequence: 'Must be registered verbatim with the IdP. A mismatch fails the callback after the user has already authenticated.' },
+    { key: 'oidc.scopes', label: 'Scopes', description: 'Space-separated OIDC scopes to request', type: 'string', defaultValue: 'openid profile email', risk: 'security', consequence: 'Dropping a scope your mappings depend on (the groups scope, typically) leaves every login with no groups and no mapped role.' },
+    { key: 'oidc.local_auth_enabled', label: 'Keep Local Auth Enabled', description: 'Allow username/password login alongside SSO', type: 'boolean', defaultValue: 'true', risk: 'security', consequence: 'Turning this off removes the username/password fallback. If the IdP is unreachable, nobody can sign in.' },
+    { key: 'oidc.groups_claim', label: 'Groups Claim', description: 'ID token claim name containing group membership. Supports dot-notation for nested claims (e.g., realm_access.roles)', type: 'string', defaultValue: 'groups', risk: 'security', consequence: 'A claim name your IdP does not send means no group ever matches, and every login falls through to the unmapped-user rule.' },
+    { key: 'oidc.group_role_mappings', label: 'Group-to-Role Mappings', description: 'JSON mapping of IdP group names to dashboard roles. Use * as a wildcard fallback.', type: 'string', defaultValue: '{}', risk: 'security', consequence: 'This is what decides who gets admin. A downgrade revokes the affected users’ live sessions immediately.' },
+    { key: 'oidc.allow_unmapped_viewer', label: 'Grant viewer role to all IDP users', description: 'When on, IDP users whose groups match no mapping keep access — new users get viewer, existing users keep their current role. When off, only users in a defined group (or any user, if a * wildcard mapping is set) can sign in; everyone else is denied. Local auth is unaffected.', type: 'boolean', defaultValue: 'false', risk: 'security', consequence: 'On: anyone your IdP authenticates keeps access, mapped or not. Off: unmatched users are denied and their existing sessions are revoked.' },
+    { key: 'oidc.auto_provision', label: 'Auto-Provision OIDC Users', description: 'Automatically create user records for new OIDC-authenticated users', type: 'boolean', defaultValue: 'true', risk: 'security', consequence: 'Creates a dashboard account for every new IdP user who signs in, without an admin approving it.' },
+    { key: 'oidc.allow_insecure_transport', label: 'Allow Insecure Transport (HTTP)', description: 'Permit plain-HTTP OIDC discovery and token exchange. Intended only for local development against an HTTP-only IdP.', type: 'boolean', defaultValue: 'false', risk: 'security', consequence: 'Auth codes and tokens travel unencrypted. Anyone on the network path can capture and replay them. Never enable this in production.' },
   ],
   webhooks: [
     { key: 'webhooks.enabled', label: 'Enable Webhooks', description: 'Enable outbound webhook event delivery', type: 'boolean', defaultValue: 'false' },
@@ -71,10 +84,10 @@ export const DEFAULT_SETTINGS = {
     { key: 'elasticsearch.endpoint', label: 'Elasticsearch URL', description: 'URL of your Elasticsearch cluster (e.g., https://localhost:9200)', type: 'string', defaultValue: '' },
     { key: 'elasticsearch.api_key', label: 'API Key', description: 'Elasticsearch API key for authentication (keep blank for no auth)', type: 'password', defaultValue: '' },
     { key: 'elasticsearch.index_pattern', label: 'Index Pattern', description: 'Index pattern for log searching (e.g., logs-* or filebeat-*)', type: 'string', defaultValue: 'logs-*' },
-    { key: 'elasticsearch.verify_ssl', label: 'Verify SSL', description: 'Verify SSL certificates when connecting', type: 'boolean', defaultValue: 'true' },
+    { key: 'elasticsearch.verify_ssl', label: 'Verify SSL', description: 'Verify SSL certificates when connecting', type: 'boolean', defaultValue: 'true', risk: 'security', consequence: 'Off accepts any certificate, including one presented by a man-in-the-middle holding your API key.' },
   ],
   statusPage: [
-    { key: 'status.page.enabled', label: 'Enable Status Page', description: 'Serve a public status page at /status (no authentication required)', type: 'boolean', defaultValue: 'false' },
+    { key: 'status.page.enabled', label: 'Enable Status Page', description: 'Serve a public status page at /status (no authentication required)', type: 'boolean', defaultValue: 'false', risk: 'security', consequence: 'Publishes /status to anyone who can reach this host, with no sign-in. Endpoint health and incident history become public.' },
     { key: 'status.page.title', label: 'Page Title', description: 'Title displayed on the public status page', type: 'string', defaultValue: 'System Status' },
     { key: 'status.page.description', label: 'Page Description', description: 'Optional description shown below the title', type: 'string', defaultValue: '' },
     { key: 'status.page.show_incidents', label: 'Show Incidents', description: 'Display recent incidents on the status page', type: 'boolean', defaultValue: 'true' },
@@ -124,17 +137,17 @@ export const DEFAULT_SETTINGS = {
     { key: 'ai_tuning.log_analysis_concurrency', label: 'Log Analysis Concurrency', description: 'Parallel container log analysis tasks', type: 'number', defaultValue: '3', min: 1, max: 20 },
   ],
   metricsRetention: [
-    { key: 'infrastructure.metrics_retention_days', label: 'Metrics Retention (days)', description: 'Default retention period for container metrics', type: 'number', defaultValue: '7', min: 1, max: 365 },
-    { key: 'infrastructure.metrics_raw_retention_days', label: 'Raw Metrics Retention (days)', description: 'Retention for raw per-minute metrics', type: 'number', defaultValue: '7', min: 1, max: 90 },
-    { key: 'infrastructure.metrics_rollup_5min_retention_days', label: '5min Rollup Retention (days)', description: 'Retention for 5-minute aggregated metrics', type: 'number', defaultValue: '30', min: 1, max: 365 },
-    { key: 'infrastructure.metrics_rollup_1hour_retention_days', label: '1h Rollup Retention (days)', description: 'Retention for hourly aggregated metrics', type: 'number', defaultValue: '90', min: 1, max: 730 },
-    { key: 'infrastructure.metrics_rollup_1day_retention_days', label: '1d Rollup Retention (days)', description: 'Retention for daily aggregated metrics', type: 'number', defaultValue: '365', min: 1, max: 1825 },
-    { key: 'infrastructure.insights_retention_days', label: 'Insights Retention (days)', description: 'How long to keep AI-generated insights', type: 'number', defaultValue: '7', min: 1, max: 365 },
+    { key: 'infrastructure.metrics_retention_days', label: 'Metrics Retention (days)', description: 'Default retention period for container metrics', type: 'number', defaultValue: '7', min: 1, max: 365, risk: 'destructive', consequence: 'Lowering this deletes container metrics older than the new window on the next cleanup run.' },
+    { key: 'infrastructure.metrics_raw_retention_days', label: 'Raw Metrics Retention (days)', description: 'Retention for raw per-minute metrics', type: 'number', defaultValue: '7', min: 1, max: 90, risk: 'destructive', consequence: 'Lowering this deletes per-minute samples older than the new window. It also caps the day-of-week anomaly baseline, which cannot look back further than raw retention.' },
+    { key: 'infrastructure.metrics_rollup_5min_retention_days', label: '5min Rollup Retention (days)', description: 'Retention for 5-minute aggregated metrics', type: 'number', defaultValue: '30', min: 1, max: 365, risk: 'destructive', consequence: 'Lowering this deletes 5-minute rollups older than the new window.' },
+    { key: 'infrastructure.metrics_rollup_1hour_retention_days', label: '1h Rollup Retention (days)', description: 'Retention for hourly aggregated metrics', type: 'number', defaultValue: '90', min: 1, max: 730, risk: 'destructive', consequence: 'Lowering this deletes hourly rollups older than the new window — the series most long-range charts read from.' },
+    { key: 'infrastructure.metrics_rollup_1day_retention_days', label: '1d Rollup Retention (days)', description: 'Retention for daily aggregated metrics', type: 'number', defaultValue: '365', min: 1, max: 1825, risk: 'destructive', consequence: 'Lowering this deletes daily rollups older than the new window — the longest history the dashboard keeps.' },
+    { key: 'infrastructure.insights_retention_days', label: 'Insights Retention (days)', description: 'How long to keep AI-generated insights', type: 'number', defaultValue: '7', min: 1, max: 365, risk: 'destructive', consequence: 'Lowering this deletes insights older than the new window, along with their acknowledgements.' },
   ],
   portainerBackup: [
     { key: 'portainer_backup.enabled', label: 'Enable Scheduled Backups', description: 'Automatically back up Portainer server configuration on a schedule', type: 'boolean', defaultValue: 'false' },
     { key: 'portainer_backup.interval_hours', label: 'Backup Interval (hours)', description: 'Hours between automated Portainer backups', type: 'number', defaultValue: '24', min: 1, max: 168 },
-    { key: 'portainer_backup.max_count', label: 'Max Backups to Retain', description: 'Maximum number of Portainer backups to keep (oldest deleted first)', type: 'number', defaultValue: '10', min: 1, max: 50 },
+    { key: 'portainer_backup.max_count', label: 'Max Backups to Retain', description: 'Maximum number of Portainer backups to keep (oldest deleted first)', type: 'number', defaultValue: '10', min: 1, max: 50, risk: 'destructive', consequence: 'Lowering this deletes the oldest backup archives until only this many remain. There is no restore from this dashboard.' },
     { key: 'portainer_backup.password', label: 'Backup Password', description: 'Optional encryption password for Portainer backups', type: 'password', defaultValue: '' },
   ],
   edgeAgent: [
@@ -153,12 +166,15 @@ export const DEFAULT_SETTINGS = {
     { key: 'harbor.api_url', label: 'Harbor API URL', description: 'URL of your Harbor Registry (e.g., https://harbor.example.com)', type: 'string', defaultValue: '' },
     { key: 'harbor.robot_name', label: 'Robot Account Name', description: 'Harbor robot account username (e.g., robot$dashboard)', type: 'string', defaultValue: '' },
     { key: 'harbor.robot_secret', label: 'Robot Account Secret', description: 'Harbor robot account secret/password', type: 'password', defaultValue: '' },
-    { key: 'harbor.verify_ssl', label: 'Verify SSL', description: 'Verify SSL certificates when connecting to Harbor', type: 'boolean', defaultValue: 'true' },
+    { key: 'harbor.verify_ssl', label: 'Verify SSL', description: 'Verify SSL certificates when connecting to Harbor', type: 'boolean', defaultValue: 'true', risk: 'security', consequence: 'Off accepts any certificate, including one presented by a man-in-the-middle holding your robot account secret.' },
     { key: 'harbor.sync_interval_minutes', label: 'Sync Interval (minutes)', description: 'How often to sync vulnerabilities from Harbor', type: 'number', defaultValue: '30', min: 5, max: 1440 },
   ],
 } as const;
 
 export type SettingCategory = keyof typeof DEFAULT_SETTINGS;
+
+/** One entry of {@link DEFAULT_SETTINGS}, whichever category it came from. */
+export type SettingDescriptor = (typeof DEFAULT_SETTINGS)[SettingCategory][number];
 
 export const SETTING_CATEGORY_BY_KEY: Record<string, SettingCategory> = Object.entries(DEFAULT_SETTINGS).reduce(
   (acc, [category, settings]) => {
@@ -170,6 +186,105 @@ export const SETTING_CATEGORY_BY_KEY: Record<string, SettingCategory> = Object.e
   {} as Record<string, SettingCategory>,
 );
 
+export const SETTING_BY_KEY: Record<string, SettingDescriptor> = Object.values(DEFAULT_SETTINGS).reduce(
+  (acc, settings) => {
+    (settings as readonly SettingDescriptor[]).forEach((setting) => {
+      acc[setting.key] = setting;
+    });
+    return acc;
+  },
+  {} as Record<string, SettingDescriptor>,
+);
+
+/** The risk class of a setting, or `undefined` for the ordinary majority. */
+export function settingRisk(setting: SettingDescriptor | undefined): SettingRisk | undefined {
+  if (setting && 'risk' in setting) return setting.risk as SettingRisk;
+  return undefined;
+}
+
+/** The one-line consequence of getting a risky setting wrong, if it has one. */
+export function settingConsequence(setting: SettingDescriptor | undefined): string | undefined {
+  if (setting && 'consequence' in setting) return setting.consequence as string;
+  return undefined;
+}
+
+/**
+ * Keys that must never be committed by the debounce.
+ *
+ * Auto-save is right for cosmetics and wrong for anything that changes who can
+ * sign in or deletes stored history — a paused keystroke should not be able to
+ * publish an unauthenticated status page or drop 83 days of metrics.
+ */
+export const GUARDED_SETTING_KEYS: ReadonlySet<string> = new Set(
+  Object.values(SETTING_BY_KEY).filter((s) => settingRisk(s) !== undefined).map((s) => s.key),
+);
+
+export function isGuardedSetting(key: string): boolean {
+  return GUARDED_SETTING_KEYS.has(key);
+}
+
+/**
+ * True when a pending edit to a `destructive` setting *shrinks* its window —
+ * the only direction that deletes anything. Raising a retention window is safe.
+ */
+export function shrinksRetentionWindow(key: string, nextValue: string, previousValue: string): boolean {
+  if (settingRisk(SETTING_BY_KEY[key]) !== 'destructive') return false;
+  // A blank field is an unfinished edit, not a lowered window — `Number('')` is 0
+  // and would otherwise read as the largest shrink possible.
+  if (nextValue.trim() === '' || previousValue.trim() === '') return false;
+  const next = Number(nextValue);
+  const previous = Number(previousValue);
+  if (!Number.isFinite(next) || !Number.isFinite(previous)) return false;
+  return next < previous;
+}
+
+export interface SettingSearchMatch {
+  key: string;
+  label: string;
+  description: string;
+  category: SettingCategory;
+  risk?: SettingRisk;
+}
+
+/**
+ * Find settings by label, description or key.
+ *
+ * 107 keys across 7 tabs, and the only way to find one was to read every tab.
+ * Ranked so a label match beats a description match — searching "retention"
+ * should put "Metrics Retention (days)" above a setting that merely mentions it.
+ */
+export function searchSettings(query: string, limit = 8): SettingSearchMatch[] {
+  const needle = query.trim().toLowerCase();
+  if (needle.length < 2) return [];
+
+  const scored: { match: SettingSearchMatch; score: number }[] = [];
+  for (const [key, setting] of Object.entries(SETTING_BY_KEY)) {
+    const label = setting.label.toLowerCase();
+    const description = setting.description.toLowerCase();
+    let score = 0;
+    if (label.startsWith(needle)) score = 4;
+    else if (label.includes(needle)) score = 3;
+    else if (key.toLowerCase().includes(needle)) score = 2;
+    else if (description.includes(needle)) score = 1;
+    if (score === 0) continue;
+    scored.push({
+      score,
+      match: {
+        key,
+        label: setting.label,
+        description: setting.description,
+        category: SETTING_CATEGORY_BY_KEY[key],
+        risk: settingRisk(setting),
+      },
+    });
+  }
+
+  return scored
+    .sort((a, b) => b.score - a.score || a.match.label.localeCompare(b.match.label))
+    .slice(0, limit)
+    .map((entry) => entry.match);
+}
+
 /** Common props passed down to all settings tab components */
 export interface SettingsTabProps {
   editedValues: Record<string, string>;
@@ -179,30 +294,42 @@ export interface SettingsTabProps {
 }
 
 interface SettingInputProps {
-  setting: (typeof DEFAULT_SETTINGS)[SettingCategory][number];
+  setting: SettingDescriptor;
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
+  /** DOM id, so the row's `<label>` can point at the control. */
+  id?: string;
+  /** Ids of the description / consequence text describing this control. */
+  describedBy?: string;
 }
 
-export function SettingInput({ setting, value, onChange, disabled }: SettingInputProps) {
+export function SettingInput({ setting, value, onChange, disabled, id, describedBy }: SettingInputProps) {
   const [showPassword, setShowPassword] = useState(false);
 
   if (setting.type === 'boolean') {
+    const checked = value === 'true';
     return (
       <button
-        onClick={() => onChange(value === 'true' ? 'false' : 'true')}
+        id={id}
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={setting.label}
+        aria-describedby={describedBy}
+        onClick={() => onChange(checked ? 'false' : 'true')}
         disabled={disabled}
         className={cn(
           'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-          value === 'true' ? 'bg-primary' : 'bg-muted',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          checked ? 'bg-primary' : 'bg-muted',
           disabled && 'opacity-50 cursor-not-allowed'
         )}
       >
         <span
           className={cn(
             'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
-            value === 'true' ? 'translate-x-6' : 'translate-x-1'
+            checked ? 'translate-x-6' : 'translate-x-1'
           )}
         />
       </button>
@@ -213,16 +340,19 @@ export function SettingInput({ setting, value, onChange, disabled }: SettingInpu
     return (
       <div className="relative">
         <input
+          id={id}
           type={showPassword ? 'text' : 'password'}
           value={value}
           onChange={(e) => onChange(e.target.value)}
           disabled={disabled}
+          aria-describedby={describedBy}
           placeholder="••••••••"
           className="h-9 w-full rounded-md border border-input bg-background px-3 pr-10 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
         />
         <button
           type="button"
           onClick={() => setShowPassword(!showPassword)}
+          aria-label={showPassword ? `Hide ${setting.label}` : `Show ${setting.label}`}
           className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
         >
           {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
@@ -232,10 +362,12 @@ export function SettingInput({ setting, value, onChange, disabled }: SettingInpu
   }
 
   const inputProps = {
+    id,
     type: setting.type === 'number' ? 'number' : 'text',
     value,
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
     disabled,
+    'aria-describedby': describedBy,
     className: 'h-9 w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50',
     ...('min' in setting && { min: setting.min }),
     ...('max' in setting && { max: setting.max }),
@@ -245,8 +377,50 @@ export function SettingInput({ setting, value, onChange, disabled }: SettingInpu
   return <input {...inputProps} />;
 }
 
+/**
+ * Keys saved in the last few seconds, so a row can confirm at the row.
+ *
+ * The page-level "All changes saved" banner sits up to 2000px above the field
+ * being edited on the longer tabs, which means the only confirmation that a
+ * security setting committed is off-screen. Provided by the settings page;
+ * rows that render outside it simply never show the pill.
+ */
+const SettingsSavedKeysContext = createContext<ReadonlySet<string>>(new Set<string>());
+
+export function SettingsSavedKeysProvider({
+  savedKeys,
+  children,
+}: {
+  savedKeys: ReadonlySet<string>;
+  children: React.ReactNode;
+}) {
+  return (
+    <SettingsSavedKeysContext.Provider value={savedKeys}>{children}</SettingsSavedKeysContext.Provider>
+  );
+}
+
+/** DOM-id-safe form of a setting key (`oidc.client_id` → `setting-oidc-client_id`). */
+export function settingDomId(key: string): string {
+  return `setting-${key.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+}
+
+const RISK_CHROME: Record<SettingRisk, { rule: string; chip: string; label: string; text: string }> = {
+  security: {
+    rule: 'border-l-2 border-l-destructive/70 pl-3 -ml-px',
+    chip: 'bg-destructive/10 text-destructive',
+    label: 'Security',
+    text: 'text-destructive',
+  },
+  destructive: {
+    rule: 'border-l-2 border-l-amber-500/70 pl-3 -ml-px',
+    chip: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+    label: 'Deletes data',
+    text: 'text-amber-600 dark:text-amber-400',
+  },
+};
+
 interface SettingRowProps {
-  setting: (typeof DEFAULT_SETTINGS)[SettingCategory][number];
+  setting: SettingDescriptor;
   value: string;
   onChange: (value: string) => void;
   hasChanges: boolean;
@@ -254,21 +428,59 @@ interface SettingRowProps {
 }
 
 export function SettingRow({ setting, value, onChange, hasChanges, disabled }: SettingRowProps) {
+  const savedKeys = useContext(SettingsSavedKeysContext);
+  const risk = settingRisk(setting);
+  const consequence = settingConsequence(setting);
+  const chrome = risk ? RISK_CHROME[risk] : undefined;
+  const inputId = settingDomId(setting.key);
+  const descriptionId = `${inputId}-description`;
+  const consequenceId = `${inputId}-consequence`;
+  const justSaved = savedKeys.has(setting.key);
+
   return (
-    <div className="flex items-center justify-between py-4 border-b border-border last:border-0">
-      <div className="flex-1 pr-4">
-        <div className="flex items-center gap-2">
-          <label className="font-medium">{setting.label}</label>
+    <div
+      data-testid={`setting-row-${setting.key}`}
+      data-risk={risk ?? undefined}
+      className="flex items-center justify-between py-4 border-b border-border last:border-0"
+    >
+      <div className={cn('flex-1 pr-4', chrome?.rule)}>
+        <div className="flex flex-wrap items-center gap-2">
+          <label htmlFor={inputId} className="font-medium">{setting.label}</label>
+          {chrome && (
+            <span className={cn('rounded px-1.5 py-0.5 text-xs font-medium', chrome.chip)}>
+              {chrome.label}
+            </span>
+          )}
           {hasChanges && (
             <span className="text-xs text-amber-500 bg-amber-500/10 px-1.5 py-0.5 rounded">
-              Modified
+              {risk ? 'Unsaved' : 'Modified'}
+            </span>
+          )}
+          {justSaved && !hasChanges && (
+            <span
+              data-testid={`setting-saved-${setting.key}`}
+              className="rounded bg-emerald-500/10 px-1.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+            >
+              Saved
             </span>
           )}
         </div>
-        <p className="text-sm text-muted-foreground mt-0.5">{setting.description}</p>
+        <p id={descriptionId} className="text-sm text-muted-foreground mt-0.5">{setting.description}</p>
+        {consequence && (
+          <p id={consequenceId} className={cn('mt-1 text-sm', chrome?.text)}>
+            {consequence}
+          </p>
+        )}
       </div>
       <div className="shrink-0 w-72">
-        <SettingInput setting={setting} value={value} onChange={onChange} disabled={disabled} />
+        <SettingInput
+          setting={setting}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          id={inputId}
+          describedBy={consequence ? `${descriptionId} ${consequenceId}` : descriptionId}
+        />
       </div>
     </div>
   );

--- a/frontend/src/features/core/components/settings/tab-general.test.tsx
+++ b/frontend/src/features/core/components/settings/tab-general.test.tsx
@@ -76,52 +76,55 @@ describe('GeneralTab — system component versions', () => {
   });
 });
 
-describe('GeneralTab — cached entry keys table (DataTable migration)', () => {
-  it('renders the cache entries inside a DataTable', () => {
-    cacheStatsRef.data = {
-      size: 2,
-      l1Size: 1,
-      l2Size: 1,
-      hits: 10,
-      misses: 2,
-      hitRate: '83%',
-      backend: 'multi-layer',
-      entries: [
-        { key: 'portainer:containers', expiresIn: 30 },
-        { key: 'portainer:images', expiresIn: 60 },
-      ],
-    };
+describe('GeneralTab — raw cache keys are not product surface', () => {
+  const populatedStats = {
+    size: 2,
+    l1Size: 1,
+    l2Size: 1,
+    hits: 10,
+    misses: 2,
+    hitRate: '83%',
+    backend: 'multi-layer',
+    entries: [
+      { key: 'stats:3:eff28011ff7bd189089e1d192b14b09c95b42aed', expiresIn: 30 },
+      { key: 'portainer:images', expiresIn: 60 },
+    ],
+  };
 
-    renderTab();
-
-    const table = screen.getByTestId('data-table');
-    expect(table).toBeInTheDocument();
-
-    // Headers preserved from the original hand-rolled table
-    expect(within(table).getByText('Key')).toBeInTheDocument();
-    expect(within(table).getByText('Expires In (TTL)')).toBeInTheDocument();
-
-    // Cell rendering preserved (key + TTL with the "s" suffix)
-    expect(within(table).getByText('portainer:containers')).toBeInTheDocument();
-    expect(within(table).getByText('portainer:images')).toBeInTheDocument();
-    expect(within(table).getByText('30s')).toBeInTheDocument();
-    expect(within(table).getByText('60s')).toBeInTheDocument();
-  });
-
-  it('does not render the cache entries table when there are no entries', () => {
-    cacheStatsRef.data = {
-      size: 0,
-      l1Size: 0,
-      l2Size: 0,
-      hits: 0,
-      misses: 0,
-      hitRate: 'N/A',
-      backend: 'memory-only',
-      entries: [],
-    };
+  it('does not dump individual cache keys into the page', () => {
+    cacheStatsRef.data = populatedStats;
 
     renderTab();
 
     expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
+    expect(screen.queryByText('stats:3:eff28011ff7bd189089e1d192b14b09c95b42aed')).not.toBeInTheDocument();
+    expect(screen.queryByText('portainer:images')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Cached Entry Keys/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the aggregate counters, which do read', () => {
+    cacheStatsRef.data = populatedStats;
+
+    renderTab();
+
+    expect(screen.getByText('Hit Rate')).toBeInTheDocument();
+    expect(screen.getByText('83%')).toBeInTheDocument();
+    expect(screen.getByText('Redis Keys')).toBeInTheDocument();
+  });
+});
+
+describe('GeneralTab — placement', () => {
+  it('renders system information as a disclosure', () => {
+    renderTab();
+
+    const disclosure = screen.getByTestId('system-information');
+    expect(disclosure.tagName).toBe('DETAILS');
+    expect(within(disclosure).getByText('System Information')).toBeInTheDocument();
+  });
+
+  it('does not host cache administration — that belongs with the cache settings', () => {
+    renderTab();
+
+    expect(screen.queryByRole('button', { name: /clear all cache/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/core/components/settings/tab-general.tsx
+++ b/frontend/src/features/core/components/settings/tab-general.tsx
@@ -2,6 +2,7 @@ import { version as reactVersion } from 'react';
 import { ChevronRight, Settings2 } from 'lucide-react';
 import { useCacheStats } from '@/features/core/hooks/use-cache-admin';
 import { useSystemInfo } from '@/features/core/hooks/use-system-info';
+import { PRODUCT_NAME } from '@/shared/lib/product';
 
 export interface CacheStatsSummary {
   backend: 'multi-layer' | 'memory-only';
@@ -51,7 +52,7 @@ export function GeneralTab({ theme }: GeneralTabProps) {
         <div className="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           <div className="rounded-lg bg-muted/50 p-4">
             <p className="text-xs text-muted-foreground">Application</p>
-            <p className="font-medium mt-1">Docker Insight</p>
+            <p className="font-medium mt-1">{PRODUCT_NAME}</p>
           </div>
           <div className="rounded-lg bg-muted/50 p-4">
             <p className="text-xs text-muted-foreground">Version</p>

--- a/frontend/src/features/core/components/settings/tab-general.tsx
+++ b/frontend/src/features/core/components/settings/tab-general.tsx
@@ -1,14 +1,7 @@
-import { useMemo, version as reactVersion } from 'react';
-import { type ColumnDef } from '@tanstack/react-table';
-import { Loader2, RefreshCw, Settings2 } from 'lucide-react';
-import { DataTable } from '@/shared/components/tables/data-table';
-import { useCacheStats, useCacheClear } from '@/features/core/hooks/use-cache-admin';
+import { version as reactVersion } from 'react';
+import { ChevronRight, Settings2 } from 'lucide-react';
+import { useCacheStats } from '@/features/core/hooks/use-cache-admin';
 import { useSystemInfo } from '@/features/core/hooks/use-system-info';
-
-interface CacheEntryRow {
-  key: string;
-  expiresIn: number;
-}
 
 export interface CacheStatsSummary {
   backend: 'multi-layer' | 'memory-only';
@@ -42,52 +35,20 @@ interface GeneralTabProps {
 export function GeneralTab({ theme }: GeneralTabProps) {
   const { data: cacheStats } = useCacheStats();
   const { data: systemInfo } = useSystemInfo();
-  const cacheClear = useCacheClear();
   const redisSystemInfo = getRedisSystemInfo(cacheStats);
-
-  const cacheEntryColumns = useMemo<ColumnDef<CacheEntryRow, unknown>[]>(
-    () => [
-      {
-        accessorKey: 'key',
-        header: 'Key',
-        cell: ({ getValue }) => (
-          <span className="font-mono text-xs">{getValue<string>()}</span>
-        ),
-      },
-      {
-        accessorKey: 'expiresIn',
-        header: () => <span className="block text-right">Expires In (TTL)</span>,
-        cell: ({ getValue }) => (
-          <span className="block text-right text-muted-foreground">{getValue<number>()}s</span>
-        ),
-      },
-    ],
-    [],
-  );
 
   return (
     <div className="space-y-6">
-      {/* System Info */}
-      <div className="rounded-lg border bg-card p-6">
-        <div className="mb-4 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Settings2 className="h-5 w-5" />
-            <h2 className="text-lg font-semibold">System Information</h2>
-          </div>
-          <button
-            onClick={() => cacheClear.mutate()}
-            disabled={cacheClear.isPending}
-            className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent disabled:opacity-50"
-          >
-            {cacheClear.isPending ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <RefreshCw className="h-3.5 w-3.5" />
-            )}
-            Clear All Cache
-          </button>
-        </div>
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {/* System Info — a disclosure, because nobody opens Settings to read a
+          version string. Cache administration lives with the cache settings on
+          the Infrastructure tab. */}
+      <details data-testid="system-information" className="group rounded-lg border bg-card p-6" open>
+        <summary className="flex cursor-pointer list-none items-center gap-2 [&::-webkit-details-marker]:hidden">
+          <ChevronRight className="h-4 w-4 shrink-0 transition-transform group-open:rotate-90" />
+          <Settings2 className="h-5 w-5" />
+          <h2 className="text-lg font-semibold">System Information</h2>
+        </summary>
+        <div className="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           <div className="rounded-lg bg-muted/50 p-4">
             <p className="text-xs text-muted-foreground">Application</p>
             <p className="font-medium mt-1">Docker Insight</p>
@@ -141,36 +102,21 @@ export function GeneralTab({ theme }: GeneralTabProps) {
                 <p className="font-medium mt-1">{cacheStats?.hitRate ?? 'N/A'}</p>
               </div>
             </div>
+            {/* The per-key table that used to live here was `redis-cli KEYS`
+                shipped as product surface — its own label conceded the reader
+                had no use for it. The count is the part that reads. */}
             {cacheStats?.entries && cacheStats.entries.length > 0 && (
-              <div className="mt-4 grid gap-3 lg:grid-cols-2">
-                <div className="rounded-lg border border-border/50 bg-muted/20 p-3">
-                  <p className="text-xs font-medium">Redis Keys</p>
-                  <p className="mt-1 text-lg font-semibold">{redisSystemInfo.keys}</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Count of keys currently stored in Redis (L2 cache). More keys means more reusable cached responses.
-                  </p>
-                </div>
-                <div className="rounded-lg border border-border/50 bg-muted/20">
-                  <div className="border-b border-border/50 px-3 py-2">
-                    <p className="text-xs font-medium">Cached Entry Keys</p>
-                    <p className="text-xs text-muted-foreground">
-                      Internal cache identifiers used by the backend for stored query results.
-                    </p>
-                  </div>
-                  <div className="p-3">
-                    <DataTable
-                      columns={cacheEntryColumns}
-                      data={cacheStats.entries}
-                      getRowId={(entry) => entry.key}
-                      hideSearch
-                    />
-                  </div>
-                </div>
+              <div className="mt-4 rounded-lg border border-border/50 bg-muted/20 p-3">
+                <p className="text-xs font-medium">Redis Keys</p>
+                <p className="mt-1 text-lg font-semibold">{redisSystemInfo.keys}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Count of keys currently stored in Redis (L2 cache). More keys means more reusable cached responses.
+                </p>
               </div>
             )}
           </div>
         </div>
-      </div>
+      </details>
 
       {/* Caching model — informational, not a toggle. See #1312. */}
       <div

--- a/frontend/src/features/core/components/settings/tab-infrastructure.test.tsx
+++ b/frontend/src/features/core/components/settings/tab-infrastructure.test.tsx
@@ -22,7 +22,13 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-import { PortainerBackupManagement } from './tab-infrastructure';
+const cacheClearMutate = vi.fn();
+vi.mock('@/features/core/hooks/use-cache-admin', () => ({
+  useCacheClear: () => ({ mutate: cacheClearMutate, isPending: false }),
+}));
+
+import { InfrastructureTab, PortainerBackupManagement } from './tab-infrastructure';
+import { DEFAULT_SETTINGS } from './shared';
 
 const sampleBackups = [
   { filename: 'portainer-backup-2026-05-01.tar.gz', size: 1024 * 1024, createdAt: '2026-05-01T10:00:00Z' },
@@ -73,13 +79,56 @@ describe('PortainerBackupManagement (DataTable migration)', () => {
     expect(downloadPortainerBackup).toHaveBeenCalledWith('portainer-backup-2026-05-01.tar.gz');
   });
 
-  it('triggers delete for the correct file from a row action', () => {
+  it('does not delete on the row click alone — it opens a confirmation first', () => {
     render(<PortainerBackupManagement />);
 
     const secondRow = screen.getByText('portainer-backup-2026-05-02.tar.gz').closest('tr')!;
     fireEvent.click(within(secondRow).getByText('Delete'));
 
+    expect(deleteMutate).not.toHaveBeenCalled();
+    expect(screen.getByTestId('confirm-delete-backup')).toBeInTheDocument();
+  });
+
+  it('names the file and its creation date in the delete confirmation', () => {
+    render(<PortainerBackupManagement />);
+
+    const secondRow = screen.getByText('portainer-backup-2026-05-02.tar.gz').closest('tr')!;
+    fireEvent.click(within(secondRow).getByText('Delete'));
+
+    const dialog = screen.getByTestId('confirm-delete-backup');
+    expect(dialog).toHaveTextContent('portainer-backup-2026-05-02.tar.gz');
+    expect(dialog).toHaveTextContent(new Date('2026-05-02T10:00:00Z').toLocaleString());
+    expect(dialog).toHaveTextContent(/cannot be recovered/i);
+  });
+
+  it('deletes the confirmed file only after the confirm button is pressed', () => {
+    render(<PortainerBackupManagement />);
+
+    const secondRow = screen.getByText('portainer-backup-2026-05-02.tar.gz').closest('tr')!;
+    fireEvent.click(within(secondRow).getByText('Delete'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete backup' }));
+
     expect(deleteMutate).toHaveBeenCalledWith('portainer-backup-2026-05-02.tar.gz', expect.any(Object));
+  });
+
+  it('cancelling the confirmation deletes nothing', () => {
+    render(<PortainerBackupManagement />);
+
+    const firstRow = screen.getByText('portainer-backup-2026-05-01.tar.gz').closest('tr')!;
+    fireEvent.click(within(firstRow).getByText('Delete'));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(deleteMutate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('confirm-delete-backup')).not.toBeInTheDocument();
+  });
+
+  it('states that restore is not available here and names the recovery path', () => {
+    render(<PortainerBackupManagement />);
+
+    const note = screen.getByTestId('backup-recovery-note');
+    expect(note).toHaveTextContent(/cannot restore a backup/i);
+    expect(note).toHaveTextContent(/Restore from backup/i);
+    expect(note).toHaveTextContent(/keep a copy elsewhere/i);
   });
 
   it('refreshes the backup list when Refresh is clicked', async () => {
@@ -90,5 +139,64 @@ describe('PortainerBackupManagement (DataTable migration)', () => {
     await waitFor(() => {
       expect(refetch).toHaveBeenCalled();
     });
+  });
+});
+
+describe('InfrastructureTab', () => {
+  function renderTab() {
+    const values: Record<string, string> = {};
+    Object.values(DEFAULT_SETTINGS).flat().forEach((s) => { values[s.key] = s.defaultValue; });
+    return render(
+      <InfrastructureTab
+        editedValues={values}
+        originalValues={values}
+        onChange={vi.fn()}
+        isSaving={false}
+      />,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBackups = [...sampleBackups];
+    mockIsLoading = false;
+  });
+
+  it('puts cache administration with the cache settings', () => {
+    renderTab();
+
+    const clear = screen.getByRole('button', { name: /clear all cache/i });
+    fireEvent.click(clear);
+    expect(cacheClearMutate).toHaveBeenCalled();
+  });
+
+  it('does not badge Cache or Metrics Retention as "Configured" — they have no other state', () => {
+    renderTab();
+
+    expect(screen.queryByText('Configured')).not.toBeInTheDocument();
+  });
+
+  it('marks every retention window as data-destroying', () => {
+    renderTab();
+
+    for (const setting of DEFAULT_SETTINGS.metricsRetention) {
+      const row = screen.getByTestId(`setting-row-${setting.key}`);
+      expect(row).toHaveAttribute('data-risk', 'destructive');
+    }
+  });
+
+  it('hosts Edge Agent polling, which is infrastructure rather than an integration', () => {
+    renderTab();
+
+    expect(screen.getByText('Edge Agent')).toBeInTheDocument();
+    expect(screen.getByLabelText('Live Container Data')).toBeInTheDocument();
+  });
+
+  it('does not mark cache TTLs, which cost a cache miss and nothing else', () => {
+    renderTab();
+
+    for (const setting of DEFAULT_SETTINGS.cache) {
+      expect(screen.getByTestId(`setting-row-${setting.key}`)).not.toHaveAttribute('data-risk');
+    }
   });
 });

--- a/frontend/src/features/core/components/settings/tab-infrastructure.tsx
+++ b/frontend/src/features/core/components/settings/tab-infrastructure.tsx
@@ -9,11 +9,14 @@ import {
   Eye,
   EyeOff,
   HardDriveDownload,
+  Info,
   Loader2,
   RefreshCw,
   Trash2,
+  Wifi,
 } from 'lucide-react';
 import { SettingsSection, DEFAULT_SETTINGS, type SettingsTabProps } from './shared';
+import { useCacheClear } from '@/features/core/hooks/use-cache-admin';
 import {
   usePortainerBackups,
   useCreatePortainerBackup,
@@ -22,13 +25,17 @@ import {
   type PortainerBackupFile,
 } from '@/features/core/hooks/use-portainer-backups';
 import { DataTable } from '@/shared/components/tables/data-table';
+import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
 import { formatBytes } from '@/shared/lib/utils';
 import { toast } from 'sonner';
 
 export function InfrastructureTab({ editedValues, originalValues, onChange, isSaving }: SettingsTabProps) {
+  const cacheClear = useCacheClear();
+
   return (
     <div className="space-y-6">
-      {/* Cache Settings */}
+      {/* Cache Settings — the cache administration action lives with the cache
+          settings rather than on the tab an admin happens to land on. */}
       <SettingsSection
         title="Cache"
         icon={<Database className="h-5 w-5" />}
@@ -38,7 +45,27 @@ export function InfrastructureTab({ editedValues, originalValues, onChange, isSa
         originalValues={originalValues}
         onChange={onChange}
         disabled={isSaving}
-        status="configured"
+        footerContent={
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm text-muted-foreground">
+              Clearing drops every cached Portainer response. The next page load refetches from
+              Portainer directly, so expect one slower round of requests.
+            </p>
+            <button
+              type="button"
+              onClick={() => cacheClear.mutate()}
+              disabled={cacheClear.isPending}
+              className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent disabled:opacity-50"
+            >
+              {cacheClear.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              Clear All Cache
+            </button>
+          </div>
+        }
       />
 
       {/* Backup Schedule Settings */}
@@ -66,7 +93,19 @@ export function InfrastructureTab({ editedValues, originalValues, onChange, isSa
         originalValues={originalValues}
         onChange={onChange}
         disabled={isSaving}
-        status="configured"
+      />
+
+      {/* Edge Agent — how this dashboard polls the fleet, which is
+          infrastructure, not a third-party integration. */}
+      <SettingsSection
+        title="Edge Agent"
+        icon={<Wifi className="h-5 w-5" />}
+        category="edgeAgent"
+        settings={DEFAULT_SETTINGS.edgeAgent}
+        values={editedValues}
+        originalValues={originalValues}
+        onChange={onChange}
+        disabled={isSaving}
       />
 
       {/* Backup Management */}
@@ -82,6 +121,9 @@ export function PortainerBackupManagement() {
   const [manualPassword, setManualPassword] = useState('');
   const [showManualPassword, setShowManualPassword] = useState(false);
   const [deletingFile, setDeletingFile] = useState<string | null>(null);
+  // Deletion is permanent and there is no restore path from this screen, so the
+  // click only ever opens a confirmation naming the exact archive (#backup-delete-confirm).
+  const [pendingDelete, setPendingDelete] = useState<PortainerBackupFile | null>(null);
 
   const backups = data?.backups ?? [];
 
@@ -105,22 +147,26 @@ export function PortainerBackupManagement() {
     }
   }, []);
 
-  const handleDelete = useCallback(
-    (filename: string) => {
-      setDeletingFile(filename);
-      deleteBackupMut.mutate(filename, {
-        onSuccess: () => {
-          toast.success(`Deleted ${filename}`);
-          setDeletingFile(null);
-        },
-        onError: (err) => {
-          toast.error(`Delete failed: ${err.message}`);
-          setDeletingFile(null);
-        },
-      });
-    },
-    [deleteBackupMut],
-  );
+  const requestDelete = useCallback((backup: PortainerBackupFile) => {
+    setPendingDelete(backup);
+  }, []);
+
+  const confirmDelete = useCallback(() => {
+    if (!pendingDelete) return;
+    const filename = pendingDelete.filename;
+    setPendingDelete(null);
+    setDeletingFile(filename);
+    deleteBackupMut.mutate(filename, {
+      onSuccess: () => {
+        toast.success(`Deleted ${filename}`);
+        setDeletingFile(null);
+      },
+      onError: (err) => {
+        toast.error(`Delete failed: ${err.message}`);
+        setDeletingFile(null);
+      },
+    });
+  }, [deleteBackupMut, pendingDelete]);
 
   const columns = useMemo<ColumnDef<PortainerBackupFile, unknown>[]>(
     () => [
@@ -162,10 +208,10 @@ export function PortainerBackupManagement() {
                 Download
               </button>
               <button
-                onClick={() => handleDelete(backup.filename)}
+                onClick={() => requestDelete(backup)}
                 disabled={deletingFile === backup.filename}
                 className="flex items-center gap-1.5 rounded-md border border-destructive/30 bg-background px-2.5 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                title="Delete"
+                title={`Delete ${backup.filename}`}
               >
                 {deletingFile === backup.filename ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -179,7 +225,7 @@ export function PortainerBackupManagement() {
         },
       },
     ],
-    [handleDownload, handleDelete, deletingFile],
+    [handleDownload, requestDelete, deletingFile],
   );
 
   return (
@@ -196,6 +242,22 @@ export function PortainerBackupManagement() {
           <p className="text-sm text-muted-foreground">
             Create a manual backup of your Portainer server configuration. This calls the Portainer API and saves the resulting archive locally.
           </p>
+          {/* An operator must not discover the missing restore path during an outage. */}
+          <div
+            data-testid="backup-recovery-note"
+            className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3"
+          >
+            <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+            <div className="space-y-1 text-sm">
+              <p className="font-medium">This dashboard cannot restore a backup.</p>
+              <p className="text-muted-foreground">
+                Recovery is a Portainer operation: download the archive, then load it from a Portainer
+                instance&apos;s &quot;Restore from backup&quot; screen. Archives are written to the
+                dashboard&apos;s backup directory on this host — keep a copy elsewhere, or a host loss
+                takes the backups with it.
+              </p>
+            </div>
+          </div>
           <div className="flex items-end gap-3">
             <div className="flex-1 max-w-sm">
               <label htmlFor="manual-backup-password" className="text-sm font-medium mb-1 block">
@@ -276,6 +338,23 @@ export function PortainerBackupManagement() {
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
+        title="Delete this backup?"
+        description={
+          pendingDelete
+            ? `${pendingDelete.filename}, created ${new Date(pendingDelete.createdAt).toLocaleString()}. ` +
+              'The archive is removed from this host and cannot be recovered from Portainer. ' +
+              'Download it first if you are not certain.'
+            : ''
+        }
+        confirmLabel="Delete backup"
+        variant="danger"
+        data-testid="confirm-delete-backup"
+      />
     </div>
   );
 }

--- a/frontend/src/features/core/components/settings/tab-integrations.tsx
+++ b/frontend/src/features/core/components/settings/tab-integrations.tsx
@@ -9,7 +9,6 @@ import {
   Search,
   ShieldAlert,
   Webhook,
-  Wifi,
 } from 'lucide-react';
 import { SettingsSection, DEFAULT_SETTINGS, REDACTED_SECRET, type SettingsTabProps } from './shared';
 import { cn } from '@/shared/lib/utils';
@@ -54,31 +53,9 @@ export function IntegrationsTab({ editedValues, originalValues, onChange, isSavi
         disabled={isSaving}
       />
 
-      {/* Edge Agent Settings */}
-      <SettingsSection
-        title="Edge Agent"
-        icon={<Wifi className="h-5 w-5" />}
-        category="edgeAgent"
-        settings={DEFAULT_SETTINGS.edgeAgent}
-        values={editedValues}
-        originalValues={originalValues}
-        onChange={onChange}
-        disabled={isSaving}
-      />
-
-      {/* Status Page Settings */}
-      <SettingsSection
-        title="Public Status Page"
-        icon={<Globe className="h-5 w-5" />}
-        category="statusPage"
-        settings={DEFAULT_SETTINGS.statusPage}
-        values={editedValues}
-        originalValues={originalValues}
-        onChange={onChange}
-        disabled={isSaving}
-        status={editedValues['status.page.enabled'] === 'true' ? 'configured' : 'not-configured'}
-        statusLabel={editedValues['status.page.enabled'] === 'true' ? 'Enabled' : 'Disabled'}
-      />
+      {/* Edge Agent moved to Infrastructure — it tunes how the dashboard polls
+          the fleet, not a third-party integration. Public Status Page moved to
+          Security — it is unauthenticated external exposure. */}
     </div>
   );
 }

--- a/frontend/src/features/core/components/settings/tab-security.test.tsx
+++ b/frontend/src/features/core/components/settings/tab-security.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+
+vi.mock('@/features/security/hooks/use-security-audit', () => ({
+  useSecurityIgnoreList: () => ({
+    data: { patterns: [], defaults: [] },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useUpdateSecurityIgnoreList: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/features/core/hooks/use-oidc', () => ({
+  useOIDCEffectiveRedirectUri: () => ({ data: { source: 'none', redirectUri: '' } }),
+}));
+
+vi.mock('@/features/core/hooks/use-discovered-oidc-groups', () => ({
+  useDiscoveredOidcGroups: () => ({ data: undefined }),
+}));
+
+vi.mock('@/providers/auth-provider', () => ({
+  useAuth: () => ({ role: 'admin' }),
+}));
+
+// The users panel is a lazily loaded page of its own; it is not under test here.
+vi.mock('@/features/core/pages/users', () => ({
+  UsersPanel: () => <div data-testid="users-panel" />,
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { SecurityTab } from './tab-security';
+import { DEFAULT_SETTINGS } from './shared';
+
+function renderTab() {
+  const values: Record<string, string> = {};
+  Object.values(DEFAULT_SETTINGS).flat().forEach((s) => { values[s.key] = s.defaultValue; });
+  return render(
+    <SecurityTab
+      editedValues={values}
+      originalValues={values}
+      onChange={vi.fn()}
+      isSaving={false}
+    />,
+  );
+}
+
+describe('SecurityTab', () => {
+  it('hosts the public status page — unauthenticated exposure is a security decision', async () => {
+    renderTab();
+
+    expect(screen.getByText('Public Status Page')).toBeInTheDocument();
+    const row = screen.getByTestId('setting-row-status.page.enabled');
+    expect(row).toHaveAttribute('data-risk', 'security');
+    expect(row).toHaveTextContent(/no sign-in/i);
+    await waitFor(() => expect(screen.getByTestId('users-panel')).toBeInTheDocument());
+  });
+
+  it('says whether the status page is published, not whether it is "configured"', () => {
+    renderTab();
+
+    expect(screen.getByText('Not published')).toBeInTheDocument();
+  });
+
+  it('marks the plaintext-OIDC toggle as security-risk and states the consequence', () => {
+    renderTab();
+
+    const row = screen.getByTestId('setting-row-oidc.allow_insecure_transport');
+    expect(row).toHaveAttribute('data-risk', 'security');
+    expect(within(row).getByText('Security')).toBeInTheDocument();
+    expect(row).toHaveTextContent(/capture and replay them/i);
+    // The toggle still defaults off — presentation changed, the default did not.
+    expect(within(row).getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('no longer buries the danger in a glyph inside muted body copy', () => {
+    renderTab();
+
+    const row = screen.getByTestId('setting-row-oidc.allow_insecure_transport');
+    expect(row.textContent).not.toContain('⚠');
+  });
+});

--- a/frontend/src/features/core/components/settings/tab-security.tsx
+++ b/frontend/src/features/core/components/settings/tab-security.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
-import { Info, Loader2, Shield } from 'lucide-react';
+import { Globe, Info, Loader2, Shield } from 'lucide-react';
 import { useSecurityIgnoreList, useUpdateSecurityIgnoreList } from '@/features/security/hooks/use-security-audit';
 import { useOIDCEffectiveRedirectUri } from '@/features/core/hooks/use-oidc';
 import { useAuth } from '@/providers/auth-provider';
@@ -77,6 +77,22 @@ export function SecurityTab({ editedValues, originalValues, onChange, isSaving }
           discoveredGroups={discoveredGroups}
         />
       )}
+
+      {/* Public Status Page — unauthenticated external exposure, so it belongs
+          with the other decisions about who can reach this dashboard rather
+          than filed under third-party integrations. */}
+      <SettingsSection
+        title="Public Status Page"
+        icon={<Globe className="h-5 w-5" />}
+        category="statusPage"
+        settings={DEFAULT_SETTINGS.statusPage}
+        values={editedValues}
+        originalValues={originalValues}
+        onChange={onChange}
+        disabled={isSaving}
+        status={editedValues['status.page.enabled'] === 'true' ? 'configured' : 'not-configured'}
+        statusLabel={editedValues['status.page.enabled'] === 'true' ? 'Public' : 'Not published'}
+      />
 
       {/* Security Audit Ignore List */}
       <SecurityAuditSettingsSection />

--- a/frontend/src/features/core/lib/navigation-manifest.test.ts
+++ b/frontend/src/features/core/lib/navigation-manifest.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest';
+import type { RouteObject } from 'react-router-dom';
+import { appRoutes } from '@/router';
+import {
+  navDestinations,
+  palettePages,
+  sidebarNavigation,
+  pinnedNavDestinations,
+  mobilePrimaryDestinations,
+  mobileDrawerDestinations,
+  mobileLabel,
+  breadcrumbLabelForPath,
+  closestDestination,
+  findDestination,
+  BREADCRUMB_ONLY_LABELS,
+  ROUTES_WITHOUT_NAV_ENTRY,
+  NAV_GROUP_ORDER,
+} from './navigation-manifest';
+
+/**
+ * The route list used to live in four hand-maintained copies (sidebar,
+ * header breadcrumb, command palette, mobile bottom nav) and they drifted:
+ * 7 routes rendered "Dashboard / Dashboard", 5 were missing from the command
+ * palette, 6 were unreachable from a phone. These tests exist so that drift
+ * fails the build rather than shipping.
+ */
+
+function join(parent: string, segment: string): string {
+  if (segment.startsWith('/')) return segment;
+  const base = parent === '/' ? '' : parent;
+  return `${base}/${segment}`;
+}
+
+function collectRoutePaths(routes: RouteObject[], parent = ''): string[] {
+  const out: string[] = [];
+  for (const route of routes) {
+    const full = route.index ? parent || '/' : join(parent, route.path ?? '');
+    if (route.index || route.path !== undefined) out.push(full);
+    if (route.children) out.push(...collectRoutePaths(route.children, full));
+  }
+  return out;
+}
+
+/** Concrete, linkable paths — no `:params`, no `*` splat. */
+const concreteRoutePaths = Array.from(
+  new Set(
+    collectRoutePaths(appRoutes).filter((p) => !p.includes(':') && !p.includes('*')),
+  ),
+);
+
+const manifestPaths = navDestinations.map((d) => d.path);
+
+describe('navigation manifest — route coverage', () => {
+  it('the router exposes the routes we expect to cover', () => {
+    // Guards the walker itself: if this drops to a handful of paths the
+    // coverage assertions below would pass vacuously.
+    expect(concreteRoutePaths.length).toBeGreaterThan(20);
+    expect(concreteRoutePaths).toContain('/');
+    expect(concreteRoutePaths).toContain('/logs');
+    expect(concreteRoutePaths).toContain('/security/vulnerabilities');
+  });
+
+  it('every reachable route has a manifest entry, a breadcrumb label, or a documented exemption', () => {
+    const uncovered = concreteRoutePaths.filter(
+      (path) =>
+        !manifestPaths.includes(path) &&
+        !(path in BREADCRUMB_ONLY_LABELS) &&
+        !(path in ROUTES_WITHOUT_NAV_ENTRY),
+    );
+    expect(uncovered).toEqual([]);
+  });
+
+  it('every manifest entry points at a route that actually exists', () => {
+    const dangling = manifestPaths.filter((path) => !concreteRoutePaths.includes(path));
+    expect(dangling).toEqual([]);
+  });
+
+  it('every navigable route resolves to a breadcrumb label — never the generic "Dashboard"', () => {
+    const navigable = concreteRoutePaths.filter((p) => !(p in ROUTES_WITHOUT_NAV_ENTRY));
+    for (const path of navigable) {
+      const label = breadcrumbLabelForPath(path);
+      expect(label, `no breadcrumb label for ${path}`).toBeTruthy();
+      expect(label, `${path} still falls through to the generic label`).not.toBe('Dashboard');
+    }
+  });
+
+  it('resolves nested routes to their section label', () => {
+    expect(breadcrumbLabelForPath('/containers/1/abc123')).toBe('Workloads');
+    expect(breadcrumbLabelForPath('/investigations/42')).toBe('Investigation');
+    expect(breadcrumbLabelForPath('/security/audit')).toBe('Security Audit');
+  });
+
+  it('returns null for a genuinely unknown path instead of inventing one', () => {
+    expect(breadcrumbLabelForPath('/does-not-exist')).toBeNull();
+  });
+});
+
+describe('navigation manifest — entry integrity', () => {
+  it('gives every entry a non-empty label', () => {
+    for (const destination of navDestinations) {
+      expect(destination.label.trim(), `empty label for ${destination.path}`).not.toBe('');
+    }
+  });
+
+  it('has no duplicate paths', () => {
+    expect(new Set(manifestPaths).size).toBe(manifestPaths.length);
+  });
+
+  it('resolves each entry back to its own label', () => {
+    for (const destination of navDestinations) {
+      expect(breadcrumbLabelForPath(destination.path)).toBe(destination.label);
+    }
+  });
+
+  it('gives every entry an icon', () => {
+    for (const destination of navDestinations) {
+      expect(destination.icon, `no icon for ${destination.path}`).toBeTruthy();
+    }
+  });
+});
+
+describe('navigation manifest — the three lists cannot drift', () => {
+  it('offers every destination in the command palette', () => {
+    const palettePaths = palettePages.map((p) => p.path);
+    for (const destination of navDestinations) {
+      expect(palettePaths, `${destination.path} is missing from ⌘K`).toContain(destination.path);
+    }
+  });
+
+  it('includes the on-call destinations that ⌘K used to omit', () => {
+    const palettePaths = palettePages.map((p) => p.path);
+    for (const path of [
+      '/logs',
+      '/packet-capture',
+      '/ebpf-coverage',
+      '/reports',
+      '/security/vulnerabilities',
+    ]) {
+      expect(palettePaths).toContain(path);
+    }
+  });
+
+  it('renders every non-shortcut destination in the sidebar', () => {
+    const groups = sidebarNavigation({ harborEnabled: true });
+    const sidebarPaths = [
+      ...groups.flatMap((g) => g.items.map((i) => i.path)),
+      ...pinnedNavDestinations.map((i) => i.path),
+    ];
+    for (const destination of navDestinations) {
+      if (destination.paletteOnly) {
+        expect(sidebarPaths).not.toContain(destination.path);
+      } else {
+        expect(sidebarPaths, `${destination.path} is missing from the sidebar`).toContain(
+          destination.path,
+        );
+      }
+    }
+  });
+
+  it('reaches every non-shortcut destination from the mobile nav', () => {
+    const mobilePaths = [
+      ...mobilePrimaryDestinations.map((d) => d.path),
+      ...mobileDrawerDestinations({ harborEnabled: true }).map((d) => d.path),
+    ];
+    for (const destination of navDestinations) {
+      if (destination.paletteOnly) continue;
+      expect(mobilePaths, `${destination.path} is unreachable on mobile`).toContain(
+        destination.path,
+      );
+    }
+  });
+
+  it('keeps the sidebar and the palette using the same words for the same route', () => {
+    const groups = sidebarNavigation({ harborEnabled: true });
+    for (const group of groups) {
+      for (const item of group.items) {
+        const paletteEntry = palettePages.find((p) => p.path === item.path);
+        expect(paletteEntry?.label).toBe(item.label);
+      }
+    }
+  });
+
+  it('never puts a destination in both the mobile bar and the drawer', () => {
+    const primary = mobilePrimaryDestinations.map((d) => d.path);
+    const drawer = mobileDrawerDestinations({ harborEnabled: true }).map((d) => d.path);
+    expect(primary.filter((p) => drawer.includes(p))).toEqual([]);
+  });
+});
+
+describe('navigation manifest — grouping and gating', () => {
+  it('renders the intent-based groups in order, none empty', () => {
+    const groups = sidebarNavigation({ harborEnabled: true });
+    expect(groups.map((g) => g.title)).toEqual([...NAV_GROUP_ORDER]);
+    for (const group of groups) {
+      expect(group.items.length, `${group.title} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('hides Harbor vulnerabilities until Harbor is configured', () => {
+    const gated = sidebarNavigation({ harborEnabled: false })
+      .flatMap((g) => g.items)
+      .map((i) => i.path);
+    expect(gated).not.toContain('/security/vulnerabilities');
+
+    const drawer = mobileDrawerDestinations({ harborEnabled: false }).map((d) => d.path);
+    expect(drawer).not.toContain('/security/vulnerabilities');
+  });
+
+  it('pins Settings outside the themed groups', () => {
+    expect(pinnedNavDestinations.map((d) => d.path)).toEqual(['/settings']);
+    const grouped = sidebarNavigation({ harborEnabled: true }).flatMap((g) => g.items);
+    expect(grouped.map((i) => i.path)).not.toContain('/settings');
+  });
+
+  it('adopts the shorter mobile names as the single name everywhere', () => {
+    expect(findDestination('/workloads')?.label).toBe('Workloads');
+    expect(findDestination('/images')?.label).toBe('Images');
+    expect(findDestination('/topology')?.label).toBe('Topology');
+    expect(findDestination('/traces')?.label).toBe('Traces');
+    expect(findDestination('/assistant')?.label).toBe('Assistant');
+    expect(findDestination('/edge-logs')?.label).toBe('Edge Logs');
+  });
+
+  it('uses compact labels only in the four-slot mobile bar', () => {
+    expect(mobilePrimaryDestinations).toHaveLength(4);
+    expect(mobileLabel(findDestination('/health')!)).toBe('Health');
+    expect(mobileLabel(findDestination('/metrics')!)).toBe('Metrics');
+    // Everything without a shortLabel falls back to the one name.
+    expect(mobileLabel(findDestination('/workloads')!)).toBe('Workloads');
+  });
+});
+
+describe('closestDestination', () => {
+  it('suggests the nearest route for a near-miss URL', () => {
+    expect(closestDestination('/workload')?.path).toBe('/workloads');
+    expect(closestDestination('/log')?.path).toBe('/logs');
+    expect(closestDestination('/security')?.path).toMatch(/^\/security\//);
+  });
+
+  it('tolerates a one-character slip in a bookmarked URL', () => {
+    expect(closestDestination('/workloadz')?.path).toBe('/workloads');
+  });
+
+  it('matches on the label as well as the path', () => {
+    expect(closestDestination('/vulnerabilities')?.path).toBe('/security/vulnerabilities');
+  });
+
+  it('returns null when nothing is close', () => {
+    expect(closestDestination('/zzzzzzzz')).toBeNull();
+  });
+});

--- a/frontend/src/features/core/lib/navigation-manifest.ts
+++ b/frontend/src/features/core/lib/navigation-manifest.ts
@@ -315,3 +315,28 @@ export function closestDestination(pathname: string): NavDestination | null {
   }
   return best ? best.destination : null;
 }
+
+/**
+ * `g`-chord key assignments, paired with the manifest path they jump to.
+ *
+ * Lives here rather than in the layout so that anything needing to *label* a
+ * chord (the keyboard-shortcuts overlay) can read it without importing the
+ * layout that renders that overlay. Declaring it in app-layout.tsx created
+ * exactly that cycle, and `NAV_CHORDS` resolved to `undefined` at module-init
+ * time whenever the graph was entered through the router.
+ */
+export const NAV_CHORDS: ReadonlyArray<readonly [string, string]> = [
+  ['gh', '/'],
+  ['gw', '/workloads'],
+  ['gf', '/infrastructure'],
+  ['gl', '/health'],
+  ['gi', '/images'],
+  ['gn', '/topology'],
+  ['gm', '/metrics'],
+  ['gr', '/remediation'],
+  ['ge', '/traces'],
+  ['gx', '/assistant'],
+  ['go', '/edge-logs'],
+  ['gv', '/logs'],
+  ['gs', '/settings'],
+];

--- a/frontend/src/features/core/lib/navigation-manifest.ts
+++ b/frontend/src/features/core/lib/navigation-manifest.ts
@@ -1,0 +1,317 @@
+import type { ComponentType } from 'react';
+import {
+  LayoutDashboard,
+  Boxes,
+  Server,
+  PackageOpen,
+  HeartPulse,
+  BarChart3,
+  MessageSquare,
+  Activity,
+  GitBranch,
+  Bug,
+  Network,
+  Radio,
+  ScrollText,
+  FileSearch,
+  Shield,
+  ShieldAlert,
+  FileBarChart,
+  Settings,
+  Webhook,
+  Users,
+} from 'lucide-react';
+
+/**
+ * The one route registry.
+ *
+ * The sidebar, the header breadcrumb, the command palette and the mobile
+ * bottom nav all derive their destination lists from this file. They used to
+ * keep four hand-maintained copies, which drifted: seven routes had no
+ * breadcrumb label and rendered "Dashboard / Dashboard", five were missing
+ * from the command palette, and six (including the whole Security group and
+ * the Log Viewer) were unreachable on a phone.
+ *
+ * Adding a route means adding it here — or, if it deliberately has no
+ * navigation entry, listing it in `BREADCRUMB_ONLY_LABELS` or
+ * `ROUTES_WITHOUT_NAV_ENTRY` with a reason. `navigation-manifest.test.ts`
+ * walks the real router and fails if a route matches none of the three.
+ */
+
+/** Sidebar groups, in the order they are rendered. */
+export const NAV_GROUP_ORDER = [
+  'Overview',
+  'Monitoring',
+  'Intelligence',
+  'Diagnostics',
+  'Security',
+  'Operations',
+] as const;
+
+export type NavGroupTitle = (typeof NAV_GROUP_ORDER)[number];
+
+/**
+ * `Pinned` sits at the foot of the sidebar outside the themed groups;
+ * `Shortcuts` never appears in a nav surface at all — those entries are
+ * command-palette-only jumps to a redirect route.
+ */
+export type NavSection = NavGroupTitle | 'Pinned' | 'Shortcuts';
+
+/** Feature flags that can hide a destination entirely. */
+export type NavFeatureGate = 'harbor';
+
+export interface NavDestination {
+  /** Absolute path, exactly as registered in `router.tsx`. */
+  path: string;
+  /**
+   * The single name for this destination. Used by the sidebar, the
+   * breadcrumb, the command palette and the mobile drawer alike — the app
+   * previously used three different names for several routes.
+   */
+  label: string;
+  /**
+   * Compact label for the five-slot mobile bottom bar only, where a long
+   * label truncates below legibility. Everything else uses `label`.
+   */
+  shortLabel?: string;
+  section: NavSection;
+  icon: ComponentType<{ className?: string }>;
+  /**
+   * Reachable from the command palette only. These paths are redirects into
+   * a Settings tab, not pages with their own chrome, so they must not appear
+   * in the sidebar or the mobile nav.
+   */
+  paletteOnly?: boolean;
+  /** Hidden from every surface unless the named integration is configured. */
+  featureGate?: NavFeatureGate;
+  /** Occupies one of the four primary slots in the mobile bottom bar. */
+  mobilePrimary?: boolean;
+}
+
+/**
+ * Grouped by operator intent: what's running -> is it healthy -> ask the AI ->
+ * why -> security posture -> act. Remediation is the one mutating workflow and
+ * lives alone under Operations to keep the observer-first separation between
+ * looking and acting. Settings is pinned separately (section `Pinned`).
+ */
+export const navDestinations: readonly NavDestination[] = [
+  // Overview
+  { path: '/', label: 'Home', section: 'Overview', icon: LayoutDashboard, mobilePrimary: true },
+  { path: '/workloads', label: 'Workloads', section: 'Overview', icon: Boxes, mobilePrimary: true },
+  { path: '/infrastructure', label: 'Infrastructure', section: 'Overview', icon: Server },
+  { path: '/images', label: 'Images', section: 'Overview', icon: PackageOpen },
+
+  // Monitoring
+  {
+    path: '/health',
+    label: 'Health & Monitoring',
+    shortLabel: 'Health',
+    section: 'Monitoring',
+    icon: HeartPulse,
+    mobilePrimary: true,
+  },
+  {
+    path: '/metrics',
+    label: 'Metrics Dashboard',
+    shortLabel: 'Metrics',
+    section: 'Monitoring',
+    icon: BarChart3,
+    mobilePrimary: true,
+  },
+
+  // Intelligence
+  { path: '/assistant', label: 'Assistant', section: 'Intelligence', icon: MessageSquare },
+  { path: '/llm-observability', label: 'LLM Observability', section: 'Intelligence', icon: Activity },
+
+  // Diagnostics
+  { path: '/traces', label: 'Traces', section: 'Diagnostics', icon: GitBranch },
+  { path: '/ebpf-coverage', label: 'eBPF Coverage', section: 'Diagnostics', icon: Bug },
+  { path: '/topology', label: 'Topology', section: 'Diagnostics', icon: Network },
+  { path: '/packet-capture', label: 'Packet Capture', section: 'Diagnostics', icon: Radio },
+  { path: '/logs', label: 'Log Viewer', section: 'Diagnostics', icon: ScrollText },
+  { path: '/edge-logs', label: 'Edge Logs', section: 'Diagnostics', icon: FileSearch },
+
+  // Security
+  { path: '/security/audit', label: 'Security Audit', section: 'Security', icon: Shield },
+  {
+    path: '/security/vulnerabilities',
+    label: 'Vulnerabilities',
+    section: 'Security',
+    icon: ShieldAlert,
+    featureGate: 'harbor',
+  },
+
+  // Operations
+  { path: '/remediation', label: 'Remediation', section: 'Operations', icon: Shield },
+  { path: '/reports', label: 'Reports', section: 'Operations', icon: FileBarChart },
+
+  // Pinned at the foot of the sidebar
+  { path: '/settings', label: 'Settings', section: 'Pinned', icon: Settings },
+
+  // Command-palette-only redirect shortcuts into Settings tabs
+  { path: '/webhooks', label: 'Webhooks', section: 'Shortcuts', icon: Webhook, paletteOnly: true },
+  { path: '/users', label: 'Users', section: 'Shortcuts', icon: Users, paletteOnly: true },
+];
+
+/**
+ * Routes with no navigation entry that still need a breadcrumb. Reached from
+ * inside another page rather than from the nav.
+ */
+export const BREADCRUMB_ONLY_LABELS: Readonly<Record<string, string>> = {
+  '/backups': 'Backups',
+  '/containers': 'Workloads',
+  '/investigations': 'Investigation',
+};
+
+/**
+ * Routes that deliberately have neither a nav entry nor a breadcrumb, with the
+ * reason. The manifest test fails on any router path that is in none of the
+ * three registries, so a new route cannot be added without a decision here.
+ */
+export const ROUTES_WITHOUT_NAV_ENTRY: Readonly<Record<string, string>> = {
+  '/login': 'Unauthenticated, rendered outside AppLayout',
+  '/auth/callback': 'OIDC hand-off, redirects immediately',
+  '/status': 'Public status page, rendered outside AppLayout',
+  '/fleet': 'Alias, redirects to /infrastructure?tab=fleet',
+  '/stacks': 'Alias, redirects to /infrastructure?tab=stacks',
+  '/ai-monitor': 'Alias, redirects to /health',
+  '/comparison': 'Redirect shim into /workloads with a comparison selection',
+};
+
+// --- Derived views -------------------------------------------------------
+
+export interface NavGroup {
+  title: NavGroupTitle;
+  items: NavDestination[];
+}
+
+function passesGate(
+  destination: NavDestination,
+  enabledFeatures: { harborEnabled?: boolean },
+): boolean {
+  if (destination.featureGate === 'harbor') return enabledFeatures.harborEnabled === true;
+  return true;
+}
+
+/** Sidebar groups, in order, with feature-gated destinations removed. */
+export function sidebarNavigation(
+  enabledFeatures: { harborEnabled?: boolean } = {},
+): NavGroup[] {
+  return NAV_GROUP_ORDER.map((title) => ({
+    title,
+    items: navDestinations.filter(
+      (d) => d.section === title && passesGate(d, enabledFeatures),
+    ),
+  }));
+}
+
+/** Destinations pinned below the sidebar groups (Settings). */
+export const pinnedNavDestinations: readonly NavDestination[] = navDestinations.filter(
+  (d) => d.section === 'Pinned',
+);
+
+/**
+ * Every destination the command palette offers, including the palette-only
+ * Settings shortcuts. Feature-gated entries stay listed: the palette is a
+ * search surface, and a gated page still renders its own not-configured state.
+ */
+export const palettePages: readonly NavDestination[] = navDestinations;
+
+/** The four destinations promoted to the mobile bottom bar. */
+export const mobilePrimaryDestinations: readonly NavDestination[] = navDestinations.filter(
+  (d) => d.mobilePrimary,
+);
+
+/**
+ * Everything else, for the mobile "More" drawer. The drawer is a scrollable
+ * grid — there is no reason for this list to be curated, and curating it is
+ * what left the entire Security group unreachable from a phone.
+ */
+export function mobileDrawerDestinations(
+  enabledFeatures: { harborEnabled?: boolean } = {},
+): NavDestination[] {
+  return navDestinations.filter(
+    (d) => !d.mobilePrimary && !d.paletteOnly && passesGate(d, enabledFeatures),
+  );
+}
+
+/** The label the mobile bottom bar shows (compact where one is defined). */
+export function mobileLabel(destination: NavDestination): string {
+  return destination.shortLabel ?? destination.label;
+}
+
+const destinationByPath = new Map(navDestinations.map((d) => [d.path, d]));
+
+export function findDestination(pathname: string): NavDestination | undefined {
+  return destinationByPath.get(pathname);
+}
+
+/**
+ * The breadcrumb label for a pathname: exact match first, then the longest
+ * registered prefix so nested routes (`/containers/1/abc`,
+ * `/investigations/42`) still name their section. Returns `null` when the
+ * path is genuinely unknown — callers must not substitute a generic word,
+ * which is how "Dashboard / Dashboard" happened.
+ */
+export function breadcrumbLabelForPath(pathname: string): string | null {
+  const exact = destinationByPath.get(pathname);
+  if (exact) return exact.label;
+  if (BREADCRUMB_ONLY_LABELS[pathname]) return BREADCRUMB_ONLY_LABELS[pathname];
+
+  const candidates: Array<[string, string]> = [
+    ...navDestinations.map((d): [string, string] => [d.path, d.label]),
+    ...Object.entries(BREADCRUMB_ONLY_LABELS),
+  ];
+
+  let best: [string, string] | null = null;
+  for (const candidate of candidates) {
+    const [prefix] = candidate;
+    if (prefix === '/') continue;
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      if (!best || prefix.length > best[0].length) best = candidate;
+    }
+  }
+  return best ? best[1] : null;
+}
+
+/**
+ * Best guess at what an operator meant when a URL does not resolve — used by
+ * the 404 page so a stale bookmark points somewhere instead of silently
+ * becoming Home. Scores on shared path segments, then on substring overlap.
+ */
+function sharedPrefixLength(a: string, b: string): number {
+  const max = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < max && a[i] === b[i]) i += 1;
+  return i;
+}
+
+export function closestDestination(pathname: string): NavDestination | null {
+  const wanted = pathname.toLowerCase().split('/').filter(Boolean);
+  if (wanted.length === 0) return null;
+
+  let best: { destination: NavDestination; score: number } | null = null;
+  for (const destination of navDestinations) {
+    if (destination.path === '/') continue;
+    const segments = destination.path.toLowerCase().split('/').filter(Boolean);
+    let score = 0;
+    for (const segment of segments) {
+      for (const term of wanted) {
+        if (segment === term) score += 10;
+        else if (segment.startsWith(term) || term.startsWith(segment)) score += 5;
+        else if (segment.includes(term) || term.includes(segment)) score += 3;
+        // Tolerate a one-character slip in a bookmarked URL.
+        else if (sharedPrefixLength(segment, term) >= 4) score += 2;
+      }
+    }
+    const labelTerms = destination.label.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+    for (const labelTerm of labelTerms) {
+      for (const term of wanted) {
+        if (labelTerm === term) score += 4;
+        else if (labelTerm.startsWith(term) && term.length >= 3) score += 2;
+      }
+    }
+    if (score > 0 && (!best || score > best.score)) best = { destination, score };
+  }
+  return best ? best.destination : null;
+}

--- a/frontend/src/features/core/pages/auth-callback.test.tsx
+++ b/frontend/src/features/core/pages/auth-callback.test.tsx
@@ -176,4 +176,37 @@ describe('AuthCallbackPage', () => {
       });
     });
   });
+
+  describe('failure affordances', () => {
+    it('announces the failure via role="alert", matching the sign-in form', async () => {
+      mockApiPost.mockRejectedValue(new Error('OIDC exchange failed'));
+
+      renderPage('?code=c&state=s');
+
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent('OIDC exchange failed');
+      expect(alert).toBe(screen.getByTestId('auth-callback-error'));
+    });
+
+    /** Nobody should have to sit out a three-second timer to get back to a form. */
+    it('offers an immediate way back to sign-in instead of only the 3s bounce', async () => {
+      renderPage('?error=access_denied&error_description=User%20cancelled');
+
+      const link = screen.getByRole('link', { name: 'Back to sign-in' });
+      expect(link).toHaveAttribute('href', '/login');
+      expect(screen.getByText(/Redirecting to login/i)).toBeInTheDocument();
+    });
+
+    it('cancels the pending redirect when the page unmounts', async () => {
+      vi.useFakeTimers();
+      const { unmount } = renderPage('?state=only-state');
+
+      expect(screen.getByText(/Missing authorization code or state/i)).toBeInTheDocument();
+
+      unmount();
+      vi.advanceTimersByTime(3000);
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/features/core/pages/auth-callback.tsx
+++ b/frontend/src/features/core/pages/auth-callback.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { api } from '@/shared/lib/api';
 import { useAuth } from '@/features/core/hooks/use-auth';
+
+/** How long the failure is left on screen before the automatic bounce to /login. */
+const REDIRECT_DELAY_MS = 3000;
 
 export default function AuthCallbackPage() {
   const [searchParams] = useSearchParams();
@@ -15,16 +18,30 @@ export default function AuthCallbackPage() {
     const errorParam = searchParams.get('error');
     const errorDescription = searchParams.get('error_description');
 
+    // Owned by this effect run, so a re-run or an unmount cancels it. Without
+    // the cleanup a torn-down page could still navigate three seconds later.
+    let redirectTimer: number | null = null;
+    const scheduleRedirect = () => {
+      redirectTimer = window.setTimeout(
+        () => navigate('/login', { replace: true }),
+        REDIRECT_DELAY_MS,
+      );
+    };
+
     if (errorParam) {
       setError(errorDescription || errorParam);
-      setTimeout(() => navigate('/login', { replace: true }), 3000);
-      return;
+      scheduleRedirect();
+      return () => {
+        if (redirectTimer !== null) window.clearTimeout(redirectTimer);
+      };
     }
 
     if (!code || !state) {
       setError('Missing authorization code or state');
-      setTimeout(() => navigate('/login', { replace: true }), 3000);
-      return;
+      scheduleRedirect();
+      return () => {
+        if (redirectTimer !== null) window.clearTimeout(redirectTimer);
+      };
     }
 
     async function exchangeCode() {
@@ -38,23 +55,40 @@ export default function AuthCallbackPage() {
         navigate('/', { replace: true });
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Authentication failed');
-        setTimeout(() => navigate('/login', { replace: true }), 3000);
+        scheduleRedirect();
       }
     }
 
     exchangeCode();
+
+    return () => {
+      if (redirectTimer !== null) window.clearTimeout(redirectTimer);
+    };
   }, [searchParams, navigate, loginWithToken]);
 
   if (error) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background px-4">
         <div className="w-full max-w-sm rounded-lg border bg-card p-8 shadow-lg text-center">
-          <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive mb-4">
+          {/* Matches the sign-in form: a failure has to reach a screen reader. */}
+          <div
+            role="alert"
+            data-testid="auth-callback-error"
+            className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive mb-4"
+          >
             {error}
           </div>
           <p className="text-sm text-muted-foreground">
             Redirecting to login...
           </p>
+          {/* The 3s bounce stays, but nobody has to sit through it. */}
+          <Link
+            to="/login"
+            replace
+            className="mt-3 inline-block text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Back to sign-in
+          </Link>
         </div>
       </div>
     );
@@ -63,8 +97,11 @@ export default function AuthCallbackPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm rounded-lg border bg-card p-8 shadow-lg text-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4" />
-        <p className="text-sm text-muted-foreground">
+        <div
+          className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"
+          aria-hidden="true"
+        />
+        <p className="text-sm text-muted-foreground" role="status">
           Completing sign-in...
         </p>
       </div>

--- a/frontend/src/features/core/pages/home.test.tsx
+++ b/frontend/src/features/core/pages/home.test.tsx
@@ -42,8 +42,21 @@ vi.mock('@/features/containers/hooks/use-endpoints', () => ({
   useEndpoints: () => ({ data: [] }),
 }));
 
+// Captures the `onTick` the page passes so a test can assert the refresh
+// dropdown actually schedules fetches (the hook owns the timer since #phase-1).
+const capturedAutoRefresh: { onTick?: () => void } = {};
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn(), enabled: true, toggle: vi.fn() }),
+  useAutoRefresh: (_default?: number, opts?: { onTick?: () => void }) => {
+    capturedAutoRefresh.onTick = opts?.onTick;
+    return {
+      interval: 30,
+      setRefreshInterval: vi.fn(),
+      setInterval: vi.fn(),
+      enabled: true,
+      toggle: vi.fn(),
+      options: [0, 15, 30, 60, 120, 300],
+    };
+  },
 }));
 
 vi.mock('@/shared/hooks/use-force-refresh', () => ({
@@ -178,12 +191,14 @@ function renderPage() {
 describe('HomePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    capturedAutoRefresh.onTick = undefined;
     // Default: containers query is idle / empty. Individual tests override
     // this when they need a specific fleet shape (e.g. 9 healthy / 1 unhealthy).
     mockUseContainers.mockReturnValue({
       data: [],
       isLoading: false,
       isError: false,
+      refetch: vi.fn(),
     } as any);
   });
 
@@ -245,7 +260,7 @@ describe('HomePage', () => {
     expect(within(hero).getByText('Security Findings')).toBeInTheDocument();
   });
 
-  it('navigates to the security audit when the Security Findings tile is clicked', () => {
+  it('renders the Security Findings tile as a real link to the audit page', () => {
     mockUseDashboardFull.mockReturnValue({
       data: makeDashboardData(),
       isLoading: false,
@@ -257,8 +272,36 @@ describe('HomePage', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: /Security Findings/i }));
-    expect(mockNavigate).toHaveBeenCalledWith('/security/audit');
+    // Was an onClick-only div-ish button: no href, no middle-click, no
+    // "open in new tab", and indistinguishable from the five dead tiles.
+    expect(screen.getByTestId('fleet-tile-link-Security Findings')).toHaveAttribute(
+      'href',
+      '/security/audit',
+    );
+  });
+
+  it('links the Stopped tile into a filtered Workload Explorer', () => {
+    mockUseDashboardFull.mockReturnValue({
+      data: makeDashboardData(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+    mockUseContainers.mockReturnValue({
+      data: [makeContainer({ id: 'e1', name: 'e1', state: 'exited' })],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    renderPage();
+
+    expect(screen.getByTestId('fleet-tile-link-Stopped')).toHaveAttribute(
+      'href',
+      '/workloads?state=exited',
+    );
   });
 
   it('does not render Recent Containers section (#801)', () => {
@@ -308,7 +351,7 @@ describe('HomePage', () => {
     expect(screen.queryByText('Endpoints')).not.toBeInTheDocument();
   });
 
-  it('renders the Overall Health Score with 9 healthy / 1 unhealthy (green)', () => {
+  it('leads with a needs-attention count and keeps the pass rate secondary', () => {
     mockUseDashboardFull.mockReturnValue({
       data: makeDashboardData(),
       isLoading: false,
@@ -318,7 +361,6 @@ describe('HomePage', () => {
       isFetching: false,
     } as any);
 
-    // 9 healthy + 1 unhealthy → score = 90.0% → green band (>= 80%)
     const healthy = Array.from({ length: 9 }, (_, i) =>
       makeContainer({ id: `h${i}`, name: `h${i}`, healthStatus: 'healthy' }),
     );
@@ -327,18 +369,19 @@ describe('HomePage', () => {
       data: [...healthy, ...unhealthy],
       isLoading: false,
       isError: false,
+      refetch: vi.fn(),
     } as any);
 
     renderPage();
 
     expect(screen.getByTestId('health-score-card')).toBeInTheDocument();
-    expect(screen.getByTestId('health-score')).toHaveTextContent('90.0%');
-    // ≥80% renders the green CheckCircle2 icon.
-    expect(screen.getByTestId('health-score-icon-green')).toBeInTheDocument();
-    expect(screen.getByText('9 of 10 reporting healthy')).toBeInTheDocument();
+    expect(screen.getByTestId('needs-attention-count')).toHaveTextContent('1');
+    // The old hero: "Overall Health Score 90.0%" in a ring that never moved.
+    expect(screen.queryByText(/Overall Health Score/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('healthcheck-pass-rate')).toHaveTextContent('90%');
   });
 
-  it('renders the page subtitle without mentioning recent containers', () => {
+  it('spends the subtitle on live fleet state rather than naming its own widgets', () => {
     mockUseDashboardFull.mockReturnValue({
       data: makeDashboardData(),
       isLoading: false,
@@ -350,6 +393,111 @@ describe('HomePage', () => {
 
     renderPage();
 
-    expect(screen.getByText('Dashboard overview with KPIs and charts')).toBeInTheDocument();
+    expect(screen.queryByText('Dashboard overview with KPIs and charts')).not.toBeInTheDocument();
+    expect(screen.getByTestId('page-header-subtitle')).toHaveTextContent(
+      '2 endpoints · 5 containers',
+    );
+  });
+
+  it('renders the page title through the shared PageHeader', () => {
+    mockUseDashboardFull.mockReturnValue({
+      data: makeDashboardData(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    renderPage();
+
+    const header = screen.getByTestId('page-header');
+    expect(within(header).getByRole('heading', { level: 1 })).toHaveTextContent('Home');
+  });
+
+  // ---------------------------------------------------------------------------
+  // The refresh control used to schedule nothing on this page while rendering a
+  // pulsing "live" dot, and nothing on screen showed when the data landed.
+  // ---------------------------------------------------------------------------
+
+  it('wires the auto-refresh dropdown to real refetches via onTick', () => {
+    const refetch = vi.fn();
+    const refetchContainers = vi.fn();
+    mockUseDashboardFull.mockReturnValue({
+      data: makeDashboardData(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch,
+      isFetching: false,
+      dataUpdatedAt: Date.now(),
+    } as any);
+    mockUseContainers.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: refetchContainers,
+    } as any);
+
+    renderPage();
+
+    expect(capturedAutoRefresh.onTick).toBeTypeOf('function');
+    capturedAutoRefresh.onTick?.();
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(refetchContainers).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a data-freshness stamp beside the refresh control', () => {
+    mockUseDashboardFull.mockReturnValue({
+      data: makeDashboardData(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: Date.now(),
+    } as any);
+
+    renderPage();
+
+    const actions = screen.getByTestId('page-header-actions');
+    expect(within(actions).getByText(/^Updated /)).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fix by subtraction: "everything is running" was stated seven times above one
+  // fold, two of those arithmetically guaranteed complements.
+  // ---------------------------------------------------------------------------
+
+  it('no longer renders the Fleet Summary card or its Top Contributors ranking', () => {
+    mockUseDashboardFull.mockReturnValue({
+      data: makeDashboardData(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    renderPage();
+
+    expect(screen.queryByText('Fleet Summary')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-fleet')).not.toBeInTheDocument();
+  });
+
+  it('does not title a card "Top Workloads" when it holds no workloads', () => {
+    mockUseDashboardFull.mockReturnValue({
+      data: makeDashboardData(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
+
+    renderPage();
+
+    expect(screen.queryByText('Top Workloads')).not.toBeInTheDocument();
+    expect(screen.getByText('Stacks by container count')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/core/pages/home.tsx
+++ b/frontend/src/features/core/pages/home.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo } from 'react';
+import { lazy, Suspense, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertTriangle, Star, ShieldAlert, PackageOpen } from 'lucide-react';
 import { useDashboardFull } from '@/features/core/hooks/use-dashboard-full';
@@ -8,7 +8,9 @@ import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { FleetHealthSummary } from '@/features/ai-intelligence/components/fleet-health-summary';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { DataFreshness } from '@/shared/components/feedback/data-freshness';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { RefreshControls } from '@/shared/components/ui/refresh-controls';
 import { useForceRefresh } from '@/shared/hooks/use-force-refresh';
 import { FavoriteButton } from '@/shared/components/ui/favorite-button';
@@ -19,33 +21,55 @@ import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 // Lazy-loaded chart components — lets KPI cards render first
 const EndpointHealthOctagons = lazy(() => import('@/shared/components/charts/endpoint-health-octagons').then(m => ({ default: m.EndpointHealthOctagons })));
 const WorkloadTopBar = lazy(() => import('@/shared/components/charts/workload-top-bar').then(m => ({ default: m.WorkloadTopBar })));
-const FleetSummaryCard = lazy(() => import('@/shared/components/charts/fleet-summary-card').then(m => ({ default: m.FleetSummaryCard })));
 const ResourceOverviewCard = lazy(() => import('@/shared/components/charts/resource-overview-card').then(m => ({ default: m.ResourceOverviewCard })));
 
 function ChartSkeleton({ className }: { className?: string }) {
   return <div className={`animate-pulse rounded-lg bg-muted/50 ${className ?? 'h-[200px]'}`} />;
 }
 
+const PAGE_TITLE = 'Home';
+
 export default function HomePage() {
   const navigate = useNavigate();
   // Unified fetch: summary + resources + endpoints in one request
-  const { data: fullData, isLoading, isError, error, refetch, isFetching } = useDashboardFull(8);
+  const {
+    data: fullData,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetching,
+    dataUpdatedAt,
+  } = useDashboardFull(8);
   const data = fullData?.summary;
   const resourcesData = fullData?.resources;
   const endpoints = fullData?.endpoints;
   const isLoadingResources = isLoading;
   const { forceRefresh, isForceRefreshing } = useForceRefresh('endpoints', refetch);
-  const { interval, setInterval } = useAutoRefresh(30);
   const favoriteIds = useFavoritesStore((s) => s.favoriteIds);
   const { data: favoriteContainers = [] } = useFavoriteContainers(favoriteIds);
 
-  // Containers feed the Overall Health Score row. Uses the same
-  // helpers as the Health & Monitoring page so the two views never disagree.
+  // Containers feed the Fleet Vitals hero. Uses the same helpers as the
+  // Health & Monitoring page so the two views never disagree.
   const {
     data: containers,
     isLoading: isLoadingContainers,
     isError: isContainersError,
+    refetch: refetchContainers,
   } = useContainers();
+
+  // The refresh dropdown now schedules the fetches it advertises. It used to
+  // write a localStorage preference and nothing else: this page armed no timer,
+  // `useContainers` sets no `refetchInterval`, and the control still rendered a
+  // pulsing "live" dot — so the hero's health numbers were frozen at mount with
+  // nothing on screen to say so. `DataFreshness` beside the control is the
+  // second signal that makes a stalled poll visible.
+  const handleTick = useCallback(() => {
+    refetch();
+    refetchContainers?.();
+  }, [refetch, refetchContainers]);
+  const { interval, setRefreshInterval } = useAutoRefresh(30, { onTick: handleTick });
+
   const healthStats = useMemo(() => {
     if (!containers) return null;
     return calculateHealthStats(containers);
@@ -72,18 +96,37 @@ export default function HomePage() {
       running: stack.runningCount,
       stopped: stack.stoppedCount,
       total: stack.containerCount,
+      // A bar you can click has to land somewhere real: the chart used to
+      // navigate to `/endpoints/:id`, a route this router does not define.
+      href: `/workloads?stack=${encodeURIComponent(stack.name)}`,
     }));
   }, [resourcesData]);
+
+  // Live state, not a description of the page's own widgets. The previous
+  // subtitle ("Dashboard overview with KPIs and charts") named the furniture
+  // and restated the title.
+  const subtitle = data
+    ? `${data.kpis.endpoints} endpoint${data.kpis.endpoints === 1 ? '' : 's'} · ` +
+      `${data.kpis.total} container${data.kpis.total === 1 ? '' : 's'}`
+    : undefined;
+
+  const headerActions = (
+    <>
+      <DataFreshness lastUpdated={dataUpdatedAt || null} onRefresh={() => refetch()} />
+      <RefreshControls
+        interval={interval}
+        onIntervalChange={setRefreshInterval}
+        onRefresh={() => refetch()}
+        onForceRefresh={forceRefresh}
+        isLoading={isFetching || isForceRefreshing}
+      />
+    </>
+  );
 
   if (isError) {
     return (
       <MotionPage>
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Home</h1>
-          <p className="text-muted-foreground">
-            Dashboard overview with KPIs and charts
-          </p>
-        </div>
+        <PageHeader title={PAGE_TITLE} />
         <EmptyState
           variant="error"
           icon={AlertTriangle}
@@ -102,21 +145,10 @@ export default function HomePage() {
 
   return (
     <MotionPage>
-      {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Home</h1>
-          <p className="text-muted-foreground">
-            Dashboard overview with KPIs and charts
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <RefreshControls interval={interval} onIntervalChange={setInterval} onRefresh={() => refetch()} onForceRefresh={forceRefresh} isLoading={isFetching || isForceRefreshing} />
-        </div>
-      </div>
+      <PageHeader title={PAGE_TITLE} subtitle={subtitle} actions={headerActions} />
 
-      {/* Overall Health Score — full-width hero. Security Findings and Stopped
-          live INSIDE the pane as extra stat tiles (below the container-status
+      {/* Fleet Vitals — full-width hero. Security Findings and Stopped live
+          INSIDE the pane as extra stat tiles (below the container-status
           tiles), reusing FleetHealthSummary so Home and Health & Monitoring
           never drift. */}
       <MotionStagger stagger={0.05}>
@@ -126,7 +158,7 @@ export default function HomePage() {
               variant="error"
               icon={AlertTriangle}
               title="Failed to load fleet health"
-              description="Could not compute the Overall Health Score from container data."
+              description="Could not read container health from Portainer."
             />
           ) : (
             <SpotlightCard>
@@ -139,17 +171,18 @@ export default function HomePage() {
                     icon: PackageOpen,
                     label: 'Stopped',
                     value: healthStats?.stopped ?? 0,
-                    percentage:
-                      healthStats && healthStats.total > 0
-                        ? (healthStats.stopped / healthStats.total) * 100
-                        : undefined,
+                    // No link at zero: a chevron into an empty filtered table
+                    // is the dead end this was meant to fix.
+                    to: (healthStats?.stopped ?? 0) > 0 ? '/workloads?state=exited' : undefined,
                   },
                   {
                     icon: ShieldAlert,
                     label: 'Security Findings',
                     value: data?.security.flagged ?? 0,
                     variant: (data?.security.flagged ?? 0) > 0 ? 'danger' : 'default',
-                    onClick: () => navigate('/security/audit'),
+                    // Always linked: the audit page is worth opening at zero
+                    // findings too — it shows what was actually checked.
+                    to: '/security/audit',
                   },
                 ]}
               />
@@ -195,74 +228,64 @@ export default function HomePage() {
         </MotionReveal>
       )}
 
-      {/* Endpoint Health — full width, dynamic height */}
-      {isLoading ? (
-        <SkeletonChart size="lg" />
-      ) : data ? (
+      {/* Fleet resources — two fleet-wide gauges. These used to sit inside a
+          card titled "Top Workloads" that contained no workloads. */}
+      {isLoading || isLoadingResources ? (
+        <SkeletonChart size="md" />
+      ) : resourcesData ? (
         <MotionReveal>
           <SpotlightCard>
-            <div className="flex flex-col rounded-lg border bg-card p-6 shadow-sm">
-              <h3 className="mb-4 text-sm font-medium text-muted-foreground">
-                Endpoint Health
-              </h3>
-              <Suspense fallback={<ChartSkeleton className="h-[200px]" />}>
-                <EndpointHealthOctagons endpoints={endpointChartData} />
+            <div className="rounded-lg border bg-card p-6 shadow-sm">
+              <h3 className="mb-4 text-sm font-medium text-muted-foreground">Fleet Resources</h3>
+              <Suspense fallback={<ChartSkeleton className="h-[88px]" />}>
+                <ResourceOverviewCard
+                  cpuPercent={resourcesData.fleetCpuPercent}
+                  memoryPercent={resourcesData.fleetMemoryPercent}
+                />
               </Suspense>
             </div>
           </SpotlightCard>
         </MotionReveal>
       ) : null}
 
-      {/* Top Workloads + Fleet Summary */}
-      {isLoading || isLoadingResources ? (
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-          <SkeletonChart size="lg" className="lg:col-span-2" />
+      {/* Endpoint health + stacks. Two panes across the full width so a wide
+          display carries content rather than gradient; the Fleet Summary card
+          that used to sit here restated "everything is running" a third and
+          fourth time (a 100%/0% complement bar and a one-row "Top
+          Contributors" ranking) and was deleted rather than restyled. */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+          <SkeletonChart size="lg" className="xl:col-span-2" />
           <SkeletonChart size="lg" />
         </div>
       ) : data && resourcesData ? (
-        <MotionStagger className="grid grid-cols-1 gap-4 lg:grid-cols-3" stagger={0.05}>
-            <MotionReveal className="lg:col-span-2">
-              <SpotlightCard>
-                <div className="flex h-[520px] flex-col rounded-lg border bg-card p-6 shadow-sm">
-                  <h3 className="mb-4 text-sm font-medium text-muted-foreground">
-                    Top Workloads
-                  </h3>
-                  <Suspense fallback={<ChartSkeleton className="h-[60px] mb-4" />}>
-                    <div className="mb-4">
-                      <ResourceOverviewCard
-                        cpuPercent={resourcesData.fleetCpuPercent}
-                        memoryPercent={resourcesData.fleetMemoryPercent}
-                      />
-                    </div>
-                  </Suspense>
-                  <Suspense fallback={<ChartSkeleton className="flex-1" />}>
-                    <div className="flex-1 min-h-0 overflow-y-auto">
-                      <WorkloadTopBar endpoints={stackChartData} />
-                    </div>
-                  </Suspense>
-                </div>
-              </SpotlightCard>
-            </MotionReveal>
-            <MotionReveal>
-              <SpotlightCard>
-                <div className="flex h-[520px] flex-col rounded-lg border bg-card p-6 shadow-sm">
-                  <h3 className="mb-4 text-sm font-medium text-muted-foreground">
-                    Fleet Summary
-                  </h3>
-                  <Suspense fallback={<ChartSkeleton className="flex-1" />}>
-                    <div className="flex-1 min-h-0">
-                      <FleetSummaryCard
-                        endpoints={endpointChartData}
-                        totalContainers={data.kpis.total}
-                      />
-                    </div>
-                  </Suspense>
-                </div>
-              </SpotlightCard>
-            </MotionReveal>
-          </MotionStagger>
+        <MotionStagger className="grid grid-cols-1 gap-4 xl:grid-cols-3" stagger={0.05}>
+          <MotionReveal className="xl:col-span-2">
+            <SpotlightCard>
+              <div className="flex h-full min-h-[360px] flex-col rounded-lg border bg-card p-6 shadow-sm">
+                <h3 className="mb-4 text-sm font-medium text-muted-foreground">Endpoint Health</h3>
+                <Suspense fallback={<ChartSkeleton className="h-[200px]" />}>
+                  <EndpointHealthOctagons endpoints={endpointChartData} />
+                </Suspense>
+              </div>
+            </SpotlightCard>
+          </MotionReveal>
+          <MotionReveal>
+            <SpotlightCard>
+              <div className="flex h-full min-h-[360px] flex-col rounded-lg border bg-card p-6 shadow-sm">
+                <h3 className="mb-4 text-sm font-medium text-muted-foreground">
+                  Stacks by container count
+                </h3>
+                <Suspense fallback={<ChartSkeleton className="flex-1" />}>
+                  <div className="flex-1 min-h-0 overflow-y-auto">
+                    <WorkloadTopBar series={stackChartData} />
+                  </div>
+                </Suspense>
+              </div>
+            </SpotlightCard>
+          </MotionReveal>
+        </MotionStagger>
       ) : null}
-
     </MotionPage>
   );
 }

--- a/frontend/src/features/core/pages/login.test.tsx
+++ b/frontend/src/features/core/pages/login.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import LoginPage from './login';
+import { PRODUCT_NAME } from '@/shared/lib/product';
+import {
+  LOGIN_BAD_CREDENTIALS_MESSAGE,
+  LOGIN_RATE_LIMITED_MESSAGE,
+} from '@/providers/auth-provider';
 
 const mockNavigate = vi.fn();
 const mockLogin = vi.fn();
@@ -73,7 +78,7 @@ describe('LoginPage', () => {
     vi.useRealTimers();
   });
 
-  it('renders cinematic login elements', () => {
+  it('renders the sign-in form under the product wordmark', () => {
     render(
       <MemoryRouter>
         <LoginPage />
@@ -81,11 +86,44 @@ describe('LoginPage', () => {
     );
 
     expect(screen.getByTestId('login-gradient')).toBeInTheDocument();
-    expect(screen.getByText(/Powered by AI/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(PRODUCT_NAME);
     expect(screen.getByLabelText('Username')).toHaveValue('');
     expect(screen.getByLabelText('Password')).toHaveValue('');
-    expect(document.querySelectorAll('.login-particle')).toHaveLength(10);
     expect(screen.getByRole('img', { name: 'Brain logo' })).toBeInTheDocument();
+  });
+
+  it('uses the shared product name, not one of its three rivals', () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Container Insights');
+    expect(screen.queryByText(/Docker Insights?/)).not.toBeInTheDocument();
+  });
+
+  it('drops the "powered by AI" typewriter tagline', () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText(/powered by ai/i)).not.toBeInTheDocument();
+    expect(document.querySelector('.login-typewriter')).toBeNull();
+  });
+
+  it('drops the floating particles, keeping the gradient mesh and the staggered entrance', () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(document.querySelectorAll('.login-particle')).toHaveLength(0);
+    expect(screen.getByTestId('login-gradient').className).toContain('login-gradient-mesh-animate');
+    expect(document.querySelectorAll('.login-stage-in').length).toBeGreaterThan(0);
   });
 
   it('renders the username and password fields empty on initial render', () => {
@@ -95,11 +133,11 @@ describe('LoginPage', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByLabelText(/username/i)).toHaveValue('');
-    expect(screen.getByLabelText(/password/i)).toHaveValue('');
+    expect(screen.getByLabelText('Username')).toHaveValue('');
+    expect(screen.getByLabelText('Password')).toHaveValue('');
   });
 
-  it('respects reduced motion by disabling decorative particles', () => {
+  it('respects reduced motion by disabling the entrance animation', () => {
     stubMatchMedia(true);
 
     render(
@@ -108,8 +146,47 @@ describe('LoginPage', () => {
       </MemoryRouter>,
     );
 
-    expect(document.querySelectorAll('.login-particle')).toHaveLength(0);
+    expect(document.querySelectorAll('.login-stage-in')).toHaveLength(0);
+    expect(screen.getByTestId('login-gradient').className).not.toContain('login-gradient-mesh-animate');
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+  });
+
+  it('keeps muted card text on an opaque card so it clears AA contrast', () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    const card = document.querySelector('.login-card');
+    expect(card).not.toBeNull();
+    // `bg-card/85` let the page background through, which is the pairing that
+    // measures 4.31:1 for `text-muted-foreground` (AA needs 4.5:1).
+    expect(card!.className).toContain('bg-card');
+    expect(card!.className).not.toContain('bg-card/');
+  });
+
+  it('toggles password visibility so a pasted vault secret can be checked', () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    const passwordField = screen.getByLabelText('Password');
+    expect(passwordField).toHaveAttribute('type', 'password');
+
+    const toggle = screen.getByRole('button', { name: 'Show password' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(toggle);
+    expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text');
+
+    const hide = screen.getByRole('button', { name: 'Hide password' });
+    expect(hide).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(hide);
+    expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password');
   });
 
   it('announces login failure to screen readers via role="alert" (#1541)', async () => {
@@ -128,8 +205,14 @@ describe('LoginPage', () => {
     expect(alert).toBe(screen.getByTestId('login-error'));
   });
 
-  it('shows loading state and delays navigation for success animation', async () => {
-    mockLogin.mockResolvedValue({ defaultLandingPage: '/health' });
+  /**
+   * The wrong-password path was fixed at the API layer (`suppressSessionExpiry`
+   * on `/api/auth/login` plus `describeLoginFailure` in `AuthProvider`). This
+   * asserts the page renders that message verbatim and never the session-expiry
+   * string, which is what a bad password used to report.
+   */
+  it('renders "Incorrect username or password" for a wrong password, never "Session expired"', async () => {
+    mockLogin.mockRejectedValue(new Error(LOGIN_BAD_CREDENTIALS_MESSAGE));
 
     render(
       <MemoryRouter>
@@ -138,18 +221,43 @@ describe('LoginPage', () => {
     );
 
     fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'admin' } });
-    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'changeme123' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrong' } });
     fireEvent.submit(screen.getByRole('button', { name: 'Sign in' }));
 
-    expect(screen.getByText('Signing in...')).toBeInTheDocument();
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Incorrect username or password');
+    expect(alert).not.toHaveTextContent(/session expired/i);
+    expect(screen.queryByText(/session expired/i)).not.toBeInTheDocument();
+  });
 
-    await waitFor(() => {
-      expect(screen.getByText('Signed in')).toBeInTheDocument();
-    });
+  it('renders the rate-limit message when the server throttles sign-in', async () => {
+    mockLogin.mockRejectedValue(new Error(LOGIN_RATE_LIMITED_MESSAGE));
 
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/health', { replace: true });
-    }, { timeout: 1200 });
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.submit(screen.getByRole('button', { name: 'Sign in' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Too many sign-in attempts. Wait a minute before trying again.');
+  });
+
+  it('re-enables the form after a failed attempt', async () => {
+    mockLogin.mockRejectedValue(new Error(LOGIN_BAD_CREDENTIALS_MESSAGE));
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.submit(screen.getByRole('button', { name: 'Sign in' }));
+
+    await screen.findByRole('alert');
+    expect(screen.getByRole('button', { name: 'Sign in' })).not.toBeDisabled();
   });
 
   it('prefetches dashboard data immediately after login succeeds', async () => {
@@ -175,10 +283,15 @@ describe('LoginPage', () => {
         staleTime: 2 * 60_000,
       }),
     );
-
   });
 
-  it('navigates after minimum animation time AND prefetch both complete', async () => {
+  /**
+   * The regression this guards: a `Promise.all([minTimer, …])` held the loading
+   * screen for a full second after a correct password, so an operator signing in
+   * during an incident waited on an animation. Navigation is now bounded only by
+   * the prefetch.
+   */
+  it('navigates as soon as the prefetch resolves, with no minimum delay', async () => {
     vi.useFakeTimers();
 
     let resolvePrefetch!: () => void;
@@ -197,24 +310,75 @@ describe('LoginPage', () => {
 
     // Flush login() microtask
     await vi.advanceTimersByTimeAsync(0);
-
-    // Min timer not elapsed, prefetch still pending — should not navigate
     expect(mockNavigate).not.toHaveBeenCalled();
 
-    // Advance to exactly the 1s minimum timer
-    await vi.advanceTimersByTimeAsync(1000);
-
-    // Prefetch still pending — navigation should be blocked
-    expect(mockNavigate).not.toHaveBeenCalled();
-
-    // Resolve prefetch — navigation should fire now
+    // 50ms in — well under any old minimum — the prefetch lands and we go.
+    await vi.advanceTimersByTimeAsync(50);
     resolvePrefetch();
     await vi.advanceTimersByTimeAsync(0);
 
     expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
   });
 
-  it('navigates after max timeout even when prefetch is slow', async () => {
+  it('never mounts the loading screen when the prefetch resolves quickly', async () => {
+    vi.useFakeTimers();
+
+    let resolvePrefetch!: () => void;
+    mockPrefetchQuery.mockReturnValue(new Promise<void>((r) => { resolvePrefetch = r; }));
+    mockLogin.mockResolvedValue({ defaultLandingPage: '/' });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'admin' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'changeme123' } });
+    fireEvent.submit(screen.getByRole('button', { name: 'Sign in' }));
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(100);
+    resolvePrefetch();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+
+    // The slow-path timer must have been cancelled, not merely outraced.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(screen.queryByRole('img', { name: 'Loading logo' })).toBeNull();
+  });
+
+  it('shows the loading screen only once the prefetch runs past the slow-path threshold', async () => {
+    vi.useFakeTimers();
+
+    mockPrefetchQuery.mockReturnValue(new Promise<void>(() => {}));
+    mockLogin.mockResolvedValue({ defaultLandingPage: '/' });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'admin' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'changeme123' } });
+    fireEvent.submit(screen.getByRole('button', { name: 'Sign in' }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(299);
+    });
+    expect(screen.queryByRole('img', { name: 'Loading logo' })).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(screen.getByRole('img', { name: 'Loading logo' })).toBeInTheDocument();
+  });
+
+  it('navigates after the cap even when the prefetch never resolves', async () => {
     vi.useFakeTimers();
 
     // Prefetch that never resolves (simulates very slow network)
@@ -233,14 +397,32 @@ describe('LoginPage', () => {
 
     await vi.advanceTimersByTimeAsync(0);
 
-    // Should not navigate before max timeout
-    await vi.advanceTimersByTimeAsync(4999);
+    await vi.advanceTimersByTimeAsync(2999);
     expect(mockNavigate).not.toHaveBeenCalled();
 
-    // Advance past 5s max cap — navigation should fire
     await vi.advanceTimersByTimeAsync(1);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  it('does not fire a confetti burst on a successful sign-in', async () => {
+    mockLogin.mockResolvedValue({ defaultLandingPage: '/' });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'admin' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'changeme123' } });
+    fireEvent.submit(screen.getByRole('button', { name: 'Sign in' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Signed in')).toBeInTheDocument();
+    });
+
+    expect(document.querySelectorAll('.login-burst')).toHaveLength(0);
   });
 });

--- a/frontend/src/features/core/pages/login.tsx
+++ b/frontend/src/features/core/pages/login.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState, type CSSProperties, type FormEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type FormEvent } from "react";
 import { Navigate, useNavigate } from "react-router-dom";
 import { createPortal } from "react-dom";
 import { useQueryClient } from "@tanstack/react-query";
+import { Eye, EyeOff } from "lucide-react";
 import { useAuth } from "@/features/core/hooks/use-auth";
 import { useOIDCStatus } from "@/features/core/hooks/use-oidc";
 import { LoginLogo } from "@/shared/components/icons/login-logo";
@@ -9,19 +10,21 @@ import { useUiStore } from "@/stores/ui-store";
 import { PostLoginLoading } from "@/shared/components/layout/post-login-loading";
 import { AnimatePresence } from "framer-motion";
 import { api } from "@/shared/lib/api";
+import { PRODUCT_NAME } from "@/shared/lib/product";
 
-const PARTICLES = [
-  { left: "8%", delay: "0s", duration: "12s", size: "7px" },
-  { left: "18%", delay: "0.8s", duration: "15s", size: "9px" },
-  { left: "28%", delay: "0.4s", duration: "13s", size: "6px" },
-  { left: "39%", delay: "1.2s", duration: "14s", size: "8px" },
-  { left: "48%", delay: "0.2s", duration: "16s", size: "7px" },
-  { left: "57%", delay: "1.5s", duration: "12s", size: "8px" },
-  { left: "66%", delay: "0.6s", duration: "17s", size: "9px" },
-  { left: "75%", delay: "1.1s", duration: "11s", size: "6px" },
-  { left: "84%", delay: "0.9s", duration: "15s", size: "8px" },
-  { left: "92%", delay: "0.3s", duration: "13s", size: "7px" },
-];
+/**
+ * How long the prefetch may run before the loading screen appears.
+ *
+ * The screen used to be shown immediately and held for a **one-second minimum**
+ * even when the prefetch had already resolved, so a correct password during an
+ * incident cost the operator a second of animation. It is now a slow-path
+ * affordance only: under this threshold the sign-in feels instant and the
+ * screen never mounts.
+ */
+const LOADING_SCREEN_DELAY_MS = 300;
+
+/** Hard cap on the post-login prefetch so a slow network cannot trap the user. */
+const PREFETCH_MAX_WAIT_MS = 3000;
 
 function usePrefersReducedMotion(): boolean {
   const [reducedMotion, setReducedMotion] = useState(false);
@@ -47,15 +50,25 @@ export default function LoginPage() {
   const reducedMotion = prefersReducedMotion || potatoMode;
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [submitState, setSubmitState] = useState<"idle" | "loading" | "success">("idle");
   const [showPostLoginLoading, setShowPostLoginLoading] = useState(false);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const slowPathTimerRef = useRef<number | null>(null);
 
   const stagedClass = useMemo(
     () => (reducedMotion ? "" : "login-stage-in"),
     [reducedMotion],
   );
+
+  useEffect(() => {
+    return () => {
+      if (slowPathTimerRef.current !== null) {
+        window.clearTimeout(slowPathTimerRef.current);
+      }
+    };
+  }, []);
 
   if (isAuthenticated && !isLoggingIn) {
     return <Navigate to="/" replace />;
@@ -70,7 +83,7 @@ export default function LoginPage() {
     try {
       const { defaultLandingPage } = await login(username, password);
       setSubmitState("success");
-      
+
       // Always prefetch dashboard data after login, regardless of motion preference
       const prefetchPromise = queryClient.prefetchQuery({
         queryKey: ['dashboard', 'full', 8],
@@ -78,34 +91,27 @@ export default function LoginPage() {
         staleTime: 2 * 60 * 1000,
       });
 
-      if (reducedMotion) {
-        // Wait for data (up to 3s) then navigate — no animation but data is ready
-        const maxTimer = new Promise<void>((resolve) =>
-          window.setTimeout(resolve, 3000),
-        );
-        Promise.race([prefetchPromise, maxTimer]).then(() =>
-          navigate(defaultLandingPage || "/", { replace: true }),
-        );
-      } else {
-        // Show the high-quality loading screen immediately
-        setShowPostLoginLoading(true);
-
-        // Prefetch was already started above — reuse the promise.
-        // Show the loading screen for at least 1s, at most 5s.
-        const minTimer = new Promise<void>((resolve) =>
-          window.setTimeout(resolve, 1000),
-        );
-        // Cap total wait at 5 s so slow networks don't trap users on the screen.
-        const maxTimer = new Promise<void>((resolve) =>
-          window.setTimeout(resolve, 5000),
-        );
-
-        // Navigate when the minimum animation has played AND either the data is
-        // ready or the max timeout fires, whichever comes first.
-        Promise.all([minTimer, Promise.race([prefetchPromise, maxTimer])]).then(
-          () => navigate(defaultLandingPage || "/", { replace: true }),
+      // Slow path only: if the prefetch is still in flight after 300ms, cover
+      // the wait. A fast prefetch navigates before this ever fires, so there is
+      // no floor on how quickly a correct password gets you to the dashboard.
+      if (!reducedMotion) {
+        slowPathTimerRef.current = window.setTimeout(
+          () => setShowPostLoginLoading(true),
+          LOADING_SCREEN_DELAY_MS,
         );
       }
+
+      const maxTimer = new Promise<void>((resolve) =>
+        window.setTimeout(resolve, PREFETCH_MAX_WAIT_MS),
+      );
+
+      Promise.race([prefetchPromise, maxTimer]).then(() => {
+        if (slowPathTimerRef.current !== null) {
+          window.clearTimeout(slowPathTimerRef.current);
+          slowPathTimerRef.current = null;
+        }
+        navigate(defaultLandingPage || "/", { replace: true });
+      });
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Invalid username or password"
@@ -140,35 +146,17 @@ export default function LoginPage() {
         data-testid="login-gradient"
       />
 
-      {!reducedMotion && (
-        <div className="pointer-events-none absolute inset-0 z-0" aria-hidden="true">
-          {PARTICLES.map((particle) => (
-            <span
-              key={`${particle.left}-${particle.delay}`}
-              className="login-particle"
-              style={
-                {
-                  left: particle.left,
-                  width: particle.size,
-                  height: particle.size,
-                  animationDelay: particle.delay,
-                  animationDuration: particle.duration,
-                } as CSSProperties
-              }
-            />
-          ))}
-        </div>
-      )}
-
-      <div className={`login-card z-10 w-full max-w-sm rounded-2xl border bg-card/85 p-8 shadow-2xl ${stagedClass}`}>
+      {/*
+        The card is deliberately opaque. At `bg-card/85` the page background bled
+        through, dropping the muted-foreground token to 4.31:1 — below AA — while
+        the same token measures 4.62:1 on an opaque card.
+      */}
+      <div className={`login-card z-10 w-full max-w-sm rounded-2xl border bg-card p-8 shadow-2xl ${stagedClass}`}>
         <div className="mb-6 text-center">
           <div className={`mx-auto mb-3 grid place-items-center ${reducedMotion ? "" : "login-logo-shell"}`}>
             <LoginLogo reducedMotion={reducedMotion} />
           </div>
-          <h1 className="text-2xl font-bold tracking-tight">Docker Insights</h1>
-          <p className={`mt-1 text-xs uppercase tracking-[0.24em] text-muted-foreground ${reducedMotion ? "" : "login-typewriter"}`}>
-            powered by AI
-          </p>
+          <h1 className="text-2xl font-bold tracking-tight">{PRODUCT_NAME}</h1>
           <p
             className={`mt-3 text-sm text-muted-foreground ${stagedClass}`}
             style={getStagedStyle(120)}
@@ -236,16 +224,36 @@ export default function LoginPage() {
             >
               Password
             </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Enter your password"
-              required
-              autoComplete="current-password"
-              className="login-input flex h-10 w-full rounded-md border border-input bg-background/85 px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none"
-            />
+            {/*
+              The password here is usually a long generated string pasted from a
+              vault, so a reveal toggle is the difference between one attempt and
+              a retry loop.
+            */}
+            <div className="relative">
+              <input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Enter your password"
+                required
+                autoComplete="current-password"
+                className="login-input flex h-10 w-full rounded-md border border-input bg-background/85 py-2 pl-3 pr-11 text-sm placeholder:text-muted-foreground focus-visible:outline-none"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((visible) => !visible)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                aria-pressed={showPassword}
+                className="absolute inset-y-0 right-0 inline-flex w-11 items-center justify-center rounded-r-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <Eye className="h-4 w-4" aria-hidden="true" />
+                )}
+              </button>
+            </div>
           </div>
 
           <button
@@ -266,14 +274,6 @@ export default function LoginPage() {
             {submitState === "success" && (
               <span className="absolute inset-0 inline-flex items-center justify-center">
                 Signed in
-              </span>
-            )}
-            {submitState === "success" && !reducedMotion && (
-              <span className="pointer-events-none absolute inset-0" aria-hidden="true">
-                <span className="login-burst login-burst-1" />
-                <span className="login-burst login-burst-2" />
-                <span className="login-burst login-burst-3" />
-                <span className="login-burst login-burst-4" />
               </span>
             )}
           </button>

--- a/frontend/src/features/core/pages/not-found.test.tsx
+++ b/frontend/src/features/core/pages/not-found.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import NotFound from './not-found';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <NotFound />
+    </MemoryRouter>,
+  );
+}
+
+describe('NotFound', () => {
+  it('names the path that was not found', () => {
+    renderAt('/workloadz');
+    expect(screen.getByRole('heading', { name: /page not found/i })).toBeInTheDocument();
+    expect(screen.getByText(/No route matches \/workloadz/)).toBeInTheDocument();
+  });
+
+  it('suggests the closest matching destination from the manifest', () => {
+    renderAt('/workloadz');
+    const suggestion = screen.getByTestId('not-found-suggestion');
+    expect(suggestion).toHaveAttribute('href', '/workloads');
+    expect(suggestion).toHaveTextContent('Workloads');
+  });
+
+  it('always offers Home and Workload Explorer as links', () => {
+    renderAt('/zzzzzzzz');
+    const links = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
+    expect(links).toContain('/');
+    expect(links).toContain('/workloads');
+  });
+
+  it('does not duplicate a fallback that is already the suggestion', () => {
+    renderAt('/workloadz');
+    const links = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
+    expect(links.filter((href) => href === '/workloads')).toHaveLength(1);
+  });
+
+  it('renders links, not a redirect — Back must still work', () => {
+    renderAt('/nope');
+    // A <Navigate> would render nothing; assert real navigation targets exist.
+    expect(screen.getAllByRole('link').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/features/core/pages/not-found.tsx
+++ b/frontend/src/features/core/pages/not-found.tsx
@@ -1,0 +1,67 @@
+import { Link, useLocation } from 'react-router-dom';
+import { FileQuestion, ArrowRight } from 'lucide-react';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { closestDestination, findDestination } from '@/features/core/lib/navigation-manifest';
+
+/**
+ * Real 404, rendered inside AppLayout so the shell (sidebar, breadcrumb,
+ * search) survives. The catch-all used to be `<Navigate to="/" replace />`,
+ * which silently turned every bad URL into Home — a stale bookmark landed the
+ * operator on a page they had not asked for, and `replace` meant Back could
+ * not get them out of it.
+ */
+export default function NotFound() {
+  const location = useLocation();
+  const attempted = location.pathname;
+  const suggestion = closestDestination(attempted);
+  const home = findDestination('/');
+  const workloads = findDestination('/workloads');
+
+  const fallbacks = [home, workloads].filter(
+    (d): d is NonNullable<typeof d> => Boolean(d) && d!.path !== suggestion?.path,
+  );
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-4 py-8">
+      <h1 className="text-2xl font-semibold text-foreground">Page not found</h1>
+
+      <EmptyState
+        variant="error"
+        icon={FileQuestion}
+        title={`No route matches ${attempted}`}
+        description="The URL may be a stale bookmark, or the page may have been renamed. Nothing was loaded and nothing changed."
+      />
+
+      <nav aria-label="Suggested pages" className="flex flex-col gap-2">
+        {suggestion && (
+          <Link
+            to={suggestion.path}
+            data-testid="not-found-suggestion"
+            className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm transition-colors hover:bg-muted/60"
+          >
+            <suggestion.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="font-medium text-foreground">{suggestion.label}</span>
+            <span className="truncate font-mono text-xs text-muted-foreground">
+              {suggestion.path}
+            </span>
+            <ArrowRight className="ml-auto h-4 w-4 shrink-0 text-muted-foreground" />
+          </Link>
+        )}
+        {fallbacks.map((destination) => (
+          <Link
+            key={destination.path}
+            to={destination.path}
+            className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm transition-colors hover:bg-muted/60"
+          >
+            <destination.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="font-medium text-foreground">{destination.label}</span>
+            <span className="truncate font-mono text-xs text-muted-foreground">
+              {destination.path}
+            </span>
+            <ArrowRight className="ml-auto h-4 w-4 shrink-0 text-muted-foreground" />
+          </Link>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/frontend/src/features/core/pages/settings.test.tsx
+++ b/frontend/src/features/core/pages/settings.test.tsx
@@ -327,6 +327,72 @@ describe('SettingsPage — auto-save boundary', () => {
     );
   });
 
+  // A guarded edit is a promise: "nothing is applied until you save". Anything
+  // that quietly drops it breaks that promise on the tab holding
+  // oidc.client_secret and oidc.allow_insecure_transport.
+  //
+  // These use a NON-EMPTY /api/settings payload on purpose. With the suite's
+  // default `[]`, useUpdateSetting's optimistic `old.map(...)` is deep-equal to
+  // the previous data, TanStack's structural sharing hands back the same array
+  // reference, and the init effect never re-runs — so the interaction under
+  // test cannot happen and the test would pass vacuously.
+  const settingsRows = [
+    { key: 'monitoring.polling_interval', value: '30', category: 'monitoring',
+      label: 'Polling Interval', type: 'number', updatedAt: '2026-01-01T00:00:00.000Z' },
+    { key: 'monitoring.metric_retention_days', value: '7', category: 'monitoring',
+      label: 'Metric Retention', type: 'number', updatedAt: '2026-01-01T00:00:00.000Z' },
+  ];
+
+  function serveSettingsRows() {
+    mockGet.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/api/settings')) {
+        return Promise.resolve(settingsRows.map((r) => ({ ...r })));
+      }
+      return Promise.resolve({ entries: [], history: [], notifications: [] });
+    });
+  }
+
+  it('keeps a queued guarded edit when an ordinary knob auto-saves beside it', async () => {
+    serveSettingsRows();
+    await renderSettings();
+
+    const guarded = await screen.findByLabelText('Metric Retention');
+    fireEvent.change(guarded, { target: { value: '1' } });
+    expect(await screen.findByTestId('guarded-changes-bar')).toBeInTheDocument();
+
+    // Auto-saving this rewrites the ['settings'] cache, which re-runs the
+    // initialise-from-API effect.
+    fireEvent.change(await screen.findByLabelText('Polling Interval'), { target: { value: '45' } });
+    await waitFor(
+      () => expect(mockPut).toHaveBeenCalledWith(
+        '/api/settings/monitoring.polling_interval', expect.objectContaining({ value: '45' }),
+      ),
+      { timeout: 3000 },
+    );
+    // Let the invalidation-driven refetch land too.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(screen.getByLabelText('Metric Retention')).toHaveValue(1);
+    expect(screen.getByTestId('guarded-changes-bar')).toBeInTheDocument();
+    // ...and it is still only queued, never written.
+    expect(mockPut).not.toHaveBeenCalledWith(
+      '/api/settings/monitoring.metric_retention_days', expect.anything(),
+    );
+  });
+
+  it('still takes the server value for a key the operator has not touched', async () => {
+    // The guard must not freeze the form: only pending edits are preserved.
+    serveSettingsRows();
+    await renderSettings();
+
+    await screen.findByLabelText('Polling Interval');
+    settingsRows[0] = { ...settingsRows[0], value: '90' };
+    fireEvent.change(await screen.findByLabelText('Metric Retention'), { target: { value: '1' } });
+
+    await waitFor(() => expect(screen.getByLabelText('Metric Retention')).toHaveValue(1));
+    settingsRows[0] = { ...settingsRows[0], value: '30' }; // restore for other tests
+  });
+
   it('never auto-saves a retention window, however long the operator pauses', async () => {
     await renderSettings();
 

--- a/frontend/src/features/core/pages/settings.test.tsx
+++ b/frontend/src/features/core/pages/settings.test.tsx
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LlmSettingsSection, getRedisSystemInfo } from './settings';
 
 const mockGet = vi.fn();
 const mockPost = vi.fn();
+const mockPut = vi.fn();
 const mockSuccess = vi.fn();
 const mockError = vi.fn();
 
@@ -12,7 +13,12 @@ vi.mock('@/shared/lib/api', () => ({
   api: {
     get: (...args: unknown[]) => mockGet(...args),
     post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
   },
+}));
+
+vi.mock('@/providers/auth-provider', () => ({
+  useAuth: () => ({ role: 'admin', user: { username: 'admin' } }),
 }));
 
 vi.mock('sonner', () => ({
@@ -268,5 +274,190 @@ describe('Settings tab structure', () => {
     expect(LLM_SETTING_KEYS.length).toBeGreaterThan(0);
     expect(LLM_SETTING_KEYS).toContain('llm.model');
     expect(LLM_SETTING_KEYS).toContain('llm.temperature');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// The settings page itself: what commits on its own, and what does not.
+// ─────────────────────────────────────────────────────────────────────
+
+describe('SettingsPage — auto-save boundary', () => {
+  async function renderSettings(initialEntry = '/settings') {
+    const { MemoryRouter } = await import('react-router-dom');
+    const SettingsPage = (await import('./settings')).default;
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    return render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <SettingsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/api/settings')) return Promise.resolve([]);
+      return Promise.resolve({ entries: [], history: [], notifications: [] });
+    });
+    mockPut.mockResolvedValue(undefined);
+  });
+
+  it('lands on a tab that has settings on it, not the read-only About dump', async () => {
+    await renderSettings();
+
+    // Monitoring is the default: its sections render, About does not.
+    expect(await screen.findByLabelText('Polling Interval')).toBeInTheDocument();
+    expect(screen.queryByTestId('system-information')).not.toBeInTheDocument();
+  });
+
+  it('auto-saves an ordinary tuning knob', async () => {
+    await renderSettings();
+
+    const input = await screen.findByLabelText('Polling Interval');
+    fireEvent.change(input, { target: { value: '45' } });
+
+    await waitFor(
+      () => expect(mockPut).toHaveBeenCalledWith('/api/settings/monitoring.polling_interval', expect.objectContaining({ value: '45' })),
+      { timeout: 3000 },
+    );
+  });
+
+  it('never auto-saves a retention window, however long the operator pauses', async () => {
+    await renderSettings();
+
+    const input = await screen.findByLabelText('Metric Retention');
+    fireEvent.change(input, { target: { value: '1' } });
+
+    // Well past the 700ms debounce.
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it('offers an explicit, reviewed save naming the value and its consequence', async () => {
+    await renderSettings();
+
+    const input = await screen.findByLabelText('Metric Retention');
+    fireEvent.change(input, { target: { value: '1' } });
+
+    const bar = await screen.findByTestId('guarded-changes-bar');
+    expect(bar).toHaveTextContent('1 change needs review');
+    expect(within(bar).getByTestId('guarded-change-monitoring.metric_retention_days'))
+      .toHaveTextContent('7 → 1');
+    expect(bar).toHaveTextContent(/deletes stored metrics older than the new window/i);
+
+    fireEvent.click(within(bar).getByRole('button', { name: 'Save 1 change' }));
+
+    await waitFor(() =>
+      expect(mockPut).toHaveBeenCalledWith('/api/settings/monitoring.metric_retention_days', expect.objectContaining({ value: '1' })),
+    );
+  });
+
+  it('discards a guarded change without saving it', async () => {
+    await renderSettings();
+
+    const input = await screen.findByLabelText('Metric Retention');
+    fireEvent.change(input, { target: { value: '1' } });
+
+    const bar = await screen.findByTestId('guarded-changes-bar');
+    fireEvent.click(within(bar).getByRole('button', { name: 'Discard' }));
+
+    await waitFor(() => expect(screen.queryByTestId('guarded-changes-bar')).not.toBeInTheDocument());
+    expect(mockPut).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Metric Retention')).toHaveValue(7);
+  });
+
+  it('keeps Reset mounted after a save clears the change', async () => {
+    await renderSettings();
+
+    // Present, and disabled, before anything is edited.
+    const reset = await screen.findByRole('button', { name: 'Reset' });
+    expect(reset).toBeDisabled();
+
+    const input = screen.getByLabelText('Polling Interval');
+    fireEvent.change(input, { target: { value: '45' } });
+    await waitFor(() => expect(mockPut).toHaveBeenCalled(), { timeout: 3000 });
+
+    // Auto-save clears `hasChanges`; the control must not unmount with it.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Reset' })).toBeDisabled());
+  });
+
+  it('confirms the save at the row that changed, not only in the header', async () => {
+    await renderSettings();
+
+    const input = await screen.findByLabelText('Polling Interval');
+    fireEvent.change(input, { target: { value: '45' } });
+
+    expect(await screen.findByTestId('setting-saved-monitoring.polling_interval', {}, { timeout: 3000 }))
+      .toHaveTextContent('Saved');
+  });
+});
+
+describe('SettingsPage — finding one of 107 keys', () => {
+  async function renderSettings() {
+    const { MemoryRouter } = await import('react-router-dom');
+    const SettingsPage = (await import('./settings')).default;
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    return render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/settings']}>
+          <SettingsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/api/settings')) return Promise.resolve([]);
+      return Promise.resolve({ entries: [], history: [], notifications: [] });
+    });
+    mockPut.mockResolvedValue(undefined);
+  });
+
+  it('searches across tabs and names the tab each match lives on', async () => {
+    await renderSettings();
+
+    fireEvent.change(await screen.findByLabelText('Search settings'), {
+      target: { value: 'raw metrics' },
+    });
+
+    const results = await screen.findByTestId('settings-search-results');
+    expect(within(results).getByText('Raw Metrics Retention (days)')).toBeInTheDocument();
+    expect(within(results).getByText('Infrastructure')).toBeInTheDocument();
+  });
+
+  it('switches to the owning tab when a result is picked', async () => {
+    await renderSettings();
+
+    fireEvent.change(await screen.findByLabelText('Search settings'), {
+      target: { value: 'raw metrics' },
+    });
+    fireEvent.click(await screen.findByText('Raw Metrics Retention (days)'));
+
+    // The Infrastructure tab is now mounted, and the search panel has closed.
+    expect(await screen.findByTestId('setting-row-infrastructure.metrics_raw_retention_days'))
+      .toBeInTheDocument();
+    expect(screen.queryByTestId('settings-search-results')).not.toBeInTheDocument();
+  });
+
+  it('says what to try instead when nothing matches', async () => {
+    await renderSettings();
+
+    fireEvent.change(await screen.findByLabelText('Search settings'), {
+      target: { value: 'zzzzz' },
+    });
+
+    const results = await screen.findByTestId('settings-search-results');
+    expect(results).toHaveTextContent(/No setting matches/i);
+    expect(results).toHaveTextContent(/retention/i);
   });
 });

--- a/frontend/src/features/core/pages/settings.tsx
+++ b/frontend/src/features/core/pages/settings.tsx
@@ -304,6 +304,12 @@ export default function SettingsPage() {
   // Local state for edited / original values
   const [editedValues, setEditedValues] = useState<Record<string, string>>({});
   const [originalValues, setOriginalValues] = useState<Record<string, string>>({});
+  /**
+   * The last server snapshot, readable inside the init effect without making it
+   * depend on `originalValues` (which it also sets — that would re-enter). Used
+   * to tell "the operator changed this" from "the server changed this".
+   */
+  const originalValuesRef = useRef<Record<string, string>>({});
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -344,12 +350,30 @@ export default function SettingsPage() {
         }
       });
 
-      setEditedValues(values);
+      // Re-sync to the server, but never discard what the operator has typed.
+      //
+      // This effect runs on every change of the `['settings']` query data, and
+      // `useUpdateSetting` changes that data on every save — optimistically in
+      // `onMutate`, then again when `onSettled` invalidates. So it fires while
+      // the page is in use, not only on first load. Overwriting wholesale meant
+      // that auto-saving any ordinary knob silently threw away a *guarded* edit
+      // queued on the same tab — the Security tab, where the guarded keys are
+      // `oidc.client_secret` and `oidc.allow_insecure_transport`, and where the
+      // GuardedChangesBar has just promised nothing is applied until you save.
+      //
+      // A key the operator has changed but not yet saved belongs to them; every
+      // other key takes the server's value.
+      setEditedValues((pending) => {
+        const previousOriginal = originalValuesRef.current;
+        const next = { ...values };
+        for (const [key, value] of Object.entries(pending)) {
+          if (value !== previousOriginal[key]) next[key] = value;
+        }
+        return next;
+      });
+      originalValuesRef.current = values;
       setOriginalValues(values);
-      setSaveSuccess(false);
       setSaveError(null);
-      setRestartPending(false);
-      setSavedKeys(new Set<string>());
     }
   }, [settingsData]);
 
@@ -450,6 +474,10 @@ export default function SettingsPage() {
     }
 
     if (Object.keys(appliedValues).length > 0) {
+      // Keep the ref alongside the state: the init effect compares against it
+      // to decide what is a pending operator edit, and a just-saved key is no
+      // longer one.
+      originalValuesRef.current = { ...originalValuesRef.current, ...appliedValues };
       setOriginalValues((prev) => ({ ...prev, ...appliedValues }));
       setSaveSuccess(true);
       setSavedKeys(new Set(Object.keys(appliedValues)));

--- a/frontend/src/features/core/pages/settings.tsx
+++ b/frontend/src/features/core/pages/settings.tsx
@@ -1,18 +1,22 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import * as Tabs from '@radix-ui/react-tabs';
 import {
   Activity,
   AlertTriangle,
   Bot,
   CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
   HardDriveDownload,
   Info,
   Loader2,
   Palette,
   Plug,
+  Search,
   Settings2,
   Shield,
 } from 'lucide-react';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { useSettings, useUpdateSetting } from '@/features/core/hooks/use-settings';
 import { useAuth } from '@/providers/auth-provider';
 import { useThemeStore } from '@/stores/theme-store';
@@ -20,7 +24,19 @@ import { SkeletonText } from '@/shared/components/feedback/skeleton';
 import { toast } from 'sonner';
 import { useSearchParams } from 'react-router-dom';
 
-import { DEFAULT_SETTINGS, SETTING_CATEGORY_BY_KEY } from '@/features/core/components/settings/shared';
+import {
+  DEFAULT_SETTINGS,
+  SETTING_BY_KEY,
+  SETTING_CATEGORY_BY_KEY,
+  SettingsSavedKeysProvider,
+  isGuardedSetting,
+  searchSettings,
+  settingConsequence,
+  settingDomId,
+  settingRisk,
+  shrinksRetentionWindow,
+  type SettingCategory,
+} from '@/features/core/components/settings/shared';
 import { GeneralTab, getRedisSystemInfo } from '@/features/core/components/settings/tab-general';
 import { SecurityTab } from '@/features/core/components/settings/tab-security';
 import { AiLlmTab, LlmSettingsSection, LLM_SETTING_KEYS } from '@/features/core/components/settings/tab-ai-llm';
@@ -42,6 +58,15 @@ type SettingsTab = 'general' | 'security' | 'ai' | 'monitoring' | 'integrations'
 
 const VALID_TABS: SettingsTab[] = ['general', 'security', 'ai', 'monitoring', 'integrations', 'infrastructure', 'appearance'];
 
+/**
+ * The tab an admin lands on with no `?tab=`.
+ *
+ * It used to be `general`, which contains no settings at all — version strings,
+ * cache counters, and a page of Redis key hashes. Someone opening Settings has
+ * come to change something, so land them on a tab that can be changed.
+ */
+export const DEFAULT_SETTINGS_TAB: SettingsTab = 'monitoring';
+
 /** Map old bookmark/deep-link tab names to their new equivalents. */
 const TAB_ALIASES: Record<string, SettingsTab> = {
   users: 'security',
@@ -51,24 +76,221 @@ const TAB_ALIASES: Record<string, SettingsTab> = {
   'portainer-backup': 'infrastructure',
 };
 
-function resolveTab(raw: string | null): SettingsTab {
-  if (!raw) return 'general';
+export function resolveTab(raw: string | null): SettingsTab {
+  if (!raw) return DEFAULT_SETTINGS_TAB;
   if (VALID_TABS.includes(raw as SettingsTab)) return raw as SettingsTab;
-  return TAB_ALIASES[raw] ?? 'general';
+  return TAB_ALIASES[raw] ?? DEFAULT_SETTINGS_TAB;
 }
 
 const TAB_META: { value: SettingsTab; label: string; icon: React.ReactNode; adminOnly?: boolean }[] = [
-  { value: 'general', label: 'General', icon: <Settings2 className="h-4 w-4" /> },
+  { value: 'monitoring', label: 'Monitoring', icon: <Activity className="h-4 w-4" /> },
   { value: 'security', label: 'Security', icon: <Shield className="h-4 w-4" /> },
   { value: 'ai', label: 'AI & LLM', icon: <Bot className="h-4 w-4" />, adminOnly: true },
-  { value: 'monitoring', label: 'Monitoring', icon: <Activity className="h-4 w-4" /> },
   { value: 'integrations', label: 'Integrations', icon: <Plug className="h-4 w-4" /> },
   { value: 'infrastructure', label: 'Infrastructure', icon: <HardDriveDownload className="h-4 w-4" /> },
   { value: 'appearance', label: 'Appearance', icon: <Palette className="h-4 w-4" /> },
+  // Last, and named for what it holds: read-only version and cache information.
+  { value: 'general', label: 'About', icon: <Settings2 className="h-4 w-4" /> },
 ];
 
 const TAB_TRIGGER_CLASS =
-  'flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors hover:text-primary data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary';
+  'flex min-h-11 shrink-0 items-center gap-2 whitespace-nowrap px-4 py-2 text-sm font-medium transition-colors hover:text-primary data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary';
+
+const SETTINGS_SUBTITLE = 'Environment, backup, monitoring, and cache configuration';
+
+/** Which tab renders each settings category — the target of a search result. */
+const TAB_BY_CATEGORY: Record<SettingCategory, SettingsTab> = {
+  monitoring: 'monitoring',
+  anomaly: 'monitoring',
+  notifications: 'monitoring',
+  authentication: 'security',
+  statusPage: 'security',
+  llm: 'ai',
+  mcp: 'ai',
+  aiTuning: 'ai',
+  webhooks: 'integrations',
+  elasticsearch: 'integrations',
+  harbor: 'integrations',
+  cache: 'infrastructure',
+  portainerBackup: 'infrastructure',
+  metricsRetention: 'infrastructure',
+  edgeAgent: 'infrastructure',
+};
+
+// ─── Tab strip ───────────────────────────────────────────────────────
+
+/**
+ * Horizontally scrollable tab row with an honest overflow affordance.
+ *
+ * Seven tabs do not fit at tablet width. The row scrolled, but nothing said so —
+ * no fade, no arrow, no cut-off glyph — so 2½ tabs were simply invisible. The
+ * arrows appear only when there is something to scroll to, which in a
+ * zero-layout environment (jsdom) means never.
+ */
+function TabStrip({ children }: { children: React.ReactNode }) {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const [overflow, setOverflow] = useState({ left: false, right: false });
+
+  const measure = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    setOverflow({
+      left: el.scrollLeft > 4,
+      right: el.scrollLeft + el.clientWidth < el.scrollWidth - 4,
+    });
+  }, []);
+
+  useEffect(() => {
+    measure();
+    const el = scrollerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [measure]);
+
+  const scrollBy = (direction: -1 | 1) => {
+    scrollerRef.current?.scrollBy({ left: direction * 200, behavior: 'smooth' });
+  };
+
+  return (
+    <div className="relative border-b">
+      <div
+        ref={scrollerRef}
+        onScroll={measure}
+        className="flex items-center overflow-x-auto scrollbar-themed"
+      >
+        {children}
+      </div>
+      {overflow.left && (
+        <>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-background to-transparent"
+          />
+          <button
+            type="button"
+            aria-label="Scroll tabs left"
+            onClick={() => scrollBy(-1)}
+            className="absolute left-0 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-input bg-background text-muted-foreground hover:text-foreground"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+        </>
+      )}
+      {overflow.right && (
+        <>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent"
+          />
+          <button
+            type="button"
+            aria-label="Scroll tabs right"
+            onClick={() => scrollBy(1)}
+            className="absolute right-0 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-input bg-background text-muted-foreground hover:text-foreground"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Guarded-change review bar ───────────────────────────────────────
+
+interface GuardedChangesBarProps {
+  keys: string[];
+  editedValues: Record<string, string>;
+  originalValues: Record<string, string>;
+  isSaving: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+}
+
+/**
+ * Explicit save for the settings that auto-save must never touch.
+ *
+ * It is pinned to the viewport rather than the page header because the field
+ * being edited can sit 2000px below it, and a confirmation the operator has to
+ * scroll to find is not a confirmation. Secrets are reported as "new value
+ * entered" — the review must not print a client secret back onto the screen.
+ */
+function GuardedChangesBar({
+  keys,
+  editedValues,
+  originalValues,
+  isSaving,
+  onSave,
+  onDiscard,
+}: GuardedChangesBarProps) {
+  if (keys.length === 0) return null;
+
+  return (
+    <div
+      data-testid="guarded-changes-bar"
+      role="region"
+      aria-label="Settings awaiting review"
+      className="fixed inset-x-4 bottom-24 z-40 mx-auto max-w-3xl rounded-lg border border-amber-500/50 bg-card p-4 shadow-lg sm:bottom-6"
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+        <div className="min-w-0 flex-1">
+          <h2 className="font-medium">
+            {keys.length === 1 ? '1 change needs review' : `${keys.length} changes need review`}
+          </h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            These are not saved automatically. Nothing is applied until you save.
+          </p>
+          <ul className="mt-3 max-h-52 space-y-2 overflow-y-auto scrollbar-themed pr-1">
+            {keys.map((key) => {
+              const setting = SETTING_BY_KEY[key];
+              const isSecret = setting?.type === 'password';
+              const before = originalValues[key] ?? '';
+              const after = editedValues[key] ?? '';
+              const shrinking = shrinksRetentionWindow(key, after, before);
+              const consequence = settingConsequence(setting);
+              const showConsequence = consequence && (shrinking || settingRisk(setting) === 'security');
+              return (
+                <li key={key} data-testid={`guarded-change-${key}`} className="text-sm">
+                  <span className="font-medium">{setting?.label ?? key}</span>
+                  <span className="text-muted-foreground">
+                    {isSecret
+                      ? ' — new value entered'
+                      : ` — ${before === '' ? 'empty' : before} → ${after === '' ? 'empty' : after}`}
+                  </span>
+                  {showConsequence && (
+                    <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">{consequence}</p>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onDiscard}
+          disabled={isSaving}
+          className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
+        >
+          Discard
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={isSaving}
+          className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isSaving && <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />}
+          {keys.length === 1 ? 'Save 1 change' : `Save ${keys.length} changes`}
+        </button>
+      </div>
+    </div>
+  );
+}
 
 // ─── Page component ──────────────────────────────────────────────────
 
@@ -86,6 +308,10 @@ export default function SettingsPage() {
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [restartPending, setRestartPending] = useState(false);
+  // Keys committed in the last few seconds, so each row can confirm at the row
+  // instead of only in the page header the operator has scrolled away from.
+  const [savedKeys, setSavedKeys] = useState<ReadonlySet<string>>(() => new Set<string>());
+  const [searchQuery, setSearchQuery] = useState('');
 
   // Active tab (URL-driven)
   const initialTab = resolveTab(searchParams.get('tab'));
@@ -123,8 +349,16 @@ export default function SettingsPage() {
       setSaveSuccess(false);
       setSaveError(null);
       setRestartPending(false);
+      setSavedKeys(new Set<string>());
     }
   }, [settingsData]);
+
+  // The row-level "Saved" pill is a confirmation, not a status — it fades.
+  useEffect(() => {
+    if (savedKeys.size === 0) return;
+    const timeout = window.setTimeout(() => setSavedKeys(new Set<string>()), 4000);
+    return () => { window.clearTimeout(timeout); };
+  }, [savedKeys]);
 
   // ── Change detection ─────────────────────────────────────────────
 
@@ -218,6 +452,7 @@ export default function SettingsPage() {
     if (Object.keys(appliedValues).length > 0) {
       setOriginalValues((prev) => ({ ...prev, ...appliedValues }));
       setSaveSuccess(true);
+      setSavedKeys(new Set(Object.keys(appliedValues)));
       if (appliedRestartSetting) {
         setRestartPending(true);
       }
@@ -231,26 +466,60 @@ export default function SettingsPage() {
     setIsSaving(false);
   }, [restartKeys, updateSetting]);
 
-  // ── Auto-save (excluding LLM keys) ──────────────────────────────
+  // ── Auto-save ───────────────────────────────────────────────────
+  //
+  // Auto-save is for cosmetics and tuning knobs, where the cost of a wrong value
+  // is a cache miss. It deliberately excludes two classes: LLM keys (explicit
+  // Save in the AI tab) and *guarded* keys — anything that changes who can sign
+  // in or deletes stored history. A paused keystroke must not be able to publish
+  // an unauthenticated status page or drop 83 days of metrics.
+
+  const isAutoSaveKey = useCallback(
+    (key: string) => !(LLM_SETTING_KEYS as readonly string[]).includes(key) && !isGuardedSetting(key),
+    [],
+  );
 
   useEffect(() => {
-    // Only auto-save non-LLM keys
-    const nonLlmChanged = Object.keys(editedValues).some(
-      (key) => editedValues[key] !== originalValues[key] && !(LLM_SETTING_KEYS as readonly string[]).includes(key),
+    const autoSaveChanged = Object.keys(editedValues).some(
+      (key) => editedValues[key] !== originalValues[key] && isAutoSaveKey(key),
     );
-    if (isSaving || !nonLlmChanged) return;
+    if (isSaving || !autoSaveChanged) return;
 
     const editedSnapshot = { ...editedValues };
     const originalSnapshot = { ...originalValues };
-    // Build the filter list: every key *except* LLM keys
-    const nonLlmKeys = Object.keys(editedSnapshot).filter((k) => !(LLM_SETTING_KEYS as readonly string[]).includes(k));
+    const autoSaveKeys = Object.keys(editedSnapshot).filter(isAutoSaveKey);
 
     const timeout = window.setTimeout(() => {
-      void saveChangedSettings(editedSnapshot, originalSnapshot, nonLlmKeys);
+      void saveChangedSettings(editedSnapshot, originalSnapshot, autoSaveKeys);
     }, 700);
 
     return () => { window.clearTimeout(timeout); };
-  }, [editedValues, isSaving, originalValues, saveChangedSettings]);
+  }, [editedValues, isAutoSaveKey, isSaving, originalValues, saveChangedSettings]);
+
+  // ── Guarded settings: explicit, reviewed save ───────────────────
+
+  const guardedPendingKeys = useMemo(
+    () =>
+      Object.keys(editedValues)
+        .filter((key) => editedValues[key] !== originalValues[key] && isGuardedSetting(key))
+        .sort(),
+    [editedValues, originalValues],
+  );
+
+  const saveGuardedSettings = useCallback(async () => {
+    if (guardedPendingKeys.length === 0) return;
+    await saveChangedSettings({ ...editedValues }, { ...originalValues }, guardedPendingKeys);
+  }, [editedValues, guardedPendingKeys, originalValues, saveChangedSettings]);
+
+  const discardGuardedChanges = useCallback(() => {
+    setEditedValues((prev) => {
+      const next = { ...prev };
+      for (const key of guardedPendingKeys) {
+        next[key] = originalValues[key];
+      }
+      return next;
+    });
+  }, [guardedPendingKeys, originalValues]);
 
   // ── LLM explicit save helpers (passed to AiLlmTab) ──────────────
 
@@ -287,7 +556,7 @@ export default function SettingsPage() {
     setActiveTab(resolved);
     setSearchParams((previous) => {
       const next = new URLSearchParams(previous);
-      if (resolved === 'general') {
+      if (resolved === DEFAULT_SETTINGS_TAB) {
         next.delete('tab');
       } else {
         next.set('tab', resolved);
@@ -296,15 +565,28 @@ export default function SettingsPage() {
     }, { replace: true });
   };
 
+  // ── Search across every key ─────────────────────────────────────
+
+  const searchMatches = useMemo(() => searchSettings(searchQuery), [searchQuery]);
+
+  const goToSetting = (key: string) => {
+    const tab = TAB_BY_CATEGORY[SETTING_CATEGORY_BY_KEY[key]];
+    if (tab) handleTabChange(tab);
+    setSearchQuery('');
+    // The tab content mounts with that state update; wait a frame for the row.
+    window.requestAnimationFrame(() => {
+      const element = document.getElementById(settingDomId(key));
+      element?.scrollIntoView({ block: 'center' });
+      element?.focus?.();
+    });
+  };
+
   // ── Loading / Error states ───────────────────────────────────────
 
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
-          <p className="text-muted-foreground">Loading settings...</p>
-        </div>
+        <PageHeader title="Settings" subtitle={SETTINGS_SUBTITLE} />
         <div className="grid gap-6">
           {[0, 1, 2].map((i) => (
             <div key={i} className="rounded-lg border bg-card p-6 shadow-sm">
@@ -319,12 +601,7 @@ export default function SettingsPage() {
   if (isError) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
-          <p className="text-muted-foreground">
-            Environment, backup, monitoring, and cache configuration
-          </p>
-        </div>
+        <PageHeader title="Settings" subtitle={SETTINGS_SUBTITLE} />
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6">
           <div className="flex items-center gap-2 text-destructive">
             <AlertTriangle className="h-5 w-5" />
@@ -357,15 +634,22 @@ export default function SettingsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
-          <p className="text-muted-foreground">
-            Environment, backup, monitoring, and cache configuration
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
+      <PageHeader
+        title="Settings"
+        subtitle={SETTINGS_SUBTITLE}
+        actions={
+        <>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search settings"
+              aria-label="Search settings"
+              className="h-9 w-48 rounded-md border border-input bg-background pl-8 pr-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring sm:w-56"
+            />
+          </div>
           {isSaving && (
             <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -381,17 +665,51 @@ export default function SettingsPage() {
               All changes saved
             </div>
           )}
-          {hasChanges && (
-            <button
-              onClick={handleReset}
-              disabled={isSaving}
-              className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
-            >
-              Reset
-            </button>
+          {/* Mounted for the life of the tab. It used to render only while
+              `hasChanges`, which a successful auto-save clears — so the undo
+              control disappeared the moment a value committed. */}
+          <button
+            onClick={handleReset}
+            disabled={isSaving || !hasChanges}
+            className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
+          >
+            Reset
+          </button>
+        </>
+        }
+      />
+
+      {/* Search results — 107 keys across 7 tabs is not a list you scan. */}
+      {searchQuery.trim().length >= 2 && (
+        <div data-testid="settings-search-results" className="rounded-lg border bg-card">
+          {searchMatches.length === 0 ? (
+            <p className="p-4 text-sm text-muted-foreground">
+              No setting matches “{searchQuery.trim()}”. Try a word from the setting’s label, such as
+              “retention”, “OIDC” or “webhook”.
+            </p>
+          ) : (
+            <ul className="divide-y divide-border">
+              {searchMatches.map((match) => (
+                <li key={match.key}>
+                  <button
+                    type="button"
+                    onClick={() => goToSetting(match.key)}
+                    className="flex w-full flex-col items-start gap-0.5 px-4 py-3 text-left hover:bg-accent"
+                  >
+                    <span className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium">{match.label}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {TAB_META.find((t) => t.value === TAB_BY_CATEGORY[match.category])?.label}
+                      </span>
+                    </span>
+                    <span className="text-sm text-muted-foreground">{match.description}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
           )}
         </div>
-      </div>
+      )}
 
       {/* Restart Warning */}
       {(changesRequireRestart || restartPending) && (
@@ -400,8 +718,8 @@ export default function SettingsPage() {
           <div>
             <h3 className="font-medium text-amber-500">Restart Required</h3>
             <p className="text-sm text-muted-foreground mt-1">
-              Some settings changes require a backend restart to take effect.
-              Changes are auto-saved; restart the backend service to apply them.
+              Some of these settings are read once at boot. Restart the backend
+              service to apply them.
             </p>
           </div>
         </div>
@@ -409,51 +727,64 @@ export default function SettingsPage() {
 
       {/* Tabs */}
       <Tabs.Root value={activeTab} onValueChange={handleTabChange} className="space-y-6">
-        <Tabs.List className="flex items-center gap-1 border-b overflow-x-auto">
-          {TAB_META.filter((t) => !t.adminOnly || role === 'admin').map((t) => (
-            <Tabs.Trigger key={t.value} value={t.value} className={TAB_TRIGGER_CLASS}>
-              {t.icon}
-              {t.label}
-            </Tabs.Trigger>
-          ))}
-        </Tabs.List>
+        <TabStrip>
+          <Tabs.List className="flex w-max items-center gap-1">
+            {TAB_META.filter((t) => !t.adminOnly || role === 'admin').map((t) => (
+              <Tabs.Trigger key={t.value} value={t.value} className={TAB_TRIGGER_CLASS}>
+                {t.icon}
+                {t.label}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+        </TabStrip>
 
-        <Tabs.Content value="general" className="space-y-6 focus:outline-none">
-          <GeneralTab theme={theme} />
-        </Tabs.Content>
-
-        <Tabs.Content value="security" className="space-y-6 focus:outline-none">
-          <SecurityTab {...tabProps} />
-        </Tabs.Content>
-
-        {role === 'admin' && (
-          <Tabs.Content value="ai" className="space-y-6 focus:outline-none">
-            <AiLlmTab
-              {...tabProps}
-              role={role}
-              saveLlmSettings={saveLlmSettings}
-              hasLlmChanges={hasLlmChanges}
-              resetLlmValues={resetLlmValues}
-            />
+        <SettingsSavedKeysProvider savedKeys={savedKeys}>
+          <Tabs.Content value="general" className="space-y-6 focus:outline-none">
+            <GeneralTab theme={theme} />
           </Tabs.Content>
-        )}
 
-        <Tabs.Content value="monitoring" className="space-y-6 focus:outline-none">
-          <MonitoringTab {...tabProps} />
-        </Tabs.Content>
+          <Tabs.Content value="security" className="space-y-6 focus:outline-none">
+            <SecurityTab {...tabProps} />
+          </Tabs.Content>
 
-        <Tabs.Content value="integrations" className="space-y-6 focus:outline-none">
-          <IntegrationsTab {...tabProps} />
-        </Tabs.Content>
+          {role === 'admin' && (
+            <Tabs.Content value="ai" className="space-y-6 focus:outline-none">
+              <AiLlmTab
+                {...tabProps}
+                role={role}
+                saveLlmSettings={saveLlmSettings}
+                hasLlmChanges={hasLlmChanges}
+                resetLlmValues={resetLlmValues}
+              />
+            </Tabs.Content>
+          )}
 
-        <Tabs.Content value="infrastructure" className="space-y-6 focus:outline-none">
-          <InfrastructureTab {...tabProps} />
-        </Tabs.Content>
+          <Tabs.Content value="monitoring" className="space-y-6 focus:outline-none">
+            <MonitoringTab {...tabProps} />
+          </Tabs.Content>
 
-        <Tabs.Content value="appearance" className="space-y-6 focus:outline-none">
-          <AppearanceTab />
-        </Tabs.Content>
+          <Tabs.Content value="integrations" className="space-y-6 focus:outline-none">
+            <IntegrationsTab {...tabProps} />
+          </Tabs.Content>
+
+          <Tabs.Content value="infrastructure" className="space-y-6 focus:outline-none">
+            <InfrastructureTab {...tabProps} />
+          </Tabs.Content>
+
+          <Tabs.Content value="appearance" className="space-y-6 focus:outline-none">
+            <AppearanceTab />
+          </Tabs.Content>
+        </SettingsSavedKeysProvider>
       </Tabs.Root>
+
+      <GuardedChangesBar
+        keys={guardedPendingKeys}
+        editedValues={editedValues}
+        originalValues={originalValues}
+        isSaving={isSaving}
+        onSave={() => { void saveGuardedSettings(); }}
+        onDiscard={discardGuardedChanges}
+      />
     </div>
   );
 }

--- a/frontend/src/features/observability/components/no-trace-data-callout.test.tsx
+++ b/frontend/src/features/observability/components/no-trace-data-callout.test.tsx
@@ -31,4 +31,32 @@ describe('NoTraceDataCallout', () => {
     );
     expect(screen.getByText('Custom hint text')).toBeInTheDocument();
   });
+
+  // The callout used raw purple (`border-purple-400/30`, `bg-purple-500/5`,
+  // `text-purple-500`) which assumes a dark surface across 16 themes, 8 of them
+  // light — and purple is this design system's reserved AI-insight colour,
+  // which a trace empty state is not.
+  it('uses theme tokens rather than raw palette colours', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <NoTraceDataCallout />
+      </MemoryRouter>,
+    );
+    expect(container.innerHTML).not.toMatch(/purple-/);
+    const card = screen.getByTestId('no-trace-data-callout');
+    expect(card.className).toContain('border-border');
+  });
+
+  // Regression: the CTA was the only solid-fill button on /llm-observability,
+  // making a docs jump the loudest element on a page of real telemetry.
+  it('renders the Beyla CTA as a text link, not a solid-fill button', () => {
+    render(
+      <MemoryRouter>
+        <NoTraceDataCallout />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole('link', { name: /deploy beyla/i });
+    expect(link.className).not.toMatch(/bg-(purple|primary|blue)-?\d*/);
+    expect(link.className).toContain('text-primary');
+  });
 });

--- a/frontend/src/features/observability/components/no-trace-data-callout.tsx
+++ b/frontend/src/features/observability/components/no-trace-data-callout.tsx
@@ -10,25 +10,33 @@ interface NoTraceDataCalloutProps {
 
 /**
  * Empty-state callout for any page that consumes trace/RED data. Renders a
- * glassmorphic card with a friendly explanation and a CTA pointing at the
- * eBPF coverage page where operators can roll Beyla onto endpoints.
+ * bordered card explaining why the panel is empty and pointing at the eBPF
+ * coverage page, where operators roll Beyla onto endpoints.
  *
  * Use whenever a trace query succeeds but returns no data, so the UI gives a
  * clear next step instead of looking broken.
+ *
+ * Two deliberate choices, both from the design critique:
+ * - **Theme tokens, not raw purple.** The card used `border-purple-400/30` /
+ *   `bg-purple-500/5`, which assumes a dark surface and is the colour this
+ *   design system reserves for AI insight. Traces are not an AI surface.
+ * - **The link is a link.** The CTA used to be the only solid-fill button on
+ *   `/llm-observability`, which made a documentation jump the loudest element
+ *   on a page full of real telemetry. An empty state should not out-shout the
+ *   data next to it.
  */
 export function NoTraceDataCallout({ description, className }: NoTraceDataCalloutProps) {
   return (
     <div
       className={cn(
-        'rounded-lg border border-dashed border-purple-400/30 bg-purple-500/5 p-6',
-        'backdrop-blur-sm shadow-sm',
+        'rounded-lg border border-dashed border-border bg-muted/20 p-6',
         'flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between',
         className,
       )}
       data-testid="no-trace-data-callout"
     >
       <div className="flex items-start gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-purple-500/10 text-purple-500">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
           <Activity className="h-5 w-5" />
         </div>
         <div>
@@ -41,7 +49,7 @@ export function NoTraceDataCallout({ description, className }: NoTraceDataCallou
       </div>
       <Link
         to="/ebpf-coverage"
-        className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-purple-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:ring-offset-2"
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-md px-1 py-1 text-sm font-medium text-primary underline-offset-4 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         Deploy Beyla
         <ArrowRight className="h-3.5 w-3.5" />

--- a/frontend/src/features/observability/hooks/use-correlated-anomalies.ts
+++ b/frontend/src/features/observability/hooks/use-correlated-anomalies.ts
@@ -2,6 +2,40 @@ import { useQuery } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
 import { STALE_TIMES } from '@/shared/lib/query-constants';
 
+/** Stable ids for the deterministic deviation rules the backend evaluates. */
+export type MetricPatternId =
+  | 'cpu-and-memory-deviation'
+  | 'memory-only-deviation'
+  | 'cpu-only-deviation';
+
+export interface PatternMetricObservation {
+  type: string;
+  zScore: number;
+}
+
+/**
+ * Which deviation rule fired, on which metrics, at what threshold.
+ *
+ * The backend used to send a single hardcoded English sentence per rule branch
+ * ("…suggesting gradual memory accumulation"), which read as a diagnosis
+ * nothing had actually made and rendered byte-identically on every card that
+ * hit the same branch. The classification is real; the prose was not. Render
+ * the rule and its numbers.
+ */
+export interface MetricPatternMatch {
+  id: MetricPatternId;
+  /** Names what was observed, not what caused it. */
+  label: string;
+  /** The z-score each `triggeredBy` metric had to exceed. */
+  zScoreThreshold: number;
+  /** Metrics that crossed the threshold. */
+  triggeredBy: PatternMetricObservation[];
+  /** Metrics the rule inspected that stayed within the threshold. */
+  withinThreshold: PatternMetricObservation[];
+  /** Restatement of the rule and the numbers it fired on. Not an inference. */
+  summary: string;
+}
+
 export interface CorrelatedAnomaly {
   containerId: string;
   containerName: string;
@@ -12,7 +46,9 @@ export interface CorrelatedAnomaly {
     zScore: number;
   }>;
   compositeScore: number;
+  /** `patternMatch.summary`, or null when no rule fired. Prefer `patternMatch`. */
   pattern: string | null;
+  patternMatch: MetricPatternMatch | null;
   severity: 'low' | 'medium' | 'high' | 'critical';
   timestamp: string;
 }

--- a/frontend/src/features/observability/hooks/use-correlations.ts
+++ b/frontend/src/features/observability/hooks/use-correlations.ts
@@ -12,12 +12,29 @@ export interface CorrelationPair {
 }
 
 export interface CorrelationInsight {
+  /**
+   * Stable key for the (containerA, containerB, metric) triple this narrative
+   * belongs to. Join on this, never on array position: the server slices its
+   * own top-10 from the unfiltered pair list while this page slices a top-10
+   * from a list that may be filtered to one container, so the two lists are
+   * routinely different sets. Format: `containerA|containerB|metricType`.
+   */
+  pairKey: string;
   containerA: string;
   containerB: string;
   metricType: string;
   correlation: number;
   narrative: string | null;
 }
+
+/**
+ * Why narratives are missing, when they are.
+ * - `ok`          — every pair got one.
+ * - `partial`     — some did; the rest are null.
+ * - `unparsed`    — the model answered but nothing matched a pair.
+ * - `unavailable` — the model call failed.
+ */
+export type NarrativeStatus = 'ok' | 'partial' | 'unparsed' | 'unavailable';
 
 export interface CorrelationsResponse {
   pairs: CorrelationPair[];
@@ -26,6 +43,20 @@ export interface CorrelationsResponse {
 export interface CorrelationInsightsResponse {
   insights: CorrelationInsight[];
   summary: string | null;
+  narrativeStatus: NarrativeStatus;
+  /** One operator-facing sentence for a non-`ok` status. Render it once. */
+  narrativeUnavailableReason: string | null;
+  /** Total correlated pairs found, before the server's top-10 slice. */
+  pairsTotal: number;
+}
+
+/** Mirrors the server's join-key format. Container names cannot contain `|`. */
+export function correlationPairKey(
+  containerA: string,
+  containerB: string,
+  metricType: string,
+): string {
+  return `${containerA}|${containerB}|${metricType}`;
 }
 
 export function useCorrelations(hours: number = 24, enabled: boolean = true) {

--- a/frontend/src/features/observability/pages/log-viewer.test.tsx
+++ b/frontend/src/features/observability/pages/log-viewer.test.tsx
@@ -81,15 +81,152 @@ describe('LogViewerPage', () => {
       selector({ potatoMode: false }),
     );
     mockUsePageVisibility.mockReturnValue(true);
+    // `clearAllMocks` does not drop implementations set with `mockReturnValue`,
+    // so restore the stream defaults explicitly — otherwise one test's streamed
+    // entries leak into every test that follows it.
+    mockUseLogStream.mockReturnValue({
+      streamedEntries: [],
+      isStreaming: false,
+      isFallback: false,
+      reset: vi.fn(),
+    });
     mockUrlSearch = new URLSearchParams();
   });
 
   it('renders page shell and controls', () => {
     render(<LogViewerPage />);
-    expect(screen.getByText('Log Viewer')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Log Viewer');
     expect(screen.getByText('Search')).toBeInTheDocument();
-    expect(screen.getByText('Live Tail ON')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'Live tail' })).toBeInTheDocument();
     expect(screen.getByText('Select one or more containers to view aggregated logs.')).toBeInTheDocument();
+  });
+
+  it('renders exactly one h1, matching the navigation label', () => {
+    render(<LogViewerPage />);
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+  });
+
+  describe('toggles are switches with static labels', () => {
+    it('keeps the label fixed and puts the state in aria-checked', () => {
+      render(<LogViewerPage />);
+
+      const wrap = screen.getByRole('switch', { name: 'Wrap lines' });
+      expect(wrap).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(wrap);
+
+      // Same accessible name after toggling — the state lives in aria-checked,
+      // not in the label of the control that changes it.
+      expect(screen.getByRole('switch', { name: 'Wrap lines' })).toHaveAttribute(
+        'aria-checked',
+        'false',
+      );
+      expect(screen.queryByText(/Wrap (ON|OFF)/)).not.toBeInTheDocument();
+    });
+
+    it('uses a light-theme-safe green for the on state, not text-emerald-300 alone', () => {
+      render(<LogViewerPage />);
+      const wrap = screen.getByRole('switch', { name: 'Wrap lines' });
+      expect(wrap.className).toContain('text-emerald-700');
+      expect(wrap.className).toContain('dark:text-emerald-300');
+    });
+  });
+
+  describe('live tail requires a container', () => {
+    it('is off and disabled with nothing selected', () => {
+      render(<LogViewerPage />);
+
+      const liveTail = screen.getByRole('switch', { name: 'Live tail' });
+      expect(liveTail).toBeDisabled();
+      expect(liveTail).toHaveAttribute('aria-checked', 'false');
+      expect(liveTail).toHaveAttribute('title', 'Select a container to start a live tail');
+    });
+
+    it('turns on once a container is selected', async () => {
+      render(<LogViewerPage />);
+      fireEvent.click(screen.getByRole('button', { name: 'Select Container' }));
+
+      await waitFor(() => {
+        const liveTail = screen.getByRole('switch', { name: 'Live tail' });
+        expect(liveTail).toBeEnabled();
+        expect(liveTail).toHaveAttribute('aria-checked', 'true');
+      });
+    });
+
+    it('does not open a stream while nothing is selected', () => {
+      render(<LogViewerPage />);
+      const lastCall = mockUseLogStream.mock.calls.at(-1)?.[0] as
+        | { enabled: boolean }
+        | undefined;
+      expect(lastCall?.enabled).toBe(false);
+    });
+  });
+
+  describe('exports', () => {
+    it('disables both export buttons while the console is empty', () => {
+      render(<LogViewerPage />);
+
+      expect(screen.getByRole('button', { name: /Export \.log/ })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Export \.json/ })).toBeDisabled();
+      expect(screen.getByText('0 lines | 0 search matches')).toBeInTheDocument();
+    });
+
+    it('enables them once lines exist', async () => {
+      mockUseLogStream.mockReturnValue({
+        streamedEntries: [
+          {
+            id: 'e1',
+            containerId: 'c1',
+            containerName: 'api',
+            timestamp: '2026-05-05T10:00:00.000Z',
+            level: 'error' as const,
+            message: 'connection refused',
+            raw: '2026-05-05T10:00:00.000Z connection refused',
+          },
+        ],
+        isStreaming: true,
+        isFallback: false,
+        reset: vi.fn(),
+      });
+
+      render(<LogViewerPage />);
+      fireEvent.click(screen.getByRole('button', { name: 'Select Container' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Export \.log/ })).toBeEnabled();
+      });
+      expect(screen.getByRole('button', { name: /Export \.json/ })).toBeEnabled();
+    });
+  });
+
+  describe('advanced filter disclosure', () => {
+    it('hides Level, Trace ID and Buffer until Filters is opened', () => {
+      render(<LogViewerPage />);
+
+      expect(screen.queryByLabelText('Trace ID filter')).not.toBeInTheDocument();
+      expect(screen.queryByText('Level')).not.toBeInTheDocument();
+      expect(screen.queryByText('Buffer')).not.toBeInTheDocument();
+
+      const disclosure = screen.getByRole('button', { name: /Filters/ });
+      expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+      fireEvent.click(disclosure);
+
+      expect(screen.getByLabelText('Trace ID filter')).toBeInTheDocument();
+      expect(screen.getByText('Level')).toBeInTheDocument();
+      expect(screen.getByText('Buffer')).toBeInTheDocument();
+      expect(disclosure).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('opens itself when a trace deep-link arrives', () => {
+      mockUrlSearch = new URLSearchParams({ trace: 'abcdef1234567890' });
+      render(<LogViewerPage />);
+
+      expect(screen.getByRole('button', { name: /Filters/ })).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      );
+      expect(screen.getByLabelText('Trace ID filter')).toBeInTheDocument();
+    });
   });
 
   it('filter section has higher z-index than log output area (#404)', () => {
@@ -114,7 +251,10 @@ describe('LogViewerPage', () => {
 
     render(<LogViewerPage />);
 
-    expect(screen.getByText('Live Tail OFF')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'Live tail' })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
   });
 
   it('uses 5s fallback polling interval when SSE is unavailable (#519)', async () => {

--- a/frontend/src/features/observability/pages/log-viewer.tsx
+++ b/frontend/src/features/observability/pages/log-viewer.tsx
@@ -2,11 +2,24 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { useSearchParams } from 'react-router-dom';
 import { useQueries } from '@tanstack/react-query';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Search, Download, WrapText, Activity, ArrowDown, Radio, Link2, X } from 'lucide-react';
+import {
+  Search,
+  Download,
+  WrapText,
+  Activity,
+  ArrowDown,
+  Radio,
+  Link2,
+  X,
+  SlidersHorizontal,
+  ChevronDown,
+} from 'lucide-react';
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
 import { useContainers } from '@/features/containers/hooks/use-containers';
 import { api } from '@/shared/lib/api';
 import { cn } from '@/shared/lib/utils';
+import { PageHeader } from '@/shared/components/layout/page-header';
+import { findDestination } from '@/features/core/lib/navigation-manifest';
 import { ContainerMultiSelect } from '@/shared/components/forms/container-multi-select';
 import { buildSearchMatcher, filterLines, parseLogs, sortByTimestamp, toLocalTimestamp, type LogLevel, type ParsedLogEntry } from '@/features/observability/lib/log-viewer';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
@@ -26,8 +39,65 @@ const LEVEL_OPTIONS: Array<{ value: LogLevel | 'all'; label: string }> = [
 ];
 const CONTAINER_COLORS = ['text-cyan-300', 'text-emerald-300', 'text-yellow-300', 'text-fuchsia-300', 'text-blue-300'];
 
+const PAGE_TITLE = findDestination('/logs')?.label ?? 'Log Viewer';
+
 interface LogsResponse {
   logs: string;
+}
+
+/**
+ * A real switch, with a label that does not change when you press it.
+ *
+ * These were buttons reading `Live Tail ON` / `Wrap ON` — the state written
+ * into the label of the control that changes it, so the label named what you
+ * were looking at *and* what pressing it would do, ambiguously. They also drew
+ * `text-emerald-300` on `bg-emerald-500/15`: about 1.6:1 on the eight light
+ * themes, the palest text on the page. `emerald-700` in light / `emerald-300`
+ * in dark clears AA in both.
+ */
+function ToggleSwitch({
+  label,
+  icon,
+  checked,
+  disabled,
+  title,
+  onToggle,
+}: {
+  label: string;
+  icon: ReactNode;
+  checked: boolean;
+  disabled?: boolean;
+  title?: string;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      title={title}
+      onClick={onToggle}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md border px-2 py-1 transition-colors',
+        checked
+          ? 'log-toggle-on border-emerald-600/60 bg-emerald-500/15 text-emerald-700 dark:border-emerald-500/70 dark:text-emerald-300'
+          : 'border-input text-muted-foreground hover:bg-accent',
+        disabled && 'cursor-not-allowed opacity-60 hover:bg-transparent',
+      )}
+    >
+      {icon}
+      <span>{label}</span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          'h-1.5 w-1.5 rounded-full',
+          checked ? 'bg-emerald-600 dark:bg-emerald-400' : 'bg-muted-foreground/40',
+        )}
+      />
+    </button>
+  );
 }
 
 function highlightLine(line: string, needle: string | null): ReactNode {
@@ -224,6 +294,9 @@ export default function LogViewerPage() {
   const [lineWrap, setLineWrap] = useState(true);
   const [autoScroll, setAutoScroll] = useState(true);
   const [liveTail, setLiveTail] = useState(!potatoMode);
+  // Trace ID, Level and Buffer are refinements, not the first step. They cost
+  // two full rows above the console; a deep-linked trace opens them for you.
+  const [filtersOpen, setFiltersOpen] = useState(Boolean(initialTrace));
 
   const disableTraceFilter = useCallback(() => {
     setTraceFilter('');
@@ -277,13 +350,18 @@ export default function LogViewerPage() {
     })),
     [selectedContainerModels],
   );
+  // A live tail of nothing is not live. The toggle used to read "ON" with no
+  // container selected, asserting a stream that could not exist.
+  const hasSelection = selectedContainerModels.length > 0;
+  const liveTailActive = liveTail && hasSelection;
+
   const { streamedEntries, isStreaming, isFallback } = useLogStream({
     containers: streamContainers,
-    enabled: liveTail && isPageVisible,
+    enabled: liveTailActive && isPageVisible,
   });
 
   // Use polling only for: initial fetch, or when live tail is off, or SSE fallback
-  const usePollingForLiveTail = liveTail && isPageVisible && isFallback;
+  const usePollingForLiveTail = liveTailActive && isPageVisible && isFallback;
   const containerQueries = useQueries({
     queries: selectedContainerModels.map((container) => ({
       queryKey: ['log-viewer', container.endpointId, container.id, bufferSize],
@@ -365,13 +443,19 @@ export default function LogViewerPage() {
   };
 
   const isLoading = containerQueries.some((q) => q.isLoading);
+  // Both exports used to be permanently clickable, so the obvious thing to do
+  // with an empty console was download an empty file.
+  const hasLines = filteredEntries.length > 0;
+  // How many of the collapsed refinements are actually narrowing the view.
+  const activeRefinementCount =
+    (level !== 'all' ? 1 : 0) + (traceFilter ? 1 : 0) + (bufferSize !== 1000 ? 1 : 0);
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Log Viewer</h1>
-        <p className="text-muted-foreground">Live tail, search, level filtering, and multi-container aggregation.</p>
-      </div>
+      <PageHeader
+        title={PAGE_TITLE}
+        subtitle="Live tail aggregated across containers, from Docker's own stdout"
+      />
 
       {traceFilter && (
         <div
@@ -398,7 +482,8 @@ export default function LogViewerPage() {
 
       <SpotlightCard>
       <section className="relative z-20 rounded-lg border bg-card p-6 shadow-sm">
-        <div className="grid gap-3 lg:grid-cols-4">
+        {/* Container selection is the required first step, so it leads. */}
+        <div className="relative z-20 grid gap-3 lg:grid-cols-4">
           <label className="text-sm">
             <span className="mb-1 block text-muted-foreground">Endpoint</span>
             <ThemedSelect
@@ -412,101 +497,147 @@ export default function LogViewerPage() {
             />
           </label>
 
-          <label className="text-sm lg:col-span-2">
+          <div className="relative z-20 text-sm lg:col-span-3">
+            <span className="mb-1 block text-muted-foreground">Containers</span>
+            <ContainerMultiSelect
+              containers={containers}
+              selected={selectedContainers}
+              onChange={setSelectedContainers}
+            />
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-end gap-3">
+          <label className="min-w-[240px] flex-1 text-sm">
             <span className="mb-1 block text-muted-foreground">Search</span>
             <div className="relative">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <input
                 ref={searchInputRef}
                 className="w-full rounded-md border border-input bg-background pl-10 pr-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                placeholder="error"
+                placeholder='Filter lines… (e.g. "connection refused")'
                 value={searchPattern}
                 onChange={(e) => setSearchPattern(e.target.value)}
               />
             </div>
           </label>
 
-          <label className="text-sm">
-            <span className="mb-1 block text-muted-foreground">Level</span>
-            <ThemedSelect
-              className="h-9 w-full"
-              value={level}
-              onValueChange={(val) => setLevel(val as LogLevel | 'all')}
-              options={LEVEL_OPTIONS.map((option) => ({ value: option.value, label: option.label }))}
+          <button
+            type="button"
+            onClick={() => setFiltersOpen((v) => !v)}
+            aria-expanded={filtersOpen}
+            aria-controls="log-viewer-advanced-filters"
+            className="inline-flex h-[38px] items-center gap-1.5 rounded-md border border-input px-3 text-sm text-muted-foreground transition-colors hover:bg-accent"
+          >
+            <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+            Filters
+            {activeRefinementCount > 0 && (
+              <span className="rounded-full bg-primary/10 px-1.5 text-xs font-medium text-primary">
+                {activeRefinementCount}
+              </span>
+            )}
+            <ChevronDown
+              aria-hidden="true"
+              className={cn('h-4 w-4 transition-transform', filtersOpen && 'rotate-180')}
             />
-          </label>
+          </button>
         </div>
 
-        <div className="mt-3">
-          <label className="text-sm">
-            <span className="mb-1 block text-muted-foreground">Trace ID</span>
-            <input
-              type="text"
-              aria-label="Trace ID filter"
-              className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
-              placeholder="paste a trace id to filter lines"
-              value={traceFilter}
-              onChange={(e) => setTraceFilter(e.target.value)}
-            />
-          </label>
-        </div>
+        {filtersOpen && (
+          <div
+            id="log-viewer-advanced-filters"
+            className="mt-3 grid gap-3 rounded-md border border-border bg-muted/30 p-3 sm:grid-cols-2 lg:grid-cols-4"
+          >
+            <label className="text-sm">
+              <span className="mb-1 block text-muted-foreground">Level</span>
+              <ThemedSelect
+                className="h-9 w-full"
+                value={level}
+                onValueChange={(val) => setLevel(val as LogLevel | 'all')}
+                options={LEVEL_OPTIONS.map((option) => ({ value: option.value, label: option.label }))}
+              />
+            </label>
 
-        <div className="relative z-20 mt-3">
-          <span className="mb-1 block text-sm text-muted-foreground">Containers</span>
-          <ContainerMultiSelect
-            containers={containers}
-            selected={selectedContainers}
-            onChange={setSelectedContainers}
-          />
-        </div>
+            <label className="text-sm sm:col-span-2">
+              <span className="mb-1 block text-muted-foreground">Trace ID</span>
+              <input
+                type="text"
+                aria-label="Trace ID filter"
+                className="h-9 w-full rounded-md border border-input bg-background px-3 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="paste a trace id to filter lines"
+                value={traceFilter}
+                onChange={(e) => setTraceFilter(e.target.value)}
+              />
+            </label>
+
+            <label className="text-sm">
+              <span className="mb-1 block text-muted-foreground">Buffer</span>
+              <ThemedSelect
+                className="h-9 w-full"
+                value={String(bufferSize)}
+                onValueChange={(val) => setBufferSize(Number(val))}
+                options={BUFFER_OPTIONS.map((size) => ({ value: String(size), label: String(size) }))}
+              />
+            </label>
+          </div>
+        )}
 
         <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">
-          <button
-            onClick={() => setLiveTail((v) => !v)}
-            className={cn(
-              'rounded-md border px-2 py-1 transition-colors',
-              liveTail && 'log-toggle-on border-emerald-500/70 bg-emerald-500/15 text-emerald-300',
-            )}
-          >
-            <Activity className="mr-1 inline h-4 w-4" />
-            Live Tail {liveTail ? 'ON' : 'OFF'}
-          </button>
-          {liveTail && isStreaming && (
-            <span className="inline-flex items-center gap-1 text-xs text-emerald-400">
-              <Radio className="h-3 w-3 animate-pulse" />
+          <ToggleSwitch
+            label="Live tail"
+            icon={<Activity className="h-4 w-4" aria-hidden="true" />}
+            checked={liveTailActive}
+            disabled={!hasSelection}
+            title={hasSelection ? undefined : 'Select a container to start a live tail'}
+            onToggle={() => setLiveTail((v) => !v)}
+          />
+          {liveTailActive && isStreaming && (
+            <span className="inline-flex items-center gap-1 text-xs text-emerald-700 dark:text-emerald-400">
+              <Radio className="h-3 w-3 animate-pulse" aria-hidden="true" />
               SSE
             </span>
           )}
-          {liveTail && isFallback && (
-            <span className="text-xs text-amber-400">Polling (SSE unavailable)</span>
+          {liveTailActive && isFallback && (
+            <span className="text-xs text-amber-700 dark:text-amber-400">
+              Polling (SSE unavailable)
+            </span>
           )}
+          <ToggleSwitch
+            label="Wrap lines"
+            icon={<WrapText className="h-4 w-4" aria-hidden="true" />}
+            checked={lineWrap}
+            onToggle={() => setLineWrap((v) => !v)}
+          />
           <button
-            onClick={() => setLineWrap((v) => !v)}
+            type="button"
+            onClick={() => exportLogs('log')}
+            disabled={!hasLines}
+            title={hasLines ? undefined : 'Nothing to export yet'}
             className={cn(
               'rounded-md border px-2 py-1 transition-colors',
-              lineWrap && 'log-toggle-on border-emerald-500/70 bg-emerald-500/15 text-emerald-300',
+              hasLines
+                ? 'border-input hover:bg-accent'
+                : 'cursor-not-allowed border-border bg-muted/50 text-muted-foreground',
             )}
           >
-            <WrapText className="mr-1 inline h-4 w-4" />
-            Wrap {lineWrap ? 'ON' : 'OFF'}
-          </button>
-          <button onClick={() => exportLogs('log')} className="rounded-md border px-2 py-1">
-            <Download className="mr-1 inline h-4 w-4" />
+            <Download className="mr-1 inline h-4 w-4" aria-hidden="true" />
             Export .log
           </button>
-          <button onClick={() => exportLogs('json')} className="rounded-md border px-2 py-1">
-            <Download className="mr-1 inline h-4 w-4" />
+          <button
+            type="button"
+            onClick={() => exportLogs('json')}
+            disabled={!hasLines}
+            title={hasLines ? undefined : 'Nothing to export yet'}
+            className={cn(
+              'rounded-md border px-2 py-1 transition-colors',
+              hasLines
+                ? 'border-input hover:bg-accent'
+                : 'cursor-not-allowed border-border bg-muted/50 text-muted-foreground',
+            )}
+          >
+            <Download className="mr-1 inline h-4 w-4" aria-hidden="true" />
             Export .json
           </button>
-          <label className="ml-auto inline-flex items-center text-sm">
-            <span className="mr-2 text-muted-foreground">Buffer</span>
-            <ThemedSelect
-              className="h-9"
-              value={String(bufferSize)}
-              onValueChange={(val) => setBufferSize(Number(val))}
-              options={BUFFER_OPTIONS.map((size) => ({ value: String(size), label: String(size) }))}
-            />
-          </label>
         </div>
 
         <div className="mt-2 text-xs text-muted-foreground">

--- a/frontend/src/features/observability/pages/metrics-dashboard.test.tsx
+++ b/frontend/src/features/observability/pages/metrics-dashboard.test.tsx
@@ -102,8 +102,12 @@ vi.mock('@/features/observability/hooks/use-forecasts', () => ({
   useAiForecastNarrative: (...args: unknown[]) => mockUseAiForecastNarrative(...args),
 }));
 
+// Captured, not stubbed blind: the page's contract with this hook (a real
+// `onTick` and its own storage key) is exactly what was missing, so the
+// arguments are what the tests assert on.
+const mockUseAutoRefresh = vi.fn();
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: vi.fn().mockReturnValue({ interval: 0, setInterval: vi.fn() }),
+  useAutoRefresh: (...args: unknown[]) => mockUseAutoRefresh(...args),
 }));
 
 // Mock recharts to avoid canvas issues in jsdom
@@ -186,8 +190,22 @@ function renderPage() {
 
 describe('MetricsDashboardPage', () => {
   beforeEach(() => {
+    // The page now remembers the last endpoint/container in localStorage, and
+    // jsdom keeps one store for the whole file — without this, a selection made
+    // in one test would be restored on the next test's mount.
+    localStorage.clear();
+    mockUseAutoRefresh.mockReturnValue({
+      interval: 0,
+      setRefreshInterval: vi.fn(),
+      setInterval: vi.fn(),
+    });
     useHeaderContextStore.setState({ metricsContainerName: null });
-    vi.mocked(useContainerMetrics).mockReturnValue({ data: null, isLoading: false, isError: false } as never);
+    vi.mocked(useContainerMetrics).mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+      dataUpdatedAt: Date.now(),
+    } as never);
     mockUseContainerMetricsMeta.mockReturnValue({
       data: { memoryLimitBytes: 536870912, onlineCpus: 4, usedBytes: 337641472 },
     });
@@ -323,11 +341,15 @@ describe('MetricsDashboardPage', () => {
     });
 
     renderPage();
-    expect(screen.getByText('Forecast Overview (Next 24h)')).toBeTruthy();
+    // Both forecast sections now name the same horizon the same way; scope is
+    // what differs, and scope is what the headings carry.
+    expect(screen.getByText('Capacity Forecast — Fleet (Next 24h)')).toBeTruthy();
     expect(screen.getByText('api-1')).toBeTruthy();
     expect(screen.getByText('worker-2')).toBeTruthy();
     expect(screen.getByText('Critical: 1')).toBeTruthy();
     expect(screen.getByText('Healthy: 1')).toBeTruthy();
+    // Nothing is in the warning bucket, and a zero is not news.
+    expect(screen.queryByText('Warning: 0')).toBeNull();
   });
 
   it('renders the forecast overview as a DataTable with column headers and rows', () => {
@@ -718,6 +740,293 @@ describe('MetricsDashboardPage', () => {
     const grid = screen.getByTestId('metrics-charts-grid');
     expect(grid.className).toContain('lg:grid-cols-2');
     expect(within(grid).getAllByTestId('metrics-chart')).toHaveLength(3);
+  });
+
+  describe('auto-refresh', () => {
+    it('schedules the fetches the dropdown advertises, under its own storage key', () => {
+      // `interval` used to be read once and passed to <RefreshControls> and
+      // nowhere else in 1,262 lines: the control rendered a pulsing live dot
+      // over a timer that did not exist. The shared storage key was the other
+      // half — this page asked for 0 and opened showing "Every 30s".
+      const metricsRefetch = vi.fn();
+      vi.mocked(useContainerMetrics).mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+        refetch: metricsRefetch,
+      } as never);
+      const forecastRefetch = vi.fn();
+      mockUseForecasts.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+        refetch: forecastRefetch,
+      });
+
+      renderPage();
+
+      const lastCall = mockUseAutoRefresh.mock.calls.at(-1) as [
+        number,
+        { onTick?: () => void; storageKey?: string },
+      ];
+      expect(lastCall[0]).toBe(0);
+      expect(lastCall[1].storageKey).toBe('metrics');
+      expect(typeof lastCall[1].onTick).toBe('function');
+
+      lastCall[1].onTick?.();
+      expect(metricsRefetch).toHaveBeenCalled();
+      expect(forecastRefetch).toHaveBeenCalled();
+    });
+
+    it('shows a data-freshness stamp beside the control', () => {
+      renderPage();
+      expect(screen.getByText(/^Updated /)).toBeInTheDocument();
+    });
+  });
+
+  describe('arriving on the page', () => {
+    const SELECTION_KEY = 'metrics-dashboard:last-selection';
+
+    it('auto-selects the only endpoint instead of gating on a one-answer click', () => {
+      renderPage();
+
+      const [endpointSelect, , containerSelect] = screen.getAllByRole('combobox');
+      expect(endpointSelect.textContent).toContain('local');
+      expect(containerSelect).not.toBeDisabled();
+      // The container is still the operator's choice, so the empty state stands.
+      expect(screen.getByText('Select a container')).toBeInTheDocument();
+    });
+
+    it('restores the container it was last showing', async () => {
+      localStorage.setItem(
+        SELECTION_KEY,
+        JSON.stringify({ endpointId: 1, containerId: 'c2' }),
+      );
+      renderPage();
+
+      await waitFor(() =>
+        expect(useHeaderContextStore.getState().metricsContainerName).toBe('worker-1'),
+      );
+      expect(screen.getByText('Network RX/TX by Network')).toBeInTheDocument();
+    });
+
+    it('ignores a remembered container that no longer exists', () => {
+      localStorage.setItem(
+        SELECTION_KEY,
+        JSON.stringify({ endpointId: 1, containerId: 'deleted-container' }),
+      );
+      renderPage();
+
+      expect(screen.getByText('Select a container')).toBeInTheDocument();
+    });
+
+    it('ignores a malformed remembered selection', () => {
+      localStorage.setItem(SELECTION_KEY, 'not json');
+      renderPage();
+      expect(screen.getByText('Select a container')).toBeInTheDocument();
+    });
+
+    it('remembers the selection the operator makes', () => {
+      renderPage();
+      const containerSelect = screen.getAllByRole('combobox')[2];
+      fireEvent.click(containerSelect);
+      fireEvent.click(screen.getByRole('option', { name: 'worker-1' }));
+
+      expect(JSON.parse(localStorage.getItem(SELECTION_KEY) ?? 'null')).toEqual({
+        endpointId: 1,
+        containerId: 'c2',
+      });
+    });
+  });
+
+  it('renders one page header with a single h1', () => {
+    renderPage();
+    expect(screen.getByTestId('page-header')).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Metrics Dashboard');
+  });
+
+  it('no longer offers a "zoom" that only scaled the chart height', () => {
+    // A time series zooms by changing its time window — which the range picker
+    // three controls to its left already does.
+    renderPage();
+    expect(screen.queryByTitle('Zoom in')).toBeNull();
+    expect(screen.queryByTitle('Zoom out')).toBeNull();
+    expect(screen.queryByText('100%')).toBeNull();
+  });
+
+  it('attaches the container filter to the select it narrows', () => {
+    renderPage();
+
+    const filter = screen.getByLabelText('Search containers');
+    const containerSelect = screen.getAllByRole('combobox')[2];
+    // Same control group. It used to be a full-width, card-backed search pill
+    // sitting above the select — higher contrast than the control it feeds, and
+    // easily read as a page-wide search.
+    expect(containerSelect.parentElement).toContainElement(filter);
+    expect(filter.className).not.toMatch(/rounded-xl|py-3/);
+
+    fireEvent.change(filter, { target: { value: 'worker' } });
+    expect(screen.getByTestId('container-filter-count').textContent).toBe('1 of 4');
+  });
+
+  describe('denominator captions', () => {
+    function selectWorker() {
+      const containerSelect = screen.getAllByRole('combobox')[2];
+      fireEvent.click(containerSelect);
+      fireEvent.click(screen.getByRole('option', { name: 'worker-1' }));
+    }
+
+    beforeEach(() => {
+      vi.mocked(useContainerMetrics).mockReturnValue({
+        data: { data: [{ timestamp: '2024-01-01T00:00:00Z', value: 50 }] },
+        isLoading: false,
+        isError: false,
+      } as never);
+    });
+
+    it('states the CPU convention beside the axis it explains', () => {
+      renderPage();
+      selectWorker();
+
+      const note = screen.getByTestId('cpu-axis-note').textContent ?? '';
+      expect(note).toContain('100% = one full CPU core');
+      expect(note).toContain('4 cores online');
+      expect(note).toContain('400%');
+    });
+
+    it('states the memory denominator beside the axis it explains', () => {
+      renderPage();
+      selectWorker();
+
+      const note = screen.getByTestId('memory-axis-note').textContent ?? '';
+      expect(note).toContain('(usage − cache) ÷ limit');
+      expect(note).toContain('Limit: 512 MB');
+    });
+
+    it('names the host as the denominator when no limit is set', () => {
+      mockUseContainerMetricsMeta.mockReturnValue({
+        data: { memoryLimitBytes: 34359738368, onlineCpus: 4, usedBytes: 2791728742 },
+      });
+      renderPage();
+      selectWorker();
+
+      expect(screen.getByTestId('memory-axis-note').textContent).toContain('No limit set');
+    });
+
+    it('keeps the reasoning out of a hover-only title attribute', () => {
+      // `title=` has no keyboard access, no touch access and a ~1s hover delay,
+      // and this page ships on phones.
+      renderPage();
+      selectWorker();
+
+      expect(screen.getByText(/of 4 cores/)).not.toHaveAttribute('title');
+      expect(screen.getByText(/512 MB limit/)).not.toHaveAttribute('title');
+    });
+  });
+
+  describe('fleet forecast overview', () => {
+    function healthyForecasts(count: number) {
+      return Array.from({ length: count }, (_, i) => ({
+        containerId: `c-${i}`,
+        containerName: `svc-${i}`,
+        metricType: i % 2 === 0 ? 'cpu' : 'memory',
+        currentValue: 19.5 + i,
+        trend: i % 3 === 0 ? ('increasing' as const) : ('stable' as const),
+        slope: 0.01,
+        r_squared: 0.2,
+        forecast: [],
+        timeToThreshold: null,
+        confidence: 'low' as const,
+      }));
+    }
+
+    it('renders the one sentence it has to say, with the table behind a disclosure', () => {
+      // Twenty rows over two pages, eight columns and a per-row button, all to
+      // convey "nothing is projected to breach".
+      mockUseForecasts.mockReturnValue({
+        data: healthyForecasts(20),
+        isLoading: false,
+        error: null,
+      });
+
+      renderPage();
+
+      const allClear = screen.getByTestId('forecast-overview-all-clear');
+      expect(allClear.textContent).toContain('No capacity breaches projected in the next 24h');
+      expect(allClear.textContent).toContain('20 container/metric series checked');
+      expect(screen.getByText('Show all 20 series')).toBeInTheDocument();
+      // Zero buckets are not news.
+      expect(screen.queryByText('Critical: 0')).toBeNull();
+      expect(screen.queryByText('Warning: 0')).toBeNull();
+    });
+
+    it('states what the rank actually orders by when no series has a breach ETA', () => {
+      // With `timeToThreshold` null everywhere the score collapses to trend
+      // bucket plus current value, so "Rank 1" was a container at 19.5% memory.
+      mockUseForecasts.mockReturnValue({
+        data: healthyForecasts(20),
+        isLoading: false,
+        error: null,
+      });
+
+      renderPage();
+      expect(
+        screen.getByText('No series has a projected breach time, so rank orders by trend, then by current value.'),
+      ).toBeInTheDocument();
+    });
+
+    it('goes straight back to the table as soon as one series is not healthy', () => {
+      mockUseForecasts.mockReturnValue({
+        data: [
+          ...healthyForecasts(3),
+          {
+            containerId: 'c-risk',
+            containerName: 'api-1',
+            metricType: 'cpu',
+            currentValue: 92,
+            trend: 'increasing' as const,
+            slope: 1.1,
+            r_squared: 0.9,
+            forecast: [],
+            timeToThreshold: 1,
+            confidence: 'high' as const,
+          },
+        ],
+        isLoading: false,
+        error: null,
+      });
+
+      renderPage();
+
+      expect(screen.queryByTestId('forecast-overview-all-clear')).toBeNull();
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+      expect(screen.getByText('Critical: 1')).toBeInTheDocument();
+    });
+
+    it('badges the risk level rather than printing a raw lowercase status', () => {
+      mockUseForecasts.mockReturnValue({
+        data: [
+          {
+            containerId: 'c-risk',
+            containerName: 'api-1',
+            metricType: 'cpu',
+            currentValue: 92,
+            trend: 'increasing' as const,
+            slope: 1.1,
+            r_squared: 0.9,
+            forecast: [],
+            timeToThreshold: 1,
+            confidence: 'high' as const,
+          },
+        ],
+        isLoading: false,
+        error: null,
+      });
+
+      renderPage();
+      expect(screen.getByText('critical').className).toContain('capitalize');
+    });
   });
 
   it('publishes the selected container name to the header store and clears on unmount', async () => {

--- a/frontend/src/features/observability/pages/metrics-dashboard.tsx
+++ b/frontend/src/features/observability/pages/metrics-dashboard.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { type ColumnDef } from '@tanstack/react-table';
 import {
@@ -9,10 +9,10 @@ import {
   Network,
   Download,
   Clock,
+  Search,
   Server,
   Box,
-  ZoomIn,
-  ZoomOut,
+  ShieldCheck,
   TrendingUp,
   TrendingDown,
   Minus,
@@ -30,7 +30,8 @@ import { MetricsLineChart } from '@/shared/components/charts/metrics-line-chart'
 import { AnomalySparkline } from '@/shared/components/charts/anomaly-sparkline';
 import { NetworkTrafficTooltip } from '@/shared/components/charts/network-traffic-tooltip';
 import { RefreshControls } from '@/shared/components/ui/refresh-controls';
-import { FleetSearch } from '@/features/containers/components/fleet/fleet-search';
+import { PageHeader } from '@/shared/components/layout/page-header';
+import { DataFreshness } from '@/shared/components/feedback/data-freshness';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { SkeletonText, SkeletonChart, SkeletonTableRow } from '@/shared/components/feedback/skeleton';
 import { DataTable } from '@/shared/components/tables/data-table';
@@ -97,6 +98,60 @@ function formatMemSize(bytes: number): string {
   return `${Math.round(mb)} MB`;
 }
 
+/**
+ * The last endpoint/container the operator looked at.
+ *
+ * The page's whole subject sat behind two clicks on every visit, and in a
+ * one-endpoint fleet the first of those clicks had exactly one answer. This is
+ * re-validated against the live container list before it is applied, so a
+ * container that has since been removed falls back to the empty state rather
+ * than selecting something that no longer exists.
+ */
+const LAST_SELECTION_KEY = 'metrics-dashboard:last-selection';
+
+export interface MetricsSelection {
+  endpointId: number;
+  containerId: string;
+}
+
+export function readLastSelection(): MetricsSelection | null {
+  try {
+    const raw = localStorage.getItem(LAST_SELECTION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<MetricsSelection>;
+    if (typeof parsed?.endpointId !== 'number' || typeof parsed?.containerId !== 'string') {
+      return null;
+    }
+    return { endpointId: parsed.endpointId, containerId: parsed.containerId };
+  } catch {
+    return null;
+  }
+}
+
+function writeLastSelection(selection: MetricsSelection): void {
+  try {
+    localStorage.setItem(LAST_SELECTION_KEY, JSON.stringify(selection));
+  } catch {
+    // Ignore storage errors (private mode, quota).
+  }
+}
+
+/**
+ * Docker reports the host's total RAM as a container's `limit` when no explicit
+ * cap is set, so "limit == host total" is the signal for an unconstrained
+ * container rather than a missing reading.
+ */
+function resolveMemoryLimit(
+  limitBytes: number | null | undefined,
+  hostTotalBytes: number | null | undefined,
+): { limit: number; isHostTotal: boolean } | null {
+  if (limitBytes == null) return null;
+  return {
+    limit: limitBytes,
+    isHostTotal: hostTotalBytes != null && limitBytes >= hostTotalBytes * 0.99,
+  };
+}
+
 function exportToCSV(data: Array<{ timestamp: string; value: number }>, filename: string) {
   const csv = [
     'timestamp,value',
@@ -153,10 +208,8 @@ export default function MetricsDashboardPage() {
   const [selectedContainer, setSelectedContainer] = useState<string | null>(null);
   const [containerQuery, setContainerQuery] = useState('');
   const [timeRange, setTimeRange] = useState('1h');
-  const [zoomLevel, setZoomLevel] = useState(1);
   const [chatOpen, setChatOpen] = useState(false);
   const [showSecondaryPanels, setShowSecondaryPanels] = useState(false);
-  const { interval, setInterval } = useAutoRefresh(0);
 
   // Check if LLM is available (hide Ask AI button when the LLM endpoint is unreachable)
   const { data: llmModels } = useLlmModels();
@@ -166,7 +219,8 @@ export default function MetricsDashboardPage() {
   const { data: endpoints, isLoading: endpointsLoading, isPending: endpointsPending } = useEndpoints();
 
   // Fetch containers
-  const { data: allContainers, isLoading: containersLoading, isPending: containersPending, refetch, isFetching } = useContainers();
+  const containersQuery = useContainers();
+  const { data: allContainers, isLoading: containersLoading, isPending: containersPending, refetch, isFetching } = containersQuery;
   const { data: networkRatesData } = useNetworkRates(selectedEndpoint ?? undefined);
   const { data: stacks } = useStacks();
 
@@ -250,37 +304,29 @@ export default function MetricsDashboardPage() {
   }, [selectedContainerData, networkRatesData]);
 
   // Fetch metrics for each type
-  const {
-    data: cpuMetrics,
-    isLoading: cpuLoading,
-    isError: cpuError,
-  } = useContainerMetrics(
+  const cpuQuery = useContainerMetrics(
     selectedEndpoint ?? undefined,
     selectedContainer ?? undefined,
     'cpu',
     timeRange
   );
+  const { data: cpuMetrics, isLoading: cpuLoading, isError: cpuError } = cpuQuery;
 
-  const {
-    data: memoryMetrics,
-    isLoading: memoryLoading,
-    isError: memoryError,
-  } = useContainerMetrics(
+  const memoryQuery = useContainerMetrics(
     selectedEndpoint ?? undefined,
     selectedContainer ?? undefined,
     'memory',
     timeRange
   );
+  const { data: memoryMetrics, isLoading: memoryLoading, isError: memoryError } = memoryQuery;
 
-  const {
-    data: memoryBytesMetrics,
-    isLoading: memoryBytesLoading,
-  } = useContainerMetrics(
+  const memoryBytesQuery = useContainerMetrics(
     selectedEndpoint ?? undefined,
     selectedContainer ?? undefined,
     'memory_bytes',
     timeRange
   );
+  const { data: memoryBytesMetrics, isLoading: memoryBytesLoading } = memoryBytesQuery;
 
   const { data: containerMeta } = useContainerMetricsMeta(
     selectedEndpoint ?? undefined,
@@ -304,6 +350,35 @@ export default function MetricsDashboardPage() {
   const hasForecastData =
     (cpuForecast && !('error' in cpuForecast)) ||
     (memoryForecast && !('error' in memoryForecast));
+
+  // The refresh dropdown now schedules the fetches it advertises. It used to be
+  // read once and passed to `<RefreshControls>` and nowhere else — the control
+  // rendered a pulsing "live" dot over a timer that did not exist. The
+  // page-specific `storageKey` is the other half: with one shared key this page
+  // asked for `useAutoRefresh(0)` and opened showing "Every 30s" because a
+  // different page had stored 30.
+  const handleTick = useCallback(() => {
+    refetch?.();
+    cpuQuery.refetch?.();
+    memoryQuery.refetch?.();
+    memoryBytesQuery.refetch?.();
+    forecastOverviewQuery.refetch?.();
+  }, [refetch, cpuQuery, memoryQuery, memoryBytesQuery, forecastOverviewQuery]);
+  const { interval, setRefreshInterval } = useAutoRefresh(0, {
+    onTick: handleTick,
+    storageKey: 'metrics',
+  });
+
+  // Second signal for a stalled poll: the newest fetch time of what is on
+  // screen. Without it a frozen page and a healthy one look identical.
+  const lastUpdated = useMemo(() => {
+    const stamps = [
+      containersQuery.dataUpdatedAt,
+      cpuQuery.dataUpdatedAt,
+      memoryQuery.dataUpdatedAt,
+    ].filter((t): t is number => typeof t === 'number' && t > 0);
+    return stamps.length > 0 ? Math.max(...stamps) : null;
+  }, [containersQuery.dataUpdatedAt, cpuQuery.dataUpdatedAt, memoryQuery.dataUpdatedAt]);
 
   // Pre-filter explanations by metric type for reuse
   const cpuExplanations = useMemo(
@@ -387,8 +462,10 @@ export default function MetricsDashboardPage() {
   }, [containerMeta, selectedEndpointData, stats.cpu.avg]);
 
   const memoryDenominatorLabel = useMemo(() => {
-    const limit = containerMeta?.memoryLimitBytes ?? null;
-    const hostTotal = selectedEndpointData?.totalMemory ?? null;
+    const resolved = resolveMemoryLimit(
+      containerMeta?.memoryLimitBytes,
+      selectedEndpointData?.totalMemory,
+    );
     // Numerator matches the "Avg Memory %" headline above this label: use the
     // range-average used bytes (memoryBytesData is in MB → ×1MiB) when the series
     // has data, falling back to the live `/meta` sample only when it's empty.
@@ -396,12 +473,35 @@ export default function MetricsDashboardPage() {
       ? stats.memoryBytes.avg * 1024 * 1024
       : null;
     const used = avgUsedBytes ?? containerMeta?.usedBytes ?? null;
-    if (limit == null || used == null) return null;
-    const isHostTotal = hostTotal != null && limit >= hostTotal * 0.99;
-    return isHostTotal
-      ? `${formatMemSize(used)} / ${formatMemSize(limit)} host (no limit set)`
-      : `${formatMemSize(used)} / ${formatMemSize(limit)} limit`;
+    if (resolved == null || used == null) return null;
+    return resolved.isHostTotal
+      ? `${formatMemSize(used)} / ${formatMemSize(resolved.limit)} host (no limit set)`
+      : `${formatMemSize(used)} / ${formatMemSize(resolved.limit)} limit`;
   }, [containerMeta, selectedEndpointData, stats.memoryBytes.avg, memoryBytesData]);
+
+  // The reasoning behind each percentage used to live in a native `title=` on
+  // the KPI sub-label: no keyboard access, no touch access, ~1s hover delay, and
+  // this page ships on phones. It is now a persistent caption under the chart —
+  // where the axis it explains is actually read.
+  const cpuAxisNote = useMemo(() => {
+    const cores = containerMeta?.onlineCpus ?? selectedEndpointData?.totalCpu ?? null;
+    const convention = 'Docker stats convention: 100% = one full CPU core.';
+    return cores
+      ? `${convention} ${cores} core${cores === 1 ? '' : 's'} online, so this axis reaches ${cores * 100}%.`
+      : `${convention} On a multi-core host the axis can exceed 100%.`;
+  }, [containerMeta, selectedEndpointData]);
+
+  const memoryAxisNote = useMemo(() => {
+    const resolved = resolveMemoryLimit(
+      containerMeta?.memoryLimitBytes,
+      selectedEndpointData?.totalMemory,
+    );
+    const formula = 'Memory % = (usage − cache) ÷ limit.';
+    if (resolved == null) return formula;
+    return resolved.isHostTotal
+      ? `${formula} No limit set, so the denominator is the host's ${formatMemSize(resolved.limit)} of RAM.`
+      : `${formula} Limit: ${formatMemSize(resolved.limit)}.`;
+  }, [containerMeta, selectedEndpointData]);
 
   const rankedForecasts = useMemo<RankedForecast[]>(() => {
     const forecasts = forecastOverviewQuery.data ?? [];
@@ -421,6 +521,20 @@ export default function MetricsDashboardPage() {
     );
   }, [rankedForecasts]);
 
+  const allForecastsHealthy =
+    rankedForecasts.length > 0 && riskBuckets.critical === 0 && riskBuckets.warning === 0;
+
+  // State the basis of the ordering rather than letting "Rank 1" imply a
+  // projected breach. With no `timeToThreshold` anywhere, `getForecastRiskScore`
+  // falls back to trend bucket plus current value — which is how a container
+  // sitting at 19.5% memory ended up ranked first.
+  const forecastRankBasisNote = useMemo(() => {
+    if (rankedForecasts.length === 0) return null;
+    return rankedForecasts.every((forecast) => forecast.timeToThreshold === null)
+      ? 'No series has a projected breach time, so rank orders by trend, then by current value.'
+      : null;
+  }, [rankedForecasts]);
+
   useEffect(() => {
     const timeoutId = window.setTimeout(() => setShowSecondaryPanels(true), 250);
 
@@ -428,6 +542,39 @@ export default function MetricsDashboardPage() {
       window.clearTimeout(timeoutId);
     };
   }, []);
+
+  // Open on something. This page's subject is one container's series, and it
+  // opened on an empty state behind two dropdowns — the first of which, in a
+  // one-endpoint fleet, has exactly one answer. Runs once, and only while the
+  // operator has not already chosen.
+  const autoSelectedRef = useRef(false);
+  useEffect(() => {
+    if (autoSelectedRef.current) return;
+    if (!endpoints || !allContainers) return;
+    if (selectedEndpoint !== null) {
+      autoSelectedRef.current = true;
+      return;
+    }
+    autoSelectedRef.current = true;
+
+    const last = readLastSelection();
+    const restored = last
+      ? allContainers.find((c) => c.id === last.containerId && c.endpointId === last.endpointId)
+      : undefined;
+    if (restored && endpoints.some((ep) => ep.id === restored.endpointId)) {
+      setSelectedEndpoint(restored.endpointId);
+      setSelectedContainer(restored.id);
+      return;
+    }
+    if (endpoints.length === 1) {
+      setSelectedEndpoint(endpoints[0].id);
+    }
+  }, [endpoints, allContainers, selectedEndpoint]);
+
+  useEffect(() => {
+    if (selectedEndpoint === null || !selectedContainer) return;
+    writeLastSelection({ endpointId: selectedEndpoint, containerId: selectedContainer });
+  }, [selectedEndpoint, selectedContainer]);
 
   // Handle endpoint change
   const handleEndpointChange = (endpointId: number) => {
@@ -437,9 +584,10 @@ export default function MetricsDashboardPage() {
     setContainerQuery('');
   };
 
-  const handleRefresh = () => {
-    refetch();
-  };
+  // Manual refresh and a scheduled tick do the same work — a "Refresh" that
+  // reloaded only the container list while the charts stayed put would be the
+  // same broken promise the dropdown used to make.
+  const handleRefresh = handleTick;
 
   const drillIntoForecast = useCallback((containerId: string) => {
     const match = allContainers?.find((container) => container.id === containerId);
@@ -490,7 +638,7 @@ export default function MetricsDashboardPage() {
       cell: ({ row }) => {
         const riskLevel = getForecastRiskLevel(row.original);
         return (
-          <span className={cn('inline-flex rounded-full px-2 py-0.5 text-xs font-medium', RISK_BADGE_STYLES[riskLevel])}>
+          <span className={cn('inline-flex rounded-full px-2 py-0.5 text-xs font-medium capitalize', RISK_BADGE_STYLES[riskLevel])}>
             {riskLevel}
           </span>
         );
@@ -524,27 +672,25 @@ export default function MetricsDashboardPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Metrics Dashboard</h1>
-          <p className="text-muted-foreground">
-            CPU/memory time series with anomaly detection
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {hasSelection && llmAvailable && (
-            <button
-              onClick={() => setChatOpen(true)}
-              className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-blue-600 to-purple-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition-all hover:shadow-md"
-            >
-              <Bot className="h-4 w-4" />
-              Ask AI
-            </button>
-          )}
-          <RefreshControls interval={interval} onIntervalChange={setInterval} onRefresh={handleRefresh} isLoading={isFetching} />
-        </div>
-      </div>
+      <PageHeader
+        title="Metrics Dashboard"
+        subtitle="CPU/memory time series with anomaly detection"
+        actions={
+          <>
+            {hasSelection && llmAvailable && (
+              <button
+                onClick={() => setChatOpen(true)}
+                className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-blue-600 to-purple-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition-all hover:shadow-md"
+              >
+                <Bot className="h-4 w-4" />
+                Ask AI
+              </button>
+            )}
+            <DataFreshness lastUpdated={lastUpdated} onRefresh={handleRefresh} />
+            <RefreshControls interval={interval} onIntervalChange={setRefreshInterval} onRefresh={handleRefresh} isLoading={isFetching} />
+          </>
+        }
+      />
 
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-card p-4">
@@ -566,7 +712,7 @@ export default function MetricsDashboardPage() {
           />
         </div>
 
-        {/* Container Selector */}
+        {/* Stack Selector */}
         <div className="flex items-center gap-2">
           <Box className="h-4 w-4 text-muted-foreground" />
           <ThemedSelect
@@ -592,32 +738,52 @@ export default function MetricsDashboardPage() {
           />
         </div>
 
-        {/* Container Selector */}
-        <div className="flex flex-col gap-2 min-w-[16rem]">
-          <FleetSearch
-            key={`${selectedEndpoint ?? 'none'}-${selectedStack ?? 'all'}`}
-            label="Search containers"
-            placeholder="Search containers..."
-            onSearch={setContainerQuery}
-            totalCount={filteredContainers.length}
-            filteredCount={searchedContainers.length}
+        {/* Container Selector + its own filter.
+            The filter used to be a full-width, card-backed search pill sitting
+            above this select — wider and higher contrast than the control it
+            narrows, and easily read as a page-wide search when it only ever
+            filtered this dropdown's options. It is now a compact field attached
+            to the select, sized and styled to match it. */}
+        <div className="flex items-center gap-2">
+          <Box className="h-4 w-4 text-muted-foreground" />
+          <ThemedSelect
+            value={selectedContainer ?? '__placeholder__'}
+            onValueChange={(val) => val !== '__placeholder__' && setSelectedContainer(val)}
+            placeholder="Select container..."
+            disabled={!selectedEndpoint || containersLoading}
+            options={[
+              { value: '__placeholder__', label: 'Select container...', disabled: true },
+              ...groupedContainerOptions,
+            ]}
           />
-          <div className="flex items-center gap-2">
-            <Box className="h-4 w-4 text-muted-foreground" />
-            <ThemedSelect
-              value={selectedContainer ?? '__placeholder__'}
-              onValueChange={(val) => val !== '__placeholder__' && setSelectedContainer(val)}
-              placeholder="Select container..."
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="text"
+              value={containerQuery}
+              onChange={(event) => setContainerQuery(event.target.value)}
+              placeholder="Filter"
+              aria-label="Search containers"
               disabled={!selectedEndpoint || containersLoading}
-              options={[
-                { value: '__placeholder__', label: 'Select container...', disabled: true },
-                ...groupedContainerOptions,
-              ]}
+              className={cn(
+                'h-9 w-28 rounded-md border border-input bg-background pl-7 pr-2 text-[16px] sm:text-sm shadow-xs',
+                'placeholder:text-muted-foreground/70',
+                'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+              )}
             />
           </div>
+          {containerQuery.trim() !== '' && (
+            <span className="text-xs text-muted-foreground" data-testid="container-filter-count">
+              {searchedContainers.length} of {filteredContainers.length}
+            </span>
+          )}
         </div>
 
-        {/* Time Range Selector */}
+        {/* Time Range Selector — the only zoom a time series has. A separate
+            magnifier pair used to sit at the end of this row scaling the chart's
+            pixel height; it promised a time-window change this control already
+            makes, so it is gone rather than relabelled. */}
         <div className="flex items-center gap-2">
           <Clock className="h-4 w-4 text-muted-foreground" />
           <div className="flex rounded-md border border-input overflow-hidden">
@@ -636,27 +802,6 @@ export default function MetricsDashboardPage() {
               </button>
             ))}
           </div>
-        </div>
-
-        {/* Zoom Controls */}
-        <div className="flex items-center gap-1 ml-auto">
-          <button
-            onClick={() => setZoomLevel((z) => Math.max(0.5, z - 0.25))}
-            className="rounded-md p-2 hover:bg-muted"
-            title="Zoom out"
-          >
-            <ZoomOut className="h-4 w-4" />
-          </button>
-          <span className="text-sm text-muted-foreground min-w-[3rem] text-center">
-            {Math.round(zoomLevel * 100)}%
-          </span>
-          <button
-            onClick={() => setZoomLevel((z) => Math.min(2, z + 0.25))}
-            className="rounded-md p-2 hover:bg-muted"
-            title="Zoom in"
-          >
-            <ZoomIn className="h-4 w-4" />
-          </button>
         </div>
       </div>
 
@@ -756,12 +901,7 @@ export default function MetricsDashboardPage() {
                   <p className="text-sm font-medium text-muted-foreground">Avg CPU</p>
                   <p className="mt-2 text-3xl font-bold tracking-tight">{stats.cpu.avg.toFixed(1)}%</p>
                   {cpuCoresLabel && (
-                    <p
-                      className="text-xs text-muted-foreground mt-1"
-                      title="Docker stats convention — 100% = one full CPU core, so this peaks at 100% × online cores."
-                    >
-                      {cpuCoresLabel}
-                    </p>
+                    <p className="text-xs text-muted-foreground mt-1">{cpuCoresLabel}</p>
                   )}
                   <AnomalySparkline
                     values={cpuData.map((d) => d.value)}
@@ -775,12 +915,7 @@ export default function MetricsDashboardPage() {
                   <p className="text-sm font-medium text-muted-foreground">Avg Memory</p>
                   <p className="mt-2 text-3xl font-bold tracking-tight">{stats.memory.avg.toFixed(1)}%</p>
                   {memoryDenominatorLabel && (
-                    <p
-                      className="text-xs text-muted-foreground mt-1"
-                      title="memory% = (usage − cache) ÷ limit. Unconstrained containers report the host's total RAM as the limit."
-                    >
-                      {memoryDenominatorLabel}
-                    </p>
+                    <p className="text-xs text-muted-foreground mt-1">{memoryDenominatorLabel}</p>
                   )}
                   <AnomalySparkline
                     values={memoryData.map((d) => d.value)}
@@ -850,9 +985,12 @@ export default function MetricsDashboardPage() {
                   label="CPU Usage"
                   color="#3b82f6"
                   unit="%"
-                  height={300 * zoomLevel}
+                  height={300}
                   anomalyExplanations={cpuExplanations}
                 />
+                <p className="mt-2 text-xs text-muted-foreground" data-testid="cpu-axis-note">
+                  {cpuAxisNote}
+                </p>
                 {cpuError && (
                   <div className="mt-4 flex items-center gap-2 text-sm text-destructive">
                     <AlertTriangle className="h-4 w-4" />
@@ -884,9 +1022,12 @@ export default function MetricsDashboardPage() {
                   label="Memory Usage"
                   color="#8b5cf6"
                   unit="%"
-                  height={300 * zoomLevel}
+                  height={300}
                   anomalyExplanations={memoryExplanations}
                 />
+                <p className="mt-2 text-xs text-muted-foreground" data-testid="memory-axis-note">
+                  {memoryAxisNote}
+                </p>
                 {memoryError && (
                   <div className="mt-4 flex items-center gap-2 text-sm text-destructive">
                     <AlertTriangle className="h-4 w-4" />
@@ -921,8 +1062,11 @@ export default function MetricsDashboardPage() {
                   label="Memory"
                   color="#06b6d4"
                   unit=" MB"
-                  height={300 * zoomLevel}
+                  height={300}
                 />
+                <p className="mt-2 text-xs text-muted-foreground" data-testid="memory-bytes-axis-note">
+                  Resident memory in MB — the numerator of the percentage beside it.
+                </p>
               </div>
               </SpotlightCard>
             </div>
@@ -932,8 +1076,10 @@ export default function MetricsDashboardPage() {
           <div className="space-y-6">
             <div className="flex items-center gap-2">
               <TrendingUp className="h-5 w-5 text-indigo-500" />
-              <h3 className="text-lg font-semibold">Capacity Forecasts</h3>
-              <span className="text-sm text-muted-foreground">(24h projection)</span>
+              {/* Same horizon as the fleet-wide section below, so it is named
+                  the same way; scope is what differs and scope is what the
+                  headings now carry. */}
+              <h3 className="text-lg font-semibold">Capacity Forecast — This Container (Next 24h)</h3>
             </div>
 
             {hasForecastData ? (
@@ -996,21 +1142,30 @@ export default function MetricsDashboardPage() {
       <div className="rounded-lg border bg-card p-6 shadow-sm">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h2 className="text-xl font-semibold">Forecast Overview (Next 24h)</h2>
+            <h2 className="text-xl font-semibold">Capacity Forecast — Fleet (Next 24h)</h2>
             <p className="text-sm text-muted-foreground">
               Risk-ranked capacity outlook across containers.
             </p>
           </div>
+          {/* Zero buckets are not news. The row used to read
+              "Critical: 0  Warning: 0  Healthy: 20" above a table whose every
+              row said the same thing. */}
           <div className="flex flex-wrap items-center gap-2 text-xs">
-            <span className="rounded-full bg-red-100 px-2.5 py-1 font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400">
-              Critical: {riskBuckets.critical}
-            </span>
-            <span className="rounded-full bg-amber-100 px-2.5 py-1 font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-              Warning: {riskBuckets.warning}
-            </span>
-            <span className="rounded-full bg-emerald-100 px-2.5 py-1 font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
-              Healthy: {riskBuckets.healthy}
-            </span>
+            {riskBuckets.critical > 0 && (
+              <span className="rounded-full bg-red-100 px-2.5 py-1 font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400">
+                Critical: {riskBuckets.critical}
+              </span>
+            )}
+            {riskBuckets.warning > 0 && (
+              <span className="rounded-full bg-amber-100 px-2.5 py-1 font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                Warning: {riskBuckets.warning}
+              </span>
+            )}
+            {riskBuckets.healthy > 0 && (
+              <span className="rounded-full bg-emerald-100 px-2.5 py-1 font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                Healthy: {riskBuckets.healthy}
+              </span>
+            )}
           </div>
         </div>
 
@@ -1037,8 +1192,46 @@ export default function MetricsDashboardPage() {
             title="No forecast data available"
             description="Keep metrics collection running to build cross-container forecast insights."
           />
+        ) : allForecastsHealthy ? (
+          /* One sentence, because that is the entire content. This was eight
+             columns and two pages of pagination whose every row read
+             "No breach predicted / healthy" — the table is still one click
+             away, and it comes back automatically the moment a row is not
+             healthy. */
+          <div className="mt-4" data-testid="forecast-overview-all-clear">
+            <div className="flex items-start gap-2 text-sm">
+              <ShieldCheck className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden />
+              <p>
+                No capacity breaches projected in the next 24h
+                {' '}
+                <span className="text-muted-foreground">
+                  ({rankedForecasts.length} container/metric series checked)
+                </span>
+              </p>
+            </div>
+            <details className="mt-3">
+              <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
+                Show all {rankedForecasts.length} series
+              </summary>
+              <div className="mt-3">
+                {forecastRankBasisNote && (
+                  <p className="mb-2 text-xs text-muted-foreground">{forecastRankBasisNote}</p>
+                )}
+                <DataTable
+                  columns={forecastColumns}
+                  data={rankedForecasts}
+                  getRowId={(forecast) => `${forecast.containerId}-${forecast.metricType}`}
+                  hideSearch
+                  minTableWidth={880}
+                />
+              </div>
+            </details>
+          </div>
         ) : (
           <div className="mt-4">
+            {forecastRankBasisNote && (
+              <p className="mb-2 text-xs text-muted-foreground">{forecastRankBasisNote}</p>
+            )}
             <DataTable
               columns={forecastColumns}
               data={rankedForecasts}

--- a/frontend/src/features/observability/pages/reports-dienststellen.test.tsx
+++ b/frontend/src/features/observability/pages/reports-dienststellen.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { DienststellenOverview, parseStackName } from './reports';
+import { StackTaxonomyOverview, parseStackName } from './reports';
 import type { Container } from '@/features/containers/hooks/use-containers';
 
 function makeContainer(overrides: Partial<Container> = {}): Container {
@@ -101,20 +101,20 @@ describe('parseStackName', () => {
 });
 
 // ---------------------------------------------------------------------------
-// DienststellenOverview component tests
+// StackTaxonomyOverview component tests
 // ---------------------------------------------------------------------------
 
-describe('DienststellenOverview', () => {
+describe('StackTaxonomyOverview', () => {
   it('renders nothing when containers is undefined', () => {
     const { container } = render(
-      <DienststellenOverview containers={undefined} />,
+      <StackTaxonomyOverview containers={undefined} />,
     );
     expect(container.innerHTML).toBe('');
   });
 
   it('renders nothing when containers array is empty', () => {
     const { container } = render(
-      <DienststellenOverview containers={[]} />,
+      <StackTaxonomyOverview containers={[]} />,
     );
     expect(container.innerHTML).toBe('');
   });
@@ -135,13 +135,30 @@ describe('DienststellenOverview', () => {
       }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
     expect(screen.getByText('Berlin')).toBeInTheDocument();
     expect(screen.getByText('Munich')).toBeInTheDocument();
   });
 
-  it('shows total Dienststellen count (excluding Standalone)', () => {
+  it('renders nothing when no stack follows the convention', () => {
+    // The whole block used to render `Total Dienststellen 0` on every fleet
+    // that does not use this customer's naming scheme.
+    const { container } = render(
+      <StackTaxonomyOverview
+        containers={[
+          makeContainer({ id: 'c1', name: 'orphan-1', labels: {} }),
+          makeContainer({
+            id: 'c2', name: 'orphan-2',
+            labels: { 'com.docker.compose.project': 'mystack' },
+          }),
+        ]}
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('counts offices, departments and containers in one header line', () => {
     const containers = [
       makeContainer({
         id: 'c1', name: 'web',
@@ -149,16 +166,33 @@ describe('DienststellenOverview', () => {
       }),
       makeContainer({
         id: 'c2', name: 'api',
-        labels: { 'com.docker.compose.project': 'IT_Munich_api' },
+        labels: { 'com.docker.compose.project': 'HR_Munich_api' },
       }),
       makeContainer({ id: 'c3', name: 'orphan', labels: {} }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
-    expect(screen.getByText('Total Dienststellen')).toBeInTheDocument();
-    // 2 Dienststellen (Berlin + Munich), Standalone not counted
-    expect(screen.getByText('2')).toBeInTheDocument();
+    // Berlin + Munich; Standalone is not an office.
+    expect(
+      screen.getByText('2 offices · 2 departments · 3 containers'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders no untranslated German label', () => {
+    render(
+      <StackTaxonomyOverview
+        containers={[
+          makeContainer({
+            id: 'c1', name: 'web',
+            labels: { 'com.docker.compose.project': 'IT_Berlin_web' },
+          }),
+        ]}
+      />,
+    );
+
+    expect(document.body.textContent).not.toMatch(/Dienststelle/i);
+    expect(screen.getByText('Containers by office')).toBeInTheDocument();
   });
 
   it('shows department badges', () => {
@@ -169,27 +203,11 @@ describe('DienststellenOverview', () => {
       }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
     expect(screen.getByText('IT')).toBeInTheDocument();
   });
 
-  it('shows departments KPI', () => {
-    const containers = [
-      makeContainer({
-        id: 'c1', name: 'web',
-        labels: { 'com.docker.compose.project': 'IT_Berlin_web' },
-      }),
-      makeContainer({
-        id: 'c2', name: 'api',
-        labels: { 'com.docker.compose.project': 'HR_Munich_api' },
-      }),
-    ];
-
-    render(<DienststellenOverview containers={containers} />);
-
-    expect(screen.getByText('Departments')).toBeInTheDocument();
-  });
 
   it('shows prod/test environment badges on the group row', () => {
     const containers = [
@@ -203,7 +221,7 @@ describe('DienststellenOverview', () => {
       }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
     expect(screen.getByText('prod')).toBeInTheDocument();
     expect(screen.getByText('test')).toBeInTheDocument();
@@ -218,7 +236,7 @@ describe('DienststellenOverview', () => {
       }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
     // Click to expand
     fireEvent.click(screen.getByText('Berlin'));
@@ -236,7 +254,7 @@ describe('DienststellenOverview', () => {
       }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
     fireEvent.click(screen.getByText('Berlin'));
     expect(screen.getByText('my-app')).toBeInTheDocument();
@@ -261,20 +279,24 @@ describe('DienststellenOverview', () => {
       }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
     expect(screen.getByText('2 running')).toBeInTheDocument();
     expect(screen.getByText('1 stopped')).toBeInTheDocument();
     expect(screen.getByText('3 total')).toBeInTheDocument();
   });
 
-  it('puts standalone containers (no stack label) in Standalone group', () => {
+  it('puts containers with no parsable stack label in the Standalone group', () => {
     const containers = [
+      makeContainer({
+        id: 'c0', name: 'classified',
+        labels: { 'com.docker.compose.project': 'IT_Berlin_web' },
+      }),
       makeContainer({ id: 'c1', name: 'orphan-1', labels: {} }),
       makeContainer({ id: 'c2', name: 'orphan-2', labels: {} }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
     expect(screen.getByText('Standalone')).toBeInTheDocument();
     expect(screen.getByText('2 total')).toBeInTheDocument();
@@ -293,7 +315,7 @@ describe('DienststellenOverview', () => {
       makeContainer({ id: 'c3', name: 'orphan', labels: {} }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
     const buttons = screen.getAllByRole('button');
     const names = buttons.map((b) => b.textContent);
@@ -308,12 +330,16 @@ describe('DienststellenOverview', () => {
   it('handles non-convention stack names as Standalone', () => {
     const containers = [
       makeContainer({
+        id: 'c0', name: 'classified',
+        labels: { 'com.docker.compose.project': 'IT_Berlin_web' },
+      }),
+      makeContainer({
         id: 'c1', name: 'app',
         labels: { 'com.docker.compose.project': 'mystack' },
       }),
     ];
 
-    render(<DienststellenOverview containers={containers} />);
+    render(<StackTaxonomyOverview containers={containers} />);
 
     expect(screen.getByText('Standalone')).toBeInTheDocument();
   });

--- a/frontend/src/features/observability/pages/reports.test.tsx
+++ b/frontend/src/features/observability/pages/reports.test.tsx
@@ -48,6 +48,21 @@ const reportState = vi.hoisted(() => ({
           issues: ['CPU over-utilized (avg > 80%) — consider increasing CPU limits'],
         },
       ],
+      // Per-rule rollup the backend ships alongside `recommendations`, so the
+      // page can state a rule once instead of once per matching container.
+      recommendationSummary: [
+        {
+          id: 'cpu-underutilized',
+          metric: 'cpu',
+          statistic: 'p95',
+          comparison: 'below',
+          threshold: 10,
+          unit: 'percent',
+          recommendation: 'consider reducing CPU limits',
+          container_count: 2,
+          container_names: ['web-1', 'web-2'],
+        },
+      ] as Array<Record<string, unknown>> | undefined,
     },
     '7d': {
       timeRange: '7d',
@@ -210,6 +225,22 @@ vi.mock('@/features/containers/hooks/use-containers', () => ({
         labels: {},
         networks: [],
       },
+      // One container that follows the `<department>_<office>_<stack>`
+      // convention, so the taxonomy panel renders (it returns null when no
+      // stack parses).
+      {
+        id: 'c3',
+        name: 'berlin-web',
+        image: 'nginx:alpine',
+        state: 'running',
+        status: 'Up 2h',
+        endpointId: 1,
+        endpointName: 'local',
+        ports: [],
+        created: 1700000000,
+        labels: { 'com.docker.compose.project': 'IT_Berlin_web' },
+        networks: [],
+      },
     ],
     isLoading: false,
     isError: false,
@@ -239,6 +270,19 @@ describe('ReportsPage', () => {
   beforeEach(() => {
     mockExportToCsv.mockReset();
     mockExportManagementPdf.mockReset();
+    reportState.byRange['24h'].recommendationSummary = [
+      {
+        id: 'cpu-underutilized',
+        metric: 'cpu',
+        statistic: 'p95',
+        comparison: 'below',
+        threshold: 10,
+        unit: 'percent',
+        recommendation: 'consider reducing CPU limits',
+        container_count: 2,
+        container_names: ['web-1', 'web-2'],
+      },
+    ];
     reportState.byRange['24h'].containers = [
       {
         container_id: 'c1',
@@ -296,10 +340,21 @@ describe('ReportsPage', () => {
     ];
   });
 
-  it('renders the page header', () => {
+  it('renders one PageHeader whose title matches the nav label', () => {
     renderWithProviders(<ReportsPage />);
-    expect(screen.getByText('Resource Reports')).toBeTruthy();
-    expect(screen.getByText(/Utilization analysis/)).toBeTruthy();
+    expect(screen.getByRole('heading', { level: 1, name: 'Reports' })).toBeInTheDocument();
+    // The old subtitle listed the page's own sections; this one carries state.
+    expect(screen.getByTestId('page-header-subtitle')).toHaveTextContent(
+      '1 containers over the last 24 hours',
+    );
+    expect(screen.queryByText(/Utilization analysis/)).not.toBeInTheDocument();
+  });
+
+  it('formats the container count as an integer and names the CPU denominator', () => {
+    renderWithProviders(<ReportsPage />);
+    // A COUNT used to render as "13.0" because every stat went through toFixed(1).
+    expect(screen.queryByText('1.0')).not.toBeInTheDocument();
+    expect(screen.getAllByText('100% = one core').length).toBe(2);
   });
 
   it('renders fleet summary KPIs', () => {
@@ -337,22 +392,41 @@ describe('ReportsPage', () => {
     expect(screen.getByText(/CPU Avg ↓/)).toBeTruthy();
   });
 
-  it('renders the Dienststelle DataTable when a group is expanded', () => {
+  it('renders the office DataTable when a group is expanded', () => {
     renderWithProviders(<ReportsPage />);
     const before = screen.getAllByTestId('data-table').length;
-    // Expand the "Standalone" group (both mock containers have no stack label).
+    // Expand the "Standalone" group (two mock containers have no stack label).
     fireEvent.click(screen.getByRole('button', { name: /Standalone/i }));
     const after = screen.getAllByTestId('data-table').length;
     expect(after).toBeGreaterThan(before);
-    // The Dienststelle table exposes its own column set.
+    // The grouped table exposes its own column set.
     expect(screen.getByText('Stack')).toBeTruthy();
     expect(screen.getByText('Env')).toBeTruthy();
     expect(screen.getByText('Image')).toBeTruthy();
   });
 
-  it('renders recommendations section', () => {
+  it('states each right-sizing rule once with a container count, not once per container', () => {
     renderWithProviders(<ReportsPage />);
-    expect(screen.getByText('Right-Sizing Recommendations')).toBeTruthy();
+
+    expect(screen.getByText('Right-sizing rules')).toBeTruthy();
+    // Two containers, both matching the same rule → one line, not two.
+    const lines = screen.getAllByTestId('right-sizing-rule');
+    expect(lines).toHaveLength(1);
+    expect(screen.getByText('2 containers')).toBeInTheDocument();
+    expect(screen.getByText(/CPU p95 below 10% — consider reducing CPU limits/)).toBeInTheDocument();
+    expect(screen.getByText('web-1, web-2')).toBeInTheDocument();
+  });
+
+  it('falls back to grouping the legacy per-container issue strings', () => {
+    // Backend that predates the rollup: no `recommendationSummary`.
+    reportState.byRange['24h'].recommendationSummary = undefined;
+    renderWithProviders(<ReportsPage />);
+
+    const lines = screen.getAllByTestId('right-sizing-rule');
+    expect(lines).toHaveLength(1);
+    expect(
+      screen.getByText(/CPU over-utilized \(avg > 80%\) — consider increasing CPU limits/),
+    ).toBeInTheDocument();
   });
 
   it('renders export CSV button', () => {
@@ -360,9 +434,9 @@ describe('ReportsPage', () => {
     expect(screen.getByText('Export CSV')).toBeTruthy();
   });
 
-  it('renders export management PDF button', () => {
+  it('renders the PDF export button', () => {
     renderWithProviders(<ReportsPage />);
-    expect(screen.getByRole('button', { name: /export management pdf/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /export pdf report/i })).toBeTruthy();
   });
 
   it('exports service-manager CSV rows with required fields', () => {
@@ -421,36 +495,41 @@ describe('ReportsPage', () => {
     expect(screen.getByText('Memory Trend (Fleet Avg)')).toBeTruthy();
   });
 
-  it('exports management PDF with default 7d range and infrastructure excluded', async () => {
+  it('inherits the page time range and infrastructure filter when opened', async () => {
     renderWithProviders(<ReportsPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: /export management pdf/i }));
+    // Page filter is 24h with infrastructure excluded; the panel used to reset
+    // to 7d and phrase the same filter with the opposite polarity.
+    fireEvent.click(screen.getByRole('button', { name: /export pdf report/i }));
+    expect(screen.getAllByLabelText(/^exclude infrastructure services$/i)).toHaveLength(2);
+    expect(screen.queryByLabelText(/include infrastructure services/i)).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: /generate pdf/i }));
 
     // The export module is loaded via dynamic import() in the handler (#1507),
     // so the mocked export function is called asynchronously.
     await waitFor(() => expect(mockExportManagementPdf).toHaveBeenCalledTimes(1));
     const [payload, filename] = mockExportManagementPdf.mock.calls[0];
-    expect(payload.timeRange).toBe('7d');
+    expect(payload.timeRange).toBe('24h');
     expect(payload.includeInfrastructure).toBe(false);
     expect(payload.containers).toHaveLength(1);
     expect(payload.containers[0].container_name).toBe('test-web');
-    expect(filename).toMatch(/^management-report-7d-all-endpoints-\d{4}-\d{2}-\d{2}\.pdf$/);
+    expect(filename).toMatch(/^management-report-24h-all-endpoints-\d{4}-\d{2}-\d{2}\.pdf$/);
   });
 
   it('exports management PDF with overrides when selected', async () => {
     renderWithProviders(<ReportsPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: /export management pdf/i }));
-    fireEvent.click(screen.getAllByRole('button', { name: '24 Hours' })[1]);
-    fireEvent.click(screen.getByLabelText(/^include infrastructure services$/i));
+    fireEvent.click(screen.getByRole('button', { name: /export pdf report/i }));
+    fireEvent.click(screen.getAllByRole('button', { name: '7 Days' })[1]);
+    // Second checkbox is the panel's own copy of the page filter.
+    fireEvent.click(screen.getAllByLabelText(/^exclude infrastructure services$/i)[1]);
     fireEvent.click(screen.getByRole('button', { name: /generate pdf/i }));
 
     await waitFor(() => expect(mockExportManagementPdf).toHaveBeenCalledTimes(1));
     const [payload, filename] = mockExportManagementPdf.mock.calls[0];
-    expect(payload.timeRange).toBe('24h');
+    expect(payload.timeRange).toBe('7d');
     expect(payload.includeInfrastructure).toBe(true);
     expect(payload.containers).toHaveLength(2);
-    expect(filename).toMatch(/^management-report-24h-all-endpoints-\d{4}-\d{2}-\d{2}\.pdf$/);
+    expect(filename).toMatch(/^management-report-7d-all-endpoints-\d{4}-\d{2}-\d{2}\.pdf$/);
   });
 });

--- a/frontend/src/features/observability/pages/reports.test.tsx
+++ b/frontend/src/features/observability/pages/reports.test.tsx
@@ -417,6 +417,33 @@ describe('ReportsPage', () => {
     expect(screen.getByText('web-1, web-2')).toBeInTheDocument();
   });
 
+  it('counts with container_count, not the capped name sample', () => {
+    // The backend caps `container_names` at 500 but leaves `container_count`
+    // the real total. Counting the array would report "500 containers" for a
+    // fleet of 525 — an under-count presented as fact, on exactly the large
+    // fleet the cap exists for.
+    reportState.byRange['24h'].recommendationSummary = [
+      {
+        id: 'cpu-underutilized',
+        metric: 'cpu',
+        statistic: 'p95',
+        comparison: 'below',
+        threshold: 10,
+        unit: 'percent',
+        recommendation: 'consider reducing CPU limits',
+        container_count: 525,
+        container_names: Array.from({ length: 500 }, (_, i) => `svc-${i}`),
+        names_truncated: true,
+      },
+    ];
+    renderWithProviders(<ReportsPage />);
+
+    expect(screen.getByText('525 containers')).toBeInTheDocument();
+    expect(screen.queryByText('500 containers')).not.toBeInTheDocument();
+    // "and N more" is relative to the true total too.
+    expect(screen.getByText(/and 519 more/)).toBeInTheDocument();
+  });
+
   it('falls back to grouping the legacy per-container issue strings', () => {
     // Backend that predates the rollup: no `recommendationSummary`.
     reportState.byRange['24h'].recommendationSummary = undefined;

--- a/frontend/src/features/observability/pages/reports.tsx
+++ b/frontend/src/features/observability/pages/reports.tsx
@@ -15,8 +15,6 @@ import {
   Building2,
   ChevronDown,
   ChevronRight,
-  Box,
-  Tag,
 } from 'lucide-react';
 import {
   useUtilizationReport,
@@ -30,11 +28,10 @@ import { MetricsLineChart } from '@/shared/components/charts/metrics-line-chart'
 import { DataTable } from '@/shared/components/tables/data-table';
 import { SkeletonKpi } from '@/shared/components/feedback/skeleton';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { cn } from '@/shared/lib/utils';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
-import { TiltCard } from '@/shared/components/data-display/tilt-card';
-import { KpiCard } from '@/shared/components/data-display/kpi-card';
 import { exportToCsv } from '@/shared/lib/csv-export';
 // Only the lightweight theme metadata is imported statically; the jsPDF-backed
 // export module is loaded via dynamic import() inside handleExportPdf (#1507)
@@ -50,6 +47,43 @@ const TIME_RANGES = [
   { value: '30d', label: '30 Days' },
 ];
 const DEFAULT_PDF_TIME_RANGE = '7d';
+/**
+ * CPU% here follows Docker's `docker stats` convention — 100% is one core — so
+ * a bare "Avg CPU 0.5 %" is ambiguous without it. `/metrics` was given the same
+ * denominator treatment for exactly this reason (#1429); it can name the core
+ * count because it queries per-container metadata, which a fleet-wide roll-up
+ * has no single answer for.
+ */
+const CPU_DENOMINATOR_LABEL = '100% = one core';
+/** How many container names to spell out under a right-sizing rule before "and N more". */
+const RULE_CONTAINER_PREVIEW = 6;
+
+/**
+ * `recommendationSummary` from `GET /api/reports/utilization` — the per-rule
+ * rollup that lets this page state a rule once instead of repeating byte-
+ * identical advice per container.
+ *
+ * Declared here rather than in `use-reports.ts` only because that hook is owned
+ * by another workstream this pass; it belongs on `UtilizationReport`.
+ */
+interface RightSizingRuleSummary {
+  id: string;
+  metric: string;
+  statistic: string;
+  comparison: string;
+  threshold: number;
+  unit: string;
+  recommendation: string;
+  container_count: number;
+  container_names: string[];
+}
+
+/** One rendered line: the rule, and every container it matched. */
+interface RightSizingGroup {
+  id: string;
+  statement: string;
+  containerNames: string[];
+}
 const PDF_BRANDING_STORAGE_KEY = 'reports-management-pdf-branding-v1';
 const PDF_BRAND_PROFILES = [
   { value: 'management', label: 'Management (Recommended)', theme: 'ocean', reportTitle: 'Management Resource Report' },
@@ -65,12 +99,22 @@ function StatCard({
   unit,
   icon: Icon,
   trend,
+  decimals,
+  sublabel,
 }: {
   label: string;
   value: number;
   unit: string;
   icon: React.ComponentType<{ className?: string }>;
   trend?: 'up' | 'down' | 'neutral';
+  /**
+   * Digits after the decimal point. Every stat used to go through the same
+   * `toFixed(1)`, which is why a COUNT of containers rendered as "13.0".
+   * Defaults to 1 for measured percentages; pass 0 for counts.
+   */
+  decimals?: number;
+  /** The denominator, where the number alone is ambiguous (see CPU). */
+  sublabel?: string;
 }) {
   return (
     <SpotlightCard className="h-full">
@@ -80,9 +124,10 @@ function StatCard({
           <Icon className="h-5 w-5 text-muted-foreground" />
         </div>
         <div className="mt-2 flex items-baseline gap-1">
-          <p className="text-3xl font-bold tracking-tight">{value.toFixed(1)}</p>
+          <p className="text-3xl font-bold tracking-tight">{value.toFixed(decimals ?? 1)}</p>
           <span className="text-sm text-muted-foreground">{unit}</span>
         </div>
+        {sublabel && <p className="mt-1 text-xs text-muted-foreground">{sublabel}</p>}
         {trend && trend !== 'neutral' && (
           <div className={cn('mt-1 flex items-center gap-1 text-xs', trend === 'up' ? 'text-red-500' : 'text-green-500')}>
             {trend === 'up' ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
@@ -186,7 +231,19 @@ function groupContainersByDienststelle(
     });
 }
 
-export function DienststellenOverview({
+/**
+ * Grouped view of the customer stack-naming convention
+ * `<department>_<office>_<stackname>-<prod|test>`.
+ *
+ * It renders **only when at least one stack actually parses**. Before that gate
+ * existed this block owned the whole fold on every fleet that does not use the
+ * convention, and showed three permanent zeroes as the first thing an operator
+ * saw. The parser's field names keep the original German (`dienststelle`) —
+ * they are the data contract, including the CSV column — but nothing on screen
+ * does: an English UI does not get to render one untranslated label beside an
+ * English one for the same concept.
+ */
+export function StackTaxonomyOverview({
   containers,
 }: {
   containers: Container[] | undefined;
@@ -269,7 +326,7 @@ export function DienststellenOverview({
     },
   ], []);
 
-  const totalDienststellen = groups.filter((g) => g.dienststelle !== 'Standalone').length;
+  const totalOffices = groups.filter((g) => g.dienststelle !== 'Standalone').length;
   const totalContainers = groups.reduce((sum, g) => sum + g.containers.length, 0);
   const uniqueDepartments = new Set(groups.flatMap((g) => g.departments));
 
@@ -283,39 +340,30 @@ export function DienststellenOverview({
   };
 
   if (!containers || containers.length === 0) return null;
+  // Nothing parsed: the convention is not in use here, so this whole block is
+  // noise. Do not render zeroes for a taxonomy this fleet does not have.
+  if (totalOffices === 0) return null;
 
   return (
     <div className="space-y-4">
-      {/* Dienststellen KPIs */}
-      <div className="grid gap-4 md:grid-cols-4">
-        <TiltCard>
-          <KpiCard label="Total Dienststellen" value={totalDienststellen} icon={<Building2 className="h-5 w-5" />} />
-        </TiltCard>
-        <TiltCard>
-          <KpiCard label="Total Containers" value={totalContainers} icon={<Box className="h-5 w-5" />} />
-        </TiltCard>
-        <TiltCard>
-          <KpiCard label="Departments" value={uniqueDepartments.size} icon={<Tag className="h-5 w-5" />} />
-        </TiltCard>
-        <TiltCard>
-          <KpiCard
-            label="Avg Containers / Dienststelle"
-            value={totalDienststellen > 0 ? (totalContainers / totalDienststellen).toFixed(1) : '0'}
-            icon={<Server className="h-5 w-5" />}
-          />
-        </TiltCard>
-      </div>
-
-      {/* Grouped table */}
+      {/*
+        The four KPI tiles that stood here restated the counts now carried in
+        this panel's own header line, and one of them ("Total Containers 13")
+        duplicated the fleet KPI row 400px below.
+      */}
       <SpotlightCard>
       <div className="rounded-lg border bg-card shadow-sm">
-        <div className="flex items-center justify-between p-4 border-b">
+        <div className="flex flex-wrap items-center justify-between gap-2 p-4 border-b">
           <div className="flex items-center gap-2">
             <Building2 className="h-5 w-5" />
-            <h3 className="text-lg font-semibold">Containers per Dienststelle</h3>
+            <h3 className="text-lg font-semibold">Containers by office</h3>
           </div>
           <span className="text-sm text-muted-foreground">
-            {totalDienststellen} Dienststelle{totalDienststellen !== 1 ? 'n' : ''}
+            {totalOffices} office{totalOffices !== 1 ? 's' : ''}
+            {' · '}
+            {uniqueDepartments.size} department{uniqueDepartments.size !== 1 ? 's' : ''}
+            {' · '}
+            {totalContainers} container{totalContainers !== 1 ? 's' : ''}
           </span>
         </div>
         <div className="divide-y">
@@ -380,7 +428,7 @@ export function DienststellenOverview({
                 )}
                 {isExpanded && grpContainers.length === 0 && (
                   <div className="border-t bg-muted/10 px-4 py-3 pl-12 text-sm text-muted-foreground italic">
-                    No containers on this Dienststelle
+                    No containers in this office
                   </div>
                 )}
               </div>
@@ -397,7 +445,11 @@ export default function ReportsPage() {
   const [timeRange, setTimeRange] = useState('24h');
   const [excludeInfrastructure, setExcludeInfrastructure] = useState(true);
   const [pdfTimeRange, setPdfTimeRange] = useState(DEFAULT_PDF_TIME_RANGE);
-  const [pdfIncludeInfrastructure, setPdfIncludeInfrastructure] = useState(false);
+  // Same polarity and same words as the page filter above. The panel used to
+  // say **Include** infrastructure services 40px from a page filter that said
+  // **Exclude** them, so checking both produced the opposite of what an
+  // operator expected in the PDF.
+  const [pdfExcludeInfrastructure, setPdfExcludeInfrastructure] = useState(true);
   const [pdfBrandProfile, setPdfBrandProfile] = useState<PdfBrandProfile>('management');
   const [pdfTheme, setPdfTheme] = useState<ManagementPdfTheme>('ocean');
   const [pdfReportTitle, setPdfReportTitle] = useState('Management Resource Report');
@@ -424,11 +476,11 @@ export default function ReportsPage() {
   const {
     data: pdfReport,
     isLoading: pdfReportLoading,
-  } = useUtilizationReport(pdfTimeRange, selectedEndpoint, undefined, !pdfIncludeInfrastructure);
+  } = useUtilizationReport(pdfTimeRange, selectedEndpoint, undefined, pdfExcludeInfrastructure);
   const {
     data: pdfTrends,
     isLoading: pdfTrendsLoading,
-  } = useTrendsReport(pdfTimeRange, selectedEndpoint, undefined, !pdfIncludeInfrastructure);
+  } = useTrendsReport(pdfTimeRange, selectedEndpoint, undefined, pdfExcludeInfrastructure);
 
   // Sort containers
   const sortedContainers = useMemo(() => {
@@ -465,6 +517,39 @@ export default function ReportsPage() {
     }));
   }, [trends]);
 
+  /**
+   * "Right-Sizing Recommendations 15" used to list 15 containers, 14 of them
+   * carrying byte-identical advice from four fixed thresholds — one fact
+   * rendered fifteen times over ~1000px of scroll. Prefer the backend rollup;
+   * fall back to grouping the legacy per-container `issues` strings so the
+   * collapse still holds against an older backend.
+   */
+  const rightSizingGroups = useMemo<RightSizingGroup[]>(() => {
+    const supplied = (report as (typeof report & { recommendationSummary?: RightSizingRuleSummary[] }) | undefined)
+      ?.recommendationSummary;
+    if (supplied?.length) {
+      return supplied.map((rule) => ({
+        id: rule.id,
+        statement: `${rule.metric.toUpperCase()} ${rule.statistic} ${rule.comparison} ${rule.threshold}${rule.unit === 'percent' ? '%' : ''} — ${rule.recommendation}`,
+        containerNames: rule.container_names,
+      }));
+    }
+
+    const byIssue = new Map<string, string[]>();
+    for (const rec of report?.recommendations ?? []) {
+      for (const issue of rec.issues) {
+        const names = byIssue.get(issue) ?? [];
+        names.push(rec.container_name);
+        byIssue.set(issue, names);
+      }
+    }
+    return Array.from(byIssue.entries()).map(([issue, containerNames]) => ({
+      id: issue,
+      statement: issue,
+      containerNames,
+    }));
+  }, [report]);
+
   const allContainersById = useMemo(() => {
     const byId = new Map<string, Container>();
     for (const container of allContainers ?? []) {
@@ -493,7 +578,7 @@ export default function ReportsPage() {
   }, [allContainersById, report?.containers]);
 
   const reusePrimaryReportForPdf = pdfTimeRange === timeRange
-    && (!pdfIncludeInfrastructure === excludeInfrastructure);
+    && (pdfExcludeInfrastructure === excludeInfrastructure);
   const effectivePdfReport = reusePrimaryReportForPdf ? report : pdfReport;
   const effectivePdfTrends = reusePrimaryReportForPdf ? trends : pdfTrends;
 
@@ -516,9 +601,12 @@ export default function ReportsPage() {
     exportToCsv(exportRows, `resource-report-${timeRange}-${scope}-${date}.csv`);
   };
 
+  // The panel opens on the filter the operator is already looking at, then lets
+  // them override it for the PDF alone. Its subtitle claimed scope was
+  // inherited while time range and infrastructure silently reset.
   const handleOpenPdfOptions = () => {
-    setPdfTimeRange(DEFAULT_PDF_TIME_RANGE);
-    setPdfIncludeInfrastructure(false);
+    setPdfTimeRange(timeRange);
+    setPdfExcludeInfrastructure(excludeInfrastructure);
     setPdfExportError(null);
     setPdfExportSuccess(null);
     setShowPdfOptions(true);
@@ -540,7 +628,7 @@ export default function ReportsPage() {
         generatedAt: date,
         timeRange: pdfTimeRange,
         scopeLabel,
-        includeInfrastructure: pdfIncludeInfrastructure,
+        includeInfrastructure: !pdfExcludeInfrastructure,
         containers: effectivePdfReport ? filteredPdfContainers : [],
         recommendations: effectivePdfReport ? filteredPdfRecommendations : [],
         trends: effectivePdfTrends?.trends,
@@ -790,32 +878,31 @@ export default function ReportsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Resource Reports</h1>
-          <p className="text-muted-foreground">
-            Utilization analysis, trends, and right-sizing recommendations
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={handleOpenPdfOptions}
-            className="flex items-center gap-2 rounded-md border bg-card px-4 py-2 text-sm font-medium hover:bg-muted"
-          >
-            <FileText className="h-4 w-4" />
-            Export Management PDF
-          </button>
-          <button
-            onClick={handleExportCsv}
-            disabled={!exportRows.length}
-            className="flex items-center gap-2 rounded-md border bg-card px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-          >
-            <Download className="h-4 w-4" />
-            Export CSV
-          </button>
-        </div>
-      </div>
+      <PageHeader
+        title="Reports"
+        subtitle={report
+          ? `${report.fleetSummary.totalContainers} containers over the last ${TIME_RANGES.find((r) => r.value === timeRange)?.label.toLowerCase() ?? timeRange}`
+          : undefined}
+        actions={(
+          <>
+            <button
+              onClick={handleOpenPdfOptions}
+              className="flex items-center gap-2 rounded-md border bg-card px-4 py-2 text-sm font-medium hover:bg-muted"
+            >
+              <FileText className="h-4 w-4" />
+              Export PDF report
+            </button>
+            <button
+              onClick={handleExportCsv}
+              disabled={!exportRows.length}
+              className="flex items-center gap-2 rounded-md border bg-card px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+            >
+              <Download className="h-4 w-4" />
+              Export CSV
+            </button>
+          </>
+        )}
+      />
 
       {/* Controls */}
       <SpotlightCard>
@@ -871,7 +958,8 @@ export default function ReportsPage() {
             <div>
               <h2 className="text-base font-semibold">Management PDF Export</h2>
               <p className="text-sm text-muted-foreground">
-                Default range is 7 days. Endpoint scope follows the current report filter.
+                Starts from the filters on this page — endpoint scope, time range and
+                infrastructure. Change them here to affect the PDF only.
               </p>
             </div>
           </div>
@@ -899,10 +987,10 @@ export default function ReportsPage() {
             <label className="flex items-center gap-2 text-sm">
               <input
                 type="checkbox"
-                checked={pdfIncludeInfrastructure}
-                onChange={(event) => setPdfIncludeInfrastructure(event.target.checked)}
+                checked={pdfExcludeInfrastructure}
+                onChange={(event) => setPdfExcludeInfrastructure(event.target.checked)}
               />
-              Include infrastructure services
+              Exclude infrastructure services
             </label>
           </div>
           <div className="grid gap-4 md:grid-cols-2">
@@ -1006,8 +1094,8 @@ export default function ReportsPage() {
         </SpotlightCard>
       )}
 
-      {/* Dienststellen Overview */}
-      <DienststellenOverview containers={allContainers} />
+      {/* Stack taxonomy (renders only when the naming convention is in use) */}
+      <StackTaxonomyOverview containers={allContainers} />
 
       {isLoading && (
         <div className="grid gap-4 md:grid-cols-4">
@@ -1026,6 +1114,7 @@ export default function ReportsPage() {
             label="Containers"
             value={report.fleetSummary.totalContainers}
             unit=""
+            decimals={0}
             icon={FileBarChart}
           />
           <StatCard
@@ -1033,12 +1122,14 @@ export default function ReportsPage() {
             value={report.fleetSummary.avgCpu}
             unit="%"
             icon={Cpu}
+            sublabel={CPU_DENOMINATOR_LABEL}
           />
           <StatCard
             label="Max CPU"
             value={report.fleetSummary.maxCpu}
             unit="%"
             icon={Cpu}
+            sublabel={CPU_DENOMINATOR_LABEL}
             trend={report.fleetSummary.maxCpu > 90 ? 'up' : 'neutral'}
           />
           <StatCard
@@ -1108,29 +1199,43 @@ export default function ReportsPage() {
         </div>
       )}
 
-      {/* Recommendations */}
-      {report && report.recommendations.length > 0 && (
+      {/* Right-sizing rules */}
+      {rightSizingGroups.length > 0 && (
         <SpotlightCard>
         <div className="rounded-lg border bg-card p-6 shadow-sm">
-          <div className="flex items-center gap-2 mb-4">
+          <div className="flex flex-wrap items-center gap-2 mb-1">
             <Lightbulb className="h-5 w-5 text-amber-500" />
-            <h3 className="text-lg font-semibold">Right-Sizing Recommendations</h3>
+            <h3 className="text-lg font-semibold">Right-sizing rules</h3>
             <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200">
-              {report.recommendations.length}
+              {rightSizingGroups.length}
             </span>
           </div>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Fixed utilization thresholds, evaluated per container. One line per rule that fired —
+            every container a rule matched gets the same advice, so it is stated once.
+          </p>
           <div className="space-y-3">
-            {report.recommendations.map((rec) => (
-              <div key={rec.container_id} className="rounded-md border p-3">
-                <p className="font-medium text-sm">{rec.container_name}</p>
-                <ul className="mt-1 space-y-1">
-                  {rec.issues.map((issue, i) => (
-                    <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
-                      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0 text-amber-500" />
-                      {issue}
-                    </li>
-                  ))}
-                </ul>
+            {rightSizingGroups.map((group) => (
+              <div key={group.id} className="rounded-md border p-3" data-testid="right-sizing-rule">
+                <div className="flex items-start gap-2 text-sm">
+                  <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0 text-amber-500" />
+                  <p>
+                    <span className="font-medium">
+                      {group.containerNames.length} container
+                      {group.containerNames.length !== 1 ? 's' : ''}
+                    </span>
+                    {': '}
+                    {group.statement}
+                  </p>
+                </div>
+                <p
+                  className="mt-1 pl-5 text-xs text-muted-foreground break-words"
+                  title={group.containerNames.join(', ')}
+                >
+                  {group.containerNames.slice(0, RULE_CONTAINER_PREVIEW).join(', ')}
+                  {group.containerNames.length > RULE_CONTAINER_PREVIEW
+                    && ` and ${group.containerNames.length - RULE_CONTAINER_PREVIEW} more`}
+                </p>
               </div>
             ))}
           </div>

--- a/frontend/src/features/observability/pages/reports.tsx
+++ b/frontend/src/features/observability/pages/reports.tsx
@@ -74,15 +74,26 @@ interface RightSizingRuleSummary {
   threshold: number;
   unit: string;
   recommendation: string;
+  /** Every container the rule fired on. Uncapped — count with this. */
   container_count: number;
+  /** A sample of the names, capped server-side; may be shorter than the count. */
   container_names: string[];
+  names_truncated?: boolean;
 }
 
-/** One rendered line: the rule, and every container it matched. */
+/** One rendered line: the rule, and the containers it matched. */
 interface RightSizingGroup {
   id: string;
   statement: string;
   containerNames: string[];
+  /**
+   * The real total. Kept separate from `containerNames.length` because the
+   * backend caps the name list — counting the array would quietly under-report
+   * exactly the large fleet the cap exists for.
+   */
+  containerCount: number;
+  /** True when `containerNames` is a sample rather than the whole list. */
+  truncated: boolean;
 }
 const PDF_BRANDING_STORAGE_KEY = 'reports-management-pdf-branding-v1';
 const PDF_BRAND_PROFILES = [
@@ -532,6 +543,8 @@ export default function ReportsPage() {
         id: rule.id,
         statement: `${rule.metric.toUpperCase()} ${rule.statistic} ${rule.comparison} ${rule.threshold}${rule.unit === 'percent' ? '%' : ''} — ${rule.recommendation}`,
         containerNames: rule.container_names,
+        containerCount: rule.container_count,
+        truncated: !!rule.names_truncated,
       }));
     }
 
@@ -547,6 +560,10 @@ export default function ReportsPage() {
       id: issue,
       statement: issue,
       containerNames,
+      // The legacy path derives the list itself, so it is complete by
+      // construction and its length is the count.
+      containerCount: containerNames.length,
+      truncated: false,
     }));
   }, [report]);
 
@@ -1221,8 +1238,8 @@ export default function ReportsPage() {
                   <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0 text-amber-500" />
                   <p>
                     <span className="font-medium">
-                      {group.containerNames.length} container
-                      {group.containerNames.length !== 1 ? 's' : ''}
+                      {group.containerCount} container
+                      {group.containerCount !== 1 ? 's' : ''}
                     </span>
                     {': '}
                     {group.statement}
@@ -1230,11 +1247,15 @@ export default function ReportsPage() {
                 </div>
                 <p
                   className="mt-1 pl-5 text-xs text-muted-foreground break-words"
-                  title={group.containerNames.join(', ')}
+                  title={
+                    group.truncated
+                      ? `${group.containerNames.join(', ')} (first ${group.containerNames.length} of ${group.containerCount})`
+                      : group.containerNames.join(', ')
+                  }
                 >
                   {group.containerNames.slice(0, RULE_CONTAINER_PREVIEW).join(', ')}
-                  {group.containerNames.length > RULE_CONTAINER_PREVIEW
-                    && ` and ${group.containerNames.length - RULE_CONTAINER_PREVIEW} more`}
+                  {group.containerCount > RULE_CONTAINER_PREVIEW
+                    && ` and ${group.containerCount - RULE_CONTAINER_PREVIEW} more`}
                 </p>
               </div>
             ))}

--- a/frontend/src/features/observability/pages/status-page.test.tsx
+++ b/frontend/src/features/observability/pages/status-page.test.tsx
@@ -20,6 +20,21 @@ vi.mock('framer-motion', () => ({
 import { useReducedMotion } from 'framer-motion';
 const mockUseReducedMotion = vi.mocked(useReducedMotion);
 
+// `/status` is public but lives inside AuthProvider, so it can tell an admin
+// (who can act on a disabled status page) from an anonymous visitor (who cannot).
+const mockUseAuth = vi.fn();
+vi.mock('@/features/core/hooks/use-auth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+function asAnonymousVisitor() {
+  mockUseAuth.mockReturnValue({ isAuthenticated: false, role: 'viewer' });
+}
+
+function asAdmin() {
+  mockUseAuth.mockReturnValue({ isAuthenticated: true, role: 'admin' });
+}
+
 function stubMatchMedia(reduce: boolean) {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -94,6 +109,7 @@ describe('StatusPage', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     stubMatchMedia(false);
     mockUseReducedMotion.mockReturnValue(false);
+    asAnonymousVisitor();
   });
 
   afterEach(() => {
@@ -252,7 +268,8 @@ describe('StatusPage', () => {
     expect(screen.queryByText('Recent Incidents')).not.toBeInTheDocument();
   });
 
-  it('shows disabled message on 404', async () => {
+  /** Render the page against a `/api/status` that answers 404 (setting is off). */
+  async function renderNotPublished() {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false,
       status: 404,
@@ -267,8 +284,94 @@ describe('StatusPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/not enabled/i)).toBeInTheDocument();
+      expect(screen.getByText('Status page is off')).toBeInTheDocument();
     });
+  }
+
+  it('renders the disabled state through the shared not-configured empty state', async () => {
+    await renderNotPublished();
+
+    expect(screen.getByTestId('empty-state-card')).toBeInTheDocument();
+    expect(screen.getByText('Status page is off')).toBeInTheDocument();
+  });
+
+  /**
+   * The old copy read "An administrator needs to enable it in Settings" and was
+   * shown to a session logged in *as* the administrator, with no link.
+   */
+  it('tells an admin how to turn it on, and links to the tab that holds the setting', async () => {
+    asAdmin();
+    await renderNotPublished();
+
+    expect(screen.getByText(/Turn it on under Settings → Security/)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /Open Settings → Security/ });
+    expect(link).toHaveAttribute('href', '/settings?tab=security');
+    expect(screen.queryByText(/An administrator/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the third-person wording for a visitor who cannot reach Settings', async () => {
+    asAnonymousVisitor();
+    await renderNotPublished();
+
+    expect(screen.getByText(/An administrator can turn it on/)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Open Settings/ })).not.toBeInTheDocument();
+  });
+
+  it('shows the disabled state inside the same page chrome as the live page', async () => {
+    await renderNotPublished();
+
+    // Same shell: gradient mesh + the page container, not a bare centred sentence.
+    expect(screen.getByTestId('status-gradient')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Status');
+  });
+
+  /**
+   * `HTTP 500` and "the admin has not switched this on" used to render the same
+   * grey sentence, so a backend outage was indistinguishable from a setting.
+   */
+  it('separates an unreachable backend from a status page that is switched off', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    } as Response);
+
+    const mod = await import('./status-page');
+    const StatusPage = mod.default;
+
+    await act(async () => {
+      render(<MemoryRouter><StatusPage /></MemoryRouter>);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not reach /api/status')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/HTTP 500/)).toBeInTheDocument();
+    expect(screen.queryByText('Status page is off')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Retry/ })).toBeInTheDocument();
+  });
+
+  it('retries the fetch from the unreachable state', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Failed to fetch'));
+
+    const mod = await import('./status-page');
+    const StatusPage = mod.default;
+
+    await act(async () => {
+      render(<MemoryRouter><StatusPage /></MemoryRouter>);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not reach /api/status')).toBeInTheDocument();
+    });
+
+    const callsBefore = fetchSpy.mock.calls.length;
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Retry/ }));
+    });
+
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsBefore);
   });
 
   it('shows refresh button', async () => {

--- a/frontend/src/features/observability/pages/status-page.tsx
+++ b/frontend/src/features/observability/pages/status-page.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import {
   CheckCircle2,
   AlertTriangle,
@@ -9,10 +10,13 @@ import {
   Server,
   Container,
   Activity,
+  Globe,
 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { formatRelativeTime } from '@/shared/lib/format-relative-time';
 import { MotionStagger, MotionReveal } from '@/shared/components/layout/motion-page';
+import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { useAuth } from '@/features/core/hooks/use-auth';
 
 interface UptimeBucket {
   date: string;
@@ -47,6 +51,15 @@ interface StatusData {
   recentIncidents?: Incident[];
   autoRefreshSeconds: number;
 }
+
+/**
+ * The two failures used to share one branch, so `HTTP 500` and "the admin has
+ * not switched this on" rendered as the same grey sentence. They are different
+ * problems with different next actions, so they are different states.
+ */
+type StatusFailure =
+  | { kind: 'not-published' }
+  | { kind: 'unreachable'; detail: string };
 
 const PARTICLES = [
   { left: '8%', delay: '0s', duration: '12s', size: '7px' },
@@ -171,6 +184,60 @@ function UptimeTimeline({ buckets, reducedMotion }: { buckets: UptimeBucket[]; r
   );
 }
 
+/**
+ * The page chrome, shared by every state.
+ *
+ * "Off", "unreachable" and "live" used to be three different-looking screens —
+ * the off state in particular was a full-viewport gradient behind a single
+ * sentence, with none of the card chrome the live page uses. One shell keeps
+ * them recognisably the same page.
+ */
+function StatusShell({
+  reducedMotion,
+  children,
+}: {
+  reducedMotion: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className="relative min-h-screen bg-background overflow-hidden"
+      data-reduced-motion={reducedMotion}
+    >
+      {/* Gradient mesh background */}
+      <div
+        className={`login-gradient-mesh ${reducedMotion ? '' : 'login-gradient-mesh-animate'}`}
+        aria-hidden="true"
+        data-testid="status-gradient"
+      />
+
+      {/* Floating particles */}
+      {!reducedMotion && (
+        <div className="pointer-events-none absolute inset-0 z-0" aria-hidden="true">
+          {PARTICLES.map((particle) => (
+            <span
+              key={`${particle.left}-${particle.delay}`}
+              className="login-particle"
+              style={
+                {
+                  left: particle.left,
+                  width: particle.size,
+                  height: particle.size,
+                  animationDelay: particle.delay,
+                  animationDuration: particle.duration,
+                } as CSSProperties
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="relative z-10 max-w-3xl mx-auto px-4 py-8">{children}</div>
+    </div>
+  );
+}
+
 function IncidentItem({ incident }: { incident: Incident }) {
   const isResolved = incident.status === 'resolved';
 
@@ -216,26 +283,33 @@ function IncidentItem({ incident }: { incident: Incident }) {
 
 export default function StatusPage() {
   const [data, setData] = useState<StatusData | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [failure, setFailure] = useState<StatusFailure | null>(null);
   const [loading, setLoading] = useState(true);
   const [lastRefresh, setLastRefresh] = useState<Date>(new Date());
   const reducedMotion = usePrefersReducedMotion();
+  // `/status` is public, but it is also the page an admin lands on right after
+  // flipping the setting — so the copy has to know which of the two is reading.
+  const { isAuthenticated, role } = useAuth();
+  const canReachSettings = isAuthenticated && role === 'admin';
 
   const fetchStatus = useCallback(async () => {
     try {
       const res = await fetch('/api/status');
       if (res.status === 404) {
-        setError('Status page is not enabled. An administrator needs to enable it in Settings.');
+        setFailure({ kind: 'not-published' });
         setData(null);
         return;
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
       setData(json);
-      setError(null);
+      setFailure(null);
       setLastRefresh(new Date());
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load status');
+      setFailure({
+        kind: 'unreachable',
+        detail: err instanceof Error ? err.message : 'an unknown error',
+      });
     } finally {
       setLoading(false);
     }
@@ -253,28 +327,71 @@ export default function StatusPage() {
 
   if (loading) {
     return (
-      <div className="relative min-h-screen bg-background flex items-center justify-center overflow-hidden">
-        <div
-          className={`login-gradient-mesh ${reducedMotion ? '' : 'login-gradient-mesh-animate'}`}
-          aria-hidden="true"
-        />
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-foreground z-10" />
-      </div>
+      <StatusShell reducedMotion={reducedMotion}>
+        <div className="flex min-h-[50vh] items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-foreground" />
+        </div>
+      </StatusShell>
     );
   }
 
-  if (error) {
+  if (failure?.kind === 'not-published') {
     return (
-      <div className="relative min-h-screen bg-background flex items-center justify-center overflow-hidden">
-        <div
-          className={`login-gradient-mesh ${reducedMotion ? '' : 'login-gradient-mesh-animate'}`}
-          aria-hidden="true"
-        />
-        <div className="text-center z-10">
-          <XCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-          <p className="text-muted-foreground">{error}</p>
+      <StatusShell reducedMotion={reducedMotion}>
+        <div className="space-y-6">
+          <div className="text-center mb-2">
+            <h1 className="text-2xl font-bold text-foreground">Status</h1>
+          </div>
+          <EmptyState
+            variant="not-configured"
+            icon={Globe}
+            title="Status page is off"
+            description={
+              canReachSettings
+                ? 'Turn it on under Settings → Security → Public Status Page. It publishes uptime and incident history at this URL to anyone who can reach this host, with no sign-in.'
+                : 'This dashboard does not publish a status page. An administrator can turn it on under Settings → Security → Public Status Page.'
+            }
+          />
+          {canReachSettings && (
+            <div className="flex justify-center">
+              <Link
+                to="/settings?tab=security"
+                className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Open Settings → Security
+              </Link>
+            </div>
+          )}
         </div>
-      </div>
+      </StatusShell>
+    );
+  }
+
+  if (failure?.kind === 'unreachable') {
+    return (
+      <StatusShell reducedMotion={reducedMotion}>
+        <div className="space-y-6">
+          <div className="text-center mb-2">
+            <h1 className="text-2xl font-bold text-foreground">Status</h1>
+          </div>
+          <EmptyState
+            variant="error"
+            icon={XCircle}
+            title="Could not reach /api/status"
+            description={`The request failed with ${failure.detail}. That is not the 404 the server returns when the status page is switched off, so check the dashboard backend rather than the setting.`}
+          />
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={fetchStatus}
+              className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              Retry
+            </button>
+          </div>
+        </div>
+      </StatusShell>
     );
   }
 
@@ -284,183 +401,149 @@ export default function StatusPage() {
   const StatusIcon = statusConf.icon;
 
   return (
-    <div
-      className="relative min-h-screen bg-background overflow-hidden"
-      data-reduced-motion={reducedMotion}
-    >
-      {/* Gradient mesh background */}
-      <div
-        className={`login-gradient-mesh ${reducedMotion ? '' : 'login-gradient-mesh-animate'}`}
-        aria-hidden="true"
-        data-testid="status-gradient"
-      />
+    <StatusShell reducedMotion={reducedMotion}>
+      <MotionStagger className="space-y-6">
+        {/* Header */}
+        <MotionReveal>
+          <div className="text-center mb-2">
+            <h1 className="text-2xl font-bold text-foreground">{data.title}</h1>
+            {data.description && (
+              <p className="text-muted-foreground mt-1">{data.description}</p>
+            )}
+          </div>
+        </MotionReveal>
 
-      {/* Floating particles */}
-      {!reducedMotion && (
-        <div className="pointer-events-none absolute inset-0 z-0" aria-hidden="true">
-          {PARTICLES.map((particle) => (
-            <span
-              key={`${particle.left}-${particle.delay}`}
-              className="login-particle"
-              style={
-                {
-                  left: particle.left,
-                  width: particle.size,
-                  height: particle.size,
-                  animationDelay: particle.delay,
-                  animationDuration: particle.duration,
-                } as CSSProperties
-              }
-            />
-          ))}
-        </div>
-      )}
-
-      {/* Content */}
-      <div className="relative z-10 max-w-3xl mx-auto px-4 py-8">
-        <MotionStagger className="space-y-6">
-          {/* Header */}
-          <MotionReveal>
-            <div className="text-center mb-2">
-              <h1 className="text-2xl font-bold text-foreground">{data.title}</h1>
-              {data.description && (
-                <p className="text-muted-foreground mt-1">{data.description}</p>
-              )}
+        {/* Overall Status Banner */}
+        <MotionReveal>
+          <div
+            className={cn(
+              'rounded-lg border p-6 text-center shadow-sm',
+              statusConf.bg,
+            )}
+            data-testid="status-banner"
+          >
+            <div className={cn('inline-flex items-center justify-center w-14 h-14 rounded-full mb-3', statusConf.iconBg)}>
+              <StatusIcon className={cn('h-8 w-8', statusConf.color)} />
             </div>
-          </MotionReveal>
+            <h2 className={cn('text-lg font-semibold', statusConf.color)}>
+              {statusConf.label}
+            </h2>
+          </div>
+        </MotionReveal>
 
-          {/* Overall Status Banner */}
+        {/* Uptime Summary — 3 side-by-side glass cards */}
+        <MotionReveal>
+          <div>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3">
+              Uptime
+            </h3>
+            <div className="grid grid-cols-3 gap-3">
+              {(['24h', '7d', '30d'] as const).map((period) => (
+                <div key={period} className={cn(GLASS_CARD, 'p-4 text-center')}>
+                  <div className={cn('text-2xl font-bold', uptimeTextColor(data.uptime[period]))}>
+                    {data.uptime[period]}%
+                  </div>
+                  <div className="text-xs text-muted-foreground uppercase mt-1">{period}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </MotionReveal>
+
+        {/* Current Snapshot */}
+        {data.snapshot && (
           <MotionReveal>
-            <div
-              className={cn(
-                'rounded-lg border p-6 text-center shadow-sm',
-                statusConf.bg,
-              )}
-              data-testid="status-banner"
-            >
-              <div className={cn('inline-flex items-center justify-center w-14 h-14 rounded-full mb-3', statusConf.iconBg)}>
-                <StatusIcon className={cn('h-8 w-8', statusConf.color)} />
+            <div className={cn(GLASS_CARD, 'p-6')}>
+              <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-4">
+                Current Status
+              </h3>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500/15">
+                    <Container className="h-4 w-4 text-emerald-500" />
+                  </div>
+                  <div>
+                    <div className="text-lg font-semibold text-foreground">{data.snapshot.containersRunning}</div>
+                    <div className="text-xs text-muted-foreground">Running</div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-muted/50">
+                    <Container className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                  <div>
+                    <div className="text-lg font-semibold text-foreground">{data.snapshot.containersStopped}</div>
+                    <div className="text-xs text-muted-foreground">Stopped</div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-yellow-500/15">
+                    <Activity className="h-4 w-4 text-yellow-500" />
+                  </div>
+                  <div>
+                    <div className="text-lg font-semibold text-foreground">{data.snapshot.containersUnhealthy}</div>
+                    <div className="text-xs text-muted-foreground">Unhealthy</div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-blue-500/15">
+                    <Server className="h-4 w-4 text-blue-500" />
+                  </div>
+                  <div>
+                    <div className="text-lg font-semibold text-foreground">{data.snapshot.endpointsUp}</div>
+                    <div className="text-xs text-muted-foreground">Endpoints Up</div>
+                  </div>
+                </div>
               </div>
-              <h2 className={cn('text-lg font-semibold', statusConf.color)}>
-                {statusConf.label}
-              </h2>
             </div>
           </MotionReveal>
+        )}
 
-          {/* Uptime Summary — 3 side-by-side glass cards */}
+        {/* 90-day Uptime Timeline */}
+        {data.uptimeTimeline.length > 0 && (
+          <MotionReveal>
+            <div className={cn(GLASS_CARD, 'p-6')}>
+              <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-4">
+                Uptime History (90 days)
+              </h3>
+              <UptimeTimeline buckets={data.uptimeTimeline} reducedMotion={reducedMotion} />
+            </div>
+          </MotionReveal>
+        )}
+
+        {/* Recent Incidents */}
+        {data.recentIncidents && data.recentIncidents.length > 0 && (
           <MotionReveal>
             <div>
               <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3">
-                Uptime
+                Recent Incidents
               </h3>
-              <div className="grid grid-cols-3 gap-3">
-                {(['24h', '7d', '30d'] as const).map((period) => (
-                  <div key={period} className={cn(GLASS_CARD, 'p-4 text-center')}>
-                    <div className={cn('text-2xl font-bold', uptimeTextColor(data.uptime[period]))}>
-                      {data.uptime[period]}%
-                    </div>
-                    <div className="text-xs text-muted-foreground uppercase mt-1">{period}</div>
-                  </div>
+              <div className="space-y-3">
+                {data.recentIncidents.map((incident) => (
+                  <IncidentItem key={incident.id} incident={incident} />
                 ))}
               </div>
             </div>
           </MotionReveal>
+        )}
 
-          {/* Current Snapshot */}
-          {data.snapshot && (
-            <MotionReveal>
-              <div className={cn(GLASS_CARD, 'p-6')}>
-                <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-4">
-                  Current Status
-                </h3>
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                  <div className="flex items-center gap-3">
-                    <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500/15">
-                      <Container className="h-4 w-4 text-emerald-500" />
-                    </div>
-                    <div>
-                      <div className="text-lg font-semibold text-foreground">{data.snapshot.containersRunning}</div>
-                      <div className="text-xs text-muted-foreground">Running</div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-muted/50">
-                      <Container className="h-4 w-4 text-muted-foreground" />
-                    </div>
-                    <div>
-                      <div className="text-lg font-semibold text-foreground">{data.snapshot.containersStopped}</div>
-                      <div className="text-xs text-muted-foreground">Stopped</div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-yellow-500/15">
-                      <Activity className="h-4 w-4 text-yellow-500" />
-                    </div>
-                    <div>
-                      <div className="text-lg font-semibold text-foreground">{data.snapshot.containersUnhealthy}</div>
-                      <div className="text-xs text-muted-foreground">Unhealthy</div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-blue-500/15">
-                      <Server className="h-4 w-4 text-blue-500" />
-                    </div>
-                    <div>
-                      <div className="text-lg font-semibold text-foreground">{data.snapshot.endpointsUp}</div>
-                      <div className="text-xs text-muted-foreground">Endpoints Up</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </MotionReveal>
-          )}
-
-          {/* 90-day Uptime Timeline */}
-          {data.uptimeTimeline.length > 0 && (
-            <MotionReveal>
-              <div className={cn(GLASS_CARD, 'p-6')}>
-                <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-4">
-                  Uptime History (90 days)
-                </h3>
-                <UptimeTimeline buckets={data.uptimeTimeline} reducedMotion={reducedMotion} />
-              </div>
-            </MotionReveal>
-          )}
-
-          {/* Recent Incidents */}
-          {data.recentIncidents && data.recentIncidents.length > 0 && (
-            <MotionReveal>
-              <div>
-                <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3">
-                  Recent Incidents
-                </h3>
-                <div className="space-y-3">
-                  {data.recentIncidents.map((incident) => (
-                    <IncidentItem key={incident.id} incident={incident} />
-                  ))}
-                </div>
-              </div>
-            </MotionReveal>
-          )}
-
-          {/* Footer */}
-          <MotionReveal>
-            <div className="flex items-center justify-between text-xs text-muted-foreground mt-4 pb-4">
-              <div className="flex items-center gap-1">
-                <Clock className="h-3 w-3" />
-                <span>Last updated: {formatTime(lastRefresh.toISOString())}</span>
-              </div>
-              <button
-                onClick={fetchStatus}
-                className="flex items-center gap-1 hover:text-foreground transition-colors"
-              >
-                <RefreshCw className="h-3 w-3" />
-                <span>Refresh</span>
-              </button>
+        {/* Footer */}
+        <MotionReveal>
+          <div className="flex items-center justify-between text-xs text-muted-foreground mt-4 pb-4">
+            <div className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              <span>Last updated: {formatTime(lastRefresh.toISOString())}</span>
             </div>
-          </MotionReveal>
-        </MotionStagger>
-      </div>
-    </div>
+            <button
+              onClick={fetchStatus}
+              className="flex items-center gap-1 hover:text-foreground transition-colors"
+            >
+              <RefreshCw className="h-3 w-3" />
+              <span>Refresh</span>
+            </button>
+          </div>
+        </MotionReveal>
+      </MotionStagger>
+    </StatusShell>
   );
 }

--- a/frontend/src/features/observability/pages/trace-explorer.test.tsx
+++ b/frontend/src/features/observability/pages/trace-explorer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { ReactElement } from 'react';
 
@@ -7,8 +7,26 @@ function renderWithRouter(ui: ReactElement, route: string = '/traces') {
   return render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>);
 }
 
+const mockUseAutoRefresh = vi.fn(() => ({ interval: 0, setRefreshInterval: vi.fn(), setInterval: vi.fn() }));
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: () => ({ interval: 0, setInterval: vi.fn() }),
+  useAutoRefresh: (...args: unknown[]) => mockUseAutoRefresh(...(args as [])),
+}));
+
+// jsdom reports every element as 0px tall, so a real virtualizer would render
+// nothing. Same shape as the log viewer / data-table tests.
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: vi.fn(({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, i) => ({
+        index: i,
+        start: i * 128,
+        end: (i + 1) * 128,
+        size: 128,
+        key: i,
+      })),
+    getTotalSize: () => count * 128,
+    measureElement: vi.fn(),
+  })),
 }));
 
 vi.mock('@/shared/components/charts/service-map', () => ({
@@ -42,44 +60,134 @@ vi.mock('@/features/observability/hooks/use-traces', () => ({
   useTraceSummary: (...args: unknown[]) => mockUseTraceSummary(...args),
 }));
 
-import TraceExplorerPage from './trace-explorer';
+import TraceExplorerPage, {
+  ANOMALY_Z_THRESHOLD,
+  computeDurationStats,
+  constantValue,
+  durationZScore,
+  isPreflightOperation,
+  percentile,
+} from './trace-explorer';
+
+interface TraceFixture {
+  trace_id: string;
+  root_span: string;
+  duration_ms: number;
+  status: string;
+  service_name: string;
+  start_time: string;
+  trace_source: string;
+  span_count: number;
+  http_route: string;
+  container_name?: string;
+}
+
+/** 11 fast GETs, one 5s outlier (z ≈ 3.3) and three CORS preflights. */
+function buildTraces(): TraceFixture[] {
+  const fast: TraceFixture[] = Array.from({ length: 11 }, (_, i) => ({
+    trace_id: `fast-${i}`,
+    root_span: `GET /health/${i}`,
+    duration_ms: 10,
+    status: 'ok',
+    service_name: 'api-gateway',
+    start_time: '2026-02-12T10:00:00.000Z',
+    trace_source: 'http',
+    span_count: 1,
+    http_route: `/health/${i}`,
+  }));
+  const slow: TraceFixture = {
+    trace_id: 'slow-1',
+    root_span: 'GET /reports/export',
+    duration_ms: 5000,
+    status: 'ok',
+    service_name: 'api-gateway',
+    start_time: '2026-02-12T10:00:00.000Z',
+    trace_source: 'http',
+    span_count: 1,
+    http_route: '/reports/export',
+  };
+  const preflights: TraceFixture[] = Array.from({ length: 3 }, (_, i) => ({
+    trace_id: `preflight-${i}`,
+    root_span: 'OPTIONS *',
+    duration_ms: 4,
+    status: 'ok',
+    service_name: 'api-gateway',
+    start_time: '2026-02-12T10:00:00.000Z',
+    trace_source: 'http',
+    span_count: 1,
+    http_route: '*',
+  }));
+  return [...fast, slow, ...preflights];
+}
+
+describe('trace duration statistics', () => {
+  it('takes the nearest-rank percentile', () => {
+    const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(percentile(sorted, 50)).toBe(5);
+    expect(percentile(sorted, 95)).toBe(10);
+    expect(percentile([], 95)).toBe(0);
+  });
+
+  it('computes p50/p95 plus the mean and stddev the z-score uses', () => {
+    const stats = computeDurationStats([10, 10, 10, 10, 50]);
+    expect(stats.count).toBe(5);
+    expect(stats.p50).toBe(10);
+    expect(stats.p95).toBe(50);
+    expect(stats.mean).toBe(18);
+    expect(stats.stdDev).toBeCloseTo(16, 5);
+  });
+
+  it('returns no z-score for a flat or single-sample window', () => {
+    expect(durationZScore(10, computeDurationStats([10, 10, 10]))).toBeNull();
+    expect(durationZScore(10, computeDurationStats([10]))).toBeNull();
+  });
+
+  it('flags the outlier at the detector threshold', () => {
+    const durations = [...Array.from({ length: 11 }, () => 10), 5000];
+    const stats = computeDurationStats(durations);
+    expect(durationZScore(5000, stats)).toBeGreaterThanOrEqual(ANOMALY_Z_THRESHOLD);
+    expect(durationZScore(10, stats)).toBeLessThan(ANOMALY_Z_THRESHOLD);
+  });
+
+  it('recognises CORS preflights by operation name', () => {
+    expect(isPreflightOperation('OPTIONS *')).toBe(true);
+    expect(isPreflightOperation('  options /api/x ')).toBe(true);
+    expect(isPreflightOperation('GET /options-page')).toBe(false);
+  });
+
+  it('reports a constant only when at least two rows agree', () => {
+    expect(constantValue(['a', 'a', 'a'])).toBe('a');
+    expect(constantValue(['a', 'b'])).toBeNull();
+    expect(constantValue(['a'])).toBeNull();
+    expect(constantValue([])).toBeNull();
+  });
+});
 
 describe('TraceExplorerPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseAutoRefresh.mockReturnValue({ interval: 0, setRefreshInterval: vi.fn(), setInterval: vi.fn() });
 
     // useTraces unwraps the { traces } envelope, so it resolves to a bare array.
     mockUseTraces.mockReturnValue({
-      data: [
-        {
-          trace_id: 'trace-1',
-          root_span: 'GET /health',
-          duration_ms: 120,
-          status: 'ok',
-          service_name: 'api',
-          start_time: '2026-02-12T10:00:00.000Z',
-          trace_source: 'ebpf',
-          span_count: 1,
-          http_route: '/health',
-          container_name: 'api-container',
-        },
-      ],
+      data: buildTraces(),
       isLoading: false,
       isError: false,
       error: null,
       refetch: vi.fn(),
       isFetching: false,
+      dataUpdatedAt: Date.now(),
     });
 
     mockUseTrace.mockReturnValue({
       data: {
-        traceId: 'trace-1',
+        traceId: 'fast-0',
         spans: [
           {
             span_id: 'span-1',
             parent_span_id: null,
-            name: 'GET /health',
-            service_name: 'api',
+            name: 'GET /health/0',
+            service_name: 'api-gateway',
             start_time: '2026-02-12T10:00:00.000Z',
             duration_ms: 120,
             status: 'ok',
@@ -87,34 +195,16 @@ describe('TraceExplorerPage', () => {
             attributes: JSON.stringify({
               endpoint: 'api-gateway',
               'container.name': 'api-container',
+              'container.id': 'container-abc',
               'service.namespace': 'production',
               'service.instance.id': 'instance-a',
               'service.version': '1.8.2',
               'deployment.environment': 'prod',
-              'container.id': 'container-abc',
-              'k8s.namespace.name': 'payments',
-              'k8s.pod.name': 'payments-api-9d7cc',
-              'k8s.container.name': 'api',
-              'server.address': '10.0.0.24',
-              'server.port': 443,
-              'client.address': '10.0.0.12',
               'url.full': 'http://api-gateway/health',
-              'url.scheme': 'http',
               'network.transport': 'tcp',
-              'network.protocol.name': 'http',
-              'network.protocol.version': '1.1',
-              'net.peer.name': 'api-gateway.internal',
-              'net.peer.port': 8080,
-              'host.name': 'srv-edge-01',
-              'os.type': 'linux',
               'process.pid': 4711,
-              'process.executable.name': 'http-echo',
               'process.command_line': '/bin/http-echo --port=8080',
               'telemetry.sdk.name': 'beyla',
-              'telemetry.sdk.language': 'go',
-              'telemetry.sdk.version': '2.8.5',
-              'otel.scope.name': 'github.com/grafana/beyla',
-              'otel.scope.version': 'v2.8.5',
             }),
           },
         ],
@@ -124,58 +214,130 @@ describe('TraceExplorerPage', () => {
     mockUseServiceMap.mockReturnValue({ data: { nodes: [], edges: [] } });
     mockUseTraceSummary.mockReturnValue({
       data: {
-        totalTraces: 12,
+        totalTraces: 15,
         avgDuration: 85,
         errorRate: 0.2,
-        services: 4,
-        sourceCounts: {
-          http: 3,
-          ebpf: 7,
-          scheduler: 2,
-          unknown: 0,
-        },
+        services: 1,
+        sourceCounts: { http: 15, ebpf: 0, scheduler: 0, unknown: 0 },
       },
     });
   });
 
-  it('renders source-scoped counters from summary', () => {
+  it('renders the manifest short label as the single page h1', () => {
     renderWithRouter(<TraceExplorerPage />);
 
-    expect(screen.getByText('Source counters:')).toBeInTheDocument();
-    expect(screen.getByText('eBPF: 7')).toBeInTheDocument();
-    expect(screen.getByText('HTTP: 3')).toBeInTheDocument();
-    expect(screen.getByText('Scheduler: 2')).toBeInTheDocument();
-    expect(screen.getByText('Tip: select a source below to focus this list.')).toBeInTheDocument();
-    expect(screen.getByText('Need precision? Filter by HTTP route/status or service and container namespaces.')).toBeInTheDocument();
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveTextContent('Traces');
   });
 
-  it('restores trace source context and span metadata details', () => {
+  it('leads with p95/p50 instead of an average the detector does not use', () => {
     renderWithRouter(<TraceExplorerPage />);
 
-    expect(screen.getByText('Tip: select a source below to focus this list.')).toBeInTheDocument();
-    expect(screen.getByText('Showing all trace sources. Use a source filter to focus on a single ingestion path.')).toBeInTheDocument();
+    const subtitle = screen.getByTestId('page-header-subtitle');
+    expect(subtitle).toHaveTextContent('15 traces');
+    expect(subtitle).toHaveTextContent('1 service');
+    // 11×10ms, 3×4ms, 1×5000ms → p95 is the 5s outlier, p50 is 10ms.
+    expect(subtitle).toHaveTextContent('p95 5.00s');
+    expect(subtitle).toHaveTextContent('p50 10ms');
+    expect(screen.queryByText(/Avg Duration/)).toBeNull();
+  });
+
+  it('drops the three "you can filter" sentences', () => {
+    renderWithRouter(<TraceExplorerPage />);
+
+    expect(screen.queryByText(/Tip: select a source below/)).toBeNull();
+    expect(screen.queryByText(/Showing all trace sources/)).toBeNull();
+    expect(screen.queryByText(/Need precision\?/)).toBeNull();
+  });
+
+  it('makes the source chips the filter and drops the parallel dropdown', () => {
+    renderWithRouter(<TraceExplorerPage />);
+
+    const sourceFilter = screen.getByTestId('source-filter');
+    const ebpfChip = within(sourceFilter).getByRole('button', { name: /eBPF/ });
+    expect(ebpfChip).toHaveAttribute('aria-pressed', 'false');
+    // The dropdown that used to duplicate this control, with its third vocabulary.
+    expect(screen.queryByText('eBPF (Apps)')).toBeNull();
+    expect(screen.queryByText('HTTP Requests')).toBeNull();
+    expect(screen.queryByText('Background Jobs')).toBeNull();
+
+    fireEvent.click(ebpfChip);
+
+    expect(mockUseTraces.mock.calls.at(-1)?.[0]).toMatchObject({ source: 'ebpf' });
+    expect(within(sourceFilter).getByRole('button', { name: /eBPF/ })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('filters to the traces the detector threshold would flag', () => {
+    renderWithRouter(<TraceExplorerPage />);
+
+    const anomalous = screen.getByRole('button', { name: /Anomalous \(1\)/ });
+    expect(anomalous).toHaveAttribute(
+      'title',
+      expect.stringContaining('TRACES_ANOMALY_P95_ZSCORE'),
+    );
+
+    fireEvent.click(anomalous);
+
+    const list = screen.getByTestId('trace-list');
+    expect(within(list).getByText('GET /reports/export')).toBeInTheDocument();
+    expect(within(list).queryByText('GET /health/0')).toBeNull();
+    // The anomaly cut is client-side; the API never sees an unknown status.
+    expect(mockUseTraces.mock.calls.at(-1)?.[0]).toMatchObject({ status: undefined });
+  });
+
+  it('states fields constant across the result set once, not on every card', () => {
+    renderWithRouter(<TraceExplorerPage />);
+
+    const constants = screen.getByTestId('constant-fields');
+    expect(constants).toHaveTextContent('api-gateway');
+    expect(constants).toHaveTextContent('source: HTTP');
+
+    // Not repeated inside the cards.
+    const list = screen.getByTestId('trace-list');
+    expect(within(list).queryByText('source: HTTP')).toBeNull();
+    expect(within(list).queryByText('api-gateway')).toBeNull();
+    // "1 services" was on every row too.
+    expect(within(list).queryByText('1 services')).toBeNull();
+  });
+
+  it('collapses CORS preflights into one aggregated row', () => {
+    renderWithRouter(<TraceExplorerPage />);
+
+    const summary = screen.getByTestId('preflight-summary');
+    expect(summary).toHaveTextContent('3 CORS preflight traces (OPTIONS)');
+    expect(summary).toHaveTextContent('p95 4ms');
+
+    const list = screen.getByTestId('trace-list');
+    expect(within(list).queryByText('OPTIONS *')).toBeNull();
+
+    fireEvent.click(summary);
+    expect(within(screen.getByTestId('trace-list')).getAllByText('OPTIONS *')).toHaveLength(3);
+  });
+
+  it('keeps the eBPF quick guide, behind the header help toggle', () => {
+    renderWithRouter(<TraceExplorerPage />);
+
+    expect(screen.queryByText('eBPF Quick Guide')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('source-guide-toggle'));
+
     expect(screen.getByText('eBPF Quick Guide')).toBeInTheDocument();
+    expect(screen.getByText(/Beyla captured runtime network spans/)).toBeInTheDocument();
+    // The source counters moved here rather than costing a strip above the list.
+    expect(screen.getByText(/Ingested in this window/)).toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: /GET \/health/i }));
+  it('gives the auto-refresh hook a tick to run', () => {
+    renderWithRouter(<TraceExplorerPage />);
 
-    expect(screen.getAllByText('endpoint: api-gateway').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('container: api-container').length).toBeGreaterThan(0);
-    expect(screen.getByText('Service Namespace')).toBeInTheDocument();
-    expect(screen.getAllByText('production').length).toBeGreaterThan(0);
-    expect(screen.getByText('Service Instance')).toBeInTheDocument();
-    expect(screen.getAllByText('instance-a').length).toBeGreaterThan(0);
-    expect(screen.getByText('Service Version')).toBeInTheDocument();
-    expect(screen.getAllByText('1.8.2').length).toBeGreaterThan(0);
-    expect(screen.getByText('Deployment Environment')).toBeInTheDocument();
-    expect(screen.getAllByText('prod').length).toBeGreaterThan(0);
-    expect(screen.getByText('URL Full')).toBeInTheDocument();
-    expect(screen.getAllByText('http://api-gateway/health').length).toBeGreaterThan(0);
-    expect(screen.getByText('Network Transport')).toBeInTheDocument();
-    expect(screen.getAllByText('tcp').length).toBeGreaterThan(0);
-    expect(screen.getByText('Process PID')).toBeInTheDocument();
-    expect(screen.getAllByText('4711').length).toBeGreaterThan(0);
-    expect(screen.getByText('Telemetry SDK Name')).toBeInTheDocument();
-    expect(screen.getAllByText('beyla').length).toBeGreaterThan(0);
+    const opts = mockUseAutoRefresh.mock.calls.at(-1) as unknown as [number, { onTick?: () => void }];
+    expect(typeof opts[1].onTick).toBe('function');
+  });
+
+  it('shows how old the loaded traces are', () => {
+    renderWithRouter(<TraceExplorerPage />);
+    expect(screen.getByText(/^Updated /)).toBeInTheDocument();
   });
 
   it('applies advanced filters through trace query state', () => {
@@ -183,87 +345,59 @@ describe('TraceExplorerPage', () => {
 
     fireEvent.click(screen.getByText('Show advanced filters'));
     fireEvent.change(screen.getByDisplayValue('Exact match'), { target: { value: 'contains' } });
-    fireEvent.change(screen.getByPlaceholderText('/api/users/:id'), { target: { value: '/health' } });
-    fireEvent.change(screen.getByPlaceholderText('500'), { target: { value: '200' } });
+    fireEvent.change(screen.getByLabelText('HTTP Route'), { target: { value: '/health' } });
+    fireEvent.change(screen.getByLabelText('HTTP Status Code'), { target: { value: '200' } });
+    fireEvent.change(screen.getByLabelText('Container Name'), { target: { value: 'api-container' } });
+
+    // The 26 OTEL attribute fields are one further click away.
+    expect(screen.queryByLabelText('Telemetry SDK Version')).toBeNull();
+    fireEvent.click(screen.getByTestId('toggle-attribute-filters'));
     fireEvent.change(screen.getByLabelText('Service Instance ID'), { target: { value: 'instance-a' } });
     fireEvent.change(screen.getByLabelText('Server Port'), { target: { value: '8443' } });
-    fireEvent.change(screen.getByPlaceholderText('http://service:8080/path'), { target: { value: 'http://api-gateway/health' } });
-    fireEvent.change(screen.getByPlaceholderText('tcp'), { target: { value: 'tcp' } });
-    fireEvent.change(screen.getByPlaceholderText('/bin/http-echo --port 8080'), { target: { value: '/bin/http-echo --port=8080' } });
-    fireEvent.change(screen.getByPlaceholderText('beyla'), { target: { value: 'beyla' } });
+    fireEvent.change(screen.getByLabelText('Telemetry SDK Name'), { target: { value: 'beyla' } });
 
     const lastCall = mockUseTraces.mock.calls.at(-1)?.[0] as Record<string, unknown>;
     expect(lastCall.httpRoute).toBe('/health');
     expect(lastCall.httpRouteMatch).toBe('contains');
     expect(lastCall.httpStatusCode).toBe(200);
+    expect(lastCall.containerName).toBe('api-container');
     expect(lastCall.serviceInstanceId).toBe('instance-a');
     expect(lastCall.serverPort).toBe(8443);
-    expect(lastCall.urlFull).toBe('http://api-gateway/health');
-    expect(lastCall.networkTransport).toBe('tcp');
-    expect(lastCall.processCommand).toBe('/bin/http-echo --port=8080');
     expect(lastCall.telemetrySdkName).toBe('beyla');
   });
 
-  it('shows container name alongside source on each trace card', () => {
+  it('keeps span metadata in the detail pane', () => {
     renderWithRouter(<TraceExplorerPage />);
 
-    expect(screen.getByText('container: api-container')).toBeInTheDocument();
+    fireEvent.click(within(screen.getByTestId('trace-list')).getByText('GET /health/0'));
+
+    expect(screen.getByText('Service Namespace')).toBeInTheDocument();
+    expect(screen.getAllByText('production').length).toBeGreaterThan(0);
+    expect(screen.getByText('Service Instance')).toBeInTheDocument();
+    expect(screen.getAllByText('instance-a').length).toBeGreaterThan(0);
+    expect(screen.getByText('Process PID')).toBeInTheDocument();
+    expect(screen.getAllByText('4711').length).toBeGreaterThan(0);
   });
 
-  it('prefers typed span columns when attributes are sparse', () => {
-    mockUseTrace.mockReturnValue({
-      data: {
-        traceId: 'trace-1',
-        spans: [
-          {
-            span_id: 'span-typed-1',
-            parent_span_id: null,
-            name: 'GET /typed',
-            service_name: 'api',
-            start_time: '2026-02-12T10:00:00.000Z',
-            duration_ms: 80,
-            status: 'ok',
-            trace_source: 'ebpf',
-            http_route: '/typed-route',
-            container_name: 'typed-container',
-            service_namespace: 'typed-namespace',
-            service_instance_id: 'typed-instance',
-            service_version: '9.9.9',
-            deployment_environment: 'staging',
-            server_address: 'typed-host.internal',
-            attributes: '{}',
-          },
-        ],
-      },
-    });
-
+  it('links a span to its logs with theme tokens, not a dark-only blue', () => {
     renderWithRouter(<TraceExplorerPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: /GET \/health/i }));
+    fireEvent.click(within(screen.getByTestId('trace-list')).getByText('GET /health/0'));
 
-    expect(screen.getAllByText('endpoint: /typed-route').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('container: typed-container').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('typed-namespace').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('typed-instance').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('9.9.9').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('staging').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('typed-host.internal').length).toBeGreaterThan(0);
+    const link = screen.getByTestId('view-logs-link');
+    expect(link.className).toContain('text-primary');
+    expect(link.className).not.toContain('text-blue-200');
   });
 
   it('pre-applies service / status / trace from URL query params', () => {
     renderWithRouter(
       <TraceExplorerPage />,
-      '/traces?service=payments-api&status=error&trace=trace-1',
+      '/traces?service=payments-api&status=error&trace=fast-0',
     );
 
-    // useTraces is called with the deep-link service + error status applied.
-    const lastCall = mockUseTraces.mock.calls.at(-1);
-    expect(lastCall).toBeDefined();
-    const opts = lastCall![0];
+    const opts = mockUseTraces.mock.calls.at(-1)?.[0] as Record<string, unknown>;
     expect(opts.serviceName).toBe('payments-api');
     expect(opts.status).toBe('error');
-    // ?trace=trace-1 selects the trace immediately, so useTrace is called with it.
-    const traceCall = mockUseTrace.mock.calls.at(-1);
-    expect(traceCall?.[0]).toBe('trace-1');
+    expect(mockUseTrace.mock.calls.at(-1)?.[0]).toBe('fast-0');
   });
 });

--- a/frontend/src/features/observability/pages/trace-explorer.tsx
+++ b/frontend/src/features/observability/pages/trace-explorer.tsx
@@ -1,5 +1,6 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   Search,
   GitBranch,
@@ -12,6 +13,7 @@ import {
   Layers,
   Timer,
   ScrollText,
+  HelpCircle,
 } from 'lucide-react';
 import { useTraces, useTrace, useServiceMap, useTraceSummary } from '@/features/observability/hooks/use-traces';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
@@ -19,11 +21,11 @@ import { ServiceMap } from '@/shared/components/charts/service-map';
 import { RefreshControls } from '@/shared/components/ui/refresh-controls';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
+import { DataFreshness } from '@/shared/components/feedback/data-freshness';
 import { SkeletonChart, SkeletonList } from '@/shared/components/feedback/skeleton';
 import { cn, formatDate } from '@/shared/lib/utils';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
-import { KpiCard } from '@/shared/components/data-display/kpi-card';
-import { TiltCard } from '@/shared/components/data-display/tilt-card';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 
 function formatDuration(ms: number): string {
@@ -31,6 +33,74 @@ function formatDuration(ms: number): string {
   if (ms < 1000) return `${Math.round(ms)}ms`;
   if (ms < 60000) return `${(ms / 1000).toFixed(2)}s`;
   return `${(ms / 60000).toFixed(2)}m`;
+}
+
+/**
+ * The z-score at which a trace is called out as anomalous.
+ *
+ * The backend trace detector flags a service whose latency `p95` deviates by
+ * `TRACES_ANOMALY_P95_ZSCORE` (default 3.0) standard deviations from its
+ * baseline. This page used to show `Avg Duration` and never mentioned p95 or a
+ * z-score at all, so an operator could not tell which traces the detector was
+ * reasoning about. The same threshold is applied here — to trace duration
+ * within the loaded window — so the two agree on what "unusual" means.
+ */
+export const ANOMALY_Z_THRESHOLD = 3;
+
+export interface DurationStats {
+  count: number;
+  p50: number;
+  p95: number;
+  mean: number;
+  stdDev: number;
+}
+
+/** Nearest-rank percentile over an ascending-sorted array. */
+export function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  const rank = Math.ceil((p / 100) * sortedAsc.length);
+  const index = Math.min(sortedAsc.length - 1, Math.max(0, rank - 1));
+  return sortedAsc[index];
+}
+
+/** p50/p95 plus the mean and population stddev the z-score filter uses. */
+export function computeDurationStats(durations: number[]): DurationStats {
+  const count = durations.length;
+  if (count === 0) return { count: 0, p50: 0, p95: 0, mean: 0, stdDev: 0 };
+  const sorted = [...durations].sort((a, b) => a - b);
+  const mean = durations.reduce((sum, d) => sum + d, 0) / count;
+  const variance = durations.reduce((sum, d) => sum + (d - mean) ** 2, 0) / count;
+  return {
+    count,
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    mean,
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+/** Deviation of one duration from the loaded window, or null when flat. */
+export function durationZScore(duration: number, stats: DurationStats): number | null {
+  if (stats.count < 2 || stats.stdDev <= 0) return null;
+  return (duration - stats.mean) / stats.stdDev;
+}
+
+/**
+ * CORS preflights. On the captured fleet 83 of 193 traces were `OPTIONS *` —
+ * they carry no diagnostic signal and crowd out the traces that do.
+ */
+export function isPreflightOperation(operationName: string): boolean {
+  return /^options\b/i.test(operationName.trim());
+}
+
+/** Fallback row height for the virtualizer before a card is measured. */
+const TRACE_ROW_ESTIMATED_HEIGHT = 128;
+
+/** The one value shared by every row, or null when it varies (or N < 2). */
+export function constantValue(values: string[]): string | null {
+  if (values.length < 2) return null;
+  const first = values[0];
+  return values.every((v) => v === first) ? first : null;
 }
 
 function getDurationColor(ms: number): string {
@@ -72,6 +142,23 @@ function parseAttributes(attributes: unknown): Record<string, unknown> {
 
 type TraceSource = 'ebpf' | 'http' | 'scheduler' | 'unknown';
 
+/**
+ * One label per source value.
+ *
+ * The page previously spoke three dialects at once for the same three-valued
+ * enum: counter chips said "eBPF / HTTP / Scheduler", the dropdown said
+ * "eBPF (Apps) / HTTP Requests / Background Jobs", and the badges said
+ * "source: ebpf / source: http / source: scheduler" — all visible together.
+ */
+const SOURCE_LABELS: Record<TraceSource, string> = {
+  ebpf: 'eBPF',
+  http: 'HTTP',
+  scheduler: 'Scheduler',
+  unknown: 'Unknown',
+};
+
+const FILTERABLE_SOURCES: TraceSource[] = ['ebpf', 'http', 'scheduler'];
+
 function normalizeSource(source: string | undefined): TraceSource {
   if (!source) return 'unknown';
   const normalized = source.toLowerCase();
@@ -104,8 +191,44 @@ function SourceBadge({ source }: { source: string | undefined }) {
       className={cn('rounded border px-1.5 py-0.5', getSourceBadgeClass(source))}
       title={getSourceDescription(source)}
     >
-      source: {normalized}
+      source: {SOURCE_LABELS[normalized]}
     </span>
+  );
+}
+
+/**
+ * The source filter. These chips used to be decorative `<span>`s sitting under
+ * copy that told the operator to click them, while the actual control was a
+ * separate dropdown with different wording. Now they are the control.
+ */
+function SourceFilterChip({
+  source,
+  count,
+  active,
+  onSelect,
+}: {
+  source: TraceSource | 'all';
+  count?: number;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const label = source === 'all' ? 'All sources' : SOURCE_LABELS[source];
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={active}
+      title={source === 'all' ? 'Every ingestion path' : getSourceDescription(source)}
+      className={cn(
+        'rounded border px-2 py-1 text-xs font-medium transition-colors',
+        source === 'all' || !active ? 'border-input bg-background hover:bg-muted' : getSourceBadgeClass(source),
+        active && 'ring-1 ring-primary',
+        active && source === 'all' && 'bg-primary text-primary-foreground hover:bg-primary/90'
+      )}
+    >
+      {label}
+      {count !== undefined && <span className="ml-1 tabular-nums opacity-80">{count}</span>}
+    </button>
   );
 }
 
@@ -271,50 +394,42 @@ function SpanBar({ span, traceStartTime, traceDuration, depth, isSelected, onCli
   );
 }
 
-interface TraceListItemProps {
-  trace: {
-    trace_id?: string;
-    traceId?: string;
-    root_span?: string;
-    rootSpan?: { serviceName?: string; operationName?: string };
-    duration_ms?: number;
-    duration?: number;
-    span_count?: number;
-    spans?: unknown[];
-    services?: string[];
-    service_name?: string;
-    serviceName?: string;
-    start_time?: string;
-    startTime?: string;
-    status: string;
-  trace_source?: string;
-  container_name?: string;
-  containerName?: string;
-  k8s_container_name?: string;
-  k8sContainerName?: string;
-};
-  isSelected: boolean;
-  onClick: () => void;
-  sourceLabel: string;
-  endpointLabel: string;
-  containerLabel: string;
+/** One row of the trace list, already flattened out of the API's two casings. */
+interface TraceRow {
+  id: string;
+  status: string;
+  duration: number;
+  operation: string;
+  service: string;
+  source: string;
+  endpoint: string;
+  container: string;
+  spanCount: number;
+  serviceCount: number;
+  startTime: string;
+  isPreflight: boolean;
+  zScore: number | null;
 }
 
-function TraceListItem({
-  trace,
-  isSelected,
-  onClick,
-  sourceLabel,
-  endpointLabel,
-  containerLabel,
-}: TraceListItemProps) {
-  const traceId = trace.traceId || trace.trace_id || '';
-  const serviceName = trace.serviceName || trace.service_name || trace.rootSpan?.serviceName || 'Unknown';
-  const operationName = trace.root_span || trace.rootSpan?.operationName || 'Unknown operation';
-  const duration = trace.duration ?? trace.duration_ms ?? 0;
-  const spanCount = trace.span_count ?? trace.spans?.length ?? 0;
-  const serviceCount = trace.services?.length ?? 1;
-  const startTime = trace.startTime || trace.start_time || '';
+/** Which of the repeated fields are identical on every loaded row. */
+interface ConstantFields {
+  service: string | null;
+  source: string | null;
+  endpoint: string | null;
+  container: string | null;
+  serviceCount: string | null;
+}
+
+interface TraceListItemProps {
+  row: TraceRow;
+  isSelected: boolean;
+  onClick: () => void;
+  /** Fields whose value is the same on every row — rendered once above the list. */
+  constants: ConstantFields;
+}
+
+function TraceListItem({ row, isSelected, onClick, constants }: TraceListItemProps) {
+  const isAnomalous = row.zScore !== null && row.zScore >= ANOMALY_Z_THRESHOLD;
 
   return (
     <button
@@ -326,37 +441,55 @@ function TraceListItem({
           : 'border-border bg-card hover:border-primary/50'
       )}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <GitBranch className="h-4 w-4 text-primary" />
-          <span className="font-mono text-xs">{traceId.slice(0, 16)}</span>
-        </div>
-        <StatusBadge status={trace.status} showDot={false} />
+      {/* Duration and status lead: they are the two fields that actually vary. */}
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-1.5 text-base font-semibold tabular-nums">
+          <Timer className="h-4 w-4 text-muted-foreground" />
+          {formatDuration(row.duration)}
+        </span>
+        <span className="flex items-center gap-2">
+          {isAnomalous && (
+            <span
+              className="rounded border border-primary/40 bg-primary/10 px-1.5 py-0.5 text-[11px] font-medium text-primary"
+              title={`Duration is ${row.zScore?.toFixed(1)} standard deviations above the mean of the loaded window.`}
+            >
+              z={row.zScore?.toFixed(1)}
+            </span>
+          )}
+          <StatusBadge status={row.status} showDot={false} />
+        </span>
       </div>
-      <div className="mt-2">
-        <p className="font-medium">{serviceName}</p>
-        <p className="truncate text-sm text-muted-foreground">{operationName}</p>
-      </div>
-      <div className="mt-2 flex items-center gap-4 text-xs text-muted-foreground">
-        <span className="flex items-center gap-1">
-          <Timer className="h-3 w-3" />
-          {formatDuration(duration)}
+      <p className="mt-2 truncate text-sm font-medium">{row.operation}</p>
+      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1 font-mono">
+          <GitBranch className="h-3 w-3" />
+          {row.id.slice(0, 12)}
         </span>
         <span className="flex items-center gap-1">
           <Layers className="h-3 w-3" />
-          {spanCount} spans
+          {row.spanCount} spans
         </span>
-        <span className="flex items-center gap-1">
-          <Server className="h-3 w-3" />
-          {serviceCount} services
-        </span>
+        {constants.service === null && (
+          <span className="flex items-center gap-1">
+            <Server className="h-3 w-3" />
+            {row.service}
+          </span>
+        )}
+        {/* "1 services" was on all 193 rows; it earns its place only when it varies. */}
+        {constants.serviceCount === null && <span>{row.serviceCount} services</span>}
+        <span>{formatDate(row.startTime)}</span>
       </div>
-      <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px]">
-        <SourceBadge source={sourceLabel} />
-        <span className="rounded border bg-muted/40 px-1.5 py-0.5">endpoint: {endpointLabel}</span>
-        <span className="rounded border bg-muted/40 px-1.5 py-0.5">container: {containerLabel}</span>
-      </div>
-      <div className="mt-2 text-xs text-muted-foreground">{formatDate(startTime)}</div>
+      {(constants.source === null || constants.endpoint === null || constants.container === null) && (
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px]">
+          {constants.source === null && <SourceBadge source={row.source} />}
+          {constants.endpoint === null && (
+            <span className="rounded border bg-muted/40 px-1.5 py-0.5">endpoint: {row.endpoint}</span>
+          )}
+          {constants.container === null && (
+            <span className="rounded border bg-muted/40 px-1.5 py-0.5">container: {row.container}</span>
+          )}
+        </div>
+      )}
     </button>
   );
 }
@@ -369,9 +502,9 @@ export default function TraceExplorerPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [serviceFilter, setServiceFilter] = useState(() => searchParams.get('service') ?? '');
   const [sourceFilter, setSourceFilter] = useState('');
-  const [statusFilter, setStatusFilter] = useState<'all' | 'ok' | 'error'>(() => {
+  const [statusFilter, setStatusFilter] = useState<'all' | 'ok' | 'error' | 'anomalous'>(() => {
     const s = searchParams.get('status');
-    return s === 'ok' || s === 'error' ? s : 'all';
+    return s === 'ok' || s === 'error' || s === 'anomalous' ? s : 'all';
   });
   const [timeRange, setTimeRange] = useState<'15m' | '1h' | '6h' | '24h' | '7d' | 'all'>('24h');
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(() => searchParams.get('trace'));
@@ -384,13 +517,20 @@ export default function TraceExplorerPage() {
     const s = searchParams.get('service');
     if (s !== null) setServiceFilter(s);
     const status = searchParams.get('status');
-    if (status === 'ok' || status === 'error' || status === 'all') setStatusFilter(status);
+    if (status === 'ok' || status === 'error' || status === 'all' || status === 'anomalous') {
+      setStatusFilter(status);
+    }
     const trace = searchParams.get('trace');
     if (trace !== null) setSelectedTraceId(trace);
   }, [searchParams]);
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
   const [showServiceMap, setShowServiceMap] = useState(false);
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
+  /** The 25 OTEL attribute filters no operator reaches for, behind a second click. */
+  const [showAllAttributeFilters, setShowAllAttributeFilters] = useState(false);
+  const [showSourceGuide, setShowSourceGuide] = useState(false);
+  const [showPreflights, setShowPreflights] = useState(false);
+  const listScrollRef = useRef<HTMLDivElement>(null);
   const [textFilterMode, setTextFilterMode] = useState<'exact' | 'contains'>('exact');
   const [httpMethodFilter, setHttpMethodFilter] = useState('');
   const [httpRouteFilter, setHttpRouteFilter] = useState('');
@@ -424,14 +564,15 @@ export default function TraceExplorerPage() {
   const [telemetrySdkVersionFilter, setTelemetrySdkVersionFilter] = useState('');
   const [otelScopeNameFilter, setOtelScopeNameFilter] = useState('');
   const [otelScopeVersionFilter, setOtelScopeVersionFilter] = useState('');
-  const { interval, setInterval } = useAutoRefresh(0);
 
   const fromTime = useMemo(() => getFromIso(timeRange), [timeRange]);
 
   const traceQuery = useMemo(() => ({
     serviceName: serviceFilter || undefined,
     source: sourceFilter || undefined,
-    status: statusFilter === 'all' ? undefined : statusFilter,
+    // `anomalous` is a client-side z-score cut over the loaded window, not a
+    // status the API knows about.
+    status: statusFilter === 'ok' || statusFilter === 'error' ? statusFilter : undefined,
     from: fromTime,
     limit: 200,
     httpMethod: httpMethodFilter || undefined,
@@ -515,10 +656,17 @@ export default function TraceExplorerPage() {
     otelScopeVersionFilter,
   ]);
 
-  const { data: tracesData, isLoading: tracesLoading, isPending: tracesPending, isError, error, refetch, isFetching } = useTraces(traceQuery);
+  const { data: tracesData, isLoading: tracesLoading, isPending: tracesPending, isError, error, refetch, isFetching, dataUpdatedAt } = useTraces(traceQuery);
   const { data: selectedTraceData } = useTrace(selectedTraceId || undefined);
   const { data: serviceMapData } = useServiceMap(traceQuery);
   const { data: summary } = useTraceSummary(traceQuery);
+
+  // The hook owns the timer. Without `onTick` the interval dropdown rendered a
+  // live indicator over a schedule that fetched nothing.
+  const { interval, setRefreshInterval } = useAutoRefresh(0, {
+    onTick: () => { void refetch(); },
+    storageKey: 'traces',
+  });
 
   // Treat both isLoading and isPending-without-data as "loading" to avoid
   // rendering a blank page during SPA navigation before data arrives.
@@ -667,20 +815,85 @@ export default function TraceExplorerPage() {
     };
   }, [selectedTraceData]);
 
-  const filteredTraces = useMemo(() => {
-    if (!traces || traces.length === 0) return [];
-    return traces.filter((trace) => {
-      if (statusFilter !== 'all' && trace.status !== statusFilter) return false;
+  // p50/p95 and the z-score baseline are measured over the whole loaded
+  // window, not the current status cut — otherwise selecting "Anomalous"
+  // would redefine the population it is measured against.
+  const durationStats = useMemo(
+    () => computeDurationStats(traces.map((t) => t.duration ?? t.duration_ms ?? 0)),
+    [traces],
+  );
+
+  const traceRows = useMemo<TraceRow[]>(() => {
+    return traces.map((trace) => {
+      const duration = trace.duration ?? trace.duration_ms ?? 0;
+      const operation = trace.root_span || trace.rootSpan?.operationName || 'Unknown operation';
+      return {
+        id: trace.traceId || trace.trace_id || '',
+        status: trace.status,
+        duration,
+        operation,
+        service: trace.serviceName || trace.service_name || trace.rootSpan?.serviceName || 'Unknown',
+        source: trace.trace_source || 'unknown',
+        endpoint: getTraceEndpointLabel(trace as Record<string, unknown>),
+        container: getTraceContainerLabel(trace as Record<string, unknown>),
+        spanCount: trace.span_count ?? trace.spans?.length ?? 0,
+        serviceCount: trace.services?.length ?? 1,
+        startTime: trace.startTime || trace.start_time || '',
+        isPreflight: isPreflightOperation(operation),
+        zScore: durationZScore(duration, durationStats),
+      };
+    });
+  }, [traces, durationStats]);
+
+  const filteredRows = useMemo(() => {
+    return traceRows.filter((row) => {
+      if (statusFilter === 'anomalous') {
+        if (row.zScore === null || row.zScore < ANOMALY_Z_THRESHOLD) return false;
+      } else if (statusFilter !== 'all' && row.status !== statusFilter) {
+        return false;
+      }
       if (!searchQuery) return true;
 
       const q = searchQuery.toLowerCase();
-      const traceId = (trace.traceId || trace.trace_id || '').toLowerCase();
-      const serviceName = (trace.serviceName || trace.service_name || trace.rootSpan?.serviceName || '').toLowerCase();
-      const operationName = (trace.root_span || trace.rootSpan?.operationName || '').toLowerCase();
-
-      return traceId.includes(q) || serviceName.includes(q) || operationName.includes(q);
+      return (
+        row.id.toLowerCase().includes(q)
+        || row.service.toLowerCase().includes(q)
+        || row.operation.toLowerCase().includes(q)
+      );
     });
-  }, [traces, searchQuery, statusFilter]);
+  }, [traceRows, searchQuery, statusFilter]);
+
+  const anomalousCount = useMemo(
+    () => traceRows.filter((r) => r.zScore !== null && r.zScore >= ANOMALY_Z_THRESHOLD).length,
+    [traceRows],
+  );
+
+  const preflightRows = useMemo(() => filteredRows.filter((r) => r.isPreflight), [filteredRows]);
+
+  /** CORS preflights collapse into one aggregated row unless asked for. */
+  const visibleRows = useMemo(
+    () => (showPreflights ? filteredRows : filteredRows.filter((r) => !r.isPreflight)),
+    [filteredRows, showPreflights],
+  );
+
+  // A field that reads the same on every row is 100% ink for 0 bits. Render it
+  // once above the list instead of once per card.
+  const constantFields = useMemo<ConstantFields>(() => ({
+    service: constantValue(filteredRows.map((r) => r.service)),
+    source: constantValue(filteredRows.map((r) => r.source)),
+    endpoint: constantValue(filteredRows.map((r) => r.endpoint)),
+    container: constantValue(filteredRows.map((r) => r.container)),
+    serviceCount: constantValue(filteredRows.map((r) => String(r.serviceCount))),
+  }), [filteredRows]);
+
+  // Virtualized like the Log Viewer. The list is capped at 200 today but
+  // unbounded in shape, and it renders ~11 nodes per card.
+  const rowVirtualizer = useVirtualizer({
+    count: visibleRows.length,
+    getScrollElement: () => listScrollRef.current,
+    estimateSize: () => TRACE_ROW_ESTIMATED_HEIGHT,
+    overscan: 8,
+  });
 
   const services = useMemo(() => {
     if (!traces || traces.length === 0) return [];
@@ -775,20 +988,29 @@ export default function TraceExplorerPage() {
     || otelScopeVersionFilter
     || textFilterMode !== 'exact'
   );
-  const sourceHint = useMemo(() => {
-    if (sourceFilter === 'ebpf') return 'Showing runtime traces from Beyla/eBPF instrumentation.';
-    if (sourceFilter === 'http') return 'Showing API gateway request traces.';
-    if (sourceFilter === 'scheduler') return 'Showing background scheduler traces.';
-    return 'Showing all trace sources. Use a source filter to focus on a single ingestion path.';
-  }, [sourceFilter]);
+
+  /**
+   * The one stat line. This was four KPI tiles, and the headline number was
+   * `Avg Duration` — the statistic the anomaly detector does not use.
+   */
+  const statLine = summary ? (
+    <span className="flex flex-wrap items-center gap-x-2 gap-y-1 tabular-nums">
+      <span>{summary.totalTraces} traces</span>
+      <span aria-hidden="true">·</span>
+      <span>{summary.services} {summary.services === 1 ? 'service' : 'services'}</span>
+      <span aria-hidden="true">·</span>
+      <span>{(summary.errorRate * 100).toFixed(1)}% errors</span>
+      <span aria-hidden="true">·</span>
+      <span title={`p95 and p50 over the ${durationStats.count} traces loaded into the list.`}>
+        p95 {formatDuration(durationStats.p95)} · p50 {formatDuration(durationStats.p50)}
+      </span>
+    </span>
+  ) : undefined;
 
   if (isError) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Trace Explorer</h1>
-          <p className="text-muted-foreground">Distributed trace visualization with service map</p>
-        </div>
+        <PageHeader title="Traces" />
         <EmptyState
           variant="error"
           icon={AlertTriangle}
@@ -807,41 +1029,45 @@ export default function TraceExplorerPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Trace Explorer</h1>
-          <p className="text-muted-foreground">Distributed trace visualization with service map</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <RefreshControls interval={interval} onIntervalChange={setInterval} onRefresh={() => refetch()} isLoading={isFetching} />
-        </div>
-      </div>
+      <PageHeader
+        title="Traces"
+        subtitle={statLine}
+        hideSubtitleOnMobile={false}
+        actions={
+          <>
+            <DataFreshness lastUpdated={dataUpdatedAt || null} onRefresh={() => refetch()} />
+            <button
+              type="button"
+              onClick={() => setShowSourceGuide((prev) => !prev)}
+              aria-expanded={showSourceGuide}
+              aria-controls="trace-source-guide"
+              className="rounded-md border border-input bg-background p-2 hover:bg-muted"
+              data-testid="source-guide-toggle"
+            >
+              <HelpCircle className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Trace sources and percentiles</span>
+            </button>
+            <RefreshControls interval={interval} onIntervalChange={setRefreshInterval} onRefresh={() => refetch()} isLoading={isFetching} />
+          </>
+        }
+      />
 
-      {summary && (
-        <>
-          <div className="grid gap-4 md:grid-cols-4">
-            <TiltCard>
-              <KpiCard label="Total Traces" value={summary.totalTraces} />
-            </TiltCard>
-            <TiltCard>
-              <KpiCard label="Avg Duration" value={formatDuration(summary.avgDuration)} />
-            </TiltCard>
-            <TiltCard>
-              <KpiCard label="Error Rate" value={`${(summary.errorRate * 100).toFixed(1)}%`} />
-            </TiltCard>
-            <TiltCard>
-              <KpiCard label="Services" value={summary.services} />
-            </TiltCard>
-          </div>
-          <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-card p-3 text-xs">
-            <span className="font-medium text-muted-foreground">Source counters:</span>
-            <span className="rounded border border-amber-500/40 bg-amber-500/15 px-2 py-1">eBPF: {sourceCounts.ebpf}</span>
-            <span className="rounded border border-sky-500/40 bg-sky-500/15 px-2 py-1">HTTP: {sourceCounts.http}</span>
-            <span className="rounded border border-violet-500/40 bg-violet-500/15 px-2 py-1">Scheduler: {sourceCounts.scheduler}</span>
-            <span className="rounded border bg-muted/40 px-2 py-1">Unknown: {sourceCounts.unknown}</span>
-            <span className="text-muted-foreground">Tip: select a source below to focus this list.</span>
-          </div>
-        </>
+      {showSourceGuide && (
+        <div
+          id="trace-source-guide"
+          className="space-y-2 rounded-lg border bg-card p-4 text-xs text-muted-foreground"
+        >
+          <p className="font-medium text-foreground">eBPF Quick Guide</p>
+          <p>
+            `source: ebpf` means Beyla captured runtime network spans. `kind=server` is inbound traffic, `kind=client` is outbound calls, and `kind=internal` is in-process work. If endpoint/container is `unknown`, instrumentation still works but metadata enrichment is missing.
+          </p>
+          <p>
+            Ingested in this window: {SOURCE_LABELS.ebpf} {sourceCounts.ebpf} · {SOURCE_LABELS.http} {sourceCounts.http} · {SOURCE_LABELS.scheduler} {sourceCounts.scheduler} · {SOURCE_LABELS.unknown} {sourceCounts.unknown}.
+          </p>
+          <p>
+            p95 and p50 are computed from the {durationStats.count} traces loaded into the list (up to 200), not from the full result set. Anomalous selects traces at least {ANOMALY_Z_THRESHOLD} standard deviations above that window&apos;s mean duration — the threshold the trace detector applies to latency p95 (`TRACES_ANOMALY_P95_ZSCORE`, default {ANOMALY_Z_THRESHOLD.toFixed(1)}).
+          </p>
+        </div>
       )}
 
       <SpotlightCard>
@@ -871,31 +1097,23 @@ export default function TraceExplorerPage() {
             />
           </div>
 
-          <div className="flex items-center gap-2">
-            <Layers className="h-4 w-4 text-muted-foreground" />
-            <ThemedSelect
-              value={sourceFilter || '__all__'}
-              onValueChange={(val) => setSourceFilter(val === '__all__' ? '' : val)}
-              options={[
-                { value: '__all__', label: 'All sources' },
-                { value: 'http', label: 'HTTP Requests' },
-                { value: 'scheduler', label: 'Background Jobs' },
-                { value: 'ebpf', label: 'eBPF (Apps)' },
-              ]}
-              className="text-sm"
+          <div className="flex flex-wrap items-center gap-2" data-testid="source-filter">
+            <Layers className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            <SourceFilterChip
+              source="all"
+              active={sourceFilter === ''}
+              onSelect={() => setSourceFilter('')}
             />
+            {FILTERABLE_SOURCES.map((source) => (
+              <SourceFilterChip
+                key={source}
+                source={source}
+                count={sourceCounts[source]}
+                active={sourceFilter === source}
+                onSelect={() => setSourceFilter(sourceFilter === source ? '' : source)}
+              />
+            ))}
           </div>
-
-          <p className="text-xs text-muted-foreground" title="Trace source legend and context">
-            {sourceHint}
-          </p>
-          {!sourceFilter && (
-            <div className="flex flex-wrap items-center gap-2 text-[11px]">
-              <SourceBadge source="ebpf" />
-              <SourceBadge source="http" />
-              <SourceBadge source="scheduler" />
-            </div>
-          )}
 
           <div className="flex items-center gap-2">
             <Timer className="h-4 w-4 text-muted-foreground" />
@@ -917,10 +1135,16 @@ export default function TraceExplorerPage() {
           <div className="flex items-center gap-2">
             <Filter className="h-4 w-4 text-muted-foreground" />
             <div className="flex overflow-hidden rounded-md border border-input">
-              {(['all', 'ok', 'error'] as const).map((status) => (
+              {(['all', 'ok', 'error', 'anomalous'] as const).map((status) => (
                 <button
                   key={status}
                   onClick={() => setStatusFilter(status)}
+                  aria-pressed={statusFilter === status}
+                  title={
+                    status === 'anomalous'
+                      ? `Duration at least ${ANOMALY_Z_THRESHOLD} standard deviations above the mean of the ${durationStats.count} loaded traces — the z-score threshold the trace detector applies to latency p95 (TRACES_ANOMALY_P95_ZSCORE, default ${ANOMALY_Z_THRESHOLD.toFixed(1)}).`
+                      : undefined
+                  }
                   className={cn(
                     'px-3 py-1.5 text-sm font-medium transition-colors',
                     statusFilter === status
@@ -928,7 +1152,7 @@ export default function TraceExplorerPage() {
                       : 'bg-background hover:bg-muted'
                   )}
                 >
-                  {status === 'all' ? 'All' : status === 'ok' ? 'Success' : 'Error'}
+                  {status === 'all' ? 'All' : status === 'ok' ? 'Success' : status === 'error' ? 'Error' : `Anomalous (${anomalousCount})`}
                 </button>
               ))}
             </div>
@@ -957,9 +1181,6 @@ export default function TraceExplorerPage() {
             >
               {showAdvancedFilters ? 'Hide advanced filters' : 'Show advanced filters'}
             </button>
-            <p className="text-xs text-muted-foreground">
-              Need precision? Filter by HTTP route/status or service and container namespaces.
-            </p>
           </div>
           {hasAdvancedFiltersApplied && (
             <button
@@ -1005,15 +1226,10 @@ export default function TraceExplorerPage() {
             </button>
           )}
         </div>
-        <div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-xs text-muted-foreground">
-          <p className="font-medium text-foreground">eBPF Quick Guide</p>
-          <p className="mt-1">
-            `source: ebpf` means Beyla captured runtime network spans. `kind=server` is inbound traffic, `kind=client` is outbound calls, and `kind=internal` is in-process work. If endpoint/container is `unknown`, instrumentation still works but metadata enrichment is missing.
-          </p>
-        </div>
 
         {showAdvancedFilters && (
-          <div className="grid gap-3 rounded-md border bg-background/60 p-3 md:grid-cols-2 xl:grid-cols-3">
+          <div className="space-y-3 rounded-md border bg-background/60 p-3">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             <div>
               <p className="mb-1 text-xs text-muted-foreground">Text Match Mode</p>
               <ThemedSelect
@@ -1067,6 +1283,43 @@ export default function TraceExplorerPage() {
             </label>
 
             <label className="text-xs text-muted-foreground">
+              Container Name
+              <input
+                type="text"
+                value={containerNameFilter}
+                onChange={(e) => setContainerNameFilter(e.target.value)}
+                placeholder="api-container"
+                className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
+              />
+            </label>
+
+            <label className="text-xs text-muted-foreground">
+              Host Name
+              <input
+                type="text"
+                value={hostNameFilter}
+                onChange={(e) => setHostNameFilter(e.target.value)}
+                placeholder="srv-edge-01"
+                className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
+              />
+            </label>
+          </div>
+
+          {/* The remaining OTEL semantic-convention attributes. They were all
+              rendered at once — 31 form fields, most with a single possible
+              value on a one-service fleet. */}
+          <button
+            type="button"
+            onClick={() => setShowAllAttributeFilters((prev) => !prev)}
+            className="text-xs font-medium text-primary hover:underline"
+            data-testid="toggle-attribute-filters"
+          >
+            {showAllAttributeFilters ? 'Hide OTEL attribute filters' : 'Show OTEL attribute filters (26)'}
+          </button>
+
+          {showAllAttributeFilters && (
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            <label className="text-xs text-muted-foreground">
               Service Namespace
               <input
                 type="text"
@@ -1117,17 +1370,6 @@ export default function TraceExplorerPage() {
                 value={containerIdFilter}
                 onChange={(e) => setContainerIdFilter(e.target.value)}
                 placeholder="f6b71bc8bca2"
-                className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
-              />
-            </label>
-
-            <label className="text-xs text-muted-foreground">
-              Container Name
-              <input
-                type="text"
-                value={containerNameFilter}
-                onChange={(e) => setContainerNameFilter(e.target.value)}
-                placeholder="api-container"
                 className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
               />
             </label>
@@ -1276,17 +1518,6 @@ export default function TraceExplorerPage() {
             </label>
 
             <label className="text-xs text-muted-foreground">
-              Host Name
-              <input
-                type="text"
-                value={hostNameFilter}
-                onChange={(e) => setHostNameFilter(e.target.value)}
-                placeholder="srv-edge-01"
-                className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
-              />
-            </label>
-
-            <label className="text-xs text-muted-foreground">
               OS Type
               <input
                 type="text"
@@ -1385,6 +1616,8 @@ export default function TraceExplorerPage() {
               />
             </label>
           </div>
+          )}
+          </div>
         )}
       </div>
       </SpotlightCard>
@@ -1405,39 +1638,89 @@ export default function TraceExplorerPage() {
             <SkeletonChart size="lg" className="h-[600px]" />
           </div>
         </div>
-      ) : filteredTraces.length === 0 ? (
+      ) : filteredRows.length === 0 ? (
         <EmptyState
           icon={GitBranch}
           title="No traces found"
           description={
-            searchQuery || serviceFilter || sourceFilter || hasAdvancedFiltersApplied
+            searchQuery || serviceFilter || sourceFilter || statusFilter !== 'all' || hasAdvancedFiltersApplied
               ? 'Try adjusting your search or filter criteria.'
               : 'No distributed traces have been collected yet.'
           }
         />
       ) : (
         <div className="grid gap-6 lg:grid-cols-3">
-          <div className="max-h-[600px] space-y-3 overflow-y-auto pr-2">
-            {filteredTraces.map((trace) => {
-              const id = trace.traceId || trace.trace_id || '';
-              const sourceLabel = trace.trace_source || 'unknown';
-              const endpointLabel = getTraceEndpointLabel(trace as Record<string, unknown>);
-              const containerLabel = getTraceContainerLabel(trace as Record<string, unknown>);
-              return (
-                <TraceListItem
-                  key={id}
-                  trace={trace}
-                  isSelected={selectedTraceId === id}
-                  sourceLabel={sourceLabel}
-                  endpointLabel={endpointLabel}
-                  containerLabel={containerLabel}
-                  onClick={() => {
-                    setSelectedTraceId(id);
-                    setSelectedSpanId(null);
-                  }}
-                />
-              );
-            })}
+          <div className="space-y-2">
+            {/* Fields identical on every row are stated once here instead of
+                being reprinted on each card. */}
+            {(constantFields.service
+              || constantFields.source
+              || constantFields.endpoint
+              || constantFields.container) && (
+              <p className="text-xs text-muted-foreground" data-testid="constant-fields">
+                All {filteredRows.length} traces:{' '}
+                {[
+                  constantFields.service,
+                  constantFields.source && `source: ${SOURCE_LABELS[normalizeSource(constantFields.source)]}`,
+                  constantFields.endpoint && `endpoint: ${constantFields.endpoint}`,
+                  constantFields.container && `container: ${constantFields.container}`,
+                ].filter(Boolean).join(' · ')}
+              </p>
+            )}
+
+            {preflightRows.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowPreflights((prev) => !prev)}
+                aria-expanded={showPreflights}
+                className="flex w-full items-center justify-between gap-2 rounded-lg border border-dashed border-border bg-muted/30 px-3 py-2 text-left text-xs text-muted-foreground hover:bg-muted/60"
+                data-testid="preflight-summary"
+              >
+                <span>
+                  {preflightRows.length} CORS preflight {preflightRows.length === 1 ? 'trace' : 'traces'} (OPTIONS) · p95{' '}
+                  {formatDuration(computeDurationStats(preflightRows.map((r) => r.duration)).p95)}
+                </span>
+                <span className="font-medium text-primary">{showPreflights ? 'Hide' : 'Show'}</span>
+              </button>
+            )}
+
+            <div
+              ref={listScrollRef}
+              className="h-[calc(100vh-22rem)] min-h-[420px] overflow-y-auto pr-2"
+              data-testid="trace-list"
+            >
+              <div style={{ height: rowVirtualizer.getTotalSize(), position: 'relative' }}>
+                {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                  const row = visibleRows[virtualRow.index];
+                  if (!row) return null;
+                  return (
+                    <div
+                      key={virtualRow.key}
+                      data-index={virtualRow.index}
+                      ref={rowVirtualizer.measureElement}
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '100%',
+                        transform: `translateY(${virtualRow.start}px)`,
+                      }}
+                      className="pb-3"
+                    >
+                      <TraceListItem
+                        row={row}
+                        constants={constantFields}
+                        isSelected={selectedTraceId === row.id}
+                        onClick={() => {
+                          setSelectedTraceId(row.id);
+                          setSelectedSpanId(null);
+                        }}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
           </div>
 
           <div className="lg:col-span-2">
@@ -1662,7 +1945,7 @@ export default function TraceExplorerPage() {
                                 (selectedSpan.endTime ? new Date(selectedSpan.endTime).getTime() : new Date(selectedSpan.startTime).getTime() + selectedSpan.duration) + 2000,
                               ).toISOString(),
                             }).toString()}`}
-                            className="inline-flex items-center gap-1.5 rounded-md border border-blue-500/40 bg-blue-500/10 px-3 py-1.5 text-xs font-medium text-blue-200 hover:bg-blue-500/20"
+                            className="inline-flex items-center gap-1.5 rounded-md border border-primary/40 bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/20"
                             data-testid="view-logs-link"
                           >
                             <ScrollText className="h-3.5 w-3.5" aria-hidden="true" />

--- a/frontend/src/features/operations/hooks/use-remediation.test.ts
+++ b/frontend/src/features/operations/hooks/use-remediation.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement, type ReactNode } from 'react';
-import { useRemediationActions } from './use-remediation';
+import {
+  useRemediationActions,
+  useApproveAction,
+  useRejectAction,
+  useExecuteAction,
+} from './use-remediation';
 
 vi.mock('@/shared/lib/api', () => ({
   api: {
@@ -19,8 +24,10 @@ vi.mock('sonner', () => ({
 }));
 
 import { api } from '@/shared/lib/api';
+import { toast } from 'sonner';
 
 const mockApi = vi.mocked(api);
+const mockToast = vi.mocked(toast);
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -64,5 +71,64 @@ describe('useRemediationActions', () => {
     expect(mockApi.get).toHaveBeenCalledWith('/api/remediation/actions', {
       params: { status: 'pending' },
     });
+  });
+});
+
+describe('remediation mutations — toasts name the action, not the UUID', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.post.mockResolvedValue(undefined as never);
+  });
+
+  it('approve quotes the human label and says nothing runs yet', async () => {
+    const { result } = renderHook(() => useApproveAction(), { wrapper: createWrapper() });
+
+    result.current.mutate({ actionId: '3f2b8c1e-uuid', label: 'Stop Container on api-service' });
+
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalled());
+    const [title, opts] = mockToast.success.mock.calls[0];
+    expect(title).toBe('Action approved');
+    expect(opts?.description).toBe(
+      'Stop Container on api-service is approved. Nothing runs until you press Execute.',
+    );
+    expect(opts?.description).not.toContain('3f2b8c1e-uuid');
+  });
+
+  it('reject sends the operator reason as the request body', async () => {
+    const { result } = renderHook(() => useRejectAction(), { wrapper: createWrapper() });
+
+    result.current.mutate({
+      actionId: 'a1',
+      label: 'Stop Container on api-service',
+      reason: '  Nightly import still running  ',
+    });
+
+    await waitFor(() => expect(mockApi.post).toHaveBeenCalled());
+    expect(mockApi.post).toHaveBeenCalledWith(
+      '/api/remediation/actions/a1/reject',
+      { reason: 'Nightly import still running' },
+    );
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalled());
+    expect(mockToast.success.mock.calls[0][1]?.description).toContain('Nightly import still running');
+  });
+
+  it('reject with a blank reason posts an empty body rather than an empty string', async () => {
+    const { result } = renderHook(() => useRejectAction(), { wrapper: createWrapper() });
+
+    result.current.mutate({ actionId: 'a1', label: 'Stop Container on api-service', reason: '   ' });
+
+    await waitFor(() => expect(mockApi.post).toHaveBeenCalled());
+    expect(mockApi.post).toHaveBeenCalledWith('/api/remediation/actions/a1/reject', {});
+  });
+
+  it('execute quotes the human label', async () => {
+    const { result } = renderHook(() => useExecuteAction(), { wrapper: createWrapper() });
+
+    result.current.mutate({ actionId: 'a1', label: 'Restart Container on lcm-server' });
+
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalled());
+    expect(mockToast.success.mock.calls[0][1]?.description).toBe(
+      'Restart Container on lcm-server has run. The row shows the result.',
+    );
   });
 });

--- a/frontend/src/features/operations/hooks/use-remediation.ts
+++ b/frontend/src/features/operations/hooks/use-remediation.ts
@@ -15,6 +15,8 @@ interface RemediationAction {
   createdAt: string;
   updatedAt: string;
   approvedBy?: string;
+  rejectedBy?: string;
+  rejectionReason?: string;
   result?: string;
 }
 
@@ -37,17 +39,35 @@ export function useRemediationActions(status?: string) {
   });
 }
 
+/**
+ * What a mutation needs to identify an action *and* to name it back to the
+ * operator. `label` is the human sentence the toast quotes — "Restart Container
+ * on api-service". The UUID stays in the URL where it belongs: an operator
+ * cannot check a toast that reads
+ * "Remediation action 3f2b8c1e-… has been approved" against anything they can
+ * see on screen.
+ */
+export interface RemediationActionRef {
+  actionId: string;
+  label: string;
+}
+
+/** Reject additionally carries the operator's reason, stored as `rejection_reason`. */
+export interface RemediationRejectRef extends RemediationActionRef {
+  reason?: string;
+}
+
 export function useApproveAction() {
   const queryClient = useQueryClient();
 
-  return useMutation<void, Error, string>({
-    mutationFn: async (actionId) => {
+  return useMutation<void, Error, RemediationActionRef>({
+    mutationFn: async ({ actionId }) => {
       await api.post(`/api/remediation/actions/${actionId}/approve`, {});
     },
-    onSuccess: (_data, actionId) => {
+    onSuccess: (_data, { label }) => {
       queryClient.invalidateQueries({ queryKey: ['remediation', 'actions'] });
       toast.success('Action approved', {
-        description: `Remediation action ${actionId} has been approved.`,
+        description: `${label} is approved. Nothing runs until you press Execute.`,
       });
     },
     onError: (error) => {
@@ -68,14 +88,21 @@ export function useApproveAction() {
 export function useRejectAction() {
   const queryClient = useQueryClient();
 
-  return useMutation<void, Error, string>({
-    mutationFn: async (actionId) => {
-      await api.post(`/api/remediation/actions/${actionId}/reject`, {});
+  return useMutation<void, Error, RemediationRejectRef>({
+    mutationFn: async ({ actionId, reason }) => {
+      const trimmed = reason?.trim();
+      await api.post(
+        `/api/remediation/actions/${actionId}/reject`,
+        trimmed ? { reason: trimmed } : {},
+      );
     },
-    onSuccess: (_data, actionId) => {
+    onSuccess: (_data, { label, reason }) => {
       queryClient.invalidateQueries({ queryKey: ['remediation', 'actions'] });
+      const trimmed = reason?.trim();
       toast.success('Action rejected', {
-        description: `Remediation action ${actionId} has been rejected.`,
+        description: trimmed
+          ? `${label} was rejected: ${trimmed}`
+          : `${label} was rejected.`,
       });
     },
     onError: (error) => {
@@ -96,14 +123,14 @@ export function useRejectAction() {
 export function useExecuteAction() {
   const queryClient = useQueryClient();
 
-  return useMutation<void, Error, string>({
-    mutationFn: async (actionId) => {
+  return useMutation<void, Error, RemediationActionRef>({
+    mutationFn: async ({ actionId }) => {
       await api.post(`/api/remediation/actions/${actionId}/execute`, {});
     },
-    onSuccess: (_data, actionId) => {
+    onSuccess: (_data, { label }) => {
       queryClient.invalidateQueries({ queryKey: ['remediation', 'actions'] });
       toast.success('Action executed', {
-        description: `Remediation action ${actionId} has been executed.`,
+        description: `${label} has run. The row shows the result.`,
       });
     },
     onError: (error) => {

--- a/frontend/src/features/operations/pages/edge-agent-logs.test.tsx
+++ b/frontend/src/features/operations/pages/edge-agent-logs.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ApiError } from '@/shared/lib/api-error';
 import EdgeAgentLogsPage from './edge-agent-logs';
 
 const mockApiGet = vi.fn();
@@ -11,8 +12,22 @@ vi.mock('@/shared/lib/api', () => ({
   },
 }));
 
+/**
+ * The real hook is used in the auto-refresh tests further down (it owns the
+ * timer), so this mock is applied per-test via `vi.doMock`-style overrides
+ * instead of globally. Here it just pins the control to "off".
+ */
+const mockUseAutoRefresh = vi.fn(() => ({
+  interval: 0,
+  setRefreshInterval: vi.fn(),
+  setInterval: vi.fn(),
+  enabled: false,
+  toggle: vi.fn(),
+  options: [0, 15, 30, 60, 120, 300],
+}));
+
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: () => ({ interval: 0, setInterval: vi.fn() }),
+  useAutoRefresh: (...args: unknown[]) => mockUseAutoRefresh(...(args as [])),
 }));
 
 function renderPage() {
@@ -26,6 +41,10 @@ function renderPage() {
   );
 }
 
+/** The server's real 503 body — note it contains no "503" anywhere. */
+const NOT_CONFIGURED_BODY =
+  'Configure Elasticsearch in Settings or set KIBANA_ENDPOINT environment variable';
+
 describe('EdgeAgentLogsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -34,6 +53,39 @@ describe('EdgeAgentLogsPage', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  describe('page header', () => {
+    it('renders one h1 matching the navigation label, in the loading branch too', async () => {
+      let resolveQuery!: (v: unknown) => void;
+      mockApiGet.mockReturnValue(
+        new Promise((resolve) => {
+          resolveQuery = resolve;
+        }),
+      );
+
+      renderPage();
+
+      const headings = screen.getAllByRole('heading', { level: 1 });
+      expect(headings).toHaveLength(1);
+      expect(headings[0]).toHaveTextContent('Edge Logs');
+
+      resolveQuery({ logs: [], total: 0 });
+      await waitFor(() => expect(screen.getByText('No logs found')).toBeInTheDocument());
+    });
+
+    it('keeps the same h1 on the not-configured branch', async () => {
+      mockApiGet.mockRejectedValue(new ApiError(503, NOT_CONFIGURED_BODY));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Elasticsearch not configured')).toBeInTheDocument();
+      });
+      const headings = screen.getAllByRole('heading', { level: 1 });
+      expect(headings).toHaveLength(1);
+      expect(headings[0]).toHaveTextContent('Edge Logs');
+    });
   });
 
   describe('loading state', () => {
@@ -49,9 +101,7 @@ describe('EdgeAgentLogsPage', () => {
       renderPage();
 
       // Heading is always present
-      expect(
-        screen.getByRole('heading', { name: 'Edge Agent Logs' }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Edge Logs' })).toBeInTheDocument();
 
       // SkeletonText renders with role="status" + aria-label="Loading"
       await waitFor(() => {
@@ -60,8 +110,8 @@ describe('EdgeAgentLogsPage', () => {
         expect(loadingNodes.length).toBeGreaterThan(0);
       });
 
-      // Stats cards (which only render with logs > 0) should be absent
-      expect(screen.queryByText('Total Logs')).not.toBeInTheDocument();
+      // The level summary (which only renders with logs > 0) should be absent
+      expect(screen.queryByText(/lines/)).not.toBeInTheDocument();
 
       // Cleanup pending promise so React Query doesn't warn
       resolveQuery({ logs: [], total: 0 });
@@ -69,15 +119,18 @@ describe('EdgeAgentLogsPage', () => {
   });
 
   describe('not-configured state (503)', () => {
-    it('renders the configuration onboarding view when the API returns 503', async () => {
-      mockApiGet.mockRejectedValue(new Error('HTTP 503'));
+    // Regression: the branch used to test `error.message.includes('503')`, but
+    // `ApiError.message` is the server's body text, which never contains the
+    // status code. The whole setup panel was unreachable.
+    it('renders the setup panel for a 503 whose message does not contain "503"', async () => {
+      mockApiGet.mockRejectedValue(new ApiError(503, NOT_CONFIGURED_BODY));
+
+      expect(NOT_CONFIGURED_BODY).not.toContain('503');
 
       renderPage();
 
       await waitFor(() => {
-        expect(
-          screen.getByText('Elasticsearch Not Configured'),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Elasticsearch not configured')).toBeInTheDocument();
       });
 
       expect(
@@ -85,12 +138,60 @@ describe('EdgeAgentLogsPage', () => {
       ).toBeInTheDocument();
       // Generic error block must NOT render in this branch
       expect(screen.queryByText('Failed to fetch logs')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+    });
+
+    it('deep-links to the Integrations settings tab and names the legacy env var', async () => {
+      mockApiGet.mockRejectedValue(new ApiError(503, NOT_CONFIGURED_BODY));
+
+      renderPage();
+
+      const link = await screen.findByRole('link', { name: /Configure Elasticsearch/i });
+      expect(link).toHaveAttribute('href', '/settings?tab=integrations');
+      expect(screen.getByText('KIBANA_ENDPOINT')).toBeInTheDocument();
+      // "Kibana" must not be presented as a second product to configure
+      expect(screen.queryByText(/Elasticsearch or Kibana/)).not.toBeInTheDocument();
+    });
+
+    it('does not poll while unconfigured', async () => {
+      // Drive the real timer through the hook's `onTick`, which the page gates
+      // on `isNotConfigured` so a 503 does not re-fail every N seconds.
+      const ticks: Array<() => void> = [];
+      mockUseAutoRefresh.mockImplementation(((
+        _default: number,
+        opts?: { onTick?: () => void },
+      ) => {
+        if (opts?.onTick) ticks.push(opts.onTick);
+        return {
+          interval: 15,
+          setRefreshInterval: vi.fn(),
+          setInterval: vi.fn(),
+          enabled: true,
+          toggle: vi.fn(),
+          options: [0, 15, 30, 60, 120, 300],
+        };
+      }) as never);
+
+      mockApiGet.mockRejectedValue(new ApiError(503, NOT_CONFIGURED_BODY));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Elasticsearch not configured')).toBeInTheDocument();
+      });
+
+      const callsBefore = mockApiGet.mock.calls.length;
+      act(() => {
+        ticks[ticks.length - 1]?.();
+      });
+      await Promise.resolve();
+      expect(mockApiGet.mock.calls.length).toBe(callsBefore);
     });
   });
 
   describe('error state (non-503)', () => {
     it('shows the failure card and a retry button', async () => {
-      mockApiGet.mockRejectedValue(new Error('HTTP 500: backend exploded'));
+      mockApiGet.mockRejectedValue(new ApiError(500, 'backend exploded'));
 
       renderPage();
 
@@ -98,13 +199,15 @@ describe('EdgeAgentLogsPage', () => {
         expect(screen.getByText('Failed to fetch logs')).toBeInTheDocument();
       });
 
-      expect(screen.getByText(/HTTP 500/)).toBeInTheDocument();
+      expect(screen.getByText(/backend exploded/)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+      // The setup panel is for 503 only
+      expect(screen.queryByText('Elasticsearch not configured')).not.toBeInTheDocument();
     });
   });
 
   describe('data state', () => {
-    it('renders log rows, stats and the export button', async () => {
+    it('renders log rows, the level summary and the export button', async () => {
       mockApiGet.mockResolvedValue({
         logs: [
           {
@@ -135,17 +238,44 @@ describe('EdgeAgentLogsPage', () => {
       });
       expect(screen.getByText('starting agent')).toBeInTheDocument();
 
-      // Stats card visible (only renders when logs > 0)
-      expect(screen.getByText('Total Logs')).toBeInTheDocument();
+      // One distribution line + bar, not five KPI tiles
+      expect(screen.getByText('2 lines')).toBeInTheDocument();
+      expect(screen.getByText('1 error')).toBeInTheDocument();
+      expect(screen.getByText('1 info')).toBeInTheDocument();
+      expect(screen.queryByText('Total Logs')).not.toBeInTheDocument();
+      expect(screen.queryByText('Warnings')).not.toBeInTheDocument();
+      expect(screen.getByRole('img', { name: '1 error, 1 info' })).toBeInTheDocument();
 
       // Results header reflects count
       expect(screen.getByText(/Log Results/)).toBeInTheDocument();
       expect(screen.getByText(/2 of 2/)).toBeInTheDocument();
 
       // Export button appears once we have logs
-      expect(
-        screen.getByRole('button', { name: /Export/ }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Export/ })).toBeInTheDocument();
+    });
+
+    it('names the total when the server has more matches than it returned', async () => {
+      mockApiGet.mockResolvedValue({
+        logs: [
+          {
+            id: '1',
+            timestamp: '2026-05-05T10:00:00Z',
+            message: 'a line',
+            hostname: 'edge-01',
+            level: 'debug',
+            source: {},
+          },
+        ],
+        total: 4212,
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('1 of 4,212 lines')).toBeInTheDocument();
+      });
+      // debug is neutral, never a green pass indicator
+      expect(screen.getByText('1 debug')).toHaveClass('text-muted-foreground');
     });
 
     it('shows the empty state when API returns no logs', async () => {
@@ -157,8 +287,8 @@ describe('EdgeAgentLogsPage', () => {
         expect(screen.getByText('No logs found')).toBeInTheDocument();
       });
 
-      // Without logs, neither the stats grid nor the export button render
-      expect(screen.queryByText('Total Logs')).not.toBeInTheDocument();
+      // Without logs, neither the level summary nor the export button render
+      expect(screen.queryByText(/^0 lines$/)).not.toBeInTheDocument();
       expect(
         screen.queryByRole('button', { name: /Export/ }),
       ).not.toBeInTheDocument();

--- a/frontend/src/features/operations/pages/edge-agent-logs.tsx
+++ b/frontend/src/features/operations/pages/edge-agent-logs.tsx
@@ -6,7 +6,6 @@ import {
   Info,
   FileText,
   Server,
-  RefreshCw,
   Download,
   Filter,
   ChevronDown,
@@ -16,19 +15,31 @@ import {
   Loader2,
   XCircle,
   AlertCircle,
-  CheckCircle2,
   Terminal,
+  Bug,
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/shared/lib/api';
+import { ApiError } from '@/shared/lib/api-error';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { RefreshControls } from '@/shared/components/ui/refresh-controls';
+import { DataFreshness } from '@/shared/components/feedback/data-freshness';
 import { SkeletonText } from '@/shared/components/feedback/skeleton';
+import { PageHeader } from '@/shared/components/layout/page-header';
+import { findDestination } from '@/features/core/lib/navigation-manifest';
 import { cn, formatDate } from '@/shared/lib/utils';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
-import { TiltCard } from '@/shared/components/data-display/tilt-card';
-import { KpiCard } from '@/shared/components/data-display/kpi-card';
+
+/**
+ * One name for the dependency. This page used to call it four things at once —
+ * "Edge Agent" in the sidebar, "via Elasticsearch" in the subtitle,
+ * "Elasticsearch or Kibana" in the setup panel, and `KIBANA_ENDPOINT` in the
+ * error — so an operator searching Settings for "Kibana" found nothing.
+ * Elasticsearch is the product; Kibana survives only as the legacy env-var name.
+ */
+const PAGE_TITLE = findDestination('/edge-logs')?.label ?? 'Edge Logs';
+const PAGE_SUBTITLE = 'Agent logs indexed in Elasticsearch';
 
 // Log levels with colors
 const LOG_LEVELS = [
@@ -91,7 +102,9 @@ function getLevelIcon(level: string) {
     case 'info':
       return <Info className="h-4 w-4 text-blue-500" />;
     case 'debug':
-      return <CheckCircle2 className="h-4 w-4 text-emerald-500" />;
+      // Neutral, deliberately. A green check made debug lines read as passing
+      // checks — debug is verbosity, not a health signal.
+      return <Bug className="h-4 w-4 text-muted-foreground" />;
     default:
       return <FileText className="h-4 w-4 text-muted-foreground" />;
   }
@@ -107,10 +120,82 @@ function getLevelColor(level: string) {
     case 'info':
       return 'text-blue-500 bg-blue-500/10';
     case 'debug':
-      return 'text-emerald-500 bg-emerald-500/10';
+      return 'text-muted-foreground bg-muted';
     default:
       return 'text-muted-foreground bg-muted';
   }
+}
+
+/** Level bands, in severity order. Drives both the summary line and the bar. */
+const LEVEL_BANDS = [
+  { key: 'error', label: 'error', text: 'text-red-500', bar: 'bg-red-500' },
+  { key: 'warn', label: 'warn', text: 'text-amber-500', bar: 'bg-amber-500' },
+  { key: 'info', label: 'info', text: 'text-blue-500', bar: 'bg-blue-500' },
+  { key: 'debug', label: 'debug', text: 'text-muted-foreground', bar: 'bg-muted-foreground/40' },
+] as const;
+
+interface LogLevelSummaryProps {
+  /** Lines returned for this search. */
+  shown: number;
+  /** Total matches Elasticsearch reports, which may exceed `shown`. */
+  total: number;
+  byLevel: Record<string, number>;
+}
+
+/**
+ * One line plus one bar, replacing five KPI cards.
+ *
+ * Total / Errors / Warnings / Info / Debug is a single distribution, and it was
+ * exploded into five glass tiles across a full row — five headings to read
+ * before the counts, and a fake `trend` arrow on Errors that compared nothing.
+ * A distribution is a bar.
+ */
+function LogLevelSummary({ shown, total, byLevel }: LogLevelSummaryProps) {
+  const counts = LEVEL_BANDS.map((band) => ({
+    ...band,
+    count:
+      band.key === 'warn'
+        ? (byLevel.warn || 0) + (byLevel.warning || 0)
+        : byLevel[band.key] || 0,
+  }));
+  const classified = counts.reduce((sum, band) => sum + band.count, 0);
+  const present = counts.filter((band) => band.count > 0);
+
+  return (
+    <div>
+      <p className="text-sm">
+        <span className="font-medium">
+          {shown.toLocaleString()}
+          {total > shown ? ` of ${total.toLocaleString()}` : ''} lines
+        </span>
+        {present.map((band) => (
+          <span key={band.key}>
+            <span className="text-muted-foreground"> · </span>
+            <span className={band.text}>
+              {band.count.toLocaleString()} {band.label}
+            </span>
+          </span>
+        ))}
+      </p>
+      {classified > 0 && (
+        <div
+          className="mt-2 flex h-2 overflow-hidden rounded-full bg-muted"
+          role="img"
+          aria-label={present
+            .map((band) => `${band.count} ${band.label}`)
+            .join(', ')}
+        >
+          {present.map((band) => (
+            <div
+              key={band.key}
+              className={band.bar}
+              style={{ width: `${(band.count / classified) * 100}%` }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 interface LogRowProps {
@@ -177,9 +262,10 @@ function NotConfiguredState() {
         <div className="rounded-full bg-amber-500/10 p-4 mb-4">
           <Settings className="h-8 w-8 text-amber-500" />
         </div>
-        <h2 className="text-xl font-semibold mb-2">Elasticsearch Not Configured</h2>
+        <h2 className="text-xl font-semibold mb-2">Elasticsearch not configured</h2>
         <p className="text-muted-foreground mb-6">
-          Edge Agent Logs require an Elasticsearch or Kibana connection to search and display logs.
+          Edge agents ship their logs to an Elasticsearch cluster. Nothing can be searched
+          here until one is connected.
         </p>
 
         <div className="w-full rounded-lg bg-muted/50 p-4 text-left mb-6">
@@ -190,7 +276,7 @@ function NotConfiguredState() {
           <ol className="space-y-3 text-sm text-muted-foreground">
             <li className="flex gap-2">
               <span className="font-medium text-foreground">1.</span>
-              <span>Go to Settings and scroll to the "Elasticsearch / Kibana" section.</span>
+              <span>Open Settings and select the Integrations tab.</span>
             </li>
             <li className="flex gap-2">
               <span className="font-medium text-foreground">2.</span>
@@ -201,10 +287,15 @@ function NotConfiguredState() {
               <span>Save and return to this page to start searching logs.</span>
             </li>
           </ol>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Self-hosted deployments can instead set the{' '}
+            <code className="bg-muted px-1 rounded">KIBANA_ENDPOINT</code> environment
+            variable — the legacy name for the same Elasticsearch URL.
+          </p>
         </div>
 
         <a
-          href="/settings"
+          href="/settings?tab=integrations"
           className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
         >
           <Settings className="h-4 w-4" />
@@ -233,7 +324,6 @@ export default function EdgeAgentLogsPage() {
   const [levelFilter, setLevelFilter] = useState('');
   const [hostnameFilter, setHostnameFilter] = useState('');
   const [expandedLogs, setExpandedLogs] = useState<Set<string>>(new Set());
-  const { interval, setInterval } = useAutoRefresh(0);
   const [refreshKey, setRefreshKey] = useState(0);
 
   // Calculate time range
@@ -248,6 +338,7 @@ export default function EdgeAgentLogsPage() {
     error,
     refetch,
     isFetching,
+    dataUpdatedAt,
   } = useQuery<LogsResponse>({
     queryKey: ['edge-agent-logs', searchQuery, from, to, levelFilter, hostnameFilter, refreshKey],
     queryFn: async () => {
@@ -269,8 +360,32 @@ export default function EdgeAgentLogsPage() {
   // rendering a blank page during SPA navigation before data arrives.
   const isLoading = logsLoading || (logsPending && !logsData);
 
-  // Check if not configured (503 error)
-  const isNotConfigured = isError && (error as Error)?.message?.includes('503');
+  // Not configured, i.e. the server answered 503.
+  //
+  // This used to sniff `error.message` for the substring "503". `ApiError.message`
+  // carries the *server's* body message — "Configure Elasticsearch in Settings or
+  // set KIBANA_ENDPOINT environment variable" — which contains no "503", so this
+  // was permanently false: the whole `NotConfiguredState` below was dead code and
+  // every operator who had simply never turned Elasticsearch on got a red
+  // "Failed to fetch logs" alarm with a Retry button that could not succeed.
+  // `ApiError` carries a typed status; use it.
+  const isNotConfigured = isError && error instanceof ApiError && error.status === 503;
+
+  // Handle refresh
+  const handleRefresh = () => {
+    setRefreshKey((k) => k + 1);
+    refetch();
+  };
+
+  // The hook owns the timer. Gated on `isNotConfigured` so a 503 stops the
+  // poller instead of re-failing every N seconds against a cluster that was
+  // never configured.
+  const { interval, setRefreshInterval } = useAutoRefresh(0, {
+    storageKey: 'edge-logs',
+    onTick: () => {
+      if (!isNotConfigured) handleRefresh();
+    },
+  });
 
   // Handle search
   const handleSearch = (e: React.FormEvent) => {
@@ -289,12 +404,6 @@ export default function EdgeAgentLogsPage() {
       }
       return next;
     });
-  };
-
-  // Handle refresh
-  const handleRefresh = () => {
-    setRefreshKey((k) => k + 1);
-    refetch();
   };
 
   // Export logs
@@ -354,12 +463,7 @@ export default function EdgeAgentLogsPage() {
   if (isNotConfigured) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Edge Agent Logs</h1>
-          <p className="text-muted-foreground">
-            Search and analyze logs from edge agents via Elasticsearch
-          </p>
-        </div>
+        <PageHeader title={PAGE_TITLE} subtitle={PAGE_SUBTITLE} />
         <NotConfiguredState />
       </div>
     );
@@ -367,18 +471,21 @@ export default function EdgeAgentLogsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Edge Agent Logs</h1>
-          <p className="text-muted-foreground">
-            Search and analyze logs from edge agents via Elasticsearch
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <RefreshControls interval={interval} onIntervalChange={setInterval} onRefresh={handleRefresh} isLoading={isFetching} />
-        </div>
-      </div>
+      <PageHeader
+        title={PAGE_TITLE}
+        subtitle={PAGE_SUBTITLE}
+        actions={
+          <>
+            <DataFreshness lastUpdated={dataUpdatedAt || null} onRefresh={handleRefresh} />
+            <RefreshControls
+              interval={interval}
+              onIntervalChange={setRefreshInterval}
+              onRefresh={handleRefresh}
+              isLoading={isFetching}
+            />
+          </>
+        }
+      />
 
       {/* Search and Filters */}
       <SpotlightCard>
@@ -460,42 +567,17 @@ export default function EdgeAgentLogsPage() {
       </div>
       </SpotlightCard>
 
-      {/* Stats Cards */}
+      {/* Level distribution — one line and one bar, not five tiles */}
       {logs.length > 0 && (
-        <div className="grid gap-4 md:grid-cols-5">
-          <TiltCard>
-            <KpiCard label="Total Logs" value={logsData?.total || logs.length} />
-          </TiltCard>
-          <TiltCard>
-            <KpiCard
-              label="Errors"
-              value={stats.error || 0}
-              icon={<XCircle className="h-5 w-5 text-red-500" />}
-              trend={(stats.error || 0) > 0 ? 'down' : 'neutral'}
+        <SpotlightCard>
+          <div className="rounded-lg border bg-card p-4 shadow-sm">
+            <LogLevelSummary
+              shown={logs.length}
+              total={logsData?.total || logs.length}
+              byLevel={stats}
             />
-          </TiltCard>
-          <TiltCard>
-            <KpiCard
-              label="Warnings"
-              value={(stats.warn || 0) + (stats.warning || 0)}
-              icon={<AlertCircle className="h-5 w-5 text-amber-500" />}
-            />
-          </TiltCard>
-          <TiltCard>
-            <KpiCard
-              label="Info"
-              value={stats.info || 0}
-              icon={<Info className="h-5 w-5 text-blue-500" />}
-            />
-          </TiltCard>
-          <TiltCard>
-            <KpiCard
-              label="Debug"
-              value={stats.debug || 0}
-              icon={<CheckCircle2 className="h-5 w-5 text-emerald-500" />}
-            />
-          </TiltCard>
-        </div>
+          </div>
+        </SpotlightCard>
       )}
 
       {/* Loading State */}

--- a/frontend/src/features/operations/pages/remediation.test.tsx
+++ b/frontend/src/features/operations/pages/remediation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import RemediationPage from './remediation';
@@ -13,6 +13,31 @@ vi.mock('react-router-dom', async () => {
     useNavigate: () => mockNavigate,
   };
 });
+
+const authState = vi.hoisted(() => ({ role: 'admin' as 'admin' | 'operator' | 'viewer' }));
+
+vi.mock('@/providers/auth-provider', () => ({
+  useAuth: () => ({
+    role: authState.role,
+    username: 'ops',
+    isAuthenticated: true,
+    token: 'token',
+    login: vi.fn(),
+    loginWithToken: vi.fn(),
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/containers/hooks/use-endpoints', () => ({
+  useEndpoints: () => ({ data: [{ id: 1, name: 'docker-dev-1' }] }),
+}));
+
+const mutationSpies = vi.hoisted(() => ({
+  approve: vi.fn(),
+  reject: vi.fn(),
+  execute: vi.fn(),
+  refetch: vi.fn(),
+}));
 
 const remediationState = vi.hoisted(() => {
   const pendingAction = {
@@ -48,16 +73,21 @@ vi.mock('@/features/operations/hooks/use-remediation', () => ({
     isLoading: false,
     isError: false,
     error: null,
-    refetch: vi.fn(),
+    refetch: mutationSpies.refetch,
     isFetching: false,
   }),
-  useApproveAction: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
-  useRejectAction: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
-  useExecuteAction: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useApproveAction: () => ({ mutate: mutationSpies.approve, isPending: false, variables: undefined }),
+  useRejectAction: () => ({ mutate: mutationSpies.reject, isPending: false, variables: undefined }),
+  useExecuteAction: () => ({ mutate: mutationSpies.execute, isPending: false, variables: undefined }),
 }));
 
+const autoRefreshOptions = vi.hoisted(() => ({ onTick: undefined as (() => void) | undefined }));
+
 vi.mock('@/shared/hooks/use-auto-refresh', () => ({
-  useAutoRefresh: () => ({ interval: 30, setInterval: vi.fn() }),
+  useAutoRefresh: (_interval: number, opts?: { onTick?: () => void }) => {
+    autoRefreshOptions.onTick = opts?.onTick;
+    return { interval: 30, setRefreshInterval: vi.fn(), setInterval: vi.fn() };
+  },
 }));
 
 vi.mock('@/providers/socket-provider', () => ({
@@ -246,15 +276,65 @@ describe('RemediationPage — execute confirmation dialog (#1539)', () => {
     remediationState.actions = [remediationState.pendingAction];
   });
 
-  it('opens an accessible modal dialog with title and description', () => {
+  it('names the action, the container and the endpoint in the accessible title', () => {
     renderPage();
 
     fireEvent.click(screen.getByRole('button', { name: /Execute/ }));
 
-    // Radix wires the title as the dialog's accessible name.
-    const dialog = screen.getByRole('dialog', { name: 'Execute Remediation Action' });
+    // Radix wires the title as the dialog's accessible name. A fixed
+    // "Execute Remediation Action" rendered identically for every row.
+    const dialog = screen.getByRole('dialog', { name: 'Run Stop Container on api-service now' });
     expect(dialog).toBeInTheDocument();
-    expect(screen.getByText(/perform the suggested operation/)).toBeInTheDocument();
+    expect(screen.getByText('docker-dev-1')).toBeInTheDocument();
+    // The consequence, not "perform the suggested operation".
+    expect(screen.getByText(/does not start again on its own/)).toBeInTheDocument();
+  });
+
+  it('quotes the rationale the decision rests on, labelled by its source', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /Execute/ }));
+
+    expect(screen.getByText('LLM analysis')).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Connection pool leak is exhausting memory over time\./).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('uses the destructive confirm styling for a container-stopping action', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /Execute/ }));
+
+    const confirm = screen.getByRole('button', { name: 'Stop Container' });
+    expect(confirm.className).toContain('bg-destructive');
+  });
+
+  it('keeps the confirm non-destructive for an investigate-only action', () => {
+    remediationState.actions = [{
+      ...remediationState.pendingAction,
+      status: 'approved',
+      action_type: 'INVESTIGATE',
+    }];
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /Execute/ }));
+
+    const confirm = screen.getByRole('button', { name: 'Investigate' });
+    expect(confirm.className).not.toContain('bg-destructive');
+    expect(screen.getByText(/nothing on the container changes/i)).toBeInTheDocument();
+  });
+
+  it('passes the action id and a human label to the mutation', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /Execute/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Stop Container' }));
+
+    expect(mutationSpies.execute).toHaveBeenCalledWith(
+      { actionId: 'action-1', label: 'Stop Container on api-service' },
+      expect.anything(),
+    );
   });
 
   it('closes the dialog on Escape', async () => {
@@ -267,5 +347,163 @@ describe('RemediationPage — execute confirmation dialog (#1539)', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('RemediationPage — approve and reject are decisions, not one clicks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.role = 'admin';
+    remediationState.actions = [remediationState.pendingAction];
+  });
+
+  it('confirms before approving instead of mutating straight from onClick', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+    expect(mutationSpies.approve).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('dialog', { name: 'Approve Stop Container on api-service' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Nothing runs until you press Execute/)).toBeInTheDocument();
+  });
+
+  it('collects a rejection reason and posts it with the rejection', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'Nightly import still running' },
+    });
+    const dialog = screen.getByTestId('remediation-decision-dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Reject' }));
+
+    expect(mutationSpies.reject).toHaveBeenCalledWith(
+      {
+        actionId: 'action-1',
+        label: 'Stop Container on api-service',
+        reason: 'Nightly import still running',
+      },
+      expect.anything(),
+    );
+  });
+});
+
+describe('RemediationPage — accountability columns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.role = 'admin';
+  });
+
+  afterEach(() => {
+    remediationState.actions = [remediationState.pendingAction];
+  });
+
+  it('shows who approved a decided action', () => {
+    remediationState.actions = [{
+      ...remediationState.pendingAction,
+      status: 'completed',
+      approved_by: 'simon',
+      execution_result: 'Container stopped in 412ms',
+    }];
+    renderPage();
+
+    expect(screen.getByRole('columnheader', { name: 'Decision' })).toBeInTheDocument();
+    expect(screen.getByText('simon')).toBeInTheDocument();
+    expect(screen.getByText(/Container stopped in 412ms/)).toBeInTheDocument();
+  });
+
+  it('shows the failure reason on a failed row instead of only the word Failed', () => {
+    remediationState.actions = [{
+      ...remediationState.pendingAction,
+      status: 'failed',
+      approved_by: 'simon',
+      execution_result: 'Portainer returned 409: container is restarting',
+    }];
+    renderPage();
+
+    expect(screen.getByText(/Portainer returned 409: container is restarting/)).toBeInTheDocument();
+  });
+
+  it('shows the rejecter and their stored reason', () => {
+    remediationState.actions = [{
+      ...remediationState.pendingAction,
+      status: 'rejected',
+      rejected_by: 'simon',
+      rejection_reason: 'Nightly import still running',
+    }];
+    renderPage();
+
+    expect(screen.getByText(/Rejected by/)).toBeInTheDocument();
+    expect(screen.getByText(/Nightly import still running/)).toBeInTheDocument();
+  });
+
+  it('says the approver is missing rather than inventing one', () => {
+    remediationState.actions = [{ ...remediationState.pendingAction, status: 'completed' }];
+    renderPage();
+
+    expect(screen.getByText('No approver recorded')).toBeInTheDocument();
+  });
+});
+
+describe('RemediationPage — role gate and header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    remediationState.actions = [remediationState.pendingAction];
+  });
+
+  afterEach(() => {
+    authState.role = 'admin';
+  });
+
+  it('hides the decision controls from a non-admin and says why', () => {
+    authState.role = 'operator';
+    renderPage();
+
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reject' })).not.toBeInTheDocument();
+    expect(screen.getByText(/require the admin role/)).toBeInTheDocument();
+    // Read-only paths stay available.
+    expect(screen.getByRole('button', { name: /Discuss with AI/ })).toBeInTheDocument();
+  });
+
+  it('renders one PageHeader whose subtitle carries the pending count', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Remediation' })).toBeInTheDocument();
+    expect(screen.getByTestId('page-header-subtitle')).toHaveTextContent(
+      '1 action awaiting approval · nothing runs without you',
+    );
+    expect(screen.queryByText(/self-healing/i)).not.toBeInTheDocument();
+  });
+
+  it('drops the KPI tiles that restated the filter chips', () => {
+    renderPage();
+
+    expect(screen.queryByText('Pending Approval')).not.toBeInTheDocument();
+    // The chips keep the counts and stay clickable.
+    expect(screen.getByRole('button', { name: /Pending/ })).toBeInTheDocument();
+  });
+
+  it('does not credit AI for an empty queue fed by a keyword rule table', () => {
+    remediationState.actions = [];
+    try {
+      renderPage();
+      expect(screen.getByText('No actions queued')).toBeInTheDocument();
+      expect(screen.queryByText(/AI monitoring/i)).not.toBeInTheDocument();
+      expect(screen.getByText(/monitoring pipeline raises an insight/)).toBeInTheDocument();
+    } finally {
+      remediationState.actions = [remediationState.pendingAction];
+    }
+  });
+
+  it('wires the auto-refresh interval to an actual refetch', () => {
+    renderPage();
+
+    expect(autoRefreshOptions.onTick).toBeTypeOf('function');
+    mutationSpies.refetch.mockClear();
+    autoRefreshOptions.onTick?.();
+    expect(mutationSpies.refetch).toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/operations/pages/remediation.test.tsx
+++ b/frontend/src/features/operations/pages/remediation.test.tsx
@@ -34,6 +34,7 @@ const remediationState = vi.hoisted(() => {
       ],
       log_analysis: 'Repeated pool exhaustion warnings precede malloc failures.',
       confidence_score: 0.82,
+      analysis_source: 'llm-analysis',
     }),
     suggested_by: 'AI Monitor',
     created_at: '2026-02-06T00:00:00Z',
@@ -125,6 +126,113 @@ describe('RemediationPage', () => {
         prefillPrompt: expect.stringContaining('Container: api-service'),
       }),
     }));
+  });
+});
+
+describe('RemediationPage — nullable confidence/severity and rationale provenance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    remediationState.actions = [remediationState.pendingAction];
+  });
+
+  /** Replace the fixture's rationale, keeping every other field intact. */
+  function withRationale(rationale: string) {
+    remediationState.actions = [{ ...remediationState.pendingAction, rationale }];
+  }
+
+  it('still renders the analysis when confidence_score and severity are null', () => {
+    withRationale(JSON.stringify({
+      root_cause: 'Connection pool leak is exhausting memory over time.',
+      severity: null,
+      recommended_actions: [],
+      log_analysis: '',
+      confidence_score: null,
+      analysis_source: 'llm-analysis',
+    }));
+    renderPage();
+
+    // The structured view is used, not the raw-JSON prose fallback.
+    expect(screen.getByText(/Root Cause:/i)).toBeInTheDocument();
+    expect(screen.getByText(/Connection pool leak is exhausting memory over time\./)).toBeInTheDocument();
+    expect(screen.queryByText(/"root_cause"/)).not.toBeInTheDocument();
+  });
+
+  it('omits the confidence badge when the model supplied no score', () => {
+    withRationale(JSON.stringify({
+      root_cause: 'Cause without a score.',
+      severity: 'warning',
+      recommended_actions: [],
+      log_analysis: '',
+      confidence_score: null,
+    }));
+    renderPage();
+
+    expect(screen.getByText('Warning')).toBeInTheDocument();
+    expect(screen.queryByText(/Confidence:/)).not.toBeInTheDocument();
+  });
+
+  it('omits the severity badge when the model supplied no severity', () => {
+    withRationale(JSON.stringify({
+      root_cause: 'Cause without a severity.',
+      severity: null,
+      recommended_actions: [],
+      log_analysis: '',
+      confidence_score: 0.4,
+    }));
+    renderPage();
+
+    expect(screen.getByText('Confidence: 40%')).toBeInTheDocument();
+    for (const label of ['Critical', 'Warning', 'Info']) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    }
+  });
+
+  it('rejects a present-but-wrong-typed confidence_score', () => {
+    withRationale(JSON.stringify({
+      root_cause: 'Cause with a bad score.',
+      severity: 'warning',
+      recommended_actions: [],
+      log_analysis: '',
+      confidence_score: 'high',
+    }));
+    renderPage();
+
+    // Falls back to prose, so the structured Root Cause label is absent.
+    expect(screen.queryByText(/Root Cause:/i)).not.toBeInTheDocument();
+  });
+
+  it('labels a non-JSON rationale as a pattern match, not AI', () => {
+    withRationale(
+      'Container may be experiencing memory pressure. Check memory limits and usage patterns before taking action.',
+    );
+    renderPage();
+
+    expect(screen.getByText('Pattern match')).toBeInTheDocument();
+    expect(screen.queryByText('AI Monitor')).not.toBeInTheDocument();
+  });
+
+  it('labels an llm-analysis rationale with the stored suggester', () => {
+    renderPage();
+    expect(screen.getByText('AI Monitor')).toBeInTheDocument();
+    expect(screen.queryByText('Pattern match')).not.toBeInTheDocument();
+  });
+
+  it('asserts no provenance when a parsed analysis omits analysis_source', () => {
+    withRationale(JSON.stringify({
+      root_cause: 'Cause from an older stored payload.',
+      severity: 'info',
+      recommended_actions: [],
+      log_analysis: '',
+      confidence_score: 0.5,
+    }));
+    renderPage();
+
+    // Stored suggester is shown as-is; nothing claims a bot produced it.
+    expect(screen.getByText('AI Monitor')).toBeInTheDocument();
+    expect(screen.queryByText('Pattern match')).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/features/operations/pages/remediation.tsx
+++ b/frontend/src/features/operations/pages/remediation.tsx
@@ -17,6 +17,7 @@ import {
   RefreshCw,
   Filter,
   MessageSquare,
+  Regex,
 } from 'lucide-react';
 import {
   useRemediationActions,
@@ -83,11 +84,23 @@ type ActionRecord = {
 type AnalysisPriority = 'high' | 'medium' | 'low';
 type AnalysisSeverity = 'critical' | 'warning' | 'info';
 
+const ANALYSIS_SEVERITIES: AnalysisSeverity[] = ['critical', 'warning', 'info'];
+
+/**
+ * Where the rationale text came from. `pattern-match` is a fixed string picked
+ * by the regex table in `remediation-service.ts`; only `llm-analysis` is model
+ * output. Mirrors `RationaleSourceSchema` in `@dashboard/contracts`.
+ */
+type AnalysisSource = 'pattern-match' | 'llm-analysis';
+
 interface ParsedAnalysis {
   root_cause: string;
-  severity: AnalysisSeverity;
+  /** Null when the model supplied no severity — render no badge, never a default. */
+  severity: AnalysisSeverity | null;
   log_analysis: string;
-  confidence_score: number;
+  /** Null when the model supplied no score — render no badge, never a default. */
+  confidence_score: number | null;
+  analysis_source?: AnalysisSource;
   recommended_actions: Array<{
     action: string;
     priority: AnalysisPriority;
@@ -101,8 +114,15 @@ function parseActionAnalysis(raw: string | undefined): ParsedAnalysis | null {
   try {
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     if (!parsed || typeof parsed !== 'object') return null;
-    if (typeof parsed.root_cause !== 'string' || typeof parsed.confidence_score !== 'number') return null;
-    if (!['critical', 'warning', 'info'].includes(String(parsed.severity))) return null;
+    if (typeof parsed.root_cause !== 'string') return null;
+    // null/absent is a first-class value for both badges: it means "the model
+    // supplied none", which must render as no badge. Only a present-but-
+    // wrong-typed value rejects the payload — rejecting on null would drop the
+    // whole analysis and fall back to printing raw JSON as prose.
+    const rawConfidence = parsed.confidence_score;
+    if (rawConfidence != null && typeof rawConfidence !== 'number') return null;
+    const rawSeverity = parsed.severity;
+    if (rawSeverity != null && !ANALYSIS_SEVERITIES.includes(rawSeverity as AnalysisSeverity)) return null;
     if (!Array.isArray(parsed.recommended_actions)) return null;
 
     const recommendedActions = parsed.recommended_actions
@@ -121,14 +141,34 @@ function parseActionAnalysis(raw: string | undefined): ParsedAnalysis | null {
 
     return {
       root_cause: parsed.root_cause,
-      severity: parsed.severity as AnalysisSeverity,
+      severity: rawSeverity == null ? null : (rawSeverity as AnalysisSeverity),
       log_analysis: typeof parsed.log_analysis === 'string' ? parsed.log_analysis : '',
-      confidence_score: Math.max(0, Math.min(1, parsed.confidence_score)),
+      confidence_score: rawConfidence == null ? null : Math.max(0, Math.min(1, rawConfidence)),
+      analysis_source:
+        parsed.analysis_source === 'pattern-match' || parsed.analysis_source === 'llm-analysis'
+          ? parsed.analysis_source
+          : undefined,
       recommended_actions: recommendedActions,
     };
   } catch {
     return null;
   }
+}
+
+/**
+ * Provenance of a row's rationale text.
+ *
+ * A rationale that does not parse as JSON is always one of the five fixed
+ * strings from the `ACTION_PATTERNS` regex table, so it is `pattern-match` by
+ * construction. A parsed analysis carries its own `analysis_source`; when an
+ * older stored payload omits it the source is genuinely unknown, and we say so
+ * rather than asserting a bot wrote it.
+ */
+function resolveAnalysisSource(rationale: string | undefined): AnalysisSource | null {
+  if (!rationale) return null;
+  const parsed = parseActionAnalysis(rationale);
+  if (!parsed) return 'pattern-match';
+  return parsed.analysis_source ?? null;
 }
 
 /**
@@ -175,14 +215,22 @@ function AnalysisSummaryCell({ action }: { action: ActionRecord }) {
             shouldCollapse && !isExpanded && 'max-h-28 overflow-hidden'
           )}
         >
-        <div className="flex flex-wrap items-center gap-2">
-          <span className={cn('rounded px-2 py-0.5 font-medium', severityClasses)}>
-            {severityLabel}
-          </span>
-          <span className="rounded bg-muted px-2 py-0.5 font-medium text-foreground">
-            Confidence: {(parsedAnalysis.confidence_score * 100).toFixed(0)}%
-          </span>
-        </div>
+        {/* Both badges are omitted when the model supplied no value. A default
+            rendered as an authoritative measurement is worse than no badge. */}
+        {(severityLabel || parsedAnalysis.confidence_score !== null) && (
+          <div className="flex flex-wrap items-center gap-2">
+            {severityLabel && (
+              <span className={cn('rounded px-2 py-0.5 font-medium', severityClasses)}>
+                {severityLabel}
+              </span>
+            )}
+            {parsedAnalysis.confidence_score !== null && (
+              <span className="rounded bg-muted px-2 py-0.5 font-medium text-foreground">
+                Confidence: {(parsedAnalysis.confidence_score * 100).toFixed(0)}%
+              </span>
+            )}
+          </div>
+        )}
         <p className="text-muted-foreground">
           <span className="font-medium text-foreground">Root Cause:</span> {parsedAnalysis.root_cause}
         </p>
@@ -502,12 +550,35 @@ export default function RemediationPage() {
       header: 'Suggested By',
       enableSorting: false,
       cell: ({ row }) => {
-        const suggestedBy = row.original.suggested_by || row.original.suggestedBy || 'AI Monitor';
+        const action = row.original;
+        const source = resolveAnalysisSource(action.rationale || action.description);
+        const suggestedBy = action.suggested_by || action.suggestedBy;
+
+        // A rule-derived rationale is not AI output and must not wear the bot.
+        if (source === 'pattern-match') {
+          return (
+            <div
+              className="flex items-center gap-2"
+              title="Fixed text selected by a keyword rule, not model output"
+            >
+              <Regex className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm">Pattern match</span>
+            </div>
+          );
+        }
+
+        if (source === 'llm-analysis') {
+          return (
+            <div className="flex items-center gap-2" title="Generated by the LLM from logs and metrics">
+              <Bot className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm">{suggestedBy || 'AI analysis'}</span>
+            </div>
+          );
+        }
+
+        // Unknown provenance: report what was stored, assert nothing about it.
         return (
-          <div className="flex items-center gap-2">
-            <Bot className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm">{suggestedBy}</span>
-          </div>
+          <span className="text-sm text-muted-foreground">{suggestedBy || '—'}</span>
         );
       },
     },

--- a/frontend/src/features/operations/pages/remediation.tsx
+++ b/frontend/src/features/operations/pages/remediation.tsx
@@ -13,8 +13,6 @@ import {
   Loader2,
   Bot,
   Box,
-  Server,
-  RefreshCw,
   Filter,
   MessageSquare,
   Regex,
@@ -25,6 +23,7 @@ import {
   useRejectAction,
   useExecuteAction,
 } from '@/features/operations/hooks/use-remediation';
+import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
 import { useAutoRefresh } from '@/shared/hooks/use-auto-refresh';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { RefreshControls } from '@/shared/components/ui/refresh-controls';
@@ -32,10 +31,11 @@ import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { DataTable } from '@/shared/components/tables/data-table';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { useSockets } from '@/providers/socket-provider';
+import { useAuth } from '@/providers/auth-provider';
 import { cn, formatDate } from '@/shared/lib/utils';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
-import { TiltCard } from '@/shared/components/data-display/tilt-card';
 
 type ActionStatus = 'all' | 'pending' | 'approved' | 'rejected' | 'executing' | 'completed' | 'failed';
 
@@ -77,9 +77,67 @@ type ActionRecord = {
   createdAt?: string;
   approved_by?: string;
   approvedBy?: string;
+  rejected_by?: string;
+  rejectedBy?: string;
+  rejection_reason?: string;
+  rejectionReason?: string;
   execution_result?: string;
   result?: string;
 };
+
+/**
+ * Action types that interrupt a running workload. These get the destructive
+ * dialog treatment; `INVESTIGATE` and the scale actions do not stop traffic.
+ */
+const DISRUPTIVE_ACTION_TYPES = new Set(['STOP_CONTAINER', 'RESTART_CONTAINER']);
+
+/** Per-type consequence line for the execute confirmation. Says what happens, not that it "performs an operation". */
+const ACTION_CONSEQUENCES: Record<string, string> = {
+  RESTART_CONTAINER: 'The container stops and starts again. In-flight requests are dropped.',
+  STOP_CONTAINER: 'The container stops and does not start again on its own.',
+  START_CONTAINER: 'The container starts with its existing configuration.',
+  INVESTIGATE: 'Diagnostics only — nothing on the container changes.',
+  SCALE_UP: 'The container is recreated with higher resource limits.',
+  SCALE_DOWN: 'The container is recreated with lower resource limits.',
+};
+
+interface ActionDescription {
+  /** "Restart Container" */
+  actionType: string;
+  actionLabel: string;
+  containerName: string;
+  endpointLabel: string;
+  /** "Restart Container on api-service" — what toasts and dialogs quote. */
+  label: string;
+  consequence: string;
+  isDisruptive: boolean;
+}
+
+/**
+ * Everything a confirmation or a toast needs to name *this* action rather than
+ * "this remediation action". With 28 rows on screen a dialog that renders
+ * identically for every one cannot catch a mis-click.
+ */
+function describeAction(
+  action: ActionRecord,
+  endpointName?: string,
+): ActionDescription {
+  const actionType = action.action_type || action.type || 'UNKNOWN_ACTION';
+  const actionLabel = ACTION_TYPE_LABELS[actionType] || actionType;
+  const containerName = action.container_name || action.containerName || 'an unnamed container';
+  const endpointId = action.endpoint_id ?? action.endpointId;
+  const endpointLabel = endpointName
+    ?? (endpointId != null ? `endpoint ${endpointId}` : 'an unknown endpoint');
+  return {
+    actionType,
+    actionLabel,
+    containerName,
+    endpointLabel,
+    label: `${actionLabel} on ${containerName}`,
+    consequence: ACTION_CONSEQUENCES[actionType] ?? `Runs ${actionLabel} against this container.`,
+    isDisruptive: DISRUPTIVE_ACTION_TYPES.has(actionType),
+  };
+}
 
 type AnalysisPriority = 'high' | 'medium' | 'low';
 type AnalysisSeverity = 'critical' | 'warning' | 'info';
@@ -169,6 +227,17 @@ function resolveAnalysisSource(rationale: string | undefined): AnalysisSource | 
   const parsed = parseActionAnalysis(rationale);
   if (!parsed) return 'pattern-match';
   return parsed.analysis_source ?? null;
+}
+
+/**
+ * One line of "why this was suggested", for the confirmation dialog. Prefers
+ * the parsed root cause; falls back to the stored text as written.
+ */
+function rationaleSummary(action: ActionRecord): string | null {
+  const raw = action.rationale || action.description;
+  if (!raw) return null;
+  const parsed = parseActionAnalysis(raw);
+  return parsed ? parsed.root_cause : raw;
 }
 
 /**
@@ -278,15 +347,72 @@ function AnalysisSummaryCell({ action }: { action: ActionRecord }) {
   );
 }
 
+/**
+ * Who decided, why, and what happened when it ran.
+ *
+ * The backend has written `approved_by`, `rejected_by`, `rejection_reason` and
+ * `execution_result` since the queue existed and none of them reached the
+ * screen — a Failed row rendered the word "Failed" and nothing else. An
+ * approval queue exists to carry accountability; without these four fields it
+ * carries only state.
+ */
+function DecisionCell({ action }: { action: ActionRecord }) {
+  const approvedBy = action.approved_by || action.approvedBy;
+  const rejectedBy = action.rejected_by || action.rejectedBy;
+  const rejectionReason = action.rejection_reason || action.rejectionReason;
+  const executionResult = action.execution_result || action.result;
+  const isFailed = action.status === 'failed';
+
+  if (action.status === 'pending') {
+    return <span className="text-xs text-muted-foreground">Awaiting approval</span>;
+  }
+
+  const decidedBy = rejectedBy
+    ? { verb: 'Rejected by', who: rejectedBy }
+    : approvedBy
+      ? { verb: 'Approved by', who: approvedBy }
+      : null;
+
+  return (
+    <div className="max-w-[15rem] space-y-1 text-xs">
+      {decidedBy ? (
+        <p className="text-muted-foreground">
+          {decidedBy.verb} <span className="font-medium text-foreground">{decidedBy.who}</span>
+        </p>
+      ) : (
+        // Never invent an approver. A row that reached a decided state without
+        // one is a gap in the audit trail and should read as one.
+        <p className="text-muted-foreground">No approver recorded</p>
+      )}
+      {rejectionReason && (
+        <p className="text-muted-foreground break-words">Reason: {rejectionReason}</p>
+      )}
+      {executionResult && (
+        <p className={cn('break-words', isFailed ? 'text-destructive' : 'text-muted-foreground')}>
+          Result: {executionResult}
+        </p>
+      )}
+      {isFailed && !executionResult && (
+        <p className="text-muted-foreground">No failure detail recorded</p>
+      )}
+    </div>
+  );
+}
+
 interface ActionButtonsCellProps {
   action: ActionRecord;
-  onApprove: (id: string) => void;
-  onReject: (id: string) => void;
-  onExecute: (id: string) => void;
+  onApprove: (action: ActionRecord) => void;
+  onReject: (action: ActionRecord) => void;
+  onExecute: (action: ActionRecord) => void;
   onDiscuss: (action: ActionRecord) => void;
   isApproving: boolean;
   isRejecting: boolean;
   isExecuting: boolean;
+  /**
+   * Every backend mutation on this queue is `requireRole('admin')`. Rendering
+   * the controls to everyone promises a decision the server will refuse.
+   */
+  canDecide: boolean;
 }
 
 /**
@@ -304,6 +430,7 @@ function ActionButtonsCell({
   isApproving,
   isRejecting,
   isExecuting,
+  canDecide,
 }: ActionButtonsCellProps) {
   return (
     <div className="flex items-center gap-2">
@@ -314,10 +441,10 @@ function ActionButtonsCell({
         <MessageSquare className="h-3 w-3" />
         Discuss with AI
       </button>
-      {action.status === 'pending' && (
+      {canDecide && action.status === 'pending' && (
         <>
           <button
-            onClick={() => onApprove(action.id)}
+            onClick={() => onApprove(action)}
             disabled={isApproving}
             className="inline-flex items-center gap-1 rounded-md bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700 hover:bg-emerald-200 disabled:opacity-50 dark:bg-emerald-900/30 dark:text-emerald-400"
           >
@@ -329,7 +456,7 @@ function ActionButtonsCell({
             Approve
           </button>
           <button
-            onClick={() => onReject(action.id)}
+            onClick={() => onReject(action)}
             disabled={isRejecting}
             className="inline-flex items-center gap-1 rounded-md bg-red-100 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-200 disabled:opacity-50 dark:bg-red-900/30 dark:text-red-400"
           >
@@ -342,9 +469,9 @@ function ActionButtonsCell({
           </button>
         </>
       )}
-      {action.status === 'approved' && (
+      {canDecide && action.status === 'approved' && (
         <button
-          onClick={() => onExecute(action.id)}
+          onClick={() => onExecute(action)}
           disabled={isExecuting}
           className="inline-flex items-center gap-1 rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
         >
@@ -355,6 +482,9 @@ function ActionButtonsCell({
           )}
           Execute
         </button>
+      )}
+      {!canDecide && (action.status === 'pending' || action.status === 'approved') && (
+        <span className="text-xs text-muted-foreground">Admin decision required</span>
       )}
       {action.status === 'executing' && (
         <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
@@ -388,10 +518,17 @@ export default function RemediationPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { remediationSocket } = useSockets();
+  const { role } = useAuth();
+  // Every mutation on this queue is `requireRole('admin')` server-side. This
+  // gate only stops the UI promising a decision the API will refuse — it is
+  // not, and must not be treated as, the enforcement point.
+  const canDecide = role === 'admin';
   const [statusFilter, setStatusFilter] = useState<ActionStatus>('all');
-  const [executeDialogOpen, setExecuteDialogOpen] = useState(false);
-  const [selectedActionId, setSelectedActionId] = useState<string | null>(null);
-  const { interval, setInterval } = useAutoRefresh(30);
+  const [pendingDecision, setPendingDecision] = useState<
+    { kind: 'approve' | 'reject' | 'execute'; action: ActionRecord } | null
+  >(null);
+  const [rejectReason, setRejectReason] = useState('');
+  const { data: endpoints } = useEndpoints();
 
   // Fetch actions
   const {
@@ -403,6 +540,11 @@ export default function RemediationPage() {
     refetch,
     isFetching,
   } = useRemediationActions(statusFilter === 'all' ? undefined : statusFilter);
+  // The hook owns the timer. Without `onTick` the interval dropdown and its
+  // pulsing "live" dot schedule nothing.
+  const { interval, setRefreshInterval } = useAutoRefresh(30, {
+    onTick: () => { void refetch(); },
+  });
   // Treat both isLoading and isPending-without-data as "loading" to avoid
   // rendering a blank page during SPA navigation before data arrives.
   const isLoading = actionsLoading || (actionsPending && !actionsData);
@@ -446,27 +588,55 @@ export default function RemediationPage() {
     };
   }, [actionsData]);
 
-  const handleApprove = useCallback((id: string) => {
-    approveAction.mutate(id);
-  }, [approveAction]);
+  const endpointNameById = useMemo(() => {
+    const byId = new Map<number, string>();
+    for (const endpoint of endpoints ?? []) byId.set(endpoint.id, endpoint.name);
+    return byId;
+  }, [endpoints]);
 
-  const handleReject = useCallback((id: string) => {
-    rejectAction.mutate(id);
-  }, [rejectAction]);
+  const describe = useCallback(
+    (action: ActionRecord) => {
+      const endpointId = action.endpoint_id ?? action.endpointId;
+      return describeAction(
+        action,
+        endpointId != null ? endpointNameById.get(endpointId) : undefined,
+      );
+    },
+    [endpointNameById],
+  );
 
-  const handleExecuteClick = useCallback((id: string) => {
-    setSelectedActionId(id);
-    setExecuteDialogOpen(true);
+  // All three decisions route through the same confirmation state, so none of
+  // them can regress to a bare one-click mutation.
+  const handleApprove = useCallback((action: ActionRecord) => {
+    setPendingDecision({ kind: 'approve', action });
   }, []);
 
-  const handleExecuteConfirm = () => {
-    if (selectedActionId) {
-      executeAction.mutate(selectedActionId, {
-        onSettled: () => {
-          setExecuteDialogOpen(false);
-          setSelectedActionId(null);
-        },
-      });
+  const handleReject = useCallback((action: ActionRecord) => {
+    setRejectReason('');
+    setPendingDecision({ kind: 'reject', action });
+  }, []);
+
+  const handleExecuteClick = useCallback((action: ActionRecord) => {
+    setPendingDecision({ kind: 'execute', action });
+  }, []);
+
+  const closeDecision = useCallback(() => {
+    setPendingDecision(null);
+    setRejectReason('');
+  }, []);
+
+  const decisionDescription = pendingDecision ? describe(pendingDecision.action) : null;
+
+  const handleDecisionConfirm = () => {
+    if (!pendingDecision || !decisionDescription) return;
+    const ref = { actionId: pendingDecision.action.id, label: decisionDescription.label };
+    const onSettled = () => closeDecision();
+    if (pendingDecision.kind === 'approve') {
+      approveAction.mutate(ref, { onSettled });
+    } else if (pendingDecision.kind === 'reject') {
+      rejectAction.mutate({ ...ref, reason: rejectReason }, { onSettled });
+    } else {
+      executeAction.mutate(ref, { onSettled });
     }
   };
 
@@ -502,9 +672,9 @@ export default function RemediationPage() {
 
   // Per-row pending flags depend on the in-flight mutation variables. Read them
   // here so the columns memo recomputes when any mutation starts/settles.
-  const approvingId = approveAction.isPending ? approveAction.variables : undefined;
-  const rejectingId = rejectAction.isPending ? rejectAction.variables : undefined;
-  const executingId = executeAction.isPending ? executeAction.variables : undefined;
+  const approvingId = approveAction.isPending ? approveAction.variables?.actionId : undefined;
+  const rejectingId = rejectAction.isPending ? rejectAction.variables?.actionId : undefined;
+  const executingId = executeAction.isPending ? executeAction.variables?.actionId : undefined;
 
   const columns = useMemo<ColumnDef<ActionRecord, unknown>[]>(() => [
     {
@@ -583,6 +753,12 @@ export default function RemediationPage() {
       },
     },
     {
+      id: 'decision',
+      header: 'Decision',
+      enableSorting: false,
+      cell: ({ row }) => <DecisionCell action={row.original} />,
+    },
+    {
       id: 'created',
       header: 'Created',
       enableSorting: false,
@@ -617,22 +793,22 @@ export default function RemediationPage() {
             isApproving={approvingId === action.id}
             isRejecting={rejectingId === action.id}
             isExecuting={executingId === action.id}
+            canDecide={canDecide}
           />
         );
       },
     },
-  ], [handleApprove, handleReject, handleExecuteClick, handleDiscuss, approvingId, rejectingId, executingId]);
+  ], [handleApprove, handleReject, handleExecuteClick, handleDiscuss, approvingId, rejectingId, executingId, canDecide]);
+
+  // A queue where a human approves everything is not self-healing; the old
+  // subtitle contradicted itself in four words. This one carries live state.
+  const subtitle = `${stats.pending} action${stats.pending === 1 ? '' : 's'} awaiting approval · nothing runs without you`;
 
   // Error state
   if (isError) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Remediation</h1>
-          <p className="text-muted-foreground">
-            Human-approved self-healing action queue
-          </p>
-        </div>
+        <PageHeader title="Remediation" subtitle={subtitle} />
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-8 text-center">
           <AlertTriangle className="mx-auto h-10 w-10 text-destructive" />
           <p className="mt-4 font-medium text-destructive">Failed to load actions</p>
@@ -652,58 +828,32 @@ export default function RemediationPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Remediation</h1>
-          <p className="text-muted-foreground">
-            Human-approved self-healing action queue
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <RefreshControls interval={interval} onIntervalChange={setInterval} onRefresh={() => refetch()} isLoading={isFetching} />
-        </div>
-      </div>
+      <PageHeader
+        title="Remediation"
+        subtitle={subtitle}
+        actions={(
+          <RefreshControls
+            interval={interval}
+            onIntervalChange={setRefreshInterval}
+            onRefresh={() => refetch()}
+            isLoading={isFetching}
+          />
+        )}
+      />
 
-      {/* Stats Cards */}
-      <div className="grid gap-4 md:grid-cols-4">
-        <TiltCard>
-          <div className="h-full rounded-lg border bg-amber-50 dark:bg-amber-900/20 p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-amber-800 dark:text-amber-200">Pending Approval</p>
-              <Clock className="h-5 w-5 text-amber-600 dark:text-amber-400" />
-            </div>
-            <p className="mt-2 text-3xl font-bold tracking-tight text-amber-900 dark:text-amber-100">{stats.pending}</p>
-          </div>
-        </TiltCard>
-        <TiltCard>
-          <div className="h-full rounded-lg border bg-blue-50 dark:bg-blue-900/20 p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-blue-800 dark:text-blue-200">Approved</p>
-              <ThumbsUp className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-            </div>
-            <p className="mt-2 text-3xl font-bold tracking-tight text-blue-900 dark:text-blue-100">{stats.approved}</p>
-          </div>
-        </TiltCard>
-        <TiltCard>
-          <div className="h-full rounded-lg border bg-emerald-50 dark:bg-emerald-900/20 p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-emerald-800 dark:text-emerald-200">Completed</p>
-              <CheckCircle2 className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-            </div>
-            <p className="mt-2 text-3xl font-bold tracking-tight text-emerald-900 dark:text-emerald-100">{stats.completed}</p>
-          </div>
-        </TiltCard>
-        <TiltCard>
-          <div className="h-full rounded-lg border bg-red-50 dark:bg-red-900/20 p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-red-800 dark:text-red-200">Failed</p>
-              <XCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
-            </div>
-            <p className="mt-2 text-3xl font-bold tracking-tight text-red-900 dark:text-red-100">{stats.failed}</p>
-          </div>
-        </TiltCard>
-      </div>
+      {!canDecide && (
+        <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+          Approving, rejecting and executing actions require the admin role. You can review the
+          queue and open any action in the assistant.
+        </div>
+      )}
+
+      {/*
+        The four KPI tiles that stood here restated the filter chips 60px below
+        them — same numbers, except the chips are clickable and two of the four
+        read 0 on any fresh install. The chips are the surface that does
+        something, so they are the surface that keeps the counts.
+      */}
 
       {/* Status Filter Tabs */}
       <SpotlightCard>
@@ -742,10 +892,12 @@ export default function RemediationPage() {
       ) : actions.length === 0 ? (
         <EmptyState
           icon={Box}
-          title="No remediation actions"
+          title="No actions queued"
+          // Most rationales in this queue come from a keyword rule table, not a
+          // model, so the empty state does not credit "AI monitoring" for them.
           description={statusFilter === 'all'
-            ? 'AI monitoring has not suggested any remediation actions yet.'
-            : `No actions with status "${statusFilter}" found.`}
+            ? 'Nothing is waiting for approval. Actions appear here when the monitoring pipeline raises an insight against a container.'
+            : `No actions with status "${statusFilter}".`}
         />
       ) : (
         <SpotlightCard>
@@ -761,20 +913,100 @@ export default function RemediationPage() {
         </SpotlightCard>
       )}
 
-      {/* Execute Confirmation Dialog */}
-      <ConfirmDialog
-        open={executeDialogOpen}
-        title="Execute Remediation Action"
-        description="Are you sure you want to execute this remediation action? This will perform the suggested operation on the target container."
-        confirmLabel="Execute"
-        variant="default"
-        isLoading={executeAction.isPending}
-        onConfirm={handleExecuteConfirm}
-        onCancel={() => {
-          setExecuteDialogOpen(false);
-          setSelectedActionId(null);
-        }}
-      />
+      {/*
+        One dialog for all three decisions. It names the action, the container
+        and the endpoint, and quotes the rationale the decision rests on — the
+        fixed "Are you sure you want to execute this remediation action?" it
+        replaces rendered identically for every row, so it could not catch a
+        mis-click.
+      */}
+      {pendingDecision && decisionDescription && (
+        <ConfirmDialog
+          open
+          data-testid="remediation-decision-dialog"
+          title={
+            pendingDecision.kind === 'approve'
+              ? `Approve ${decisionDescription.actionLabel} on ${decisionDescription.containerName}`
+              : pendingDecision.kind === 'reject'
+                ? `Reject ${decisionDescription.actionLabel} on ${decisionDescription.containerName}`
+                : `Run ${decisionDescription.actionLabel} on ${decisionDescription.containerName} now`
+          }
+          description={
+            pendingDecision.kind === 'approve'
+              ? 'Approving records your decision. Nothing runs until you press Execute.'
+              : pendingDecision.kind === 'reject'
+                ? 'Rejecting closes this action. It cannot be approved afterwards.'
+                : decisionDescription.consequence
+          }
+          confirmLabel={
+            pendingDecision.kind === 'approve'
+              ? 'Approve'
+              : pendingDecision.kind === 'reject'
+                ? 'Reject'
+                : decisionDescription.actionLabel
+          }
+          variant={
+            pendingDecision.kind === 'reject'
+              ? 'warning'
+              : pendingDecision.kind === 'execute' && decisionDescription.isDisruptive
+                ? 'danger'
+                : 'default'
+          }
+          isLoading={
+            pendingDecision.kind === 'approve'
+              ? approveAction.isPending
+              : pendingDecision.kind === 'reject'
+                ? rejectAction.isPending
+                : executeAction.isPending
+          }
+          onConfirm={handleDecisionConfirm}
+          onCancel={closeDecision}
+        >
+          <dl className="mt-4 space-y-1.5 rounded-md border bg-muted/30 p-3 text-xs">
+            <div className="flex gap-2">
+              <dt className="w-20 shrink-0 text-muted-foreground">Container</dt>
+              <dd className="min-w-0 break-words font-medium">{decisionDescription.containerName}</dd>
+            </div>
+            <div className="flex gap-2">
+              <dt className="w-20 shrink-0 text-muted-foreground">Endpoint</dt>
+              <dd className="min-w-0 break-words font-medium">{decisionDescription.endpointLabel}</dd>
+            </div>
+            {(() => {
+              const summary = rationaleSummary(pendingDecision.action);
+              if (!summary) return null;
+              const source = resolveAnalysisSource(
+                pendingDecision.action.rationale || pendingDecision.action.description,
+              );
+              return (
+                <div className="flex gap-2">
+                  <dt className="w-20 shrink-0 text-muted-foreground">
+                    {source === 'pattern-match'
+                      ? 'Rule text'
+                      : source === 'llm-analysis'
+                        ? 'LLM analysis'
+                        : 'Rationale'}
+                  </dt>
+                  <dd className="min-w-0 break-words text-muted-foreground">{summary}</dd>
+                </div>
+              );
+            })()}
+          </dl>
+          {pendingDecision.kind === 'reject' && (
+            <label className="mt-3 block text-xs">
+              <span className="mb-1 block text-muted-foreground">
+                Reason (optional — stored with the rejection)
+              </span>
+              <textarea
+                value={rejectReason}
+                onChange={(event) => setRejectReason(event.target.value)}
+                rows={2}
+                className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="Restarting would drop the nightly import that is still running."
+              />
+            </label>
+          )}
+        </ConfirmDialog>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/security/hooks/use-pcap.ts
+++ b/frontend/src/features/security/hooks/use-pcap.ts
@@ -15,7 +15,13 @@ export interface PcapAnalysisResult {
   health_status: 'healthy' | 'degraded' | 'critical';
   summary: string;
   findings: PcapFinding[];
-  confidence_score: number;
+  /**
+   * Null when the model supplied no score. Kept nullable deliberately: this
+   * interface hand-mirrors `PcapAnalysisResultSchema` in @dashboard/security and
+   * nothing machine-checks the two, so narrowing it here would let the view
+   * multiply null by 100 and print an authoritative "Confidence: 0%".
+   */
+  confidence_score: number | null;
 }
 
 export interface Capture {
@@ -36,7 +42,13 @@ export interface Capture {
   started_at: string | null;
   completed_at: string | null;
   created_at: string;
-  analysis_result: string | null;
+  /**
+   * The stored analysis. Declared as the JSONB column's real wire shape — an
+   * object — with `string` kept for tolerance: the pg driver parses JSONB, so
+   * this is not the JSON text the name suggests, and treating it as such is
+   * what made the analysis panel unreachable.
+   */
+  analysis_result: PcapAnalysisResult | string | null;
 }
 
 interface CapturesResponse {

--- a/frontend/src/features/security/pages/ebpf-coverage.test.tsx
+++ b/frontend/src/features/security/pages/ebpf-coverage.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
-import EbpfCoveragePage from './ebpf-coverage';
+import EbpfCoveragePage, { mergeEndpointCoverage, summarizeCoverage } from './ebpf-coverage';
+import type { CoverageRecord } from '@/features/security/hooks/use-ebpf-coverage';
 
 const mockSyncMutate = vi.fn();
 const mockVerifyMutate = vi.fn();
@@ -12,124 +13,58 @@ const mockEnableMutate = vi.fn();
 const mockRemoveMutate = vi.fn();
 const mockDeleteStaleMutate = vi.fn();
 
+const mockUseEbpfCoverage = vi.fn();
+const mockUseEndpoints = vi.fn();
+let mockRole = 'admin';
+
 vi.mock('@/features/security/hooks/use-ebpf-coverage', () => ({
-  useEbpfCoverage: vi.fn(() => ({
-    data: {
-      coverage: [
-        {
-          endpoint_id: 1,
-          endpoint_name: 'local-docker',
-          status: 'deployed',
-          exclusion_reason: null,
-          deployment_profile: null,
-          last_trace_at: '2025-06-01T12:00:00',
-          last_verified_at: '2025-06-01T12:05:00',
-          created_at: '2025-01-01',
-          updated_at: '2025-06-01',
-        },
-        {
-          endpoint_id: 2,
-          endpoint_name: 'staging-server',
-          status: 'not_deployed',
-          exclusion_reason: null,
-          deployment_profile: null,
-          last_trace_at: null,
-          last_verified_at: null,
-          created_at: '2025-01-01',
-          updated_at: '2025-01-01',
-        },
-        {
-          endpoint_id: 3,
-          endpoint_name: 'dev-box',
-          status: 'excluded',
-          exclusion_reason: 'Development only',
-          deployment_profile: null,
-          last_trace_at: null,
-          last_verified_at: null,
-          created_at: '2025-01-01',
-          updated_at: '2025-01-01',
-        },
-        {
-          endpoint_id: 4,
-          endpoint_name: 'prod-cluster',
-          status: 'failed',
-          exclusion_reason: null,
-          deployment_profile: null,
-          last_trace_at: null,
-          last_verified_at: null,
-          created_at: '2025-01-01',
-          updated_at: '2025-01-01',
-        },
-        {
-          endpoint_id: 5,
-          endpoint_name: 'remote-unreachable',
-          status: 'unreachable',
-          exclusion_reason: null,
-          deployment_profile: null,
-          last_trace_at: null,
-          last_verified_at: null,
-          created_at: '2025-01-01',
-          updated_at: '2025-01-01',
-        },
-        {
-          endpoint_id: 6,
-          endpoint_name: 'edge-agent-host',
-          status: 'incompatible',
-          exclusion_reason: null,
-          deployment_profile: null,
-          last_trace_at: null,
-          last_verified_at: null,
-          created_at: '2025-01-01',
-          updated_at: '2025-01-01',
-        },
-      ],
-    },
-    isLoading: false,
-  })),
-  useEbpfCoverageSummary: vi.fn(() => ({
-    data: {
-      total: 6,
-      deployed: 1,
-      planned: 0,
-      excluded: 1,
-      failed: 1,
-      unknown: 0,
-      not_deployed: 1,
-      unreachable: 1,
-      incompatible: 1,
-      coveragePercent: 17,
-    },
-    isLoading: false,
-  })),
-  useSyncCoverage: vi.fn(() => ({
-    mutate: mockSyncMutate,
-    isPending: false,
-  })),
-  useVerifyCoverage: vi.fn(() => ({
-    mutate: mockVerifyMutate,
-    isPending: false,
-  })),
-  useDeployBeyla: vi.fn(() => ({
-    mutate: mockDeployMutate,
-    isPending: false,
-  })),
-  useDisableBeyla: vi.fn(() => ({
-    mutate: mockDisableMutate,
-    isPending: false,
-  })),
-  useEnableBeyla: vi.fn(() => ({
-    mutate: mockEnableMutate,
-    isPending: false,
-  })),
-  useRemoveBeyla: vi.fn(() => ({
-    mutate: mockRemoveMutate,
-    isPending: false,
-  })),
-  useDeleteStaleCoverage: vi.fn(() => ({
-    mutate: mockDeleteStaleMutate,
-    isPending: false,
-  })),
+  useEbpfCoverage: () => mockUseEbpfCoverage(),
+  useSyncCoverage: vi.fn(() => ({ mutate: mockSyncMutate, isPending: false })),
+  useVerifyCoverage: vi.fn(() => ({ mutate: mockVerifyMutate, isPending: false })),
+  useDeployBeyla: vi.fn(() => ({ mutate: mockDeployMutate, isPending: false })),
+  useDisableBeyla: vi.fn(() => ({ mutate: mockDisableMutate, isPending: false })),
+  useEnableBeyla: vi.fn(() => ({ mutate: mockEnableMutate, isPending: false })),
+  useRemoveBeyla: vi.fn(() => ({ mutate: mockRemoveMutate, isPending: false })),
+  useDeleteStaleCoverage: vi.fn(() => ({ mutate: mockDeleteStaleMutate, isPending: false })),
 }));
+
+vi.mock('@/features/containers/hooks/use-endpoints', () => ({
+  useEndpoints: () => mockUseEndpoints(),
+}));
+
+vi.mock('@/providers/auth-provider', () => ({
+  useAuth: () => ({ role: mockRole, username: 'tester', isAuthenticated: true }),
+}));
+
+function record(overrides: Partial<CoverageRecord> & { endpoint_id: number; endpoint_name: string }): CoverageRecord {
+  return {
+    status: 'not_deployed',
+    exclusion_reason: null,
+    deployment_profile: null,
+    last_trace_at: null,
+    last_verified_at: null,
+    created_at: '2025-01-01',
+    updated_at: '2025-01-01',
+    ...overrides,
+  } as CoverageRecord;
+}
+
+const COVERAGE: CoverageRecord[] = [
+  record({
+    endpoint_id: 1,
+    endpoint_name: 'local-docker',
+    status: 'deployed',
+    last_trace_at: '2025-06-01T12:00:00',
+    last_verified_at: '2025-06-01T12:05:00',
+  }),
+  record({ endpoint_id: 2, endpoint_name: 'staging-server', status: 'not_deployed' }),
+  record({ endpoint_id: 3, endpoint_name: 'dev-box', status: 'excluded', exclusion_reason: 'Development only' }),
+  record({ endpoint_id: 4, endpoint_name: 'prod-cluster', status: 'failed' }),
+  record({ endpoint_id: 5, endpoint_name: 'remote-unreachable', status: 'unreachable' }),
+  record({ endpoint_id: 6, endpoint_name: 'edge-agent-host', status: 'incompatible' }),
+];
+
+const ENDPOINTS = COVERAGE.map((r) => ({ id: r.endpoint_id, name: r.endpoint_name }));
 
 function renderWithProviders(ui: React.ReactElement) {
   const queryClient = new QueryClient({
@@ -144,32 +79,114 @@ function renderWithProviders(ui: React.ReactElement) {
   );
 }
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRole = 'admin';
+  mockUseEbpfCoverage.mockReturnValue({ data: { coverage: COVERAGE }, isLoading: false });
+  mockUseEndpoints.mockReturnValue({ data: ENDPOINTS, isLoading: false });
+});
+
+describe('coverage row merge', () => {
+  it('keeps one row per live endpoint even with no coverage record', () => {
+    const rows = mergeEndpointCoverage([], [{ id: 1, name: 'docker-dev-1' }]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      endpoint_id: 1,
+      endpoint_name: 'docker-dev-1',
+      status: 'unknown',
+      synthetic: true,
+    });
+  });
+
+  it('prefers the stored record over a synthesised row', () => {
+    const rows = mergeEndpointCoverage(
+      [record({ endpoint_id: 1, endpoint_name: 'local-docker', status: 'deployed' })],
+      [{ id: 1, name: 'local-docker' }],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('deployed');
+    expect(rows[0].synthetic).toBeUndefined();
+  });
+
+  it('keeps coverage rows whose endpoint no longer exists', () => {
+    const rows = mergeEndpointCoverage(
+      [record({ endpoint_id: 9, endpoint_name: 'retired-host', status: 'deployed' })],
+      [{ id: 1, name: 'local-docker' }],
+    );
+    expect(rows.map((r) => r.endpoint_name)).toEqual(['local-docker', 'retired-host']);
+  });
+
+  it('counts totals from the rows on screen', () => {
+    const totals = summarizeCoverage(mergeEndpointCoverage(COVERAGE, ENDPOINTS));
+    expect(totals).toMatchObject({ total: 6, deployed: 1, missing: 5, failed: 1, planned: 0, coveragePercent: 17 });
+  });
+
+  it('reports 0% rather than NaN with no endpoints', () => {
+    expect(summarizeCoverage([]).coveragePercent).toBe(0);
+  });
+});
+
 describe('EbpfCoveragePage', () => {
-  it('renders page header', () => {
+  it('renders the page header through the shared primitive', () => {
     renderWithProviders(<EbpfCoveragePage />);
-    expect(screen.getByText('eBPF Coverage')).toBeTruthy();
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent('eBPF Coverage');
+    // PageHeader owns the scale — this page used to be one step smaller than
+    // its 17 siblings.
+    expect(heading.className).toContain('sm:text-3xl');
     expect(screen.getByText(/Track Beyla/)).toBeTruthy();
+  });
+
+  it('does not add page padding on top of the shell padding', () => {
+    const { container } = renderWithProviders(<EbpfCoveragePage />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).not.toContain('p-6');
   });
 
   it('renders summary bar with coverage stats', () => {
     renderWithProviders(<EbpfCoveragePage />);
-    const summary = screen.getByTestId('coverage-summary');
-    expect(summary).toBeTruthy();
+    expect(screen.getByTestId('coverage-summary')).toBeTruthy();
     expect(screen.getByText(/Coverage: 1\/6 endpoints \(17%\)/)).toBeTruthy();
     expect(screen.getByText('Missing: 5')).toBeTruthy();
     expect(screen.getByText('Failed: 1')).toBeTruthy();
   });
 
+  it('suppresses counters that are structurally zero', () => {
+    renderWithProviders(<EbpfCoveragePage />);
+    expect(screen.queryByText('Planned: 0')).toBeNull();
+    expect(screen.getByText('Unreachable: 1')).toBeTruthy();
+    expect(screen.getByText('Incompatible: 1')).toBeTruthy();
+  });
+
+  it('shows the live endpoint list before any sync has run', () => {
+    mockUseEbpfCoverage.mockReturnValue({ data: { coverage: [] }, isLoading: false });
+    mockUseEndpoints.mockReturnValue({ data: [{ id: 1, name: 'docker-dev-1' }], isLoading: false });
+
+    renderWithProviders(<EbpfCoveragePage />);
+
+    expect(screen.getByText('docker-dev-1')).toBeTruthy();
+    expect(screen.getByText(/Coverage: 0\/1 endpoints \(0%\)/)).toBeTruthy();
+    expect(screen.getByTestId('status-hint')).toHaveTextContent('no coverage record yet');
+    // Nothing stale to delete on a row that has no database record.
+    expect(screen.queryByTestId('row-overflow-btn')).toBeNull();
+  });
+
+  it('drops the whole summary bar when there are no endpoints at all', () => {
+    mockUseEbpfCoverage.mockReturnValue({ data: { coverage: [] }, isLoading: false });
+    mockUseEndpoints.mockReturnValue({ data: [], isLoading: false });
+
+    renderWithProviders(<EbpfCoveragePage />);
+
+    expect(screen.queryByTestId('coverage-summary')).toBeNull();
+    expect(screen.getByText(/No endpoints found. Click "Sync Endpoints"/)).toBeTruthy();
+  });
+
   it('renders coverage table with all endpoints', () => {
     renderWithProviders(<EbpfCoveragePage />);
-    const table = screen.getByTestId('coverage-table');
-    expect(table).toBeTruthy();
-    expect(screen.getByText('local-docker')).toBeTruthy();
-    expect(screen.getByText('staging-server')).toBeTruthy();
-    expect(screen.getByText('dev-box')).toBeTruthy();
-    expect(screen.getByText('prod-cluster')).toBeTruthy();
-    expect(screen.getByText('remote-unreachable')).toBeTruthy();
-    expect(screen.getByText('edge-agent-host')).toBeTruthy();
+    expect(screen.getByTestId('coverage-table')).toBeTruthy();
+    for (const name of ENDPOINTS.map((e) => e.name)) {
+      expect(screen.getByText(name)).toBeTruthy();
+    }
   });
 
   it('renders status badges with human-readable labels', () => {
@@ -191,37 +208,49 @@ describe('EbpfCoveragePage', () => {
     expect(screen.getByText('Endpoint type not supported (ACI, Kubernetes, etc.)')).toBeTruthy();
   });
 
-  it('renders unreachable and incompatible counts in summary', () => {
-    renderWithProviders(<EbpfCoveragePage />);
-    expect(screen.getByText('Unreachable: 1')).toBeTruthy();
-    expect(screen.getByText('Incompatible: 1')).toBeTruthy();
-  });
-
   it('renders sync button', () => {
     renderWithProviders(<EbpfCoveragePage />);
     expect(screen.getByTestId('sync-btn')).toBeTruthy();
     expect(screen.getByText('Sync Endpoints')).toBeTruthy();
   });
 
-  it('renders verify buttons for each endpoint', () => {
-    renderWithProviders(<EbpfCoveragePage />);
-    const verifyButtons = screen.getAllByTestId('verify-btn');
-    expect(verifyButtons.length).toBe(6);
-  });
-
   it('shows lifecycle action buttons without selecting rows', () => {
     renderWithProviders(<EbpfCoveragePage />);
+    expect(screen.getAllByTestId('verify-btn').length).toBe(6);
     expect(screen.getAllByTestId('toggle-btn').length).toBe(6);
     // deploy shown for non-deployed-ish rows, remove shown for deployed/failed rows
     expect(screen.getAllByTestId('deploy-btn').length).toBe(4);
     expect(screen.getAllByTestId('remove-btn').length).toBe(2);
-    expect(screen.getAllByTestId('delete-stale-btn').length).toBe(6);
+  });
+
+  it('disables every mutation for a viewer, since the backend gates them on admin', () => {
+    mockRole = 'viewer';
+    renderWithProviders(<EbpfCoveragePage />);
+
+    const verify = screen.getAllByTestId('verify-btn')[0];
+    expect(verify).toBeDisabled();
+    expect(verify).toHaveAttribute('title', 'Requires the admin role');
+    expect(screen.getAllByTestId('toggle-btn')[0]).toBeDisabled();
+    expect(screen.getAllByTestId('deploy-btn')[0]).toBeDisabled();
+    expect(screen.getAllByTestId('remove-btn')[0]).toBeDisabled();
+    expect(screen.getAllByTestId('row-overflow-btn')[0]).toBeDisabled();
+    expect(screen.getByTestId('sync-btn')).toBeDisabled();
+  });
+
+  it('keeps "Delete stale" out of the action row, behind an overflow menu', () => {
+    renderWithProviders(<EbpfCoveragePage />);
+
+    expect(screen.queryByTestId('delete-stale-btn')).toBeNull();
+
+    fireEvent.click(screen.getAllByTestId('row-overflow-btn')[0]);
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByTestId('delete-stale-btn')).toHaveTextContent('Delete stale record');
   });
 
   it('opens delete stale dialog and confirms delete', () => {
     renderWithProviders(<EbpfCoveragePage />);
-    const deleteButtons = screen.getAllByTestId('delete-stale-btn');
-    fireEvent.click(deleteButtons[0]);
+    fireEvent.click(screen.getAllByTestId('row-overflow-btn')[0]);
+    fireEvent.click(screen.getByTestId('delete-stale-btn'));
 
     expect(screen.getByTestId('ebpf-action-dialog')).toBeTruthy();
     fireEvent.click(screen.getByText('Confirm'));
@@ -240,7 +269,8 @@ describe('EbpfCoveragePage', () => {
 
   it('renders the confirmation as an accessible modal dialog (#1539)', () => {
     renderWithProviders(<EbpfCoveragePage />);
-    fireEvent.click(screen.getAllByTestId('delete-stale-btn')[0]);
+    fireEvent.click(screen.getAllByTestId('row-overflow-btn')[0]);
+    fireEvent.click(screen.getByTestId('delete-stale-btn'));
 
     // Radix wires the title as the dialog's accessible name.
     const dialog = screen.getByRole('dialog', { name: 'Delete stale endpoint local-docker?' });
@@ -250,7 +280,8 @@ describe('EbpfCoveragePage', () => {
 
   it('closes the dialog on Escape without running the action (#1539)', async () => {
     renderWithProviders(<EbpfCoveragePage />);
-    fireEvent.click(screen.getAllByTestId('delete-stale-btn')[0]);
+    fireEvent.click(screen.getAllByTestId('row-overflow-btn')[0]);
+    fireEvent.click(screen.getByTestId('delete-stale-btn'));
     expect(screen.getByTestId('ebpf-action-dialog')).toBeTruthy();
 
     fireEvent.keyDown(document, { key: 'Escape' });

--- a/frontend/src/features/security/pages/ebpf-coverage.tsx
+++ b/frontend/src/features/security/pages/ebpf-coverage.tsx
@@ -9,11 +9,11 @@ import {
   ShieldQuestion,
   Unplug,
   Ban,
+  MoreHorizontal,
 } from 'lucide-react';
 import { useState } from 'react';
 import {
   useEbpfCoverage,
-  useEbpfCoverageSummary,
   useSyncCoverage,
   useVerifyCoverage,
   useDeployBeyla,
@@ -23,10 +23,13 @@ import {
   useDeleteStaleCoverage,
 } from '@/features/security/hooks/use-ebpf-coverage';
 import type { CoverageRecord } from '@/features/security/hooks/use-ebpf-coverage';
+import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
+import { useAuth } from '@/providers/auth-provider';
 import { StatusBadge } from '@/shared/components/feedback/status-badge';
 import { ConfirmDialog } from '@/shared/components/feedback/confirm-dialog';
 import { SkeletonText, SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { formatDate } from '@/shared/lib/utils';
 
 /** Human-readable labels for coverage statuses */
@@ -47,6 +50,86 @@ const STATUS_HINTS: Record<string, string> = {
   unreachable: 'Could not connect to endpoint to check for Beyla',
   incompatible: 'Endpoint type not supported (ACI, Kubernetes, etc.)',
 };
+
+const NOT_ADMIN_TITLE = 'Requires the admin role';
+
+/** An endpoint known to Portainer but not yet to the coverage table. */
+const NO_COVERAGE_RECORD_HINT =
+  'Endpoint known to Portainer with no coverage record yet — Sync Endpoints or Deploy to create one';
+
+export interface CoverageRow extends CoverageRecord {
+  /** Row synthesised from the live endpoint list, not read from the DB. */
+  synthetic?: boolean;
+}
+
+/**
+ * One row per endpoint the app knows about.
+ *
+ * The page used to render only what `/api/ebpf/coverage` returned, so before a
+ * Sync it reported an empty fleet — `Coverage: 0/0 endpoints (0%)` — while five
+ * other pages showed the live endpoint and its containers. The endpoint list
+ * was never unknown; only its coverage state was.
+ */
+export function mergeEndpointCoverage(
+  coverage: CoverageRecord[],
+  endpoints: Array<{ id: number; name: string }>,
+): CoverageRow[] {
+  const byEndpointId = new Map(coverage.map((record) => [record.endpoint_id, record]));
+
+  const rows: CoverageRow[] = endpoints.map((endpoint) => {
+    const record = byEndpointId.get(endpoint.id);
+    if (record) return record;
+    return {
+      endpoint_id: endpoint.id,
+      endpoint_name: endpoint.name,
+      status: 'unknown',
+      exclusion_reason: null,
+      deployment_profile: null,
+      last_trace_at: null,
+      last_verified_at: null,
+      created_at: '',
+      updated_at: '',
+      synthetic: true,
+    };
+  });
+
+  // Coverage rows whose endpoint no longer exists in Portainer are exactly the
+  // stale records "Delete stale" is for — they must stay visible.
+  const liveIds = new Set(endpoints.map((endpoint) => endpoint.id));
+  for (const record of coverage) {
+    if (!liveIds.has(record.endpoint_id)) rows.push(record);
+  }
+
+  return rows;
+}
+
+export interface CoverageTotals {
+  total: number;
+  deployed: number;
+  missing: number;
+  failed: number;
+  planned: number;
+  unreachable: number;
+  incompatible: number;
+  coveragePercent: number;
+}
+
+/** Counted from the rows on screen, so the bar cannot contradict the table. */
+export function summarizeCoverage(rows: CoverageRow[]): CoverageTotals {
+  const countOf = (status: string) => rows.filter((row) => row.status === status).length;
+  const total = rows.length;
+  const deployed = countOf('deployed');
+  return {
+    total,
+    deployed,
+    missing: total - deployed,
+    failed: countOf('failed'),
+    planned: countOf('planned'),
+    unreachable: countOf('unreachable'),
+    incompatible: countOf('incompatible'),
+    coveragePercent: total === 0 ? 0 : Math.round((deployed / total) * 100),
+  };
+}
 
 function StatusIcon({ status }: { status: string }) {
   switch (status) {
@@ -69,14 +152,24 @@ function StatusIcon({ status }: { status: string }) {
   }
 }
 
-function SummaryBar() {
-  const { data: summary, isLoading } = useEbpfCoverageSummary();
-
-  if (isLoading || !summary) {
+function SummaryBar({ summary, isLoading }: { summary: CoverageTotals; isLoading: boolean }) {
+  if (isLoading) {
     return <SkeletonText lines={2} />;
   }
 
-  const missing = summary.total - summary.deployed;
+  // Every counter here is structurally zero when there are no endpoints, and
+  // the percentage is 0/0. The table's empty state already says what to do.
+  if (summary.total === 0) return null;
+
+  // Counters are suppressed at zero — the rule the unreachable/incompatible
+  // pair already followed.
+  const counters: Array<{ label: string; value: number; className?: string }> = [
+    { label: 'Missing', value: summary.missing },
+    { label: 'Failed', value: summary.failed },
+    { label: 'Planned', value: summary.planned },
+    { label: 'Unreachable', value: summary.unreachable, className: 'text-orange-600 dark:text-orange-400' },
+    { label: 'Incompatible', value: summary.incompatible },
+  ].filter((counter) => counter.value > 0);
 
   return (
     <SpotlightCard>
@@ -90,34 +183,14 @@ function SummaryBar() {
           Coverage: {summary.deployed}/{summary.total} endpoints ({summary.coveragePercent}%)
         </span>
       </div>
-      <span className="text-sm text-muted-foreground">|</span>
-      <span className="text-sm text-muted-foreground">
-        Missing: {missing}
-      </span>
-      <span className="text-sm text-muted-foreground">|</span>
-      <span className="text-sm text-muted-foreground">
-        Failed: {summary.failed}
-      </span>
-      <span className="text-sm text-muted-foreground">|</span>
-      <span className="text-sm text-muted-foreground">
-        Planned: {summary.planned}
-      </span>
-      {(summary.unreachable > 0) && (
-        <>
-          <span className="text-sm text-muted-foreground">|</span>
-          <span className="text-sm text-orange-600 dark:text-orange-400">
-            Unreachable: {summary.unreachable}
+      {counters.map((counter) => (
+        <span key={counter.label} className="flex items-center gap-4">
+          <span className="text-sm text-muted-foreground" aria-hidden="true">|</span>
+          <span className={`text-sm ${counter.className ?? 'text-muted-foreground'}`}>
+            {counter.label}: {counter.value}
           </span>
-        </>
-      )}
-      {(summary.incompatible > 0) && (
-        <>
-          <span className="text-sm text-muted-foreground">|</span>
-          <span className="text-sm text-muted-foreground">
-            Incompatible: {summary.incompatible}
-          </span>
-        </>
-      )}
+        </span>
+      ))}
     </div>
     </SpotlightCard>
   );
@@ -125,8 +198,11 @@ function SummaryBar() {
 
 function CoverageRow({
   record,
+  canMutate,
 }: {
-  record: CoverageRecord;
+  record: CoverageRow;
+  /** Every action below is `requireRole('admin')` on the backend. */
+  canMutate: boolean;
 }) {
   const [pendingAction, setPendingAction] = useState<null | {
     action: 'deploy' | 'disable' | 'enable' | 'remove' | 'delete_stale';
@@ -134,6 +210,7 @@ function CoverageRow({
     description: string;
     destructive?: boolean;
   }>(null);
+  const [showOverflow, setShowOverflow] = useState(false);
   const [deployOtlpEndpoint, setDeployOtlpEndpoint] = useState(record.otlp_endpoint_override || '');
 
   const verifyMutation = useVerifyCoverage();
@@ -142,7 +219,7 @@ function CoverageRow({
   const enableMutation = useEnableBeyla();
   const removeMutation = useRemoveBeyla();
   const deleteStaleMutation = useDeleteStaleCoverage();
-  const hint = STATUS_HINTS[record.status];
+  const hint = record.synthetic ? NO_COVERAGE_RECORD_HINT : STATUS_HINTS[record.status];
   const mutationPending =
     verifyMutation.isPending ||
     deployMutation.isPending ||
@@ -196,6 +273,7 @@ function CoverageRow({
   };
 
   const openDeleteStaleDialog = () => {
+    setShowOverflow(false);
     setPendingAction({
       action: 'delete_stale',
       title: `Delete stale endpoint ${record.endpoint_name}?`,
@@ -263,10 +341,16 @@ function CoverageRow({
           <div className="flex flex-nowrap items-center gap-2">
             <button
               onClick={() => verifyMutation.mutate(record.endpoint_id)}
-              disabled={mutationPending || record.status === 'incompatible'}
+              disabled={!canMutate || mutationPending || record.status === 'incompatible'}
               className="rounded-md border border-border px-3 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
               data-testid="verify-btn"
-              title={record.status === 'incompatible' ? 'Cannot verify incompatible endpoints' : 'Verify trace ingestion'}
+              title={
+                !canMutate
+                  ? NOT_ADMIN_TITLE
+                  : record.status === 'incompatible'
+                    ? 'Cannot verify incompatible endpoints'
+                    : 'Verify trace ingestion'
+              }
             >
               <span className="inline-flex items-center gap-1">
                 <CheckCircle2 className="h-3 w-3" />
@@ -275,40 +359,69 @@ function CoverageRow({
             </button>
             <button
               onClick={() => openActionDialog(canDisable ? 'disable' : 'enable')}
-              disabled={mutationPending || !canToggle}
+              disabled={!canMutate || mutationPending || !canToggle}
               className="rounded-md border border-border px-3 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
               data-testid="toggle-btn"
+              title={canMutate ? undefined : NOT_ADMIN_TITLE}
             >
               {canDisable ? 'Disable' : 'Enable'}
             </button>
             {showRemoveToggle ? (
               <button
                 onClick={() => openActionDialog('remove')}
-                disabled={mutationPending}
+                disabled={!canMutate || mutationPending}
                 className="rounded-md border border-red-300 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950/40"
                 data-testid="remove-btn"
+                title={canMutate ? 'Stops and removes the Beyla container' : NOT_ADMIN_TITLE}
               >
                 Remove
               </button>
             ) : (
               <button
                 onClick={() => openActionDialog('deploy')}
-                disabled={mutationPending || !canDeploy}
+                disabled={!canMutate || mutationPending || !canDeploy}
                 className="rounded-md border border-border px-3 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
                 data-testid="deploy-btn"
+                title={canMutate ? undefined : NOT_ADMIN_TITLE}
               >
                 Deploy
               </button>
             )}
-            <button
-              onClick={openDeleteStaleDialog}
-              disabled={mutationPending}
-              className="rounded-md border border-border px-3 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
-              data-testid="delete-stale-btn"
-              title="Delete stale coverage record"
-            >
-              Delete stale
-            </button>
+            {/* "Delete stale" removes a database row; "Remove" tears down a
+                deployed tracer. They no longer sit side by side looking alike. */}
+            {!record.synthetic && (
+              <div className="relative">
+                <button
+                  onClick={() => setShowOverflow((prev) => !prev)}
+                  disabled={!canMutate || mutationPending}
+                  aria-expanded={showOverflow}
+                  aria-haspopup="menu"
+                  className="rounded-md border border-border px-2 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+                  data-testid="row-overflow-btn"
+                  title={canMutate ? 'More actions' : NOT_ADMIN_TITLE}
+                >
+                  <MoreHorizontal className="h-3 w-3" aria-hidden="true" />
+                  <span className="sr-only">More actions for {record.endpoint_name}</span>
+                </button>
+                {showOverflow && (
+                  <div
+                    role="menu"
+                    className="absolute right-0 z-10 mt-1 w-48 rounded-md border border-border bg-card p-1 shadow-lg"
+                    onKeyDown={(e) => { if (e.key === 'Escape') setShowOverflow(false); }}
+                  >
+                    <button
+                      role="menuitem"
+                      onClick={openDeleteStaleDialog}
+                      className="w-full rounded px-2 py-1.5 text-left text-xs font-medium hover:bg-muted"
+                      data-testid="delete-stale-btn"
+                      title="Deletes the dashboard's coverage row only"
+                    >
+                      Delete stale record
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </td>
       </tr>
@@ -350,34 +463,38 @@ function CoverageRow({
 
 export default function EbpfCoveragePage() {
   const { data, isLoading: coverageLoading, isPending: coveragePending } = useEbpfCoverage();
+  const { data: endpoints, isLoading: endpointsLoading } = useEndpoints();
+  const { role } = useAuth();
+  const canMutate = role === 'admin';
   // Treat both isLoading and isPending-without-data as "loading" to avoid
   // rendering a blank page during SPA navigation before data arrives.
-  const isLoading = coverageLoading || (coveragePending && !data);
+  const isLoading = coverageLoading || (coveragePending && !data) || endpointsLoading;
   const syncMutation = useSyncCoverage();
 
+  const rows = mergeEndpointCoverage(data?.coverage ?? [], endpoints ?? []);
+  const summary = summarizeCoverage(rows);
+
   return (
-    <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">eBPF Coverage</h1>
-          <p className="text-sm text-muted-foreground">
-            Track Beyla (eBPF tracer) deployment status across all Portainer endpoints.
-          </p>
-        </div>
-        <button
-          onClick={() => syncMutation.mutate()}
-          disabled={syncMutation.isPending}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-          data-testid="sync-btn"
-        >
-          <RefreshCw className={`h-4 w-4 ${syncMutation.isPending ? 'animate-spin' : ''}`} />
-          Sync Endpoints
-        </button>
-      </div>
+    <div className="space-y-6">
+      <PageHeader
+        title="eBPF Coverage"
+        subtitle="Track Beyla (eBPF tracer) deployment status across all Portainer endpoints."
+        actions={
+          <button
+            onClick={() => syncMutation.mutate()}
+            disabled={!canMutate || syncMutation.isPending}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            data-testid="sync-btn"
+            title={canMutate ? undefined : NOT_ADMIN_TITLE}
+          >
+            <RefreshCw className={`h-4 w-4 ${syncMutation.isPending ? 'animate-spin' : ''}`} />
+            Sync Endpoints
+          </button>
+        }
+      />
 
       {/* Summary bar */}
-      <SummaryBar />
+      <SummaryBar summary={summary} isLoading={isLoading} />
 
       {/* Coverage table */}
       {isLoading ? (
@@ -406,11 +523,12 @@ export default function EbpfCoveragePage() {
               </tr>
             </thead>
             <tbody>
-              {data?.coverage && data.coverage.length > 0 ? (
-                data.coverage.map((record) => (
+              {rows.length > 0 ? (
+                rows.map((record) => (
                   <CoverageRow
                     key={record.endpoint_id}
                     record={record}
+                    canMutate={canMutate}
                   />
                 ))
               ) : (

--- a/frontend/src/features/security/pages/harbor-vulnerabilities.test.tsx
+++ b/frontend/src/features/security/pages/harbor-vulnerabilities.test.tsx
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactElement } from 'react';
 import HarborVulnerabilitiesPage from './harbor-vulnerabilities';
+
+// The page links into Settings, so it needs a router in scope.
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 vi.mock('@/features/security/hooks/use-harbor-vulnerabilities', () => ({
   useHarborStatus: vi.fn(() => ({
@@ -90,9 +97,10 @@ vi.mock('@/features/security/hooks/use-harbor-vulnerabilities', () => ({
 }));
 
 describe('HarborVulnerabilitiesPage', () => {
-  it('renders the page title', () => {
+  it('titles the page the way the nav names it', () => {
     render(<HarborVulnerabilitiesPage />);
-    expect(screen.getByText('Vulnerability Management')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Vulnerabilities' })).toBeInTheDocument();
+    expect(screen.queryByText('Vulnerability Management')).not.toBeInTheDocument();
   });
 
   it('renders summary cards', () => {
@@ -270,5 +278,26 @@ describe('HarborVulnerabilitiesPage (not configured)', () => {
 
     render(<HarborVulnerabilitiesPage />);
     expect(screen.getByText('Harbor Not Configured')).toBeInTheDocument();
+  });
+
+  it('states the consequence and ships a CTA to the page that fixes it', async () => {
+    const mod = await import('@/features/security/hooks/use-harbor-vulnerabilities');
+    vi.mocked(mod.useHarborStatus).mockReturnValueOnce({
+      data: { configured: false, connected: false, lastSync: null },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as ReturnType<typeof mod.useHarborStatus>);
+
+    render(<HarborVulnerabilitiesPage />);
+
+    // Fact, consequence, next action — the NoTraceDataCallout shape.
+    expect(screen.getByText(/no CVEs to prioritise against your running containers/)).toBeInTheDocument();
+    expect(screen.getByText(/Settings take precedence over the environment variables/)).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: /Configure Harbor/ });
+    expect(cta).toHaveAttribute('href', '/settings?tab=integrations');
+    // The env vars are still named — the previous copy named only them.
+    expect(screen.getByText('HARBOR_API_URL')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
+++ b/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { type ColumnDef } from '@tanstack/react-table';
 import {
-  Shield, ShieldAlert, ShieldCheck, Search, RefreshCw,
+  Shield, ShieldAlert, ShieldCheck, Search, RefreshCw, ArrowRight,
   ExternalLink, AlertTriangle, CheckCircle2, Package, Bug,
 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { formatRelativeTime } from '@/shared/lib/format-relative-time';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { DataTable } from '@/shared/components/tables/data-table';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
 import {
   useHarborStatus,
@@ -207,20 +209,41 @@ export default function HarborVulnerabilitiesPage() {
   if (status && !status.configured) {
     return (
       <div className="space-y-4">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Vulnerability Management</h1>
-          <p className="text-muted-foreground">Harbor Registry integration for image vulnerability tracking.</p>
-        </div>
+        <PageHeader
+          title="Vulnerabilities"
+          subtitle="Harbor is not connected, so no image CVEs are being tracked."
+        />
         <SpotlightCard>
-        <div className="rounded-lg border bg-card p-6 shadow-sm text-center">
-          <ShieldAlert className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-          <h2 className="text-xl font-semibold mb-2">Harbor Not Configured</h2>
-          <p className="text-muted-foreground max-w-md mx-auto">
-            Set <code className="text-xs bg-muted px-1 py-0.5 rounded">HARBOR_API_URL</code>,{' '}
-            <code className="text-xs bg-muted px-1 py-0.5 rounded">HARBOR_ROBOT_NAME</code>, and{' '}
-            <code className="text-xs bg-muted px-1 py-0.5 rounded">HARBOR_ROBOT_SECRET</code> environment
-            variables to connect to your Harbor registry.
-          </p>
+        <div
+          className="rounded-lg border bg-card p-6 shadow-sm"
+          data-testid="harbor-not-configured"
+        >
+          <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                <ShieldAlert className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold">Harbor Not Configured</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Without a registry connection this page has no CVEs to prioritise against your
+                  running containers. Connect Harbor in Settings → Integrations, or set{' '}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs">HARBOR_API_URL</code>,{' '}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs">HARBOR_ROBOT_NAME</code>{' '}
+                  and{' '}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs">HARBOR_ROBOT_SECRET</code>{' '}
+                  in the environment. Settings take precedence over the environment variables.
+                </p>
+              </div>
+            </div>
+            <Link
+              to="/settings?tab=integrations"
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              Configure Harbor
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </div>
         </div>
         </SpotlightCard>
       </div>
@@ -229,28 +252,31 @@ export default function HarborVulnerabilitiesPage() {
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Vulnerability Management</h1>
-          <p className="text-muted-foreground">
-            Harbor Registry vulnerabilities prioritized by running workloads.
+      <PageHeader
+        title="Vulnerabilities"
+        subtitle={(
+          <>
+            {summary
+              ? `${summary.in_use_critical} critical CVEs in running images · ${summary.total.toLocaleString()} tracked`
+              : 'Harbor CVEs, prioritised by what is actually running.'}
             {status?.lastSync?.completed_at && (
-              <span className="ml-2 text-xs">
-                Last sync: {formatTimeAgo(status.lastSync.completed_at)}
+              <span className="ml-2">
+                Last sync {formatTimeAgo(status.lastSync.completed_at)}
               </span>
             )}
-          </p>
-        </div>
-        <button
-          onClick={() => triggerSync.mutate()}
-          disabled={triggerSync.isPending}
-          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-        >
-          <RefreshCw className={cn('h-4 w-4', triggerSync.isPending && 'animate-spin')} />
-          {triggerSync.isPending ? 'Syncing...' : 'Sync Now'}
-        </button>
-      </div>
+          </>
+        )}
+        actions={(
+          <button
+            onClick={() => triggerSync.mutate()}
+            disabled={triggerSync.isPending}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            <RefreshCw className={cn('h-4 w-4', triggerSync.isPending && 'animate-spin')} />
+            {triggerSync.isPending ? 'Syncing...' : 'Sync Now'}
+          </button>
+        )}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/frontend/src/features/security/pages/packet-capture.test.tsx
+++ b/frontend/src/features/security/pages/packet-capture.test.tsx
@@ -276,6 +276,66 @@ describe('PacketCapture', () => {
     // Download is a read and stays available.
     expect(within(table).getByTitle('Download PCAP')).toBeEnabled();
   });
+
+  // The analysis panel: a confidence badge must reflect what the model said,
+  // and say nothing when the model said nothing.
+  describe('analysis confidence badge', () => {
+    // `analysis_result` is a JSONB column and the pg driver parses it, so the
+    // API sends an OBJECT. Using a JSON string here would test a shape the
+    // server never returns — which is how a `JSON.parse` on the parsed object
+    // went unnoticed while hiding this entire panel.
+    function analysisPayload(confidence: number | null) {
+      return {
+        health_status: 'degraded',
+        summary: 'Retransmissions above baseline',
+        findings: [],
+        confidence_score: confidence,
+      };
+    }
+
+    function renderWithAnalysis(confidence: number | null, asJsonString = false) {
+      const payload = analysisPayload(confidence);
+      mockUseCaptures.mockReturnValue({
+        data: {
+          captures: [
+            makeCapture({
+              id: 'cap-analysis',
+              analysis_result: asJsonString ? JSON.stringify(payload) : payload,
+            }),
+          ],
+        },
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useCaptures>);
+
+      render(<PacketCapture />);
+      fireEvent.click(screen.getByTitle('Toggle analysis'));
+    }
+
+    it('renders the panel from the parsed-JSONB object the API actually sends', () => {
+      renderWithAnalysis(0.82);
+      expect(screen.getByText('Retransmissions above baseline')).toBeInTheDocument();
+    });
+
+    it('still accepts a JSON string, for tolerance', () => {
+      renderWithAnalysis(0.82, true);
+      expect(screen.getByText('Retransmissions above baseline')).toBeInTheDocument();
+    });
+
+    it('shows the score the model supplied', () => {
+      renderWithAnalysis(0.82);
+      expect(screen.getByText('Confidence: 82%')).toBeInTheDocument();
+    });
+
+    it('omits the badge entirely when the model supplied no score', () => {
+      // Not "Confidence: 0%" — `null * 100` is 0, so an unguarded render turns
+      // "we do not know" into a confident zero, which is worse than the 50%
+      // default this replaced.
+      renderWithAnalysis(null);
+      expect(screen.getByText('Retransmissions above baseline')).toBeInTheDocument();
+      expect(screen.queryByText(/^Confidence:/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Confidence: 0%/)).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('captureStatusGroup', () => {

--- a/frontend/src/features/security/pages/packet-capture.test.tsx
+++ b/frontend/src/features/security/pages/packet-capture.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { useCaptures, type Capture } from '@/features/security/hooks/use-pcap';
 
@@ -64,7 +64,12 @@ vi.mock('@/shared/lib/api', () => ({
   },
 }));
 
-import PacketCapture from './packet-capture';
+let mockRole: 'admin' | 'operator' | 'viewer' = 'admin';
+vi.mock('@/providers/auth-provider', () => ({
+  useAuth: () => ({ role: mockRole, username: 'tester', isAuthenticated: true }),
+}));
+
+import PacketCapture, { captureStatusGroup, filterCapturesByGroup } from './packet-capture';
 
 const mockUseCaptures = vi.mocked(useCaptures);
 
@@ -95,6 +100,14 @@ function makeCapture(overrides: Partial<Capture> = {}): Capture {
 }
 
 describe('PacketCapture', () => {
+  beforeEach(() => {
+    mockRole = 'admin';
+    mockUseCaptures.mockReturnValue({
+      data: { captures: [] },
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useCaptures>);
+  });
+
   it('shows capture targets without selecting an endpoint first', () => {
     render(<PacketCapture />);
     const input = screen.getByLabelText('Search capture target container');
@@ -103,17 +116,95 @@ describe('PacketCapture', () => {
     expect(screen.getByText('api-1')).toBeInTheDocument();
   });
 
-  it('disables Start until a target is selected', () => {
+  it('renders one h1 matching the navigation label', () => {
     render(<PacketCapture />);
-    expect(screen.getByRole('button', { name: /start capture/i })).toBeDisabled();
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveTextContent('Packet Capture');
   });
 
-  it('shows the empty state when there are no captures', () => {
-    mockUseCaptures.mockReturnValue({ data: { captures: [] }, refetch: vi.fn() } as unknown as ReturnType<typeof useCaptures>);
+  it('disables Start until a target is selected, and says why', () => {
     render(<PacketCapture />);
 
-    expect(screen.getByText('No captures found')).toBeInTheDocument();
+    const start = screen.getByRole('button', { name: /start capture/i });
+    expect(start).toBeDisabled();
+    expect(start).toHaveAttribute('title', 'Select a target container');
+    // A disabled primary must not be a faded primary — it has to read as
+    // muted surface + muted text.
+    expect(start.className).toContain('bg-muted');
+    expect(start.className).not.toContain('bg-primary');
+    expect(screen.getByText('Select a target container')).toBeInTheDocument();
+  });
+
+  it('disables Start for a non-admin and names the reason', () => {
+    mockRole = 'viewer';
+    render(<PacketCapture />);
+
+    const start = screen.getByRole('button', { name: /start capture/i });
+    expect(start).toBeDisabled();
+    expect(start).toHaveAttribute('title', 'Requires the admin role');
+    expect(screen.getByText('Requires the admin role')).toBeInTheDocument();
+  });
+
+  it('shows the first-run guidance when there are no captures at all', () => {
+    render(<PacketCapture />);
+
+    // Search-result framing replaced with what an operator needs before their
+    // first capture.
+    expect(screen.queryByText('No captures found')).not.toBeInTheDocument();
+    expect(screen.getByText('No captures yet')).toBeInTheDocument();
+    expect(screen.getByText(/docker exec/)).toBeInTheDocument();
+    expect(screen.getByText(/pcap volume/)).toBeInTheDocument();
     expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
+  });
+
+  describe('status tabs', () => {
+    it('offers four groups and never Complete alongside Succeeded', () => {
+      render(<PacketCapture />);
+
+      for (const label of ['All', 'Running', 'Finished', 'Failed']) {
+        expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+      }
+      expect(screen.queryByRole('button', { name: 'Complete' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Succeeded' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Active' })).not.toBeInTheDocument();
+    });
+
+    it('lands both complete and succeeded captures in the same Finished tab', () => {
+      mockUseCaptures.mockReturnValue({
+        data: {
+          captures: [
+            makeCapture({ id: 'a-1', container_name: 'done-complete', status: 'complete' }),
+            makeCapture({ id: 'b-2', container_name: 'done-succeeded', status: 'succeeded' }),
+            makeCapture({ id: 'c-3', container_name: 'broken', status: 'failed' }),
+          ],
+        },
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useCaptures>);
+
+      render(<PacketCapture />);
+      fireEvent.click(screen.getByRole('button', { name: 'Finished' }));
+
+      const table = screen.getByTestId('data-table');
+      expect(within(table).getByText('done-complete')).toBeInTheDocument();
+      expect(within(table).getByText('done-succeeded')).toBeInTheDocument();
+      expect(within(table).queryByText('broken')).not.toBeInTheDocument();
+    });
+
+    it('tells the operator where the rest of their history went', () => {
+      mockUseCaptures.mockReturnValue({
+        data: { captures: [makeCapture({ id: 'a-1', status: 'complete' })] },
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useCaptures>);
+
+      render(<PacketCapture />);
+      fireEvent.click(screen.getByRole('button', { name: 'Failed' }));
+
+      expect(screen.getByText('No failed captures')).toBeInTheDocument();
+      expect(screen.getByText(/1 capture in history/)).toBeInTheDocument();
+      // Not the first-run guidance — there IS history, just not in this tab.
+      expect(screen.queryByText('No captures yet')).not.toBeInTheDocument();
+    });
   });
 
   it('renders the capture history in a DataTable with column headers and row data', () => {
@@ -165,5 +256,63 @@ describe('PacketCapture', () => {
     } as unknown as ReturnType<typeof useCaptures>);
     render(<PacketCapture />);
     expect(screen.getByText('local')).toBeInTheDocument();
+  });
+
+  it('disables the destructive row actions for a non-admin', () => {
+    mockRole = 'viewer';
+    mockUseCaptures.mockReturnValue({
+      data: { captures: [makeCapture({ id: 'aaaaaaaa-1111', container_name: 'web-1' })] },
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useCaptures>);
+
+    render(<PacketCapture />);
+    const table = screen.getByTestId('data-table');
+
+    // Every mutating pcap route is requireRole('admin') on the backend; the
+    // page used to show a live Delete/Stop/Analyze to a viewer regardless.
+    const gated = within(table).getAllByTitle('Requires the admin role');
+    expect(gated.length).toBeGreaterThan(0);
+    for (const button of gated) expect(button).toBeDisabled();
+    // Download is a read and stays available.
+    expect(within(table).getByTitle('Download PCAP')).toBeEnabled();
+  });
+});
+
+describe('captureStatusGroup', () => {
+  it('folds every in-flight status into one group', () => {
+    expect(captureStatusGroup('pending')).toBe('running');
+    expect(captureStatusGroup('capturing')).toBe('running');
+    expect(captureStatusGroup('processing')).toBe('running');
+  });
+
+  // The page's own action logic already treated these as synonyms; the tab row
+  // was the only place that pretended they were different.
+  it('folds complete and succeeded into one group', () => {
+    expect(captureStatusGroup('complete')).toBe('finished');
+    expect(captureStatusGroup('succeeded')).toBe('finished');
+  });
+
+  it('groups failure on its own', () => {
+    expect(captureStatusGroup('failed')).toBe('failed');
+  });
+});
+
+describe('filterCapturesByGroup', () => {
+  const captures = [
+    makeCapture({ id: '1', status: 'complete' }),
+    makeCapture({ id: '2', status: 'succeeded' }),
+    makeCapture({ id: '3', status: 'capturing' }),
+    makeCapture({ id: '4', status: 'pending' }),
+    makeCapture({ id: '5', status: 'failed' }),
+  ];
+
+  it('returns everything for the All tab, untouched', () => {
+    expect(filterCapturesByGroup(captures, 'all')).toBe(captures);
+  });
+
+  it('narrows to each group', () => {
+    expect(filterCapturesByGroup(captures, 'finished').map((c) => c.id)).toEqual(['1', '2']);
+    expect(filterCapturesByGroup(captures, 'running').map((c) => c.id)).toEqual(['3', '4']);
+    expect(filterCapturesByGroup(captures, 'failed').map((c) => c.id)).toEqual(['5']);
   });
 });

--- a/frontend/src/features/security/pages/packet-capture.tsx
+++ b/frontend/src/features/security/pages/packet-capture.tsx
@@ -36,8 +36,16 @@ import {
 import { CaptureTargetPicker, type CaptureTarget } from '@/features/security/components/capture-target-picker';
 import { CaptureBrowseFallback } from '@/features/security/components/capture-browse-fallback';
 import { BpfFilterInput } from '@/features/security/components/bpf-filter-input';
+import { PageHeader } from '@/shared/components/layout/page-header';
+import { findDestination } from '@/features/core/lib/navigation-manifest';
+import { useAuth } from '@/providers/auth-provider';
 import { cn } from '@/shared/lib/utils';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
+
+const PAGE_TITLE = findDestination('/packet-capture')?.label ?? 'Packet Capture';
+
+/** Every mutating pcap route is `requireRole('admin')` on the backend. */
+const NOT_ADMIN_REASON = 'Requires the admin role';
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
@@ -55,20 +63,53 @@ function formatElapsed(startedAt: string | null): string {
   return mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
 }
 
-const STATUS_TABS = [
-  { label: 'All', value: undefined },
-  { label: 'Active', value: 'capturing' },
-  { label: 'Complete', value: 'complete' },
-  { label: 'Succeeded', value: 'succeeded' },
+/**
+ * Four groups, not five raw enum values.
+ *
+ * The tab row used to expose **Complete** and **Succeeded** as separate
+ * filters while the page's own action logic treated them as synonyms
+ * (`status === 'complete' || status === 'succeeded'`). An internal enum
+ * duplication was handed to the operator, who had no way to know which tab
+ * their capture would land in. The grouping now lives in one place and the
+ * action logic reads from it.
+ */
+export type CaptureStatusGroup = 'running' | 'finished' | 'failed';
+
+export function captureStatusGroup(status: Capture['status']): CaptureStatusGroup {
+  switch (status) {
+    case 'pending':
+    case 'capturing':
+    case 'processing':
+      return 'running';
+    case 'complete':
+    case 'succeeded':
+      return 'finished';
+    default:
+      return 'failed';
+  }
+}
+
+export function filterCapturesByGroup(
+  captures: Capture[],
+  group: CaptureStatusGroup | 'all',
+): Capture[] {
+  if (group === 'all') return captures;
+  return captures.filter((c) => captureStatusGroup(c.status) === group);
+}
+
+const STATUS_TABS: { label: string; value: CaptureStatusGroup | 'all' }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Running', value: 'running' },
+  { label: 'Finished', value: 'finished' },
   { label: 'Failed', value: 'failed' },
-] as const;
+];
 
 export default function PacketCapture() {
   const [target, setTarget] = useState<CaptureTarget | null>(null);
   const [bpfFilter, setBpfFilter] = useState('');
   const [duration, setDuration] = useState('60');
   const [maxPackets, setMaxPackets] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string | undefined>();
+  const [statusFilter, setStatusFilter] = useState<CaptureStatusGroup | 'all'>('all');
   const [historySearch, setHistorySearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   useEffect(() => {
@@ -79,8 +120,9 @@ export default function PacketCapture() {
   const { data: endpoints } = useEndpoints();
   const { data: containers } = useContainers({ state: 'running' });
   const { data: stacks } = useStacks();
+  // The status tabs are groups, not raw enum values, so the narrowing happens
+  // here rather than as a server-side `status=` that can only match one value.
   const { data: capturesData, refetch, isFetching } = useCaptures({
-    status: statusFilter,
     search: debouncedSearch || undefined,
   });
   const [expandedAnalysis, setExpandedAnalysis] = useState<Set<string>>(new Set());
@@ -89,10 +131,16 @@ export default function PacketCapture() {
   const deleteCapture = useDeleteCapture();
   const analyzeMutation = useAnalyzeCapture();
 
-  const captures = capturesData?.captures ?? [];
-  const activeCaptures = captures.filter(
-    (c) => c.status === 'capturing' || c.status === 'pending' || c.status === 'processing',
+  const { role } = useAuth();
+  const canCapture = role === 'admin';
+
+  const allCaptures = capturesData?.captures ?? [];
+  const captures = useMemo(
+    () => filterCapturesByGroup(allCaptures, statusFilter),
+    [allCaptures, statusFilter],
   );
+  const activeCaptures = allCaptures.filter((c) => captureStatusGroup(c.status) === 'running');
+  const hasAnyCaptures = allCaptures.length > 0;
   const edgeAsyncEndpointIds = useMemo(
     () => new Set((endpoints ?? []).filter((e) => e.edgeMode === 'async').map((e) => e.id)),
     [endpoints],
@@ -106,8 +154,21 @@ export default function PacketCapture() {
   const runningContainers = containers ?? [];
   const targetIsEdgeAsync = target ? edgeAsyncEndpointIds.has(target.endpointId) : false;
 
+  /**
+   * Why Start is disabled, or `null` when it is not. A disabled primary that
+   * never says why is a dead end — the operator cannot tell whether the button
+   * is broken or whether they have missed a step.
+   */
+  const startDisabledReason: string | null = !canCapture
+    ? NOT_ADMIN_REASON
+    : !target
+      ? 'Select a target container'
+      : targetIsEdgeAsync
+        ? 'Edge Async endpoints cannot run docker exec'
+        : null;
+
   const handleStartCapture = () => {
-    if (!target || targetIsEdgeAsync) return;
+    if (!target || targetIsEdgeAsync || !canCapture) return;
 
     startCapture.mutate({
       endpointId: target.endpointId,
@@ -219,8 +280,9 @@ export default function PacketCapture() {
       enableSorting: false,
       cell: ({ row }) => {
         const capture = row.original;
-        const isActive = capture.status === 'capturing' || capture.status === 'pending' || capture.status === 'processing';
-        const hasFile = capture.capture_file && (capture.status === 'complete' || capture.status === 'succeeded');
+        const group = captureStatusGroup(capture.status);
+        const isActive = group === 'running';
+        const hasFile = Boolean(capture.capture_file) && group === 'finished';
         const canAnalyze = hasFile && !isActive;
         const isAnalyzing = analyzePending && analyzeVariables === capture.id;
         return (
@@ -228,8 +290,9 @@ export default function PacketCapture() {
             {isActive && (
               <button
                 onClick={() => handleStop(capture.id)}
-                className="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                title="Stop capture"
+                disabled={!canCapture}
+                className="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:text-muted-foreground/50 disabled:hover:bg-transparent"
+                title={canCapture ? 'Stop capture' : NOT_ADMIN_REASON}
               >
                 <Square className="h-4 w-4" />
               </button>
@@ -237,9 +300,9 @@ export default function PacketCapture() {
             {canAnalyze && (
               <button
                 onClick={() => handleAnalyze(capture.id)}
-                disabled={isAnalyzing}
-                className="rounded p-1.5 text-muted-foreground hover:bg-purple-500/10 hover:text-purple-500"
-                title="Analyze with AI"
+                disabled={isAnalyzing || !canCapture}
+                className="rounded p-1.5 text-muted-foreground hover:bg-purple-500/10 hover:text-purple-500 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                title={canCapture ? 'Analyze with AI' : NOT_ADMIN_REASON}
               >
                 {isAnalyzing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Brain className="h-4 w-4" />}
               </button>
@@ -256,8 +319,9 @@ export default function PacketCapture() {
             {!isActive && (
               <button
                 onClick={() => handleDelete(capture.id)}
-                className="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                title="Delete capture"
+                disabled={!canCapture}
+                className="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:text-muted-foreground/50 disabled:hover:bg-transparent"
+                title={canCapture ? 'Delete capture' : NOT_ADMIN_REASON}
               >
                 <Trash2 className="h-4 w-4" />
               </button>
@@ -266,7 +330,7 @@ export default function PacketCapture() {
         );
       },
     },
-  ], [endpointNameById, expandedAnalysis, toggleExpand, handleStop, handleDelete, handleDownload, handleAnalyze, analyzePending, analyzeVariables]);
+  ], [endpointNameById, expandedAnalysis, toggleExpand, handleStop, handleDelete, handleDownload, handleAnalyze, analyzePending, analyzeVariables, canCapture]);
 
   const expandedCaptures = useMemo(
     () =>
@@ -279,19 +343,11 @@ export default function PacketCapture() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold">
-            <Radio className="h-6 w-6" />
-            Packet Capture
-          </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Capture network traffic from containers using tcpdump. Download PCAP files for analysis in Wireshark.
-          </p>
-        </div>
-        <RefreshButton onClick={() => refetch()} isLoading={isFetching} />
-      </div>
+      <PageHeader
+        title={PAGE_TITLE}
+        subtitle="tcpdump runs inside the target container; PCAPs download for Wireshark"
+        actions={<RefreshButton onClick={() => refetch()} isLoading={isFetching} />}
+      />
 
       {/* New Capture Form */}
       <SpotlightCard>
@@ -357,15 +413,27 @@ export default function PacketCapture() {
           </div>
 
           {/* Start Button */}
-          <div className="flex items-end">
+          <div className="flex flex-col justify-end">
             <button
               onClick={handleStartCapture}
-              disabled={!target || targetIsEdgeAsync || startCapture.isPending}
-              className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              disabled={startDisabledReason !== null || startCapture.isPending}
+              title={startDisabledReason ?? undefined}
+              className={cn(
+                'inline-flex w-full items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium',
+                // A saturated primary at `opacity-50` reads as a soft-primary
+                // button, indistinguishable from an enabled one. A disabled
+                // control has to sit on a muted surface.
+                startDisabledReason !== null || startCapture.isPending
+                  ? 'cursor-not-allowed border border-border bg-muted text-muted-foreground'
+                  : 'bg-primary text-primary-foreground hover:bg-primary/90',
+              )}
             >
               <Play className="h-4 w-4" />
               {startCapture.isPending ? 'Starting...' : 'Start Capture'}
             </button>
+            {startDisabledReason && (
+              <p className="mt-1 text-xs text-muted-foreground">{startDisabledReason}</p>
+            )}
           </div>
         </div>
       </div>
@@ -382,6 +450,7 @@ export default function PacketCapture() {
                 capture={capture}
                 onStop={() => stopCapture.mutate(capture.id)}
                 isStopping={stopCapture.isPending}
+                canStop={canCapture}
               />
             ))}
           </div>
@@ -422,10 +491,51 @@ export default function PacketCapture() {
 
         {captures.length === 0 ? (
           <SpotlightCard>
-          <div className="rounded-lg border bg-card p-6 shadow-sm text-center text-muted-foreground">
-            <Radio className="mx-auto mb-3 h-10 w-10 opacity-50" />
-            <p className="font-medium">No captures found</p>
-            <p className="text-sm">Start a new capture above to begin monitoring network traffic.</p>
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            {/*
+              The stock version read "No captures found" / "Start a new capture
+              above to begin monitoring network traffic" — search-result framing
+              for a first-run state where nothing was searched, and a second line
+              restating the form directly above it. What an operator needs before
+              their first capture is how it runs and where the file goes.
+            */}
+            {hasAnyCaptures ? (
+              <div className="text-center text-muted-foreground">
+                <Radio className="mx-auto mb-3 h-10 w-10 opacity-50" />
+                <p className="font-medium text-foreground">
+                  No {STATUS_TABS.find((t) => t.value === statusFilter)?.label.toLowerCase()}{' '}
+                  captures
+                </p>
+                <p className="text-sm">
+                  {allCaptures.length} capture{allCaptures.length !== 1 ? 's' : ''} in history.
+                  Switch to All to see {allCaptures.length !== 1 ? 'them' : 'it'}.
+                </p>
+              </div>
+            ) : (
+              <div className="mx-auto max-w-xl">
+                <div className="flex items-start gap-3">
+                  <Radio className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                  <div>
+                    <p className="font-medium">No captures yet</p>
+                    <ul className="mt-2 space-y-1.5 text-sm text-muted-foreground">
+                      <li>
+                        tcpdump runs <span className="text-foreground">inside</span> the target
+                        container via docker exec — it sees only that container&apos;s
+                        interfaces, and the container must be running.
+                      </li>
+                      <li>
+                        A capture stops at whichever comes first: the duration, the packet
+                        cap, or Stop.
+                      </li>
+                      <li>
+                        The PCAP is written to the dashboard&apos;s pcap volume and stays
+                        downloadable from this table until you delete it.
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
           </SpotlightCard>
         ) : (
@@ -463,10 +573,13 @@ function ActiveCaptureCard({
   capture,
   onStop,
   isStopping,
+  canStop,
 }: {
   capture: Capture;
   onStop: () => void;
   isStopping: boolean;
+  /** `POST /api/pcap/captures/:id/stop` is `requireRole('admin')`. */
+  canStop: boolean;
 }) {
   return (
     <SpotlightCard>
@@ -492,8 +605,14 @@ function ActiveCaptureCard({
         </div>
         <button
           onClick={onStop}
-          disabled={isStopping || capture.status === 'processing'}
-          className="inline-flex items-center gap-1.5 rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+          disabled={isStopping || capture.status === 'processing' || !canStop}
+          title={canStop ? undefined : NOT_ADMIN_REASON}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium',
+            isStopping || capture.status === 'processing' || !canStop
+              ? 'cursor-not-allowed border border-border bg-muted text-muted-foreground'
+              : 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+          )}
         >
           <Square className="h-3 w-3" />
           Stop

--- a/frontend/src/features/security/pages/packet-capture.tsx
+++ b/frontend/src/features/security/pages/packet-capture.tsx
@@ -624,9 +624,17 @@ function ActiveCaptureCard({
 }
 
 function parseAnalysis(capture: Capture): PcapAnalysisResult | null {
-  if (!capture.analysis_result) return null;
+  const raw: unknown = capture.analysis_result;
+  if (!raw) return null;
+  // `pcap_captures.analysis_result` is JSONB, and the pg driver already parses
+  // that column into an object — so the value arriving here is normally NOT a
+  // string, and calling JSON.parse on it threw for every stored analysis,
+  // silently hiding the whole panel. Accept both shapes: the object the API
+  // actually sends, and a string in case a caller stringifies it.
+  if (typeof raw === 'object') return raw as PcapAnalysisResult;
+  if (typeof raw !== 'string') return null;
   try {
-    return JSON.parse(capture.analysis_result) as PcapAnalysisResult;
+    return JSON.parse(raw) as PcapAnalysisResult;
   } catch {
     return null;
   }
@@ -700,9 +708,17 @@ function AnalysisPanel({ analysis, onReanalyze, isAnalyzing }: { analysis: PcapA
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <HealthBadge status={analysis.health_status} />
-          <span className="text-xs text-muted-foreground">
-            Confidence: {Math.round(analysis.confidence_score * 100)}%
-          </span>
+          {/*
+            Omitted entirely when the model supplied no score, matching the
+            remediation panel. Rendering it unguarded is worse than the default
+            it replaced: `null * 100` is 0, so the badge would read a confident
+            "Confidence: 0%" precisely where nothing was measured.
+          */}
+          {analysis.confidence_score !== null && (
+            <span className="text-xs text-muted-foreground">
+              Confidence: {Math.round(analysis.confidence_score * 100)}%
+            </span>
+          )}
         </div>
         <button
           onClick={onReanalyze}

--- a/frontend/src/features/security/pages/security-audit.test.tsx
+++ b/frontend/src/features/security/pages/security-audit.test.tsx
@@ -1,15 +1,21 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 import type { ReactElement } from 'react';
 import SecurityAuditPage from './security-audit';
 
 function renderWithClient(ui: ReactElement) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </MemoryRouter>,
+  );
 }
 
-const mockEntries = [
+// `let` so a test can append a host-namespace container without redefining the fixture.
+const mockEntries: Array<Record<string, unknown>> = [
   {
     containerId: 'c1',
     containerName: 'api',
@@ -60,10 +66,79 @@ describe('SecurityAuditPage', () => {
   it('renders audit table and findings', () => {
     renderWithClient(<SecurityAuditPage />);
 
-    expect(screen.getByText('Security Audit')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Security Audit' })).toBeInTheDocument();
     expect(screen.getByText('api')).toBeInTheDocument();
     expect(screen.getByText('NET_ADMIN')).toBeInTheDocument();
     expect(screen.getByText('warning')).toBeInTheDocument();
+  });
+
+  it('leads with the posture answer instead of burying it under the table', () => {
+    renderWithClient(<SecurityAuditPage />);
+
+    expect(screen.getByTestId('page-header-subtitle')).toHaveTextContent(
+      '1 of 2 containers have added capabilities, privileged mode, or a host namespace',
+    );
+    expect(screen.getByTestId('posture-summary')).toBeInTheDocument();
+    expect(screen.getByText('Added capabilities')).toBeInTheDocument();
+  });
+
+  it('renders only exceptions by default and reveals clean containers on request', () => {
+    renderWithClient(<SecurityAuditPage />);
+
+    // redis-cache adds nothing, runs unprivileged and shares no namespace.
+    expect(screen.queryByText('redis-cache')).not.toBeInTheDocument();
+
+    const disclosure = screen.getByRole('button', { name: /Show 1 clean container/ });
+    fireEvent.click(disclosure);
+
+    expect(screen.getByText('redis-cache')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Hide 1 clean container/ })).toBeInTheDocument();
+  });
+
+  it('renders no severity badge for a container with no findings', () => {
+    renderWithClient(<SecurityAuditPage />);
+    fireEvent.click(screen.getByRole('button', { name: /Show 1 clean container/ }));
+
+    // A coloured pill reading NONE is a badge for the absence of a finding.
+    expect(screen.queryByText('none')).not.toBeInTheDocument();
+  });
+
+  it('says nothing about isolation when the container uses Docker defaults', () => {
+    renderWithClient(<SecurityAuditPage />);
+
+    expect(screen.getByRole('columnheader', { name: /Isolation/ })).toBeInTheDocument();
+    expect(screen.queryByText(/net=/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/pid=/)).not.toBeInTheDocument();
+  });
+
+  it('names a host namespace when one is actually shared', () => {
+    mockEntries.push({
+      containerId: 'c3',
+      containerName: 'node-exporter',
+      stackName: 'core',
+      endpointId: 1,
+      endpointName: 'prod',
+      state: 'running',
+      status: 'Up',
+      image: 'prom/node-exporter',
+      posture: { capAdd: [], privileged: false, networkMode: 'host', pidMode: 'host' },
+      findings: [],
+      severity: 'none',
+      ignored: false,
+    });
+    try {
+      renderWithClient(<SecurityAuditPage />);
+      expect(screen.getByText('host network, host PID namespace')).toBeInTheDocument();
+    } finally {
+      mockEntries.pop();
+    }
+  });
+
+  it('links to the page where the ignore list is actually edited', () => {
+    renderWithClient(<SecurityAuditPage />);
+
+    const link = screen.getByRole('link', { name: /Manage ignore list/ });
+    expect(link).toHaveAttribute('href', '/settings?tab=security');
   });
 
   it('renders the shared DataTable with column headers', () => {
@@ -84,7 +159,6 @@ describe('SecurityAuditPage', () => {
     renderWithClient(<SecurityAuditPage />);
 
     expect(screen.getByText('api')).toBeInTheDocument();
-    expect(screen.getByText('redis-cache')).toBeInTheDocument();
 
     fireEvent.change(screen.getByPlaceholderText('Search containers by name or image...'), { target: { value: 'redis' } });
 

--- a/frontend/src/features/security/pages/security-audit.tsx
+++ b/frontend/src/features/security/pages/security-audit.tsx
@@ -1,11 +1,13 @@
 import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { type ColumnDef } from '@tanstack/react-table';
-import { Search, ShieldAlert } from 'lucide-react';
+import { ChevronDown, ChevronRight, Search, ShieldAlert, SlidersHorizontal } from 'lucide-react';
 import { useSecurityAudit, type SecurityAuditEntry } from '@/features/security/hooks/use-security-audit';
 import { useEndpoints } from '@/features/containers/hooks/use-endpoints';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { DataTable } from '@/shared/components/tables/data-table';
 import { SkeletonTableRow } from '@/shared/components/feedback/skeleton';
+import { PageHeader } from '@/shared/components/layout/page-header';
 import { cn } from '@/shared/lib/utils';
 import { ObservedDestinationsPanel } from '@/features/security/components/observed-destinations-panel';
 import { SpotlightCard } from '@/shared/components/data-display/spotlight-card';
@@ -56,12 +58,45 @@ function capabilityBadgeClass(capability: string): string {
   return 'bg-muted text-muted-foreground';
 }
 
+/**
+ * Isolation modes worth a line of text. Docker's defaults (`bridge`, the
+ * per-compose-project network, `private` PID) are the answer for almost every
+ * container, and printing `net=container-insights_dashboard-net | pid=—` on
+ * every row spent a column on saying "normal" 13 times.
+ */
+function isolationNotes(posture: SecurityAuditEntry['posture']): string[] {
+  const notes: string[] = [];
+  const net = posture.networkMode ?? '';
+  const pid = posture.pidMode ?? '';
+  if (net === 'host') notes.push('host network');
+  else if (net.startsWith('container:')) notes.push(`network shared with ${net.slice('container:'.length)}`);
+  if (pid === 'host') notes.push('host PID namespace');
+  else if (pid.startsWith('container:')) notes.push(`PID shared with ${pid.slice('container:'.length)}`);
+  return notes;
+}
+
+/**
+ * Whether this container is worth a row at all.
+ *
+ * On a clean fleet every row read `None / No / net=… | pid=— / NONE / Active` —
+ * 13 rows of the same five constants, while the one number that mattered sat
+ * above them in 14px muted text. Rows are for exceptions; the count of
+ * everything else is a summary line.
+ */
+function isException(entry: SecurityAuditEntry): boolean {
+  return entry.findings.length > 0
+    || entry.posture.capAdd.length > 0
+    || entry.posture.privileged
+    || isolationNotes(entry.posture).length > 0;
+}
+
 export default function SecurityAuditPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedEndpoint, setSelectedEndpoint] = useState<string>('all');
   const [selectedSeverity, setSelectedSeverity] = useState<string>('all');
   const [selectedIgnored, setSelectedIgnored] = useState<string>('all');
   const [selectedStack, setSelectedStack] = useState<string>('all');
+  const [showClean, setShowClean] = useState(false);
 
   const { data: endpoints = [] } = useEndpoints();
   const { data, isLoading: auditLoading, isPending: auditPending, isError, error, refetch } = useSecurityAudit(
@@ -101,6 +136,40 @@ export default function SecurityAuditPage() {
         return a.containerName.localeCompare(b.containerName);
       });
   }, [entries, searchQuery, selectedSeverity, selectedIgnored, selectedStack]);
+
+  /**
+   * The one line an operator actually reads. It used to be 14px muted text
+   * under a table of constants; it is now the lead, and it names the three
+   * things this page checks rather than "13 containers shown".
+   */
+  const posture = useMemo(() => {
+    const withCaps = entries.filter((entry) => entry.posture.capAdd.length > 0);
+    const privileged = entries.filter((entry) => entry.posture.privileged);
+    const hostNamespaces = entries.filter((entry) => isolationNotes(entry.posture).length > 0);
+    const exceptions = entries.filter(isException);
+    return {
+      total: entries.length,
+      withCaps: withCaps.length,
+      privileged: privileged.length,
+      hostNamespaces: hostNamespaces.length,
+      exceptions: exceptions.length,
+      ignored: entries.filter((entry) => entry.ignored).length,
+    };
+  }, [entries]);
+
+  // Any active filter is an explicit request to see those rows, clean or not.
+  const isFiltered = searchQuery.trim() !== ''
+    || selectedSeverity !== 'all'
+    || selectedIgnored !== 'all'
+    || selectedStack !== 'all';
+
+  const cleanEntries = useMemo(
+    () => filteredEntries.filter((entry) => !isException(entry)),
+    [filteredEntries],
+  );
+  const visibleEntries = isFiltered || showClean
+    ? filteredEntries
+    : filteredEntries.filter(isException);
 
   const columns = useMemo<ColumnDef<SecurityAuditEntry, unknown>[]>(() => [
     {
@@ -183,14 +252,25 @@ export default function SecurityAuditPage() {
       },
     },
     {
-      id: 'networkPid',
-      header: 'Network/PID',
+      id: 'isolation',
+      header: 'Isolation',
       enableSorting: false,
       cell: ({ row }) => {
         const entry = row.original;
+        const notes = isolationNotes(entry.posture);
+        if (notes.length === 0) {
+          return (
+            <span
+              className="text-xs text-muted-foreground"
+              title={`network: ${entry.posture.networkMode ?? 'default'} · pid: ${entry.posture.pidMode ?? 'private'}`}
+            >
+              —
+            </span>
+          );
+        }
         return (
-          <span className={cn('text-xs text-muted-foreground', entry.ignored && 'opacity-70')}>
-            net={entry.posture.networkMode ?? '—'} | pid={entry.posture.pidMode ?? '—'}
+          <span className={cn('text-xs font-medium text-amber-700 dark:text-amber-400', entry.ignored && 'opacity-70')}>
+            {notes.join(', ')}
           </span>
         );
       },
@@ -202,6 +282,11 @@ export default function SecurityAuditPage() {
       sortingFn: (a, b) => severityRank(a.original.severity) - severityRank(b.original.severity),
       cell: ({ row }) => {
         const entry = row.original;
+        // A coloured badge for the ABSENCE of a finding is noise. Badges are
+        // for signal.
+        if (entry.severity === 'none') {
+          return <span className="text-xs text-muted-foreground">—</span>;
+        }
         return (
           <span
             className={cn(
@@ -239,10 +324,56 @@ export default function SecurityAuditPage() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Security Audit</h1>
-        <p className="text-muted-foreground">Container capability posture across endpoints with ignore-list visibility.</p>
-      </div>
+      <PageHeader
+        title="Security Audit"
+        subtitle={isLoading
+          ? undefined
+          : posture.exceptions === 0
+            ? `No container of ${posture.total} has added capabilities, privileged mode, or a host namespace`
+            : `${posture.exceptions} of ${posture.total} containers have added capabilities, privileged mode, or a host namespace`}
+        actions={(
+          <Link
+            to="/settings?tab=security"
+            className="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent"
+          >
+            <SlidersHorizontal className="h-4 w-4" />
+            Manage ignore list
+          </Link>
+        )}
+      />
+
+      {!isLoading && posture.total > 0 && (
+        <SpotlightCard>
+        <section className="rounded-lg border bg-card p-6 shadow-sm" data-testid="posture-summary">
+          <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <dt className="text-sm text-muted-foreground">Added capabilities</dt>
+              <dd className="mt-1 text-2xl font-bold tracking-tight">{posture.withCaps}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">Privileged</dt>
+              <dd className="mt-1 text-2xl font-bold tracking-tight">{posture.privileged}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">Host network or PID</dt>
+              <dd className="mt-1 text-2xl font-bold tracking-tight">{posture.hostNamespaces}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">On the ignore list</dt>
+              <dd className="mt-1 text-2xl font-bold tracking-tight">{posture.ignored}</dd>
+            </div>
+          </dl>
+          <p className="mt-4 text-sm text-muted-foreground">
+            Ignored containers are excluded from the dashboard security count. Edit the patterns
+            at{' '}
+            <Link to="/settings?tab=security" className="text-primary hover:underline">
+              Settings → Security
+            </Link>
+            .
+          </p>
+        </section>
+        </SpotlightCard>
+      )}
 
       <SpotlightCard>
       <section className="rounded-lg border bg-card p-6 shadow-sm">
@@ -318,8 +449,26 @@ export default function SecurityAuditPage() {
 
       <SpotlightCard>
       <section className="rounded-lg border bg-card p-6 shadow-sm">
-        <div className="mb-3 text-sm text-muted-foreground">
-          {filteredEntries.length} containers shown ({entries.filter((entry) => entry.findings.length > 0).length} with findings total)
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+          <span>
+            {isFiltered
+              ? `${filteredEntries.length} of ${entries.length} containers match the filters`
+              : `${visibleEntries.length} container${visibleEntries.length === 1 ? '' : 's'} need a look`}
+          </span>
+          {!isFiltered && cleanEntries.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowClean((prev) => !prev)}
+              aria-expanded={showClean}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 font-medium text-foreground hover:bg-accent"
+            >
+              {showClean
+                ? <ChevronDown className="h-4 w-4" />
+                : <ChevronRight className="h-4 w-4" />}
+              {showClean ? 'Hide' : 'Show'} {cleanEntries.length} clean container
+              {cleanEntries.length === 1 ? '' : 's'}
+            </button>
+          )}
         </div>
 
         {isLoading ? (
@@ -339,10 +488,18 @@ export default function SecurityAuditPage() {
             <p className="mt-3 font-medium">No matching containers</p>
             <p className="mt-1 text-sm text-muted-foreground">Try adjusting your search or filters.</p>
           </div>
+        ) : visibleEntries.length === 0 ? (
+          <div className="rounded-lg border bg-muted/30 p-8 text-center">
+            <ShieldAlert className="mx-auto h-8 w-8 text-muted-foreground" />
+            <p className="mt-3 font-medium">Nothing to review</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              No container adds a capability, runs privileged, or shares a host namespace.
+            </p>
+          </div>
         ) : (
           <DataTable
             columns={columns}
-            data={filteredEntries}
+            data={visibleEntries}
             hideSearch
             minTableWidth={1100}
           />

--- a/frontend/src/providers/auth-provider.test.tsx
+++ b/frontend/src/providers/auth-provider.test.tsx
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render } from '@testing-library/react';
 import { AUTH_TOKEN_KEY } from '@/shared/lib/auth-constants';
-import { AuthProvider, useAuth, isTokenValid } from './auth-provider';
+import { ApiError } from '@/shared/lib/api-error';
+import {
+  AuthProvider,
+  useAuth,
+  isTokenValid,
+  LOGIN_BAD_CREDENTIALS_MESSAGE,
+  LOGIN_RATE_LIMITED_MESSAGE,
+} from './auth-provider';
 
 const mockPost = vi.fn();
 const mockSetToken = vi.fn();
@@ -503,6 +510,106 @@ describe('AuthProvider — refresh timer (issue #1106)', () => {
     expect(getByTestId('authed').textContent).toBe('false');
     expect(window.localStorage.getItem(AUTH_TOKEN_KEY)).toBeNull();
     expect(mockSetToken).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('AuthProvider — login failure messages', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockSetToken.mockReset();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  function renderLogin() {
+    let loginFn: (u: string, p: string) => Promise<{ defaultLandingPage: string }> = async () => ({
+      defaultLandingPage: '/',
+    });
+    function Probe() {
+      loginFn = useAuth().login;
+      return null;
+    }
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    return (u = 'alice', p = 'wrong') => loginFn(u, p);
+  }
+
+  it('asks the API client to suppress session-expiry handling for the login call', async () => {
+    mockPost.mockResolvedValue({ token: makeJwt('viewer'), username: 'alice' });
+    const doLogin = renderLogin();
+
+    await act(async () => {
+      await doLogin('alice', 'pw');
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/auth/login',
+      { username: 'alice', password: 'pw' },
+      { suppressSessionExpiry: true },
+    );
+  });
+
+  it('reports a 401 as incorrect credentials, not "Session expired"', async () => {
+    mockPost.mockRejectedValue(new ApiError(401, 'Invalid credentials', 'req-1'));
+    const doLogin = renderLogin();
+
+    let caught: unknown;
+    await act(async () => {
+      caught = await doLogin().catch((e: unknown) => e);
+    });
+
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).status).toBe(401);
+    expect((caught as ApiError).message).toBe(LOGIN_BAD_CREDENTIALS_MESSAGE);
+    expect((caught as ApiError).message).not.toMatch(/session expired/i);
+    // requestId survives the rewrite so the failure is still traceable.
+    expect((caught as ApiError).requestId).toBe('req-1');
+  });
+
+  it('reports a 429 with the login rate-limit message', async () => {
+    mockPost.mockRejectedValue(new ApiError(429, 'HTTP 429'));
+    const doLogin = renderLogin();
+
+    let caught: unknown;
+    await act(async () => {
+      caught = await doLogin().catch((e: unknown) => e);
+    });
+
+    expect((caught as ApiError).status).toBe(429);
+    expect((caught as ApiError).message).toBe(LOGIN_RATE_LIMITED_MESSAGE);
+  });
+
+  it('leaves other failures untouched', async () => {
+    const original = new ApiError(503, 'Service temporarily unavailable');
+    mockPost.mockRejectedValue(original);
+    const doLogin = renderLogin();
+
+    let caught: unknown;
+    await act(async () => {
+      caught = await doLogin().catch((e: unknown) => e);
+    });
+
+    expect(caught).toBe(original);
+  });
+
+  it('passes a non-ApiError through unchanged (network failure)', async () => {
+    const original = new Error('Network error — check your connection');
+    mockPost.mockRejectedValue(original);
+    const doLogin = renderLogin();
+
+    let caught: unknown;
+    await act(async () => {
+      caught = await doLogin().catch((e: unknown) => e);
+    });
+
+    expect(caught).toBe(original);
   });
 });
 

--- a/frontend/src/providers/auth-provider.tsx
+++ b/frontend/src/providers/auth-provider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import { api } from '@/shared/lib/api';
+import { ApiError } from '@/shared/lib/api-error';
 import { AUTH_TOKEN_KEY } from '@/shared/lib/auth-constants';
 const AUTH_USERNAME_KEY = 'auth_username';
 const AUTH_ROLE_KEY = 'auth_role';
@@ -82,6 +83,31 @@ function parseRoleFromToken(token: string): UserRole {
   return role === 'admin' || role === 'operator' || role === 'viewer' ? role : 'viewer';
 }
 
+/** Copy for the two sign-in failures the server distinguishes. Exported so the login page and its tests can assert on them without duplicating strings. */
+export const LOGIN_BAD_CREDENTIALS_MESSAGE = 'Incorrect username or password';
+export const LOGIN_RATE_LIMITED_MESSAGE =
+  'Too many sign-in attempts. Wait a minute before trying again.';
+
+/**
+ * Rewrite the two sign-in failures that carry a useful next action.
+ *
+ * `/api/auth/login` is called with `suppressSessionExpiry` so the client no
+ * longer turns its 401 into "Session expired" (there is no session yet — see
+ * `api.ts`). The server answers a bad password with `{ error: 'Invalid
+ * credentials' }` and a throttled attempt with a bare 429, neither of which
+ * tells the operator what to do next.
+ */
+function describeLoginFailure(err: unknown): unknown {
+  if (!(err instanceof ApiError)) return err;
+  if (err.status === 401) {
+    return new ApiError(401, LOGIN_BAD_CREDENTIALS_MESSAGE, err.requestId);
+  }
+  if (err.status === 429) {
+    return new ApiError(429, LOGIN_RATE_LIMITED_MESSAGE, err.requestId);
+  }
+  return err;
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [initialAuth] = useState(() => getStoredAuth());
   const [token, setToken] = useState<string | null>(initialAuth.token);
@@ -89,10 +115,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [role, setRole] = useState<UserRole>(initialAuth.role);
 
   const login = useCallback(async (user: string, password: string) => {
-    const data = await api.post<{ token: string; username: string; defaultLandingPage?: string }>(
-      '/api/auth/login',
-      { username: user, password }
-    );
+    let data: { token: string; username: string; defaultLandingPage?: string };
+    try {
+      data = await api.post<{ token: string; username: string; defaultLandingPage?: string }>(
+        '/api/auth/login',
+        { username: user, password },
+        { suppressSessionExpiry: true }
+      );
+    } catch (err) {
+      throw describeLoginFailure(err);
+    }
     const userRole = parseRoleFromToken(data.token);
     setToken(data.token);
     setUsername(data.username);

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from 'react';
+import type { RouteObject } from 'react-router-dom';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import { AppLayout } from '@/features/core/components/layout/app-layout';
 import { RouteErrorBoundary } from '@/shared/components/feedback/route-error-boundary';
@@ -33,6 +34,7 @@ const InvestigationDetail = lazy(() => import('@/features/ai-intelligence/pages/
 const SecurityAudit = lazy(() => import('@/features/security/pages/security-audit'));
 const EbpfCoverage = lazy(() => import('@/features/security/pages/ebpf-coverage'));
 const HarborVulnerabilities = lazy(() => import('@/features/security/pages/harbor-vulnerabilities'));
+const NotFound = lazy(() => import('@/features/core/pages/not-found'));
 
 function PageLoader() {
   return (
@@ -50,7 +52,13 @@ function LazyPage({ children }: { children: React.ReactNode }) {
   );
 }
 
-export const router = createBrowserRouter([
+/**
+ * The route table, exported separately from the browser router so tests can
+ * walk it without instantiating history. `navigation-manifest.test.ts` uses it
+ * to prove every reachable route has a navigation entry or a documented
+ * exemption.
+ */
+export const appRoutes: RouteObject[] = [
   {
     path: '/login',
     element: <LazyPage><Login /></LazyPage>,
@@ -100,7 +108,12 @@ export const router = createBrowserRouter([
       { path: 'investigations/insight/:insightId', element: <LazyPage><InvestigationDetail /></LazyPage> },
       { path: 'backups', element: <ProtectedRoute requiredRole="admin"><LazyPage><Backups /></LazyPage></ProtectedRoute> },
       { path: 'settings', element: <ProtectedRoute requiredRole="admin"><LazyPage><Settings /></LazyPage></ProtectedRoute> },
+      // Real 404 inside the shell. Previously `<Navigate to="/" replace />`,
+      // which silently turned every bad URL into Home and, because of
+      // `replace`, left the user unable to go Back to where they came from.
+      { path: '*', element: <LazyPage><NotFound /></LazyPage> },
     ],
   },
-  { path: '*', element: <Navigate to="/" replace />, errorElement: <RouteErrorBoundary /> },
-]);
+];
+
+export const router = createBrowserRouter(appRoutes);

--- a/frontend/src/shared/components/charts/endpoint-health-octagons.test.tsx
+++ b/frontend/src/shared/components/charts/endpoint-health-octagons.test.tsx
@@ -1,10 +1,15 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EndpointHealthOctagons, getHealthLevel_testable } from './endpoint-health-octagons';
 
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
+  Link: ({ to, children, ...rest }: any) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock('framer-motion', () => ({
@@ -49,6 +54,20 @@ const ENDPOINTS = [
   { id: 4, name: 'Empty', running: 0, stopped: 0, total: 0 },
 ];
 
+/**
+ * Pad a fleet up to the honeycomb threshold. Below 4 endpoints the component
+ * deliberately drops the hex grid for one row per endpoint, so tests about the
+ * hexagon itself have to supply a fleet big enough to get one.
+ */
+function withHexGrid(...endpoints: (typeof ENDPOINTS)[number][]) {
+  const filler = ENDPOINTS.slice(0, Math.max(0, 4 - endpoints.length)).map((ep, i) => ({
+    ...ep,
+    id: 1000 + i,
+    name: `Filler${i}`,
+  }));
+  return [...endpoints, ...filler];
+}
+
 describe('EndpointHealthOctagons', () => {
   it('renders one hexagon per endpoint', () => {
     renderWithWidth(<EndpointHealthOctagons endpoints={ENDPOINTS} />);
@@ -65,18 +84,20 @@ describe('EndpointHealthOctagons', () => {
     // The Empty endpoint (total=0) now reads "Awaiting snapshot" instead of "No containers" —
     // it's the same gray hexagon but the label distinguishes "we haven't seen data yet"
     // from "we tried and failed" (issue #1249).
-    expect(screen.getByText('Awaiting snapshot')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('octagon-Empty')).getByText('Awaiting snapshot'),
+    ).toBeInTheDocument();
   });
 
   it('renders "Offline" inside the hexagon when status=down', () => {
-    const down = [{ id: 9, name: 'DeadNode', running: 0, stopped: 0, total: 0, status: 'down' as const }];
+    const down = withHexGrid({ id: 9, name: 'DeadNode', running: 0, stopped: 0, total: 0, status: 'down' as const });
     renderWithWidth(<EndpointHealthOctagons endpoints={down} />);
     const hex = screen.getByTestId('octagon-DeadNode');
     expect(hex.textContent).toContain('Offline');
   });
 
   it('renders "Data unavailable" when snapshotSource=unavailable (issue #1249)', () => {
-    const unavail = [{ id: 10, name: 'EdgeStandard', running: 0, stopped: 0, total: 0, status: 'up' as const, snapshotSource: 'unavailable' as const }];
+    const unavail = withHexGrid({ id: 10, name: 'EdgeStandard', running: 0, stopped: 0, total: 0, status: 'up' as const, snapshotSource: 'unavailable' as const });
     renderWithWidth(<EndpointHealthOctagons endpoints={unavail} />);
     const hex = screen.getByTestId('octagon-EdgeStandard');
     expect(hex.textContent).toContain('Data unavailable');
@@ -85,10 +106,10 @@ describe('EndpointHealthOctagons', () => {
 
   it('shows live counts and includes refresh age in the tooltip when snapshotSource=live', () => {
     const tenSecondsAgo = Date.now() - 10_000;
-    const live = [{
+    const live = withHexGrid({
       id: 11, name: 'LiveEdge', running: 4, stopped: 1, total: 5,
       status: 'up' as const, snapshotSource: 'live' as const, snapshotFetchedAt: tenSecondsAgo,
-    }];
+    });
     renderWithWidth(<EndpointHealthOctagons endpoints={live} />);
     const hex = screen.getByTestId('octagon-LiveEdge');
     expect(hex.textContent).toContain('4/5 running');
@@ -112,20 +133,66 @@ describe('EndpointHealthOctagons', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/infrastructure');
   });
 
-  it('renders the legend', () => {
+  it('renders only the legend entries for levels present in the fleet', () => {
     renderWithWidth(<EndpointHealthOctagons endpoints={ENDPOINTS} />);
-    expect(screen.getByText('>80% healthy')).toBeInTheDocument();
-    expect(screen.getByText('50-80%')).toBeInTheDocument();
-    expect(screen.getByText('<50%')).toBeInTheDocument();
+    const legend = within(screen.getByTestId('octagon-legend'));
+    // The bands measure running/total, so the copy says "running", not "healthy".
+    expect(legend.getByText('>80% running')).toBeInTheDocument();
+    expect(legend.getByText('50-80% running')).toBeInTheDocument();
+    expect(legend.getByText('<50% running')).toBeInTheDocument();
+    expect(legend.getByText('Awaiting snapshot')).toBeInTheDocument();
+    // Nothing here is offline or unavailable, so those captions are absent —
+    // the legend used to list all six states regardless.
+    expect(legend.queryByText('Offline')).not.toBeInTheDocument();
+    expect(legend.queryByText('Data unavailable')).not.toBeInTheDocument();
   });
 
   it('renders SVG hexagon paths', () => {
     const { container } = renderWithWidth(
-      <EndpointHealthOctagons endpoints={[ENDPOINTS[0]]} />,
+      <EndpointHealthOctagons endpoints={withHexGrid(ENDPOINTS[0])} />,
     );
     const paths = container.querySelectorAll('path');
-    // Each hexagon has 3 paths: shadow, glow, main
-    expect(paths.length).toBe(3);
+    // Each of the 4 hexagons has 3 paths: shadow, glow, main
+    expect(paths.length).toBe(12);
+  });
+
+  // -------------------------------------------------------------------------
+  // Small fleets: a fleet map designed for 50 hosts rendering 1, plus a
+  // six-item legend of which five were unused, is 300px spent on one fact.
+  // -------------------------------------------------------------------------
+
+  it('collapses to one inline row per endpoint below 4 endpoints', () => {
+    renderWithWidth(
+      <EndpointHealthOctagons endpoints={[{ id: 1, name: 'docker-dev-1', running: 13, stopped: 0, total: 13 }]} />,
+    );
+
+    const row = screen.getByTestId('endpoint-row-docker-dev-1');
+    expect(row).toHaveTextContent('docker-dev-1');
+    expect(row).toHaveTextContent('13/13 running');
+    expect(row).toHaveAttribute('href', '/infrastructure');
+    expect(screen.queryByTestId('octagon-docker-dev-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('octagon-legend')).not.toBeInTheDocument();
+  });
+
+  it('keeps the honeycomb once the fleet reaches 4 endpoints', () => {
+    renderWithWidth(<EndpointHealthOctagons endpoints={ENDPOINTS} />);
+
+    expect(screen.getByTestId('octagon-Production')).toBeInTheDocument();
+    expect(screen.queryByTestId('endpoint-rows')).not.toBeInTheDocument();
+  });
+
+  it('states offline and unavailable in words on the inline row', () => {
+    renderWithWidth(
+      <EndpointHealthOctagons
+        endpoints={[
+          { id: 1, name: 'DeadNode', running: 0, stopped: 0, total: 0, status: 'down' },
+          { id: 2, name: 'EdgeStandard', running: 0, stopped: 0, total: 0, status: 'up', snapshotSource: 'unavailable' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('endpoint-row-DeadNode')).toHaveTextContent('Offline');
+    expect(screen.getByTestId('endpoint-row-EdgeStandard')).toHaveTextContent('Data unavailable');
   });
 });
 

--- a/frontend/src/shared/components/charts/endpoint-health-octagons.tsx
+++ b/frontend/src/shared/components/charts/endpoint-health-octagons.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo, useRef, useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { m, useReducedMotion } from 'framer-motion';
 import { cn } from '@/shared/lib/utils';
 import { duration, easing } from '@/shared/lib/motion-tokens';
@@ -35,6 +35,41 @@ const HEALTH_COLORS = {
 } as const;
 
 type HealthLevel = keyof typeof HEALTH_COLORS;
+
+/**
+ * Legend copy, keyed by level so the legend can be derived from what is
+ * actually on screen. It used to be a hardcoded six-item row; on a one-endpoint
+ * fleet that meant a 300px pane holding a single hexagon and five captions for
+ * states nothing was in — including three near-identical greys.
+ *
+ * The three ratio bands say "running", not "healthy": `getHealthLevel` buckets
+ * `running / total`, and this pane has no healthcheck data at all.
+ */
+const LEVEL_LEGEND: Record<HealthLevel, string> = {
+  good: '>80% running',
+  warning: '50-80% running',
+  critical: '<50% running',
+  offline: 'Offline',
+  unavailable: 'Data unavailable',
+  empty: 'Awaiting snapshot',
+};
+
+/** Status dot colour per level — shared by the legend and the inline rows. */
+const LEVEL_DOT: Record<HealthLevel, string> = {
+  good: 'bg-emerald-500',
+  warning: 'bg-amber-500',
+  critical: 'bg-red-500',
+  offline: 'bg-slate-500',
+  unavailable: 'bg-stone-500',
+  empty: 'bg-slate-400',
+};
+
+/**
+ * Below this many endpoints the honeycomb is dropped for one row per endpoint.
+ * The hex grid earns its space at fleet scale; at one or two hosts it is a
+ * fleet map rendering a single tile.
+ */
+const HEX_GRID_MIN_ENDPOINTS = 4;
 
 /**
  * Map endpoint state to a hexagon color level.
@@ -375,6 +410,37 @@ export const EndpointHealthOctagons = memo(function EndpointHealthOctagons({
     );
   }
 
+  // Small fleet: one row per endpoint, no honeycomb and no legend — the row
+  // states its own status in words, so nothing needs decoding.
+  if (items.length < HEX_GRID_MIN_ENDPOINTS) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="endpoint-rows">
+        {items.map((ep) => (
+          <Link
+            key={ep.id}
+            to="/infrastructure"
+            data-testid={`endpoint-row-${ep.name}`}
+            title={getCardTitle(ep.name, ep.level, ep.running, ep.total, ep.snapshotSource, ep.snapshotFetchedAt)}
+            className="flex items-center justify-between gap-3 rounded-md border bg-background/40 px-3 py-2 transition-colors hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <span className={cn('h-2.5 w-2.5 shrink-0 rounded-full', LEVEL_DOT[ep.level])} aria-hidden />
+              <span className="truncate text-sm font-medium">{ep.name}</span>
+            </span>
+            <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+              {getStatusLabel(ep.level, ep.running, ep.total)}
+            </span>
+          </Link>
+        ))}
+      </div>
+    );
+  }
+
+  // Only the levels actually on screen get a legend entry.
+  const presentLevels = (Object.keys(LEVEL_LEGEND) as HealthLevel[]).filter((level) =>
+    items.some((ep) => ep.level === level),
+  );
+
   return (
     <div className="flex flex-col">
       {/* Hexagon honeycomb grid */}
@@ -417,32 +483,14 @@ export const EndpointHealthOctagons = memo(function EndpointHealthOctagons({
         </m.div>
       </div>
 
-      {/* Legend */}
-      <div className="flex justify-center gap-5 pt-3 shrink-0 flex-wrap">
-        <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
-          <span className="text-xs text-muted-foreground">&gt;80% healthy</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full bg-amber-500" />
-          <span className="text-xs text-muted-foreground">50-80%</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
-          <span className="text-xs text-muted-foreground">&lt;50%</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full bg-slate-500" />
-          <span className="text-xs text-muted-foreground">Offline</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full bg-stone-500" />
-          <span className="text-xs text-muted-foreground">Unavailable</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full bg-slate-400" />
-          <span className="text-xs text-muted-foreground">No data</span>
-        </div>
+      {/* Legend — only the levels present in this fleet */}
+      <div className="flex justify-center gap-5 pt-3 shrink-0 flex-wrap" data-testid="octagon-legend">
+        {presentLevels.map((level) => (
+          <div key={level} className="flex items-center gap-1.5">
+            <div className={cn('w-2.5 h-2.5 rounded-full', LEVEL_DOT[level])} />
+            <span className="text-xs text-muted-foreground">{LEVEL_LEGEND[level]}</span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/shared/components/charts/image-sunburst.test.tsx
+++ b/frontend/src/shared/components/charts/image-sunburst.test.tsx
@@ -17,4 +17,17 @@ describe('ImageSunburst', () => {
     render(<ImageSunburst data={data} />);
     expect(screen.queryByText('No image data')).not.toBeInTheDocument();
   });
+
+  it('does not render a legend that repeats the in-place slice labels', () => {
+    const data = [
+      { name: 'nginx', size: 100_000_000, registry: 'docker.io' },
+      { name: 'app', size: 40_000_000, registry: 'ghcr.io' },
+      { name: 'scanner', size: 10_000_000, registry: 'dhi.io' },
+    ];
+
+    const { container } = render(<ImageSunburst data={data} />);
+
+    expect(container.querySelector('.recharts-legend-wrapper')).toBeNull();
+    expect(container.querySelector('.recharts-default-legend')).toBeNull();
+  });
 });

--- a/frontend/src/shared/components/charts/image-sunburst.tsx
+++ b/frontend/src/shared/components/charts/image-sunburst.tsx
@@ -1,4 +1,4 @@
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 import { formatBytes } from '@/shared/lib/utils';
 
 interface ImageData {
@@ -68,14 +68,9 @@ export function ImageSunburst({ data }: ImageSunburstProps) {
           ))}
         </Pie>
         <Tooltip content={<CustomTooltip />} />
-        <Legend
-          layout="horizontal"
-          align="center"
-          verticalAlign="bottom"
-          iconType="circle"
-          iconSize={8}
-          wrapperStyle={{ fontSize: '12px', paddingTop: 16 }}
-        />
+        {/* No <Legend>: every slice is already labelled in place with its
+            registry and share, so a legend below repeats all of them and
+            spends vertical space the image table needs. */}
       </PieChart>
     </ResponsiveContainer>
   );

--- a/frontend/src/shared/components/charts/image-treemap.test.tsx
+++ b/frontend/src/shared/components/charts/image-treemap.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ImageTreemap, getLabelStyleForFill, CustomContent } from './image-treemap';
+import { ImageTreemap, getCellFillOpacity, CustomContent } from './image-treemap';
 
 // ResponsiveContainer requires a measurable parent DOM node (jsdom has no
 // layout engine), so we replace it with a simple pass-through wrapper.
@@ -28,6 +28,7 @@ function renderCell(overrides: Record<string, unknown> = {}) {
     index: 0,
     name: 'nginx',
     size: 100_000_000,
+    maxSize: 100_000_000,
     onCellClick: vi.fn(),
     ...overrides,
   };
@@ -55,14 +56,83 @@ describe('ImageTreemap', () => {
     expect(screen.queryByText('No image data')).not.toBeInTheDocument();
   });
 
-  it('uses dark text for bright treemap cell colors', () => {
-    const style = getLabelStyleForFill('#a5b4fc');
-    expect(style.fill).toBe('#0f172a');
-  });
+  describe('cell colour encodes size, not cell order', () => {
+    function renderedRect(overrides: Record<string, unknown> = {}) {
+      const { container } = render(
+        <svg>
+          <CustomContent
+            x={0}
+            y={0}
+            width={200}
+            height={100}
+            name="nginx"
+            size={100_000_000}
+            maxSize={100_000_000}
+            {...overrides}
+          />
+        </svg>,
+      );
+      return container.querySelector('rect')!;
+    }
 
-  it('uses white text for dark treemap cell colors', () => {
-    const style = getLabelStyleForFill('#1e293b');
-    expect(style.fill).toBe('#ffffff');
+    it('fills every cell from the same single hue token', () => {
+      const first = renderedRect({ index: 0, name: 'a', size: 10_000_000 });
+      const eighth = renderedRect({ index: 7, name: 'b', size: 90_000_000 });
+
+      // The old palette cycled 15 hard-coded pastel hex values by `index`.
+      expect(first.getAttribute('fill')).toBe('var(--color-chart-1)');
+      expect(eighth.getAttribute('fill')).toBe('var(--color-chart-1)');
+    });
+
+    it('does not vary the fill with the cell index at equal size', () => {
+      const a = renderedRect({ index: 0, size: 50_000_000 });
+      const b = renderedRect({ index: 9, size: 50_000_000 });
+
+      expect(a.getAttribute('fill-opacity')).toBe(b.getAttribute('fill-opacity'));
+    });
+
+    it('ramps opacity monotonically with relative size', () => {
+      const small = getCellFillOpacity(1_000_000, 100_000_000);
+      const medium = getCellFillOpacity(25_000_000, 100_000_000);
+      const large = getCellFillOpacity(100_000_000, 100_000_000);
+
+      expect(small).toBeLessThan(medium);
+      expect(medium).toBeLessThan(large);
+      expect(large).toBeCloseTo(0.85, 5);
+    });
+
+    it('floors the ramp for zero-size or unknown-max cells', () => {
+      expect(getCellFillOpacity(0, 100)).toBeCloseTo(0.2, 5);
+      expect(getCellFillOpacity(100, 0)).toBeCloseTo(0.2, 5);
+    });
+
+    it('uses theme tokens rather than raw hex for label and separator colours', () => {
+      const { container } = render(
+        <svg>
+          <CustomContent
+            x={0}
+            y={0}
+            width={200}
+            height={100}
+            name="nginx"
+            size={100_000_000}
+            maxSize={100_000_000}
+          />
+        </svg>,
+      );
+
+      const rect = container.querySelector('rect')!;
+      expect(rect.getAttribute('stroke')).toBe('var(--color-card)');
+
+      // Both label lines (name + size) must be theme-driven; a fixed white/dark
+      // pair only worked because the fill was a known pastel.
+      const texts = [...container.querySelectorAll('text')];
+      expect(texts.length).toBeGreaterThan(0);
+      for (const text of texts) {
+        expect(text.getAttribute('fill')).toMatch(/^var\(--color-/);
+        expect(text.getAttribute('stroke')).toBe('var(--color-card)');
+      }
+    });
   });
 
   describe('accessibility', () => {
@@ -138,7 +208,7 @@ describe('ImageTreemap', () => {
       fireEvent.focus(button);
       const focusRing = screen.getByTestId('focus-ring');
       expect(focusRing).toBeInTheDocument();
-      expect(focusRing.getAttribute('stroke')).toBe('#ffffff');
+      expect(focusRing.getAttribute('stroke')).toBe('var(--color-foreground)');
       expect(focusRing.getAttribute('stroke-width')).toBe('2');
       expect(focusRing.getAttribute('fill')).toBe('none');
     });

--- a/frontend/src/shared/components/charts/image-treemap.tsx
+++ b/frontend/src/shared/components/charts/image-treemap.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useState } from 'react';
+import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useMemo, useState } from 'react';
 import { Treemap, ResponsiveContainer, Tooltip } from 'recharts';
 import { formatBytes } from '@/shared/lib/utils';
 
@@ -15,52 +15,38 @@ interface ImageTreemapProps {
   onCellClick?: (name: string) => void;
 }
 
-// Soft pastel palette
-const COLORS = [
-  '#93c5fd', '#a5b4fc', '#c4b5fd', '#f9a8d4', '#fda4af',
-  '#fcd34d', '#86efac', '#6ee7b7', '#67e8f9', '#7dd3fc',
-  '#d8b4fe', '#fbcfe8', '#fde68a', '#a7f3d0', '#bae6fd',
-];
+/**
+ * One hue, luminance-ramped by size.
+ *
+ * The cells used to cycle an eight-colour pastel rainbow keyed on nothing but
+ * the cell's index — the largest saturated area in the product encoding zero
+ * information, in a design system where green means healthy and red means
+ * error. Area already encodes size; the ramp reinforces that instead of
+ * inventing a second, false variable.
+ */
+const CELL_HUE = 'var(--color-chart-1)';
+const MIN_FILL_OPACITY = 0.2;
+const MAX_FILL_OPACITY = 0.85;
 
-interface LabelStyle {
-  fill: string;
-  stroke: string;
-}
-
-function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
-  const normalized = hex.replace('#', '').trim();
-  if (!/^[0-9A-Fa-f]{6}$/.test(normalized)) return null;
-  return {
-    r: parseInt(normalized.slice(0, 2), 16),
-    g: parseInt(normalized.slice(2, 4), 16),
-    b: parseInt(normalized.slice(4, 6), 16),
-  };
-}
-
-export function getLabelStyleForFill(fill: string): LabelStyle {
-  const rgb = hexToRgb(fill);
-  if (!rgb) {
-    return { fill: '#ffffff', stroke: 'rgba(15, 23, 42, 0.85)' };
-  }
-
-  // WCAG relative luminance approximation for contrast-aware text color.
-  const luminance = (0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b) / 255;
-  if (luminance > 0.62) {
-    return { fill: '#0f172a', stroke: 'rgba(255, 255, 255, 0.8)' };
-  }
-
-  return { fill: '#ffffff', stroke: 'rgba(15, 23, 42, 0.85)' };
+/**
+ * @internal Exported for testing. Maps a cell's size, relative to the largest
+ * cell in the same treemap, onto the fill-opacity ramp. `sqrt` keeps the middle
+ * of the range separable — image sizes are heavily skewed, so a linear ramp
+ * collapses everything but the largest one or two cells onto the floor.
+ */
+export function getCellFillOpacity(size: number, maxSize: number): number {
+  if (!(size > 0) || !(maxSize > 0)) return MIN_FILL_OPACITY;
+  const ratio = Math.min(size / maxSize, 1);
+  return MIN_FILL_OPACITY + (MAX_FILL_OPACITY - MIN_FILL_OPACITY) * Math.sqrt(ratio);
 }
 
 /** @internal Exported for testing only */
 export function CustomContent(props: any) {
-  const { x, y, width, height, index, name, size, onCellClick } = props;
+  const { x, y, width, height, name, size, maxSize, onCellClick } = props;
   const [focused, setFocused] = useState(false);
 
-  // Always render the colored rect — no invisible blank cells
-  const fill = COLORS[index % COLORS.length];
-  const opacity = 0.6 + Math.min((size || 0) / 1e9, 1) * 0.4;
-  const labelStyle = getLabelStyleForFill(fill);
+  // Always render the coloured rect — no invisible blank cells
+  const opacity = getCellFillOpacity(size, maxSize);
 
   const handleKeyDown = (e: ReactKeyboardEvent<SVGGElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -100,9 +86,9 @@ export function CustomContent(props: any) {
         y={y}
         width={width}
         height={height}
-        fill={fill}
+        fill={CELL_HUE}
         fillOpacity={opacity}
-        stroke="rgba(255,255,255,0.3)"
+        stroke="var(--color-card)"
         strokeWidth={1}
       />
       {/* Visible focus ring for keyboard navigation */}
@@ -114,23 +100,25 @@ export function CustomContent(props: any) {
           width={Math.max(0, width - inset * 2)}
           height={Math.max(0, height - inset * 2)}
           fill="none"
-          stroke="#ffffff"
+          stroke="var(--color-foreground)"
           strokeWidth={2}
           rx={2}
           ry={2}
           pointerEvents="none"
         />
       )}
-      {/* Show name label when cell is large enough */}
+      {/* Show name label when cell is large enough. Foreground text with a
+          card-coloured halo reads on every theme; the old fixed white-on-dark
+          pair assumed the cell fill was known at build time. */}
       {width > 50 && height > 24 && (
         <text
           x={x + width / 2}
           y={y + height / 2 - (height > 36 ? 6 : 0)}
           textAnchor="middle"
           dominantBaseline="central"
-          fill={labelStyle.fill}
-          stroke={labelStyle.stroke}
-          strokeWidth={0.8}
+          fill="var(--color-foreground)"
+          stroke="var(--color-card)"
+          strokeWidth={2}
           paintOrder="stroke"
           fontSize={Math.min(11, width / 8)}
         >
@@ -145,12 +133,11 @@ export function CustomContent(props: any) {
           x={x + width / 2}
           y={y + height / 2 + 10}
           textAnchor="middle"
-          fill={labelStyle.fill}
-          stroke={labelStyle.stroke}
-          strokeWidth={0.7}
+          fill="var(--color-muted-foreground)"
+          stroke="var(--color-card)"
+          strokeWidth={2}
           paintOrder="stroke"
           fontSize={10}
-          opacity={0.8}
         >
           {formatBytes(size || 0)}
         </text>
@@ -178,6 +165,11 @@ export function ImageTreemap({ data, onCellClick }: ImageTreemapProps) {
     [onCellClick],
   );
 
+  const maxSize = useMemo(
+    () => data.reduce((max, d) => (d.size > max ? d.size : max), 0),
+    [data],
+  );
+
   if (!data.length) {
     return (
       <div className="flex h-[400px] items-center justify-center text-muted-foreground">
@@ -193,8 +185,8 @@ export function ImageTreemap({ data, onCellClick }: ImageTreemapProps) {
           data={data}
           dataKey="size"
           aspectRatio={4 / 3}
-          stroke="#fff"
-          content={<CustomContent onCellClick={handleCellClick} />}
+          stroke="var(--color-card)"
+          content={<CustomContent onCellClick={handleCellClick} maxSize={maxSize} />}
         >
           <Tooltip content={<CustomTooltip />} />
         </Treemap>

--- a/frontend/src/shared/components/charts/resource-overview-card.test.tsx
+++ b/frontend/src/shared/components/charts/resource-overview-card.test.tsx
@@ -98,4 +98,19 @@ describe('ResourceOverviewCard', () => {
       expect(container.firstChild).toBeNull();
     });
   });
+
+  describe('theming', () => {
+    it('draws both gauges from the theme accent, not raw palette hues', () => {
+      const { container } = render(
+        <ResourceOverviewCard cpuPercent={45.5} memoryPercent={62.3} />,
+      );
+      const bars = screen.getAllByRole('progressbar');
+      // Purple/violet is reserved for AI insight and a memory series is not
+      // one; cyan/blue gradients also ignore the 16 shipped themes.
+      expect(bars[0].className).toContain('bg-primary');
+      expect(bars[1].className).toContain('bg-primary/60');
+      expect(container.querySelector('.from-violet-300')).toBeNull();
+      expect(container.querySelector('.from-cyan-300')).toBeNull();
+    });
+  });
 });

--- a/frontend/src/shared/components/charts/resource-overview-card.tsx
+++ b/frontend/src/shared/components/charts/resource-overview-card.tsx
@@ -14,17 +14,23 @@ export interface ResourceOverviewCardProps {
   isLoading?: boolean;
 }
 
+/**
+ * Two fleet gauges, one hue.
+ *
+ * The bars were `from-cyan-300 to-blue-400` and `from-violet-300 to-purple-400`
+ * — raw palette values that ignore the 16 themes, and violet/purple is the hue
+ * DESIGN.md reserves for AI insight. A memory series is not an AI insight and
+ * not a status. Two intensities of the theme accent separate the two series
+ * without borrowing a meaning from somewhere else; each bar is labelled anyway.
+ */
 function ProgressBar({ percent, variant }: { percent: number; variant: 'cpu' | 'memory' }) {
   const clamped = Math.min(100, Math.max(0, percent));
-  const gradient =
-    variant === 'cpu'
-      ? 'from-cyan-300 to-blue-400'
-      : 'from-violet-300 to-purple-400';
+  const fill = variant === 'cpu' ? 'bg-primary' : 'bg-primary/60';
 
   return (
     <div className="h-3 w-full overflow-hidden rounded-full bg-muted/50">
       <div
-        className={`h-full bg-gradient-to-r ${gradient} transition-all duration-500`}
+        className={`h-full ${fill} transition-all duration-500`}
         style={{ width: `${clamped}%` }}
         role="progressbar"
         aria-valuenow={clamped}
@@ -88,7 +94,7 @@ export const ResourceOverviewCard = memo(function ResourceOverviewCard({
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div className="flex flex-col gap-2 rounded-xl border border-border/60 bg-background/35 p-4">
             <div className="flex items-center gap-2">
-              <Cpu className="h-4 w-4 text-cyan-400" />
+              <Cpu className="h-4 w-4 text-muted-foreground" />
               <span className="text-sm font-medium text-muted-foreground">Total CPU</span>
             </div>
             <span className="text-xl font-semibold">{totalCpu.toFixed(2)}</span>
@@ -96,7 +102,7 @@ export const ResourceOverviewCard = memo(function ResourceOverviewCard({
           </div>
           <div className="flex flex-col gap-2 rounded-xl border border-border/60 bg-background/35 p-4">
             <div className="flex items-center gap-2">
-              <MemoryStick className="h-4 w-4 text-violet-400" />
+              <MemoryStick className="h-4 w-4 text-muted-foreground" />
               <span className="text-sm font-medium text-muted-foreground">Total Memory</span>
             </div>
             <span className="text-xl font-semibold">{(totalMemory / 1024 / 1024 / 1024).toFixed(2)}</span>

--- a/frontend/src/shared/components/charts/workload-top-bar.test.tsx
+++ b/frontend/src/shared/components/charts/workload-top-bar.test.tsx
@@ -12,8 +12,8 @@ vi.mock('recharts', async (importOriginal) => {
   };
 });
 
-function makeEndpoint(id: number, name: string, running: number, stopped: number) {
-  return { id, name, running, stopped, total: running + stopped };
+function makeSeries(name: string, running: number, stopped: number, href?: string) {
+  return { name, running, stopped, total: running + stopped, href };
 }
 
 function renderWithRouter(ui: React.ReactElement) {
@@ -21,17 +21,16 @@ function renderWithRouter(ui: React.ReactElement) {
 }
 
 describe('buildChartData', () => {
-  it('returns empty array for no endpoints', () => {
+  it('returns empty array for no series', () => {
     expect(buildChartData([])).toEqual([]);
   });
 
-  it('returns all endpoints when fewer than 8 (no Others row)', () => {
-    const endpoints = [
-      makeEndpoint(1, 'A', 10, 2),  // total=12
-      makeEndpoint(2, 'B', 8, 1),   // total=9
-      makeEndpoint(3, 'C', 5, 3),   // total=8
-    ];
-    const rows = buildChartData(endpoints);
+  it('returns all rows when fewer than 8 (no Others row)', () => {
+    const rows = buildChartData([
+      makeSeries('A', 10, 2),  // total=12
+      makeSeries('B', 8, 1),   // total=9
+      makeSeries('C', 5, 3),   // total=8
+    ]);
     expect(rows).toHaveLength(3);
     expect(rows[0].label).toBe('A');
     expect(rows[1].label).toBe('B');
@@ -39,62 +38,81 @@ describe('buildChartData', () => {
   });
 
   it('sorts by total descending', () => {
-    const endpoints = [
-      makeEndpoint(1, 'Small', 2, 1),
-      makeEndpoint(2, 'Big', 20, 5),
-      makeEndpoint(3, 'Medium', 10, 3),
-    ];
-    const rows = buildChartData(endpoints);
+    const rows = buildChartData([
+      makeSeries('Small', 2, 1),
+      makeSeries('Big', 20, 5),
+      makeSeries('Medium', 10, 3),
+    ]);
     expect(rows.map((r) => r.label)).toEqual(['Big', 'Medium', 'Small']);
   });
 
   it('aggregates beyond top 8 into Others row', () => {
-    const endpoints = Array.from({ length: 15 }, (_, i) =>
-      makeEndpoint(i + 1, `EP-${i + 1}`, 20 + (15 - i), i),
+    const rows = buildChartData(
+      Array.from({ length: 15 }, (_, i) => makeSeries(`EP-${i + 1}`, 20 + (15 - i), i)),
     );
-    const rows = buildChartData(endpoints);
     expect(rows).toHaveLength(9); // 8 + 1 Others
     const others = rows[8];
     expect(others.label).toBe('Others (7 more)');
-    expect(others.endpointId).toBeUndefined();
+    expect(others.href).toBeUndefined();
     expect(others.running).toBeGreaterThanOrEqual(0);
     expect(others.stopped).toBeGreaterThanOrEqual(0);
   });
 });
 
 describe('WorkloadTopBar', () => {
-  it('shows empty state when no endpoints', () => {
-    renderWithRouter(<WorkloadTopBar endpoints={[]} />);
-    expect(screen.getByText('No workload data')).toBeInTheDocument();
+  it('shows empty state when the series is empty', () => {
+    renderWithRouter(<WorkloadTopBar series={[]} />);
+    expect(screen.getByText('No data')).toBeInTheDocument();
   });
 
   it('shows loading state', () => {
-    renderWithRouter(<WorkloadTopBar endpoints={[]} isLoading />);
+    renderWithRouter(<WorkloadTopBar series={[]} isLoading />);
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
-  it('renders chart with 5 endpoints (no Others)', () => {
-    const endpoints = Array.from({ length: 5 }, (_, i) =>
-      makeEndpoint(i + 1, `Endpoint-${i + 1}`, 10 + i, i),
+  it('renders a chart for 5 series rows (no Others)', () => {
+    const rows = Array.from({ length: 5 }, (_, i) =>
+      makeSeries(`Stack-${i + 1}`, 10 + i, i),
     );
-    renderWithRouter(<WorkloadTopBar endpoints={endpoints} />);
+    renderWithRouter(<WorkloadTopBar series={rows} />);
     expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
     expect(screen.getByText('Running')).toBeInTheDocument();
     expect(screen.getByText('Stopped')).toBeInTheDocument();
   });
 
-  it('renders chart with 15 endpoints', () => {
-    const endpoints = Array.from({ length: 15 }, (_, i) =>
-      makeEndpoint(i + 1, `Endpoint-${i + 1}`, 20 - i, i),
+  it('renders a chart for 15 series rows', () => {
+    const rows = Array.from({ length: 15 }, (_, i) =>
+      makeSeries(`Stack-${i + 1}`, 20 - i, i),
     );
-    renderWithRouter(<WorkloadTopBar endpoints={endpoints} />);
+    renderWithRouter(<WorkloadTopBar series={rows} />);
     expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
   });
 
-  it('handles single endpoint', () => {
+  it('handles a single series row', () => {
     renderWithRouter(
-      <WorkloadTopBar endpoints={[makeEndpoint(1, 'Solo', 5, 0)]} />,
+      <WorkloadTopBar series={[makeSeries('Solo', 5, 0)]} />,
     );
     expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('carries each row href through and drops it on the aggregated Others row', () => {
+    // The chart used to navigate to `/endpoints/:id`, a route router.tsx does
+    // not define — so on the one population that carried an id, clicking a bar
+    // landed on the 404.
+    const rows = buildChartData(
+      Array.from({ length: 10 }, (_, i) =>
+        makeSeries(`S-${i}`, 10 - i, 0, `/workloads?stack=S-${i}`),
+      ),
+    );
+    expect(rows[0].href).toBe('/workloads?stack=S-0');
+    expect(rows[rows.length - 1].label).toContain('Others');
+    expect(rows[rows.length - 1].href).toBeUndefined();
+  });
+
+  it('does not claim a pointer affordance when no row is navigable', () => {
+    const { container } = renderWithRouter(
+      <WorkloadTopBar series={[makeSeries('Solo', 5, 0)]} />,
+    );
+    expect(container.querySelector('.cursor-pointer')).toBeNull();
   });
 });

--- a/frontend/src/shared/components/charts/workload-top-bar.tsx
+++ b/frontend/src/shared/components/charts/workload-top-bar.tsx
@@ -1,14 +1,25 @@
 import { memo, useMemo } from 'react';
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, Cell } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
 import { useNavigate } from 'react-router-dom';
 
+/**
+ * A stacked running/stopped bar per series row.
+ *
+ * The prop used to be called `endpoints` while its only caller passed *stacks*,
+ * and the bar click navigated to `/endpoints/:id` — a route that does not exist
+ * in `router.tsx`, so on the one population that carried an id the click landed
+ * on the 404. The series is now generic and each row carries its own `href`;
+ * rows without one are not clickable and do not claim to be with a pointer
+ * cursor.
+ */
 export interface WorkloadTopBarProps {
-  endpoints: Array<{
-    id?: number;
+  series: Array<{
     name: string;
     running: number;
     stopped: number;
     total: number;
+    /** Where this bar drills to. Omit and the bar is not interactive. */
+    href?: string;
   }>;
   isLoading?: boolean;
 }
@@ -17,20 +28,20 @@ interface ChartRow {
   label: string;
   running: number;
   stopped: number;
-  endpointId?: number;
+  href?: string;
 }
 
-function buildChartData(endpoints: WorkloadTopBarProps['endpoints']): ChartRow[] {
-  if (!endpoints || endpoints.length === 0) return [];
-  const sorted = [...endpoints].sort((a, b) => b.total - a.total);
+function buildChartData(series: WorkloadTopBarProps['series']): ChartRow[] {
+  if (!series || series.length === 0) return [];
+  const sorted = [...series].sort((a, b) => b.total - a.total);
   const top = sorted.slice(0, 8);
   const rest = sorted.slice(8);
 
-  const rows: ChartRow[] = top.map((ep) => ({
-    label: ep.name,
-    running: ep.running,
-    stopped: ep.stopped,
-    endpointId: ep.id, // May be undefined for stacks
+  const rows: ChartRow[] = top.map((item) => ({
+    label: item.name,
+    running: item.running,
+    stopped: item.stopped,
+    href: item.href,
   }));
 
   if (rest.length > 0) {
@@ -99,11 +110,11 @@ const CustomXAxisTick = ({ x, y, payload }: any) => {
 };
 
 export const WorkloadTopBar = memo(function WorkloadTopBar({
-  endpoints,
+  series,
   isLoading,
 }: WorkloadTopBarProps) {
   const navigate = useNavigate();
-  const chartData = useMemo(() => buildChartData(endpoints), [endpoints]);
+  const chartData = useMemo(() => buildChartData(series), [series]);
 
   if (isLoading) {
     return (
@@ -113,10 +124,10 @@ export const WorkloadTopBar = memo(function WorkloadTopBar({
     );
   }
 
-  if (endpoints.length === 0) {
+  if (series.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-muted-foreground">
-        No workload data
+        No data
       </div>
     );
   }
@@ -124,11 +135,12 @@ export const WorkloadTopBar = memo(function WorkloadTopBar({
   const rowHeight = 32;
   const chartHeight = Math.max(120, chartData.length * rowHeight + 24);
 
+  const isNavigable = chartData.some((row) => !!row.href);
+
   const handleBarClick = (data: any) => {
-    if (data?.endpointId != null && typeof data.endpointId === 'number') {
-      navigate(`/endpoints/${data.endpointId}`);
+    if (typeof data?.href === 'string' && data.href) {
+      navigate(data.href);
     }
-    // For stacks without endpoint ID, clicking does nothing
   };
 
   return (
@@ -176,7 +188,7 @@ export const WorkloadTopBar = memo(function WorkloadTopBar({
             radius={[0, 0, 0, 0]}
             barSize={14}
             onClick={handleBarClick}
-            className="cursor-pointer"
+            className={isNavigable ? 'cursor-pointer' : undefined}
           />
           <Bar
             dataKey="stopped"
@@ -186,7 +198,7 @@ export const WorkloadTopBar = memo(function WorkloadTopBar({
             radius={[0, 4, 4, 0]}
             barSize={14}
             onClick={handleBarClick}
-            className="cursor-pointer"
+            className={isNavigable ? 'cursor-pointer' : undefined}
           />
         </BarChart>
       </ResponsiveContainer>

--- a/frontend/src/shared/components/data-display/health-score-card.test.tsx
+++ b/frontend/src/shared/components/data-display/health-score-card.test.tsx
@@ -18,80 +18,104 @@ function makeStats(overrides: Partial<HealthStats> = {}): HealthStats {
 }
 
 describe('HealthScoreCard', () => {
-  it('renders the score and green icon when ≥80%', () => {
-    render(
-      <HealthScoreCard
-        stats={makeStats({ total: 10, healthy: 9, unhealthy: 1, running: 10 })}
-      />,
-    );
-
-    expect(screen.getByTestId('health-score')).toHaveTextContent('90.0%');
-    expect(screen.getByTestId('health-score-icon-green')).toBeInTheDocument();
-    expect(screen.getByText('9 of 10 reporting healthy')).toBeInTheDocument();
-  });
-
-  it('renders the amber icon between 50% and 80%', () => {
-    render(
-      <HealthScoreCard
-        stats={makeStats({ total: 4, healthy: 2, unhealthy: 2, running: 4 })}
-      />,
-    );
-
-    expect(screen.getByTestId('health-score-icon-amber')).toBeInTheDocument();
-  });
-
-  it('renders the red icon when below 50%', () => {
-    render(
-      <HealthScoreCard
-        stats={makeStats({ total: 4, healthy: 1, unhealthy: 3, running: 4 })}
-      />,
-    );
-
-    expect(screen.getByTestId('health-score-icon-red')).toBeInTheDocument();
-  });
-
-  it('renders the "no healthchecks configured" gray state when score is null', () => {
-    render(
-      <HealthScoreCard
-        stats={makeStats({ total: 3, running: 3, noHealthcheck: 3, unknown: 3 })}
-      />,
-    );
-
-    expect(screen.getByTestId('health-score-na')).toHaveTextContent(
-      'No healthchecks configured',
-    );
-    expect(
-      screen.getByText(/3 containers tracked\. Configure Docker healthchecks/),
-    ).toBeInTheDocument();
-  });
-
-  it('surfaces "needs attention" when there are unhealthy or stopped containers', () => {
+  it('leads with an actionable count, not a percentage', () => {
     render(
       <HealthScoreCard
         stats={makeStats({ total: 5, healthy: 3, unhealthy: 1, stopped: 1, running: 4 })}
       />,
     );
 
-    // 1 unhealthy + 1 stopped = 2 issues
-    expect(screen.getByText(/2 containers need attention/)).toBeInTheDocument();
+    expect(screen.getByTestId('needs-attention-count')).toHaveTextContent('2');
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    expect(screen.getByTestId('needs-attention-breakdown')).toHaveTextContent('2 containers');
   });
 
-  it('appends "N without healthcheck" suffix when running containers lack a healthcheck', () => {
+  it('adds unacknowledged critical + warning insights to the hero count', () => {
+    // The regression this exists for: the hero read "100.0%" in green with
+    // "14 Critical" in the same card. The hero must be able to see the 14.
     render(
       <HealthScoreCard
-        stats={makeStats({
-          total: 5,
-          healthy: 3,
-          unhealthy: 0,
-          running: 5,
-          noHealthcheck: 2,
-          unknown: 2,
-        })}
+        stats={makeStats({ total: 11, healthy: 11, running: 11 })}
+        insightCounts={{ critical: 14, warning: 3 }}
       />,
     );
 
-    expect(
-      screen.getByText(/3 of 3 reporting healthy · 2 without healthcheck/),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('needs-attention-count')).toHaveTextContent('17');
+    expect(screen.getByTestId('needs-attention-breakdown')).toHaveTextContent(
+      '17 unacknowledged insights',
+    );
+    // The pass rate is still 100% — and still rendered, just not as the hero.
+    expect(screen.getByTestId('healthcheck-pass-rate')).toHaveTextContent('100%');
+  });
+
+  it('names the healthcheck pass rate and states its exclusion inline', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({ total: 13, healthy: 11, unhealthy: 0, running: 13, noHealthcheck: 2, unknown: 2 })}
+      />,
+    );
+
+    const rate = screen.getByTestId('healthcheck-pass-rate');
+    expect(rate).toHaveTextContent('Healthcheck pass rate');
+    expect(rate).toHaveTextContent('11 of 11 containers with a healthcheck');
+    expect(rate).toHaveTextContent('2 without one, excluded');
+    expect(screen.queryByText(/Overall Health Score/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the pass rate as a whole percent (no false precision on small fleets)', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({ total: 11, healthy: 10, unhealthy: 1, running: 11 })}
+      />,
+    );
+
+    // 10/11 = 90.909…; "90.9%" implies a resolution 11 containers do not have.
+    expect(screen.getByTestId('healthcheck-pass-rate')).toHaveTextContent('91%');
+    expect(screen.getByTestId('healthcheck-pass-rate')).not.toHaveTextContent('90.9');
+  });
+
+  it('explains an unavailable pass rate instead of printing a number', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({ total: 3, running: 3, noHealthcheck: 3, unknown: 3 })}
+      />,
+    );
+
+    expect(screen.getByTestId('healthcheck-pass-rate')).toHaveTextContent(
+      /Healthcheck pass rate unavailable/,
+    );
+  });
+
+  it('shows the clear state when nothing needs attention', () => {
+    render(
+      <HealthScoreCard
+        stats={makeStats({ total: 3, healthy: 3, running: 3 })}
+        insightCounts={{ critical: 0, warning: 0 }}
+      />,
+    );
+
+    expect(screen.getByTestId('needs-attention-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('attention-icon-clear')).toBeInTheDocument();
+  });
+
+  it('uses the critical icon when a container is unhealthy and the warning icon otherwise', () => {
+    const { unmount } = render(
+      <HealthScoreCard stats={makeStats({ total: 2, healthy: 1, unhealthy: 1, running: 2 })} />,
+    );
+    expect(screen.getByTestId('attention-icon-critical')).toBeInTheDocument();
+    unmount();
+
+    render(<HealthScoreCard stats={makeStats({ total: 2, healthy: 1, stopped: 1, running: 1 })} />);
+    expect(screen.getByTestId('attention-icon-warning')).toBeInTheDocument();
+  });
+
+  it('does not draw a static full-circle ring around the icon', () => {
+    // `border-8 border-primary/20` read as a radial progress meter and
+    // rendered identically at 100% and at 12%.
+    const { container } = render(
+      <HealthScoreCard stats={makeStats({ total: 2, healthy: 1, unhealthy: 1, running: 2 })} />,
+    );
+
+    expect(container.querySelector('.border-8')).toBeNull();
   });
 });

--- a/frontend/src/shared/components/data-display/health-score-card.tsx
+++ b/frontend/src/shared/components/data-display/health-score-card.tsx
@@ -1,67 +1,112 @@
-import { AlertCircle, AlertTriangle, CheckCircle2, HelpCircle, XCircle } from 'lucide-react';
-import { calculateHealthScore, type HealthStats } from '@/shared/lib/health-score';
+import { AlertCircle, CheckCircle2, XCircle } from 'lucide-react';
+import {
+  calculateHealthcheckPassRate,
+  calculateNeedsAttention,
+  type HealthStats,
+  type InsightAttentionCounts,
+} from '@/shared/lib/health-score';
 
 /**
- * Presentational tile that surfaces the Overall Health Score. Extracted from
- * `fleet-health-summary.tsx` so the Home page and the Health & Monitoring page
- * stay in sync — both render through this component and reuse the shared
- * `calculateHealthStats` / `calculateHealthScore` helpers for the formula and
- * color-band thresholds (≥80% green, ≥50% amber, <50% red, null = gray).
+ * The hero tile of the Fleet Vitals pane, shared by Home and Health &
+ * Monitoring so the two pages can never disagree about the fleet's headline
+ * number.
  *
- * The score is derived internally from `stats` via `calculateHealthScore` so
- * callers can't accidentally pass a score that disagrees with the stats.
+ * It used to lead with "Overall Health Score 100.0%" — the Docker healthcheck
+ * pass rate under a name that claimed to summarise the fleet. On Health &
+ * Monitoring that green 100.0% rendered two inches from "14 Critical", because
+ * the rate is structurally blind to insights. The rate is still here and still
+ * correct; it is now named for what it measures, states its own exclusion
+ * inline, and is secondary to a count the operator can act on.
+ *
+ * Both numbers are derived internally from `stats` (+ the caller's
+ * unacknowledged insight counts) rather than accepted as props, so no caller
+ * can pass a number that disagrees with the data beside it.
+ *
+ * There is deliberately no ring around the icon. The old one was
+ * `border-8 border-primary/20` — a static full circle that read as a radial
+ * progress meter and rendered identically at 100% and at 12%.
  */
 export interface HealthScoreCardProps {
   /** Aggregated container health stats from `calculateHealthStats`. */
   stats: HealthStats;
+  /**
+   * Unacknowledged critical / warning insight counts. Pages that don't load
+   * the insight feed (Home) omit this; the count then covers container state
+   * only and the breakdown line says so rather than implying zero insights.
+   */
+  insightCounts?: InsightAttentionCounts;
 }
 
-export function HealthScoreCard({ stats }: HealthScoreCardProps) {
-  const score = calculateHealthScore(stats);
+function plural(n: number, singular: string, plural_: string): string {
+  return `${n} ${n === 1 ? singular : plural_}`;
+}
+
+export function HealthScoreCard({ stats, insightCounts }: HealthScoreCardProps) {
+  const passRate = calculateHealthcheckPassRate(stats);
   const reporting = stats.healthy + stats.unhealthy;
-  const issueCount = stats.unhealthy + stats.stopped;
+  const attention = calculateNeedsAttention(stats, insightCounts);
+
+  const isClear = attention.total === 0;
+  const isCritical = stats.unhealthy > 0 || (insightCounts?.critical ?? 0) > 0;
+
+  const breakdownParts: string[] = [];
+  if (attention.containers > 0) {
+    breakdownParts.push(plural(attention.containers, 'container', 'containers'));
+  }
+  if (attention.insights > 0) {
+    breakdownParts.push(
+      `${plural(attention.insights, 'unacknowledged insight', 'unacknowledged insights')}`,
+    );
+  }
+  const breakdown = isClear
+    ? insightCounts
+      ? 'No unhealthy or stopped containers, no unacknowledged critical or warning insights.'
+      : 'No unhealthy or stopped containers.'
+    : breakdownParts.join(' · ');
 
   return (
     <div className="flex items-center gap-5 min-w-0" data-testid="health-score-card">
-      <div className="flex h-24 w-24 flex-shrink-0 items-center justify-center rounded-full border-8 border-primary/20 bg-muted/30">
-        {score === null ? (
-          <HelpCircle className="h-12 w-12 text-muted-foreground" />
-        ) : score >= 80 ? (
-          <CheckCircle2 className="h-12 w-12 text-emerald-500" data-testid="health-score-icon-green" />
-        ) : score >= 50 ? (
-          <AlertCircle className="h-12 w-12 text-amber-500" data-testid="health-score-icon-amber" />
+      <div className="flex h-20 w-20 flex-shrink-0 items-center justify-center rounded-full bg-muted/40">
+        {isClear ? (
+          <CheckCircle2 className="h-10 w-10 text-emerald-500" data-testid="attention-icon-clear" />
+        ) : isCritical ? (
+          <XCircle className="h-10 w-10 text-red-500" data-testid="attention-icon-critical" />
         ) : (
-          <XCircle className="h-12 w-12 text-red-500" data-testid="health-score-icon-red" />
+          <AlertCircle className="h-10 w-10 text-amber-500" data-testid="attention-icon-warning" />
         )}
       </div>
       <div className="min-w-0">
-        <p className="text-sm font-medium text-muted-foreground">Overall Health Score</p>
-        {score === null ? (
-          <>
-            <p className="text-2xl font-semibold text-muted-foreground" data-testid="health-score-na">
-              No healthchecks configured
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              {stats.total} containers tracked. Configure Docker healthchecks to enable scoring.
-            </p>
-          </>
-        ) : (
-          <>
-            <p className="text-4xl font-bold tabular-nums leading-none mt-1" data-testid="health-score">
-              {score.toFixed(1)}%
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              {stats.healthy} of {reporting} reporting healthy
-              {stats.noHealthcheck > 0 && ` · ${stats.noHealthcheck} without healthcheck`}
-            </p>
-          </>
-        )}
-        {issueCount > 0 && (
-          <p className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium text-red-700 dark:text-red-400">
-            <AlertTriangle className="h-4 w-4" />
-            {issueCount} container{issueCount === 1 ? '' : 's'} need{issueCount === 1 ? 's' : ''} attention
-          </p>
-        )}
+        <p className="text-sm font-medium text-muted-foreground">Needs attention</p>
+        <p
+          className="text-4xl font-bold tabular-nums leading-none mt-1"
+          data-testid="needs-attention-count"
+        >
+          {attention.total}
+        </p>
+        <p className="text-xs text-muted-foreground mt-1" data-testid="needs-attention-breakdown">
+          {breakdown}
+        </p>
+        {/* Secondary, and named for what it measures. Whole percent only: on a
+            fleet of 11 reporting containers the tenths digit is noise — one
+            container moves the number 9.1 points, and the exact fraction is
+            spelled out on the same line anyway. */}
+        <p className="mt-3 border-t pt-2 text-xs text-muted-foreground" data-testid="healthcheck-pass-rate">
+          {passRate === null ? (
+            <>
+              Healthcheck pass rate unavailable — none of the {stats.total} containers has a Docker
+              healthcheck configured.
+            </>
+          ) : (
+            <>
+              Healthcheck pass rate{' '}
+              <span className="font-medium text-foreground tabular-nums">
+                {Math.round(passRate)}%
+              </span>{' '}
+              — {stats.healthy} of {reporting} containers with a healthcheck
+              {stats.noHealthcheck > 0 && ` · ${stats.noHealthcheck} without one, excluded`}
+            </>
+          )}
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/shared/components/forms/workload-smart-search.test.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.test.tsx
@@ -89,12 +89,55 @@ describe('WorkloadSmartSearch', () => {
     expect(screen.getByPlaceholderText('Custom placeholder')).toBeInTheDocument();
   });
 
-  it('shows filter chips and AI chips when input empty', () => {
+  it('derives every suggested chip from the loaded containers', () => {
     renderComponent();
-    expect(screen.getByRole('button', { name: /state:running/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /image:nginx/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /stopped containers using high memory/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /all nginx containers on prod/i })).toBeInTheDocument();
+    const group = screen.getByRole('group', { name: 'Suggested filters' });
+    const labels = Array.from(group.querySelectorAll('button')).map((b) => b.textContent);
+    expect(labels.length).toBeGreaterThan(0);
+    // 2 running / 1 exited — the rarest state is the one worth suggesting.
+    expect(labels).toContain('state:exited');
+    // Fixture images are nginx / postgres / redis, so `image:nginx` is real here.
+    expect(labels).toContain('image:nginx');
+    // The literals that used to ship: none of them exist in this fixture.
+    expect(labels).not.toContain('stack:traefik');
+    expect(labels).not.toContain('endpoint:prod');
+  });
+
+  it('every suggested chip returns rows — none empties the table', () => {
+    const { onFiltered } = renderComponent();
+    const group = screen.getByRole('group', { name: 'Suggested filters' });
+    const buttons = Array.from(group.querySelectorAll('button'));
+
+    for (const button of buttons) {
+      fireEvent.click(button);
+      const last = onFiltered.mock.calls[onFiltered.mock.calls.length - 1][0] as Container[];
+      expect(last.length).toBeGreaterThan(0);
+      expect(last.length).toBeLessThan(containers.length);
+    }
+  });
+
+  it('shows no chips for an empty fleet', () => {
+    renderComponent({ containers: [], totalCount: 0 });
+    expect(screen.queryByRole('group', { name: 'Suggested filters' })).not.toBeInTheDocument();
+  });
+
+  it('no suggested chip spends an LLM call', () => {
+    renderComponent();
+    const group = screen.getByRole('group', { name: 'Suggested filters' });
+    for (const button of Array.from(group.querySelectorAll('button'))) {
+      fireEvent.click(button);
+    }
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('names every supported field prefix, including label:, in the syntax hint', () => {
+    renderComponent();
+    const hint = screen.getByText(/prefix a term to target one field/i);
+    for (const field of ['name', 'image', 'state', 'status', 'stack', 'endpoint', 'port', 'label']) {
+      expect(hint.textContent).toContain(field);
+    }
+    // The AI path is stated in visible copy, not only in the placeholder.
+    expect(hint.textContent).toMatch(/press\s*Enter\s*for AI search/i);
   });
 
   it('does not render the redundant container-count label (issue #1309)', () => {
@@ -135,28 +178,38 @@ describe('WorkloadSmartSearch', () => {
   it('hides chips when input has value', () => {
     renderComponent();
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'nginx' } });
-    expect(screen.queryByRole('button', { name: /state:running/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('group', { name: 'Suggested filters' })).not.toBeInTheDocument();
   });
 
-  it('keeps the in-field example chips mounted while the empty field is focused (keyboard reachability)', () => {
+  it('keeps the chips mounted while the empty field is focused (keyboard reachability)', () => {
     renderComponent();
     const input = screen.getByRole('textbox');
-    expect(screen.getByRole('button', { name: 'state:running' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Suggested filters' })).toBeInTheDocument();
 
-    // Focusing the input must NOT unmount the chips — a keyboard user needs to
-    // be able to Tab from the input onto them.
     fireEvent.focus(input);
-    expect(screen.getByRole('button', { name: 'state:running' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Suggested filters' })).toBeInTheDocument();
   });
 
-  it('clicking the empty example strip focuses the input', () => {
+  it('never hides the placeholder behind the chips', () => {
     renderComponent();
     const input = screen.getByRole('textbox');
-    const strip = screen.getByRole('group', { name: 'Example searches' });
+    // `placeholder:text-transparent` used to blank the only instruction the
+    // empty field carried, precisely when the field was empty.
+    expect(input.className).not.toContain('placeholder:text-transparent');
+  });
 
-    expect(document.activeElement).not.toBe(input);
-    fireEvent.click(strip);
-    expect(document.activeElement).toBe(input);
+  it('renders the chips below the field, not overlaid inside it', () => {
+    renderComponent();
+    const input = screen.getByRole('textbox');
+    const group = screen.getByRole('group', { name: 'Suggested filters' });
+    // Overlaying meant absolute positioning inside the input's wrapper; on a
+    // phone the chips then consumed the whole field.
+    expect(group.className).not.toContain('absolute');
+    expect(group.className).toContain('flex-wrap');
+    expect(input.parentElement?.contains(group)).toBe(false);
+    expect(
+      input.compareDocumentPosition(group) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it('pressing Enter calls mutate (AI mode) and shows AI badge', async () => {
@@ -234,27 +287,13 @@ describe('WorkloadSmartSearch', () => {
     expect(document.activeElement).not.toBe(input);
   });
 
-  it('right-aligns the example chips via ml-auto on the first chip', () => {
-    renderComponent();
-    // ml-auto on the leading chip pushes the row to the right when it fits and
-    // collapses to a left-aligned scrollable row when the chips overflow.
-    expect(screen.getByRole('button', { name: 'state:running' })).toHaveClass('ml-auto');
-  });
-
   it('clicking a filter chip sets query and filters', () => {
     const { onFiltered } = renderComponent();
-    fireEvent.click(screen.getByRole('button', { name: 'state:running' }));
+    fireEvent.click(screen.getByRole('button', { name: 'state:exited' }));
 
-    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('state:running');
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('state:exited');
     const lastCall = onFiltered.mock.calls[onFiltered.mock.calls.length - 1][0] as Container[];
-    expect(lastCall).toHaveLength(2); // c1 and c3 are running
-  });
-
-  it('clicking an AI chip triggers mutate', () => {
-    renderComponent();
-    fireEvent.click(screen.getByRole('button', { name: /stopped containers using high memory/i }));
-
-    expect(mockMutate).toHaveBeenCalledWith('stopped containers using high memory', expect.any(Object));
+    expect(lastCall).toHaveLength(1); // only c2 is exited
   });
 
   it('shows answer result card after AI search', async () => {

--- a/frontend/src/shared/components/forms/workload-smart-search.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.tsx
@@ -1,22 +1,14 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Search, Sparkles, Loader2, ArrowRight, AlertCircle, X, Filter } from 'lucide-react';
 import { useNlQuery, type NlQueryResult } from '@/features/ai-intelligence/hooks/use-nl-query';
 import { cn } from '@/shared/lib/utils';
 import type { Container } from '@/features/containers/hooks/use-containers';
-import { filterContainers } from '@/features/containers/lib/workload-search-filter';
-
-const FILTER_CHIPS = [
-  { label: 'state:running' },
-  { label: 'image:nginx' },
-  { label: 'stack:traefik' },
-  { label: 'endpoint:prod' },
-];
-
-const AI_CHIPS = [
-  { label: 'stopped containers using high memory' },
-  { label: 'all nginx containers on prod' },
-];
+import {
+  filterContainers,
+  deriveSearchChips,
+  SEARCH_FIELDS,
+} from '@/features/containers/lib/workload-search-filter';
 
 type SearchMode = 'filter' | 'ai';
 
@@ -155,27 +147,22 @@ export function WorkloadSmartSearch({
     [applyFilter, containers],
   );
 
-  const handleAiChipClick = useCallback(
-    (label: string) => {
-      setQuery(label);
-      setMode('ai');
-      setAiResult(null);
-      setAiFilteredCount(null);
-      nlQuery.mutate(label, {
-        onSuccess: handleAiResult,
-        onError: () =>
-          setAiResult({ action: 'error', text: 'Failed to process query. Is the LLM service available?' }),
-      });
-    },
-    [nlQuery, handleAiResult],
-  );
-
   const isAiMode = mode === 'ai';
   const isAiFilterActive = isAiMode && aiResult?.action === 'filter' && aiFilteredCount !== null;
-  // Example chips overlay the field while it is empty and idle. They stay
-  // mounted on focus (rather than unmounting) so a keyboard user can Tab from
-  // the input onto them; the first keystroke fills the field and removes them.
-  const showExamples = !query && !nlQuery.isPending;
+
+  // Suggestions are read off the containers currently loaded, so every chip
+  // matches at least one row. The literals this replaced (`image:nginx`,
+  // `stack:traefik`, `endpoint:prod`) were live controls pointed at
+  // infrastructure that did not exist, so a click emptied the table.
+  const chips = useMemo(
+    () => deriveSearchChips(containers, knownStackNames),
+    [containers, knownStackNames],
+  );
+  // Chips sit under the field, not inside it: overlaying them meant hiding the
+  // placeholder, which left an empty 1500px field with no visible instruction —
+  // and on a phone the chips consumed the whole input.
+  const showChips = !query && !nlQuery.isPending && chips.length > 0;
+  const showSyntaxHint = !query && !nlQuery.isPending;
 
   return (
     <div className="space-y-3">
@@ -202,9 +189,6 @@ export function WorkloadSmartSearch({
             'placeholder:text-muted-foreground/50',
             'focus:outline-none transition-all duration-200',
             'text-[16px] sm:text-sm',
-            // While example chips overlay the empty field, hide the placeholder
-            // text (kept in the DOM for a11y/tests) so the two don't collide.
-            showExamples && 'placeholder:text-transparent',
             isAiMode
               ? 'ring-2 ring-purple-500/40 border-purple-500/50 focus:ring-2 focus:ring-purple-500/40 focus:border-purple-500/50'
               : 'focus:ring-2 focus:ring-primary/30 focus:border-primary/50',
@@ -227,58 +211,44 @@ export function WorkloadSmartSearch({
             </button>
           )}
         </div>
-        {/* Example searches — overlaid inside the empty field; click fills the
-            search. Kept mounted whenever the field is empty (incl. while
-            focused) so they stay keyboard-reachable; the first keystroke removes
-            them, so typed text is never obscured. Long AI prompts scroll. */}
-        {showExamples && (
-          <div
-            role="group"
-            aria-label="Example searches"
-            onClick={(e) => {
-              // A click on the empty strip (not a chip) focuses the input so the
-              // user can start typing. Using onClick (not onMouseDown) leaves
-              // drag-to-scroll of overflowing chips intact.
-              if (e.target === e.currentTarget) {
-                inputRef.current?.focus();
-              }
-            }}
-            className="absolute inset-y-0 left-11 right-3 flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-          >
-            {FILTER_CHIPS.map((chip, i) => (
-              <button
-                key={chip.label}
-                onClick={() => handleFilterChipClick(chip.label)}
-                className={cn(
-                  'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-border/60 bg-card/80 px-2 py-0.5 text-xs font-medium',
-                  'text-muted-foreground backdrop-blur-sm transition-colors duration-200',
-                  'hover:bg-primary/10 hover:text-primary hover:border-primary/30',
-                  // Right-align the chip row: ml-auto on the first chip absorbs
-                  // free space so chips sit at the right when they fit, and
-                  // collapses to a left-aligned scrollable row when they overflow.
-                  i === 0 && 'ml-auto',
-                )}
-              >
-                {chip.label}
-              </button>
-            ))}
-            {AI_CHIPS.map((chip) => (
-              <button
-                key={chip.label}
-                onClick={() => handleAiChipClick(chip.label)}
-                className={cn(
-                  'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-border/60 bg-card/80 px-2 py-0.5 text-xs font-medium',
-                  'text-muted-foreground backdrop-blur-sm transition-colors duration-200',
-                  'hover:bg-purple-500/10 hover:text-purple-600 hover:border-purple-500/30',
-                )}
-              >
-                <Sparkles className="h-3 w-3" />
-                {chip.label}
-              </button>
-            ))}
-          </div>
-        )}
       </div>
+
+      {/* Suggested filters — their own row under the field, so the placeholder
+          stays visible and the chips wrap instead of eating the input on a
+          phone. Each label is derived from the loaded containers. */}
+      {showChips && (
+        <div
+          role="group"
+          aria-label="Suggested filters"
+          className="flex flex-wrap items-center gap-1.5"
+        >
+          {chips.map((chip) => (
+            <button
+              key={chip}
+              type="button"
+              onClick={() => handleFilterChipClick(chip)}
+              className={cn(
+                'inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-border/60 bg-card/80 px-2.5 py-1 text-xs font-medium',
+                'text-muted-foreground backdrop-blur-sm transition-colors duration-200',
+                'hover:bg-primary/10 hover:text-primary hover:border-primary/30',
+                'min-h-[36px] sm:min-h-0',
+              )}
+            >
+              {chip}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Syntax hint — names every supported field prefix, including `label:`,
+          which is what finds an image by its `com.docker.dhi.name` label when
+          `image:` only sees the local tag. */}
+      {showSyntaxHint && (
+        <p className="text-xs text-muted-foreground">
+          Prefix a term to target one field: {SEARCH_FIELDS.join(', ')}. Press{' '}
+          <kbd className="rounded bg-muted px-1.5 py-0.5 text-xs">Enter</kbd> for AI search.
+        </p>
+      )}
 
       {/* Hint text — filter mode with query */}
       {query && mode === 'filter' && !aiResult && !nlQuery.isPending && (

--- a/frontend/src/shared/components/layout/page-header.test.tsx
+++ b/frontend/src/shared/components/layout/page-header.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PageHeader } from './page-header';
+
+describe('PageHeader', () => {
+  it('renders the title as the page h1', () => {
+    render(<PageHeader title="Workload Explorer" />);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent('Workload Explorer');
+    // Exactly one h1 — the reason 11 files wrote their title string twice was
+    // that nothing owned this element.
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+  });
+
+  it('uses the established desktop title scale and steps down on small viewports', () => {
+    render(<PageHeader title="Health" />);
+    const heading = screen.getByRole('heading', { level: 1 });
+    // text-3xl font-bold tracking-tight is the scale on 17 of 20 pages.
+    expect(heading).toHaveClass('sm:text-3xl', 'font-bold', 'tracking-tight');
+    // Mobile loses ~370px of fold to title chrome, so the h1 shrinks below sm.
+    expect(heading).toHaveClass('text-xl');
+  });
+
+  it('omits the subtitle element entirely when no subtitle is given', () => {
+    render(<PageHeader title="Health" />);
+    expect(screen.queryByTestId('page-header-subtitle')).toBeNull();
+  });
+
+  it('renders a muted subtitle when provided', () => {
+    render(<PageHeader title="Traces" subtitle="193 traces · 1 service · last 24h" />);
+    const subtitle = screen.getByTestId('page-header-subtitle');
+    expect(subtitle).toHaveTextContent('193 traces · 1 service · last 24h');
+    expect(subtitle).toHaveClass('text-muted-foreground');
+  });
+
+  it('accepts a ReactNode subtitle', () => {
+    render(<PageHeader title="Fleet" subtitle={<span data-testid="live">13 containers</span>} />);
+    expect(screen.getByTestId('live')).toHaveTextContent('13 containers');
+  });
+
+  it('hides the subtitle below sm by default', () => {
+    render(<PageHeader title="Fleet" subtitle="13 containers across 1 endpoint" />);
+    const subtitle = screen.getByTestId('page-header-subtitle');
+    expect(subtitle).toHaveClass('hidden', 'sm:block');
+  });
+
+  it('keeps the subtitle on mobile when hideSubtitleOnMobile is false', () => {
+    render(
+      <PageHeader
+        title="Fleet"
+        subtitle="13 containers across 1 endpoint"
+        hideSubtitleOnMobile={false}
+      />,
+    );
+    const subtitle = screen.getByTestId('page-header-subtitle');
+    expect(subtitle).not.toHaveClass('hidden');
+    expect(subtitle).not.toHaveClass('sm:block');
+  });
+
+  it('renders actions on the title row and omits the slot when absent', () => {
+    const { rerender } = render(<PageHeader title="Fleet" />);
+    expect(screen.queryByTestId('page-header-actions')).toBeNull();
+
+    rerender(<PageHeader title="Fleet" actions={<button type="button">Refresh</button>} />);
+    const actions = screen.getByTestId('page-header-actions');
+    expect(actions).toContainElement(screen.getByRole('button', { name: 'Refresh' }));
+    // Same row as the title, right-aligned by the wrapper's justify-between.
+    expect(screen.getByTestId('page-header')).toHaveClass('justify-between');
+    expect(screen.getByTestId('page-header')).toContainElement(actions);
+  });
+
+  it('has no gradient, icon tile or per-page title escape hatch', () => {
+    // The Assistant's h1 drifted into a blue-purple gradient with an icon tile
+    // precisely because nothing enforced the shape. There is no prop for it.
+    render(<PageHeader title="LLM Assistant" subtitle="anything" />);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading.className).not.toMatch(/gradient|bg-clip-text|text-transparent/);
+    expect(heading.querySelector('svg')).toBeNull();
+    expect(heading.children).toHaveLength(0);
+  });
+
+  it('merges extra wrapper classes without dropping the layout classes', () => {
+    render(<PageHeader title="Fleet" className="mb-6" />);
+    const wrapper = screen.getByTestId('page-header');
+    expect(wrapper).toHaveClass('mb-6', 'flex', 'justify-between');
+  });
+});

--- a/frontend/src/shared/components/layout/page-header.tsx
+++ b/frontend/src/shared/components/layout/page-header.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/shared/lib/utils';
+
+export interface PageHeaderProps {
+  /** The page title. Rendered as the page's single `<h1>`. */
+  title: string;
+  /**
+   * One line under the title. Omit it rather than filling the slot: if deleting
+   * the subtitle costs the operator nothing, it was decoration.
+   * Inline content only — it renders inside a `<div>`, so a badge or a `<span>`
+   * with live state is fine, a card is not.
+   */
+  subtitle?: ReactNode;
+  /** Right-aligned controls on the title row (refresh controls, buttons, filters). */
+  actions?: ReactNode;
+  /**
+   * Hide the subtitle below `sm`. Default `true` — on a phone the header block
+   * costs a large share of the fold, and the title alone identifies the page.
+   * Set `false` only when the subtitle carries state the title does not.
+   */
+  hideSubtitleOnMobile?: boolean;
+  /** Extra classes on the wrapper (spacing only — do not restyle the title). */
+  className?: string;
+}
+
+/**
+ * The one page-header shape.
+ *
+ * Every page used to hand-roll this block, 11 files wrote the same title string
+ * twice (loading branch + loaded branch), and with nothing enforcing the shape
+ * one page's `<h1>` drifted into a gradient with an icon tile while its 19
+ * siblings stayed plain. There are deliberately no per-page escape hatches: no
+ * gradient, no icon slot, no title size override. `text-3xl font-bold
+ * tracking-tight` is the established desktop scale (17 of 20 pages); it steps
+ * down to `text-xl` below `sm`.
+ *
+ * Render it in the loading branch too — passing the same `title` while the data
+ * is in flight is what stops the string being written twice.
+ */
+export function PageHeader({
+  title,
+  subtitle,
+  actions,
+  hideSubtitleOnMobile = true,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      data-testid="page-header"
+      className={cn('flex flex-wrap items-start justify-between gap-3', className)}
+    >
+      <div className="min-w-0">
+        <h1 className="text-xl font-bold tracking-tight sm:text-3xl">{title}</h1>
+        {subtitle != null && subtitle !== false && (
+          <div
+            data-testid="page-header-subtitle"
+            className={cn(
+              'mt-1 text-sm text-muted-foreground',
+              hideSubtitleOnMobile && 'hidden sm:block'
+            )}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {actions != null && actions !== false && (
+        <div
+          data-testid="page-header-actions"
+          className="flex shrink-0 flex-wrap items-center gap-2"
+        >
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { DataTable } from './data-table';
 import type { ColumnDef } from '@tanstack/react-table';
 
@@ -945,6 +946,147 @@ describe('DataTable', () => {
       act(() => container.focus());
       fireEvent.keyDown(container, { key: 'j' });
       expect(document.activeElement).toBe(screen.getByTestId('table-row-0'));
+    });
+  });
+
+  describe('rowHref — real anchors for navigating rows', () => {
+    const href = (row: TestRow) => `/containers/1/${row.id}`;
+
+    function renderWithRouter(ui: React.ReactElement) {
+      return render(<MemoryRouter>{ui}</MemoryRouter>);
+    }
+
+    it('renders no anchor and no role when rowHref is omitted (byte-identical to before)', () => {
+      render(<DataTable columns={testColumns} data={makeRows(3)} onRowClick={vi.fn()} />);
+      const row = screen.getByTestId('table-row-0');
+      expect(row.querySelector('a')).toBeNull();
+      expect(row).not.toHaveAttribute('role');
+      expect(row).not.toHaveAttribute('aria-label');
+      expect(row).toHaveAttribute('tabindex', '0');
+    });
+
+    it('wraps the first cell content in a real anchor carrying the destination', () => {
+      renderWithRouter(
+        <DataTable columns={testColumns} data={makeRows(3)} onRowClick={vi.fn()} rowHref={href} />
+      );
+
+      const row = screen.getByTestId('table-row-1');
+      const anchors = row.querySelectorAll('a');
+      // Exactly one anchor per row — a link per cell would be noise.
+      expect(anchors).toHaveLength(1);
+      // ...on the FIRST cell, and it is a real href so cmd/middle-click,
+      // "open in new tab" and "copy link address" all work.
+      expect(row.querySelector('td')!.contains(anchors[0])).toBe(true);
+      expect(anchors[0]).toHaveAttribute('href', '/containers/1/2');
+    });
+
+    it('announces the row as a link with an accessible name', () => {
+      renderWithRouter(
+        <DataTable
+          columns={testColumns}
+          data={makeRows(2)}
+          onRowClick={vi.fn()}
+          rowHref={href}
+          rowLabel={(row) => `Open container ${row.name}`}
+        />
+      );
+
+      const row = screen.getByTestId('table-row-0');
+      expect(row).toHaveAttribute('role', 'link');
+      expect(row).toHaveAttribute('aria-label', 'Open container container-1');
+    });
+
+    it('omits aria-label rather than inventing one when rowLabel is not supplied', () => {
+      renderWithRouter(
+        <DataTable columns={testColumns} data={makeRows(2)} onRowClick={vi.fn()} rowHref={href} />
+      );
+      const row = screen.getByTestId('table-row-0');
+      expect(row).toHaveAttribute('role', 'link');
+      expect(row).not.toHaveAttribute('aria-label');
+    });
+
+    it('keeps whole-row click working as a convenience', () => {
+      const onRowClick = vi.fn();
+      const data = makeRows(3);
+      renderWithRouter(
+        <DataTable columns={testColumns} data={data} onRowClick={onRowClick} rowHref={href} />
+      );
+
+      // Click a cell that is NOT the anchor.
+      const nameCell = screen.getByTestId('table-row-0').querySelectorAll('td')[1];
+      expect(nameCell.querySelector('a')).toBeNull();
+      fireEvent.click(nameCell);
+      expect(onRowClick).toHaveBeenCalledWith(data[0]);
+    });
+
+    it('does not double-navigate when the anchor itself is clicked', () => {
+      const onRowClick = vi.fn();
+      renderWithRouter(
+        <DataTable columns={testColumns} data={makeRows(3)} onRowClick={onRowClick} rowHref={href} />
+      );
+
+      const anchor = screen.getByTestId('table-row-0').querySelector('a')!;
+      fireEvent.click(anchor);
+      // The anchor already navigates; running onRowClick too would push the
+      // same route twice.
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
+
+    it('keeps the existing keyboard handler working', () => {
+      const onRowClick = vi.fn();
+      const data = makeRows(3);
+      renderWithRouter(
+        <DataTable columns={testColumns} data={data} onRowClick={onRowClick} rowHref={href} />
+      );
+
+      const row = screen.getByTestId('table-row-1');
+      act(() => row.focus());
+      expect(row.className).toContain('keyboard-selected');
+      fireEvent.keyDown(row, { key: 'Enter' });
+      expect(onRowClick).toHaveBeenCalledWith(data[1]);
+
+      fireEvent.keyDown(row, { key: 'j' });
+      expect(document.activeElement).toBe(screen.getByTestId('table-row-2'));
+    });
+
+    it('skips the selection checkbox column when choosing the anchor cell', () => {
+      renderWithRouter(
+        <DataTable
+          columns={testColumns}
+          data={makeRows(3)}
+          onRowClick={vi.fn()}
+          rowHref={href}
+          enableRowSelection
+        />
+      );
+
+      const row = screen.getByTestId('table-row-0');
+      const cells = row.querySelectorAll('td');
+      // First cell keeps its checkbox untouched; the anchor lands on the first
+      // data cell instead.
+      expect(cells[0].querySelector('input[type="checkbox"]')).not.toBeNull();
+      expect(cells[0].querySelector('a')).toBeNull();
+      expect(cells[1].querySelector('a')).toHaveAttribute('href', '/containers/1/1');
+    });
+
+    it('renders the anchor without a clickable row too', () => {
+      renderWithRouter(<DataTable columns={testColumns} data={makeRows(2)} rowHref={href} />);
+      const row = screen.getByTestId('table-row-0');
+      expect(row.querySelector('a')).toHaveAttribute('href', '/containers/1/1');
+      // No onRowClick means no focusable row and no link role on the <tr>.
+      expect(row).not.toHaveAttribute('tabindex');
+      expect(row).not.toHaveAttribute('role');
+    });
+
+    it('applies to virtualized rows as well', () => {
+      renderWithRouter(
+        <DataTable columns={testColumns} data={makeRows(100)} onRowClick={vi.fn()} rowHref={href} />
+      );
+      expect(screen.getByTestId('virtual-scroll-container')).toBeInTheDocument();
+      expect(screen.getByTestId('table-row-0').querySelector('a')).toHaveAttribute(
+        'href',
+        '/containers/1/1'
+      );
     });
   });
 

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -980,7 +980,7 @@ describe('DataTable', () => {
       expect(anchors[0]).toHaveAttribute('href', '/containers/1/2');
     });
 
-    it('announces the row as a link with an accessible name', () => {
+    it('names the anchor, and leaves the row a row', () => {
       renderWithRouter(
         <DataTable
           columns={testColumns}
@@ -992,8 +992,53 @@ describe('DataTable', () => {
       );
 
       const row = screen.getByTestId('table-row-0');
-      expect(row).toHaveAttribute('role', 'link');
-      expect(row).toHaveAttribute('aria-label', 'Open container container-1');
+      // The accessible name belongs to the anchor — that is the thing that
+      // navigates.
+      expect(row.querySelector('a')).toHaveAttribute('aria-label', 'Open container container-1');
+      expect(
+        screen.getByRole('link', { name: 'Open container container-1' })
+      ).toBeInTheDocument();
+    });
+
+    it('does not override the row role, which would break table semantics', () => {
+      // An explicit role on <tr> replaces the implicit `row` that each <td>'s
+      // `cell` role requires as an ancestor — and the virtual container is a
+      // `role="grid"`. Overriding it disables screen-reader table navigation
+      // on precisely the tables this prop was added to improve.
+      renderWithRouter(
+        <DataTable
+          columns={testColumns}
+          data={makeRows(2)}
+          onRowClick={vi.fn()}
+          rowHref={href}
+          rowLabel={(row) => `Open container ${row.name}`}
+        />
+      );
+
+      const row = screen.getByTestId('table-row-0');
+      expect(row).not.toHaveAttribute('role');
+      expect(row).not.toHaveAttribute('aria-label');
+      expect(row.tagName).toBe('TR');
+    });
+
+    it('exposes exactly one link per row, so the destination is announced once', () => {
+      // The row used to carry role="link" while containing a real anchor with
+      // the same name: a link nested in a link (axe `nested-interactive`),
+      // read out twice.
+      renderWithRouter(
+        <DataTable
+          columns={testColumns}
+          data={makeRows(3)}
+          onRowClick={vi.fn()}
+          rowHref={href}
+          rowLabel={(row) => `Open container ${row.name}`}
+        />
+      );
+
+      expect(screen.getAllByRole('link')).toHaveLength(3);
+      expect(
+        screen.getAllByRole('link', { name: 'Open container container-1' })
+      ).toHaveLength(1);
     });
 
     it('omits aria-label rather than inventing one when rowLabel is not supplied', () => {
@@ -1001,8 +1046,9 @@ describe('DataTable', () => {
         <DataTable columns={testColumns} data={makeRows(2)} onRowClick={vi.fn()} rowHref={href} />
       );
       const row = screen.getByTestId('table-row-0');
-      expect(row).toHaveAttribute('role', 'link');
+      expect(row).not.toHaveAttribute('role');
       expect(row).not.toHaveAttribute('aria-label');
+      expect(row.querySelector('a')).not.toHaveAttribute('aria-label');
     });
 
     it('keeps whole-row click working as a convenience', () => {

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -15,6 +15,7 @@ import {
   type Updater,
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { Link } from 'react-router-dom';
 import { cn } from '@/shared/lib/utils';
 import { Checkbox } from '@/shared/components/ui/checkbox';
 import { ArrowUpDown, ChevronLeft, ChevronRight, ArrowUp, ArrowDown } from 'lucide-react';
@@ -102,6 +103,26 @@ interface DataTableProps<T> {
    * `<tr className=...>` previously provided.
    */
   rowClassName?: (row: T) => string;
+  /**
+   * Destination for a row that *navigates*. Supply it on tables whose
+   * `onRowClick` pushes a route; the first data cell then renders inside a real
+   * `<a href>` (react-router `<Link>`), so ⌘/middle-click, "Open in new tab",
+   * "Copy link address" and the hover status-bar preview all work, and a screen
+   * reader hears a link with a destination instead of a bare focusable row.
+   *
+   * Omit it for rows whose click is a local action (expand/collapse, select) —
+   * those are button-like, not links. When omitted the row renders exactly as
+   * it did before this prop existed. Returning `''` for an individual row skips
+   * the anchor for that row only.
+   */
+  rowHref?: (row: T) => string;
+  /**
+   * Accessible name for a navigating row, e.g. ``(r) => `Open container ${r.name}` ``.
+   * Applied to both the row and its anchor. Only used when `rowHref` is
+   * supplied. Omit it and the names are computed from cell text — usually
+   * adequate, but the row's name then reads out every column.
+   */
+  rowLabel?: (row: T) => string;
 }
 
 export function DataTable<T>({
@@ -124,6 +145,8 @@ export function DataTable<T>({
   autoFit,
   minTableWidth,
   rowClassName,
+  rowHref,
+  rowLabel,
 }: DataTableProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -436,45 +459,78 @@ export function DataTable<T>({
     );
   };
 
-  const renderRow = (row: Row<T>) => (
-    <tr
-      key={row.id}
-      data-testid={`table-row-${row.id}`}
-      className={cn(
-        'group/row border-b transition-colors duration-200 hover:bg-muted/30',
-        onRowClick && 'cursor-pointer',
-        onRowClick && focusedRowId === row.id && 'keyboard-selected',
-        enableRowSelection && row.getIsSelected() && 'bg-primary/5',
-        rowClassName?.(row.original)
-      )}
-      onClick={() => onRowClick?.(row.original)}
-      {...(onRowClick
-        ? {
-            tabIndex: 0,
-            onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) =>
-              handleRowKeyDown(e, row.original),
-            onFocus: (e: React.FocusEvent<HTMLTableRowElement>) => {
-              if (e.target === e.currentTarget) setFocusedRowId(row.id);
-            },
-            onBlur: (e: React.FocusEvent<HTMLTableRowElement>) => {
-              if (e.target === e.currentTarget) {
-                setFocusedRowId((prev) => (prev === row.id ? null : prev));
+  const renderRow = (row: Row<T>) => {
+    const href = rowHref?.(row.original);
+    const cells = row.getVisibleCells();
+    // The anchor goes on the first *data* cell — the selection checkbox column
+    // is chrome, and wrapping it in a link would swallow the checkbox.
+    const linkCellIndex = href ? cells.findIndex((c) => c.column.id !== '_selection') : -1;
+
+    return (
+      <tr
+        key={row.id}
+        data-testid={`table-row-${row.id}`}
+        className={cn(
+          'group/row border-b transition-colors duration-200 hover:bg-muted/30',
+          onRowClick && 'cursor-pointer',
+          onRowClick && focusedRowId === row.id && 'keyboard-selected',
+          enableRowSelection && row.getIsSelected() && 'bg-primary/5',
+          rowClassName?.(row.original)
+        )}
+        onClick={
+          href
+            ? (e: React.MouseEvent<HTMLTableRowElement>) => {
+                // A click that landed on the anchor is already a navigation;
+                // letting onRowClick run too would push the same route twice.
+                if ((e.target as HTMLElement | null)?.closest?.('a')) return;
+                onRowClick?.(row.original);
               }
-            },
-          }
-        : {})}
-    >
-      {row.getVisibleCells().map((cell) => (
-        <td
-          key={cell.id}
-          style={{ width: cell.column.getSize() !== 150 ? cell.column.getSize() : undefined }}
-          className="px-4 py-3 align-middle"
-        >
-          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-        </td>
-      ))}
-    </tr>
-  );
+            : () => onRowClick?.(row.original)
+        }
+        {...(href && onRowClick
+          ? { role: 'link', 'aria-label': rowLabel?.(row.original) }
+          : {})}
+        {...(onRowClick
+          ? {
+              tabIndex: 0,
+              onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) =>
+                handleRowKeyDown(e, row.original),
+              onFocus: (e: React.FocusEvent<HTMLTableRowElement>) => {
+                if (e.target === e.currentTarget) setFocusedRowId(row.id);
+              },
+              onBlur: (e: React.FocusEvent<HTMLTableRowElement>) => {
+                if (e.target === e.currentTarget) {
+                  setFocusedRowId((prev) => (prev === row.id ? null : prev));
+                }
+              },
+            }
+          : {})}
+      >
+        {cells.map((cell, index) => {
+          const content = flexRender(cell.column.columnDef.cell, cell.getContext());
+          return (
+            <td
+              key={cell.id}
+              style={{ width: cell.column.getSize() !== 150 ? cell.column.getSize() : undefined }}
+              className="px-4 py-3 align-middle"
+            >
+              {href && index === linkCellIndex ? (
+                <Link
+                  to={href}
+                  aria-label={rowLabel?.(row.original)}
+                  className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {content}
+                </Link>
+              ) : (
+                content
+              )}
+            </td>
+          );
+        })}
+      </tr>
+    );
+  };
 
   const renderHeader = () => (
     <thead className={cn('[&_tr]:border-b', useVirtual && 'sticky top-0 z-10 bg-card')}>

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -118,9 +118,10 @@ interface DataTableProps<T> {
   rowHref?: (row: T) => string;
   /**
    * Accessible name for a navigating row, e.g. ``(r) => `Open container ${r.name}` ``.
-   * Applied to both the row and its anchor. Only used when `rowHref` is
-   * supplied. Omit it and the names are computed from cell text — usually
-   * adequate, but the row's name then reads out every column.
+   * Applied to the row's anchor — and only there, so the destination is
+   * announced once and the `<tr>` keeps its `row` role. Only used when
+   * `rowHref` is supplied. Omit it and the link is named from the first cell's
+   * text, which is usually adequate.
    */
   rowLabel?: (row: T) => string;
 }
@@ -466,6 +467,15 @@ export function DataTable<T>({
     // is chrome, and wrapping it in a link would swallow the checkbox.
     const linkCellIndex = href ? cells.findIndex((c) => c.column.id !== '_selection') : -1;
 
+    // The <tr> below deliberately carries no `role`. An explicit role replaces
+    // the implicit `row` that each <td>'s `cell` role requires as its ancestor
+    // — and the virtual scroll container declares `role="grid"`. Overriding it
+    // collapses the table's structure for assistive tech, disabling the very
+    // row/column navigation an operator uses to read a fleet table. It would
+    // also nest a link (the row) inside a link (the anchor) with the same
+    // accessible name, announcing the destination twice. The anchor is what
+    // makes the row a link; `rowLabel` names it there.
+
     return (
       <tr
         key={row.id}
@@ -487,9 +497,6 @@ export function DataTable<T>({
               }
             : () => onRowClick?.(row.original)
         }
-        {...(href && onRowClick
-          ? { role: 'link', 'aria-label': rowLabel?.(row.original) }
-          : {})}
         {...(onRowClick
           ? {
               tabIndex: 0,

--- a/frontend/src/shared/components/ui/keyboard-shortcuts-overlay.test.tsx
+++ b/frontend/src/shared/components/ui/keyboard-shortcuts-overlay.test.tsx
@@ -1,6 +1,45 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { KeyboardShortcutsOverlay } from './keyboard-shortcuts-overlay';
+import { NAV_CHORDS } from '@/features/core/components/layout/app-layout';
+import { breadcrumbLabelForPath } from '@/features/core/lib/navigation-manifest';
+
+describe('KeyboardShortcutsOverlay — labels derive from the navigation manifest', () => {
+  // This overlay used to carry its own hardcoded copy of the route labels — the
+  // sixth such copy in the app — and it had already drifted, advertising "Go to
+  // Network Topology" / "Go to Trace Explorer" / "Go to LLM Assistant" while the
+  // sidebar and breadcrumb said Topology / Traces / Assistant. These tests fail
+  // if anyone reintroduces a hand-written label here.
+
+  it('renders one navigation entry per chord, labelled from the manifest', () => {
+    render(<KeyboardShortcutsOverlay open onClose={vi.fn()} />);
+
+    for (const [, path] of NAV_CHORDS) {
+      const label = breadcrumbLabelForPath(path);
+      expect(
+        label,
+        `no manifest breadcrumb label for chord target ${path}`,
+      ).toBeTruthy();
+      expect(screen.getByText(`Go to ${label}`)).toBeInTheDocument();
+    }
+  });
+
+  it('shows no label that the manifest does not know about', () => {
+    render(<KeyboardShortcutsOverlay open onClose={vi.fn()} />);
+
+    const known = new Set(
+      NAV_CHORDS.map(([, path]) => `Go to ${breadcrumbLabelForPath(path)}`),
+    );
+    const rendered = screen
+      .getAllByText(/^Go to /)
+      .map((el) => el.textContent?.trim() ?? '');
+
+    expect(rendered.length).toBe(NAV_CHORDS.length);
+    for (const label of rendered) {
+      expect(known, `stale hand-written label: ${label}`).toContain(label);
+    }
+  });
+});
 
 describe('KeyboardShortcutsOverlay', () => {
   it('should not render when open is false', () => {

--- a/frontend/src/shared/components/ui/keyboard-shortcuts-overlay.test.tsx
+++ b/frontend/src/shared/components/ui/keyboard-shortcuts-overlay.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { KeyboardShortcutsOverlay } from './keyboard-shortcuts-overlay';
-import { NAV_CHORDS } from '@/features/core/components/layout/app-layout';
-import { breadcrumbLabelForPath } from '@/features/core/lib/navigation-manifest';
+import {
+  NAV_CHORDS,
+  breadcrumbLabelForPath,
+} from '@/features/core/lib/navigation-manifest';
 
 describe('KeyboardShortcutsOverlay — labels derive from the navigation manifest', () => {
   // This overlay used to carry its own hardcoded copy of the route labels — the

--- a/frontend/src/shared/components/ui/keyboard-shortcuts-overlay.tsx
+++ b/frontend/src/shared/components/ui/keyboard-shortcuts-overlay.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useCallback } from 'react';
 import { cn } from '@/shared/lib/utils';
+import { NAV_CHORDS } from '@/features/core/components/layout/app-layout';
+import { breadcrumbLabelForPath } from '@/features/core/lib/navigation-manifest';
 
 interface ShortcutEntry {
   keys: string[];
@@ -11,23 +13,23 @@ interface ShortcutCategory {
   shortcuts: ShortcutEntry[];
 }
 
+/**
+ * Chord labels are derived from the navigation manifest rather than written out
+ * again here. This file used to hold a sixth independent copy of the route
+ * labels, and it had already drifted — it advertised "Go to Network Topology",
+ * "Go to Trace Explorer" and "Go to LLM Assistant" while the nav and breadcrumb
+ * said Topology, Traces and Assistant. Deriving them means a renamed
+ * destination cannot leave a stale label behind in the shortcuts overlay.
+ */
+const navigationShortcuts: ShortcutEntry[] = NAV_CHORDS.map(([keys, path]) => ({
+  keys: keys.split(''),
+  label: `Go to ${breadcrumbLabelForPath(path) ?? path}`,
+}));
+
 const categories: ShortcutCategory[] = [
   {
     title: 'Navigation (vim-style)',
-    shortcuts: [
-      { keys: ['g', 'h'], label: 'Go to Home' },
-      { keys: ['g', 'w'], label: 'Go to Workloads' },
-      { keys: ['g', 'f'], label: 'Go to Fleet' },
-      { keys: ['g', 'l'], label: 'Go to Health & Monitoring' },
-      { keys: ['g', 'i'], label: 'Go to Images' },
-      { keys: ['g', 'n'], label: 'Go to Network Topology' },
-      { keys: ['g', 'm'], label: 'Go to Metrics' },
-      { keys: ['g', 'r'], label: 'Go to Remediation' },
-      { keys: ['g', 'e'], label: 'Go to Trace Explorer' },
-      { keys: ['g', 'x'], label: 'Go to LLM Assistant' },
-      { keys: ['g', 'o'], label: 'Go to Edge Logs' },
-      { keys: ['g', 's'], label: 'Go to Settings' },
-    ],
+    shortcuts: navigationShortcuts,
   },
   {
     title: 'Quick Actions',

--- a/frontend/src/shared/components/ui/keyboard-shortcuts-overlay.tsx
+++ b/frontend/src/shared/components/ui/keyboard-shortcuts-overlay.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useCallback } from 'react';
 import { cn } from '@/shared/lib/utils';
-import { NAV_CHORDS } from '@/features/core/components/layout/app-layout';
-import { breadcrumbLabelForPath } from '@/features/core/lib/navigation-manifest';
+import {
+  NAV_CHORDS,
+  breadcrumbLabelForPath,
+} from '@/features/core/lib/navigation-manifest';
 
 interface ShortcutEntry {
   keys: string[];

--- a/frontend/src/shared/hooks/use-auto-refresh.test.ts
+++ b/frontend/src/shared/hooks/use-auto-refresh.test.ts
@@ -186,4 +186,40 @@ describe('useAutoRefresh', () => {
       expect(JSON.parse(window.localStorage.getItem(SHARED_KEY)!).interval).toBe(30);
     });
   });
+
+  describe('persistence records choices, not defaults', () => {
+    it('writes nothing on mount', () => {
+      renderHook(() => useAutoRefresh(30));
+      expect(window.localStorage.getItem(SHARED_KEY)).toBeNull();
+
+      renderHook(() => useAutoRefresh(60, { storageKey: 'images' }));
+      expect(window.localStorage.getItem(`${SHARED_KEY}:images`)).toBeNull();
+    });
+
+    it('does not let one page seed the shared cadence for every other page', () => {
+      // Image Footprint asks for 60s on the SHARED key while the dashboards ask
+      // for 30s. Mounting it used to write 60, silently slowing every dashboard
+      // query elsewhere in the app.
+      renderHook(() => useAutoRefresh(60));
+
+      const dashboard = renderHook(() => useAutoRefresh(30));
+      expect(dashboard.result.current.interval).toBe(30);
+    });
+
+    it('persists a re-selection of the value already shown', () => {
+      // Guards against "fix" by value-comparison: picking 30 when 30 is already
+      // displayed is still the user making a choice, and it must be recorded.
+      const { result } = renderHook(() => useAutoRefresh(30));
+      act(() => result.current.setRefreshInterval(30));
+      expect(JSON.parse(window.localStorage.getItem(SHARED_KEY)!).interval).toBe(30);
+    });
+
+    it('rehydrates a stored cadence without rewriting it', () => {
+      window.localStorage.setItem(SHARED_KEY, JSON.stringify({ interval: 120, enabled: true }));
+      const { result } = renderHook(() => useAutoRefresh(30));
+
+      expect(result.current.interval).toBe(120);
+      expect(JSON.parse(window.localStorage.getItem(SHARED_KEY)!).interval).toBe(120);
+    });
+  });
 });

--- a/frontend/src/shared/hooks/use-auto-refresh.test.ts
+++ b/frontend/src/shared/hooks/use-auto-refresh.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useAutoRefresh } from './use-auto-refresh';
+
+const SHARED_KEY = 'ai-portainer-auto-refresh';
+
+describe('useAutoRefresh', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.localStorage.clear();
+  });
+
+  describe('state (unchanged contract)', () => {
+    it('starts at the requested default and derives enabled from it', () => {
+      const { result } = renderHook(() => useAutoRefresh(30));
+      expect(result.current.interval).toBe(30);
+      expect(result.current.enabled).toBe(true);
+    });
+
+    it('treats an interval of 0 as disabled', () => {
+      const { result } = renderHook(() => useAutoRefresh(0));
+      expect(result.current.interval).toBe(0);
+      expect(result.current.enabled).toBe(false);
+    });
+
+    it('persists the interval and rehydrates it', () => {
+      const { result } = renderHook(() => useAutoRefresh(30));
+      act(() => result.current.setRefreshInterval(60));
+      expect(JSON.parse(window.localStorage.getItem(SHARED_KEY)!)).toEqual({
+        interval: 60,
+        enabled: true,
+      });
+
+      const second = renderHook(() => useAutoRefresh(30));
+      expect(second.result.current.interval).toBe(60);
+    });
+
+    it('exposes the valid interval options', () => {
+      const { result } = renderHook(() => useAutoRefresh(30));
+      expect(result.current.options).toEqual([0, 15, 30, 60, 120, 300]);
+    });
+
+    it('toggle() flips enabled, but never enables a 0 interval', () => {
+      const { result } = renderHook(() => useAutoRefresh(30));
+      act(() => result.current.toggle());
+      expect(result.current.enabled).toBe(false);
+
+      act(() => result.current.setRefreshInterval(0));
+      act(() => result.current.toggle());
+      expect(result.current.enabled).toBe(false);
+    });
+  });
+
+  describe('setInterval alias', () => {
+    // Existing call sites destructure `setInterval` (which shadows
+    // window.setInterval in the consuming module — the very reason hand-wiring
+    // the timer was error-prone). The alias keeps them compiling.
+    it('is the same function as setRefreshInterval', () => {
+      const { result } = renderHook(() => useAutoRefresh(30));
+      expect(result.current.setInterval).toBe(result.current.setRefreshInterval);
+    });
+
+    it('still updates the interval', () => {
+      const { result } = renderHook(() => useAutoRefresh(30));
+      act(() => result.current.setInterval(15));
+      expect(result.current.interval).toBe(15);
+    });
+  });
+
+  describe('scheduling (the hook owns the timer)', () => {
+    it('calls onTick once per interval while enabled', () => {
+      const onTick = vi.fn();
+      renderHook(() => useAutoRefresh(30, { onTick }));
+
+      expect(onTick).not.toHaveBeenCalled();
+      act(() => void vi.advanceTimersByTime(30_000));
+      expect(onTick).toHaveBeenCalledTimes(1);
+      act(() => void vi.advanceTimersByTime(60_000));
+      expect(onTick).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not schedule anything when the interval is 0', () => {
+      const onTick = vi.fn();
+      renderHook(() => useAutoRefresh(0, { onTick }));
+      act(() => void vi.advanceTimersByTime(10 * 60_000));
+      expect(onTick).not.toHaveBeenCalled();
+    });
+
+    it('re-arms at the new cadence when the dropdown changes', () => {
+      const onTick = vi.fn();
+      const { result } = renderHook(() => useAutoRefresh(30, { onTick }));
+
+      act(() => result.current.setRefreshInterval(15));
+      act(() => void vi.advanceTimersByTime(15_000));
+      expect(onTick).toHaveBeenCalledTimes(1);
+
+      // The old 30s timer must be gone, not merely superseded.
+      onTick.mockClear();
+      act(() => result.current.setRefreshInterval(0));
+      act(() => void vi.advanceTimersByTime(5 * 60_000));
+      expect(onTick).not.toHaveBeenCalled();
+    });
+
+    it('stops ticking when toggled off and resumes when toggled on', () => {
+      const onTick = vi.fn();
+      const { result } = renderHook(() => useAutoRefresh(15, { onTick }));
+
+      act(() => result.current.toggle());
+      act(() => void vi.advanceTimersByTime(60_000));
+      expect(onTick).not.toHaveBeenCalled();
+
+      act(() => result.current.toggle());
+      act(() => void vi.advanceTimersByTime(15_000));
+      expect(onTick).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the timer on unmount', () => {
+      const onTick = vi.fn();
+      const { unmount } = renderHook(() => useAutoRefresh(15, { onTick }));
+      unmount();
+      act(() => void vi.advanceTimersByTime(60_000));
+      expect(onTick).not.toHaveBeenCalled();
+    });
+
+    it('does not restart the timer when the callback identity changes', () => {
+      // Consumers pass inline arrows; a new function every render must not
+      // reset the countdown, or a frequently-rendering page would never tick.
+      const spy = vi.fn();
+      const { rerender } = renderHook(() => useAutoRefresh(30, { onTick: () => spy() }));
+
+      act(() => void vi.advanceTimersByTime(20_000));
+      rerender();
+      rerender();
+      act(() => void vi.advanceTimersByTime(10_000));
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls the latest callback, not the one captured at mount', () => {
+      const first = vi.fn();
+      const second = vi.fn();
+      const { rerender } = renderHook(
+        ({ cb }: { cb: () => void }) => useAutoRefresh(30, { onTick: cb }),
+        { initialProps: { cb: first } },
+      );
+
+      rerender({ cb: second });
+      act(() => void vi.advanceTimersByTime(30_000));
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    it('is inert for consumers that pass no callback', () => {
+      // The 20-odd existing call sites read `interval` and drive react-query
+      // themselves; they must not gain a second refresh path.
+      expect(() => {
+        renderHook(() => useAutoRefresh(15));
+        act(() => void vi.advanceTimersByTime(60_000));
+      }).not.toThrow();
+    });
+  });
+
+  describe('storageKey', () => {
+    it('defaults to the shared key so existing consumers keep their stored cadence', () => {
+      const { result } = renderHook(() => useAutoRefresh(30));
+      act(() => result.current.setRefreshInterval(120));
+      expect(window.localStorage.getItem(SHARED_KEY)).not.toBeNull();
+    });
+
+    it('scopes persistence per page when supplied, so one page cannot show another page cadence', () => {
+      const shared = renderHook(() => useAutoRefresh(30));
+      act(() => shared.result.current.setRefreshInterval(30));
+
+      // A page that asks for "off" must open showing off, not the 30s another
+      // page happened to store under the shared key.
+      const scoped = renderHook(() => useAutoRefresh(0, { storageKey: 'metrics' }));
+      expect(scoped.result.current.interval).toBe(0);
+      expect(scoped.result.current.enabled).toBe(false);
+
+      act(() => scoped.result.current.setRefreshInterval(15));
+      expect(JSON.parse(window.localStorage.getItem(`${SHARED_KEY}:metrics`)!).interval).toBe(15);
+      expect(JSON.parse(window.localStorage.getItem(SHARED_KEY)!).interval).toBe(30);
+    });
+  });
+});

--- a/frontend/src/shared/hooks/use-auto-refresh.ts
+++ b/frontend/src/shared/hooks/use-auto-refresh.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 const STORAGE_KEY = 'ai-portainer-auto-refresh';
 const VALID_INTERVALS = [0, 15, 30, 60, 120, 300] as const;
@@ -10,9 +10,33 @@ interface AutoRefreshState {
   enabled: boolean;
 }
 
-function loadState(defaultInterval: RefreshInterval): AutoRefreshState {
+export interface AutoRefreshOptions {
+  /**
+   * Called every `interval` seconds while auto-refresh is enabled.
+   *
+   * The hook owns the timer. Before this existed the hook owned only state and
+   * scheduled nothing, so every consumer had to remember to write its own
+   * `window.setInterval` effect — one page did (with a comment naming the trap)
+   * and two did not, leaving their refresh dropdowns purely decorative.
+   */
+  onTick?: () => void;
+  /**
+   * Suffix for the localStorage key, so a page can keep its own cadence.
+   *
+   * Omitted, every page shares one key — which is why a page asking for
+   * `useAutoRefresh(0)` could open showing "Every 30s" because a different page
+   * had stored 30. Pass a stable, page-specific string to opt out.
+   */
+  storageKey?: string;
+}
+
+function resolveStorageKey(storageKey?: string): string {
+  return storageKey ? `${STORAGE_KEY}:${storageKey}` : STORAGE_KEY;
+}
+
+function loadState(defaultInterval: RefreshInterval, storageKey?: string): AutoRefreshState {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = localStorage.getItem(resolveStorageKey(storageKey));
     if (stored) {
       const parsed = JSON.parse(stored) as AutoRefreshState;
       if (VALID_INTERVALS.includes(parsed.interval as RefreshInterval)) {
@@ -28,24 +52,28 @@ function loadState(defaultInterval: RefreshInterval): AutoRefreshState {
   };
 }
 
-function saveState(state: AutoRefreshState): void {
+function saveState(state: AutoRefreshState, storageKey?: string): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    localStorage.setItem(resolveStorageKey(storageKey), JSON.stringify(state));
   } catch {
     // Ignore storage errors
   }
 }
 
-export function useAutoRefresh(defaultInterval: RefreshInterval = 30) {
+export function useAutoRefresh(
+  defaultInterval: RefreshInterval = 30,
+  opts: AutoRefreshOptions = {}
+) {
+  const { onTick, storageKey } = opts;
   const [state, setState] = useState<AutoRefreshState>(() =>
-    loadState(defaultInterval)
+    loadState(defaultInterval, storageKey)
   );
 
   useEffect(() => {
-    saveState(state);
-  }, [state]);
+    saveState(state, storageKey);
+  }, [state, storageKey]);
 
-  const setInterval = useCallback((interval: RefreshInterval) => {
+  const setRefreshInterval = useCallback((interval: RefreshInterval) => {
     setState({
       interval,
       enabled: interval > 0,
@@ -59,9 +87,36 @@ export function useAutoRefresh(defaultInterval: RefreshInterval = 30) {
     }));
   }, []);
 
+  // Held in a ref so a consumer passing an inline arrow (the normal case)
+  // doesn't tear down and re-arm the timer on every render — only a change of
+  // interval/enabled restarts it.
+  const onTickRef = useRef(onTick);
+  useEffect(() => {
+    onTickRef.current = onTick;
+  }, [onTick]);
+
+  const hasOnTick = !!onTick;
+  useEffect(() => {
+    if (!hasOnTick || !state.enabled || state.interval <= 0) return;
+    // `window.setInterval`, not the bare global: this module and most call
+    // sites bind a local named `setInterval` (the deprecated alias returned
+    // below), which shadows the global and is exactly why wiring the timer by
+    // hand at each call site was error-prone.
+    const id = window.setInterval(() => {
+      onTickRef.current?.();
+    }, state.interval * 1000);
+    return () => window.clearInterval(id);
+  }, [hasOnTick, state.enabled, state.interval]);
+
   return {
     interval: state.interval,
-    setInterval,
+    setRefreshInterval,
+    /**
+     * @deprecated Use `setRefreshInterval`. Destructuring this shadows
+     * `window.setInterval` in the consuming module. Kept so existing call sites
+     * keep compiling.
+     */
+    setInterval: setRefreshInterval,
     enabled: state.enabled,
     toggle,
     options: VALID_INTERVALS,

--- a/frontend/src/shared/hooks/use-auto-refresh.ts
+++ b/frontend/src/shared/hooks/use-auto-refresh.ts
@@ -69,7 +69,23 @@ export function useAutoRefresh(
     loadState(defaultInterval, storageKey)
   );
 
+  // The state this hook mounted with, held by identity so the effect below can
+  // tell "the default we started with" from "a value the user picked".
+  const initialStateRef = useRef(state);
   useEffect(() => {
+    // Do not persist on mount. Merely visiting a page must not record its
+    // default as a choice, or "never touched the control" becomes
+    // indistinguishable from "explicitly chose this cadence" — and on the
+    // shared key it was worse than cosmetic: opening Image Footprint, which
+    // asks for 60s, wrote 60 to the fleet-wide key and quietly slowed every
+    // dashboard query on every other page.
+    //
+    // Compared by identity, not by value: `setRefreshInterval` and `toggle`
+    // both build a fresh object, so re-selecting the value already shown still
+    // persists. Identity also survives StrictMode's mount/cleanup/mount, which
+    // a boolean first-run flag would not — the flag would be spent on the
+    // first invocation and the second would write the default anyway.
+    if (state === initialStateRef.current) return;
     saveState(state, storageKey);
   }, [state, storageKey]);
 

--- a/frontend/src/shared/lib/api.test.ts
+++ b/frontend/src/shared/lib/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { api } from './api';
+import { ApiError } from './api-error';
 import { AUTH_TOKEN_KEY } from './auth-constants';
 
 // Mock fetch globally
@@ -213,7 +214,85 @@ describe('ApiClient', () => {
     });
   });
 
+  // A 401 answering a request that is trying to *establish* a session is not an
+  // expired session. Before this, a mistyped password surfaced as the literal
+  // text "Session expired" on the login form and tore down auth state.
+  describe('suppressSessionExpiry', () => {
+    it('does not rewrite the message or fire auth:expired on a suppressed 401', async () => {
+      const eventSpy = vi.fn();
+      window.addEventListener('auth:expired', eventSpy);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'Invalid credentials' }),
+      });
+
+      api.setToken('some-token');
+
+      await expect(
+        api.post('/api/auth/login', { username: 'a', password: 'b' }, { suppressSessionExpiry: true })
+      ).rejects.toThrow('Invalid credentials');
+
+      expect(eventSpy).not.toHaveBeenCalled();
+      expect(api.getToken()).toBe('some-token');
+
+      window.removeEventListener('auth:expired', eventSpy);
+    });
+
+    it('carries the 401 status through on a suppressed 401 so callers can branch on it', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({}),
+      });
+
+      const err = await api
+        .post('/api/auth/login', {}, { suppressSessionExpiry: true })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(401);
+    });
+
+    it('still applies session-expiry handling when the flag is not set', async () => {
+      const eventSpy = vi.fn();
+      window.addEventListener('auth:expired', eventSpy);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'Invalid credentials' }),
+      });
+
+      await expect(api.post('/api/auth/login', {})).rejects.toThrow('Session expired');
+      expect(eventSpy).toHaveBeenCalled();
+
+      window.removeEventListener('auth:expired', eventSpy);
+    });
+
+    it('does not forward the flag to the server as a fetch option', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      await api.post('/api/auth/login', { username: 'a' }, { suppressSessionExpiry: true });
+
+      const init = mockFetch.mock.calls[0][1] as Record<string, unknown>;
+      expect(init).not.toHaveProperty('suppressSessionExpiry');
+    });
+  });
+
   describe('error handling', () => {
+    it('describes a 429 as a rate limit rather than a bare HTTP code', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        json: () => Promise.resolve({}),
+      });
+
+      await expect(api.get('/api/busy')).rejects.toThrow('Too many requests — rate limit reached');
+    });
+
+
     it('should throw error for non-ok response', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/frontend/src/shared/lib/api.ts
+++ b/frontend/src/shared/lib/api.ts
@@ -5,6 +5,7 @@ const API_BASE = import.meta.env.VITE_API_URL || '';
 
 function describeHttpError(status: number): string {
   switch (status) {
+    case 429: return 'Too many requests — rate limit reached';
     case 502: return 'Portainer connection failed';
     case 503: return 'Service temporarily unavailable';
     case 504: return 'Gateway timeout — Portainer did not respond';
@@ -15,6 +16,18 @@ function describeHttpError(status: number): string {
 interface RequestOptions extends RequestInit {
   params?: Record<string, string | number | boolean | undefined>;
   timeoutMs?: number;
+  /**
+   * Opt out of the blanket "a 401 means the session expired" handling.
+   *
+   * Every 401 used to be rewritten to `ApiError(401, 'Session expired')` and to
+   * fire `handleUnauthorized()`. That is correct for a request made *with* a
+   * session, but wrong for one that is trying to *establish* one: a mistyped
+   * password produced the message "Session expired" and tore down auth state
+   * that was never there. Credential endpoints pass this flag; the 401 then
+   * falls through to the normal error path (server message, else
+   * `describeHttpError`) and the caller decides the wording.
+   */
+  suppressSessionExpiry?: boolean;
 }
 
 class ApiClient {
@@ -56,7 +69,7 @@ class ApiClient {
     path: string,
     options: RequestOptions = {}
   ): Promise<T> {
-    const { params, timeoutMs = 30000, ...fetchOptions } = options;
+    const { params, timeoutMs = 30000, suppressSessionExpiry, ...fetchOptions } = options;
     const headers = new Headers(fetchOptions.headers);
     if (fetchOptions.body) {
       headers.set('Content-Type', 'application/json');
@@ -91,7 +104,7 @@ class ApiClient {
 
     const requestId = headers.get('X-Request-ID') ?? undefined;
 
-    if (response.status === 401) {
+    if (response.status === 401 && !suppressSessionExpiry) {
       this.handleUnauthorized();
       throw new ApiError(401, 'Session expired', requestId);
     }
@@ -113,11 +126,12 @@ class ApiClient {
     return this.request<T>(path, { method: 'GET', ...options });
   }
 
-  post<T>(path: string, body?: unknown, options?: { timeoutMs?: number }) {
+  post<T>(path: string, body?: unknown, options?: { timeoutMs?: number; suppressSessionExpiry?: boolean }) {
     return this.request<T>(path, {
       method: 'POST',
       body: body ? JSON.stringify(body) : undefined,
       timeoutMs: options?.timeoutMs,
+      suppressSessionExpiry: options?.suppressSessionExpiry,
     });
   }
 

--- a/frontend/src/shared/lib/health-score.test.ts
+++ b/frontend/src/shared/lib/health-score.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { Container } from '@/features/containers/hooks/use-containers';
-import { calculateHealthScore, calculateHealthStats } from './health-score';
+import {
+  calculateHealthcheckPassRate,
+  calculateHealthStats,
+  calculateNeedsAttention,
+} from './health-score';
 
 function makeContainer(overrides: Partial<Container> = {}): Container {
   return {
@@ -220,7 +224,7 @@ describe('calculateHealthStats', () => {
     ];
 
     const stats = calculateHealthStats(containers);
-    const score = calculateHealthScore(stats);
+    const score = calculateHealthcheckPassRate(stats);
 
     expect(stats.total).toBe(4);
     expect(stats.healthy).toBe(2);
@@ -237,7 +241,7 @@ describe('calculateHealthStats', () => {
     ];
 
     const stats = calculateHealthStats(containers);
-    const score = calculateHealthScore(stats);
+    const score = calculateHealthcheckPassRate(stats);
 
     expect(stats.healthy).toBe(1);
     expect(stats.unhealthy).toBe(1);
@@ -254,7 +258,7 @@ describe('calculateHealthStats', () => {
     ];
 
     const stats = calculateHealthStats(containers);
-    const score = calculateHealthScore(stats);
+    const score = calculateHealthcheckPassRate(stats);
 
     expect(stats.healthy).toBe(0);
     expect(stats.unhealthy).toBe(0);
@@ -264,7 +268,7 @@ describe('calculateHealthStats', () => {
 
   it('score: empty fleet returns null (no division-by-zero)', () => {
     const stats = calculateHealthStats([]);
-    const score = calculateHealthScore(stats);
+    const score = calculateHealthcheckPassRate(stats);
 
     expect(score).toBeNull();
   });
@@ -276,7 +280,7 @@ describe('calculateHealthStats', () => {
     ];
 
     const stats = calculateHealthStats(containers);
-    const score = calculateHealthScore(stats);
+    const score = calculateHealthcheckPassRate(stats);
 
     expect(score).toBe(100);
   });
@@ -287,7 +291,7 @@ describe('calculateHealthStats', () => {
     ];
 
     const stats = calculateHealthStats(containers);
-    const score = calculateHealthScore(stats);
+    const score = calculateHealthcheckPassRate(stats);
 
     expect(score).toBe(0);
   });
@@ -418,5 +422,67 @@ describe('calculateHealthStats', () => {
     const second = calculateHealthStats(containers);
 
     expect(first).toEqual(second);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateNeedsAttention — the hero number. A pass rate of 100% next to "14
+// Critical" is what this replaces: the count has to be able to see both
+// registers, and it has to say which one each item came from.
+// ---------------------------------------------------------------------------
+
+describe('calculateNeedsAttention', () => {
+  const emptyStats = calculateHealthStats([]);
+
+  it('counts unhealthy and stopped containers when no insights are supplied', () => {
+    const stats = calculateHealthStats([
+      makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
+      makeContainer({ id: '2', state: 'running', healthStatus: 'unhealthy' }),
+      makeContainer({ id: '3', state: 'exited', healthStatus: undefined }),
+    ]);
+
+    expect(calculateNeedsAttention(stats)).toEqual({
+      containers: 2,
+      insights: 0,
+      total: 2,
+    });
+  });
+
+  it('adds unacknowledged critical + warning insights to the container count', () => {
+    const stats = calculateHealthStats([
+      makeContainer({ id: '1', state: 'running', healthStatus: 'unhealthy' }),
+    ]);
+
+    expect(calculateNeedsAttention(stats, { critical: 14, warning: 3 })).toEqual({
+      containers: 1,
+      insights: 17,
+      total: 18,
+    });
+  });
+
+  it('is zero on a fleet with nothing wrong, so the clear state is reachable', () => {
+    const stats = calculateHealthStats([
+      makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
+      makeContainer({ id: '2', state: 'running', healthStatus: undefined }),
+    ]);
+
+    // A running container without a healthcheck is not an issue — it is
+    // excluded from the pass rate for the same reason.
+    expect(calculateNeedsAttention(stats, { critical: 0, warning: 0 }).total).toBe(0);
+  });
+
+  it('ignores info-severity insights (the caller passes only critical + warning)', () => {
+    // 20 Info insights that are the same two facts restated hourly must not
+    // inflate the number an operator is asked to act on.
+    expect(calculateNeedsAttention(emptyStats, { critical: 0, warning: 0 }).total).toBe(0);
+  });
+
+  it('does not read the pass rate — a 100% pass rate can still need attention', () => {
+    const stats = calculateHealthStats([
+      makeContainer({ id: '1', state: 'running', healthStatus: 'healthy' }),
+    ]);
+
+    expect(calculateHealthcheckPassRate(stats)).toBe(100);
+    expect(calculateNeedsAttention(stats, { critical: 14, warning: 0 }).total).toBe(14);
   });
 });

--- a/frontend/src/shared/lib/health-score.ts
+++ b/frontend/src/shared/lib/health-score.ts
@@ -52,12 +52,68 @@ export function calculateHealthStats(containers: Container[]): HealthStats {
 }
 
 /**
- * Score = healthy / (healthy + unhealthy). Containers without a healthcheck
- * are excluded so the operator's choice not to configure one doesn't drag
- * the score down. Returns null when no container reports a health signal.
+ * Healthcheck pass rate = healthy / (healthy + unhealthy). Containers without a
+ * healthcheck are excluded so the operator's choice not to configure one doesn't
+ * drag the number down. Returns null when no container reports a health signal.
+ *
+ * It was previously called `calculateHealthScore` and rendered as "Overall
+ * Health Score" — a name that promised a verdict on the fleet while measuring
+ * only Docker healthcheck exit status. It is blind to every anomaly insight, so
+ * the page could read "100.0%" in green beside "14 Critical". The formula is
+ * unchanged and correct; only the claim it makes about itself is narrower now.
+ * Render it with its exclusion stated inline (see `HealthScoreCard`).
  */
-export function calculateHealthScore(stats: HealthStats): number | null {
+export function calculateHealthcheckPassRate(stats: HealthStats): number | null {
   const reporting = stats.healthy + stats.unhealthy;
   if (reporting === 0) return null;
   return (stats.healthy / reporting) * 100;
+}
+
+/**
+ * Unacknowledged insight counts feeding the "Needs attention" number. Supplied
+ * by pages that load the insight feed (Health & Monitoring); omitted by pages
+ * that don't (Home), in which case only container state contributes.
+ */
+export interface InsightAttentionCounts {
+  /** Unacknowledged insights at `critical` severity. */
+  critical: number;
+  /** Unacknowledged insights at `warning` severity. */
+  warning: number;
+}
+
+/**
+ * The hero number and the two registers it is summed from. Kept as a breakdown
+ * rather than a bare total so the card can state its own basis — a count of
+ * "items across two lists" is only honest if it names both lists.
+ */
+export interface AttentionBreakdown {
+  /** Containers that are unhealthy or stopped. */
+  containers: number;
+  /** Unacknowledged critical + warning insights. `0` when none were supplied. */
+  insights: number;
+  /** `containers + insights` — what the operator has to look at. */
+  total: number;
+}
+
+/**
+ * How many things need an operator's attention right now.
+ *
+ * A count, not a percentage: "3 need attention" is something you can act on,
+ * where a pass rate is not — and a pass rate of a subset of containers even
+ * less so. Derived from `stats` (and, when the caller has them, unacknowledged
+ * insight counts) rather than accepted as a number, for the same reason
+ * `HealthScoreCard` derives the pass rate internally: two surfaces must not be
+ * able to disagree about what the fleet's headline number means.
+ */
+export function calculateNeedsAttention(
+  stats: HealthStats,
+  insights?: InsightAttentionCounts,
+): AttentionBreakdown {
+  const containers = stats.unhealthy + stats.stopped;
+  const insightCount = insights ? insights.critical + insights.warning : 0;
+  return {
+    containers,
+    insights: insightCount,
+    total: containers + insightCount,
+  };
 }

--- a/frontend/src/shared/lib/product.test.ts
+++ b/frontend/src/shared/lib/product.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { PRODUCT_NAME } from './product';
+
+const SRC_ROOT = resolve(__dirname, '../..');
+
+describe('PRODUCT_NAME', () => {
+  it('is the name PRODUCT.md and the compose project already use', () => {
+    expect(PRODUCT_NAME).toBe('Container Insights');
+  });
+
+  /**
+   * The point of the constant is that no surface hardcodes a rival name. This
+   * is scoped to the sign-in / status surfaces, which is what this change owns;
+   * the remaining call sites (`sidebar.tsx`, `tab-general.tsx`, `index.html`,
+   * the PWA manifest in `vite.config.ts`) are owned by other work and are
+   * listed as hand-offs. Widen this list as they adopt the constant.
+   */
+  it('is the only product name in the sign-in and status surfaces', () => {
+    const owned = [
+      join(SRC_ROOT, 'features', 'core', 'pages', 'login.tsx'),
+      join(SRC_ROOT, 'features', 'core', 'pages', 'auth-callback.tsx'),
+      join(SRC_ROOT, 'features', 'observability', 'pages', 'status-page.tsx'),
+    ];
+
+    for (const file of owned) {
+      const source = readFileSync(file, 'utf8');
+      expect(source, `${file} hardcodes a rival product name`).not.toMatch(
+        /Docker Insights?\b/
+      );
+    }
+  });
+});

--- a/frontend/src/shared/lib/product.ts
+++ b/frontend/src/shared/lib/product.ts
@@ -1,0 +1,20 @@
+/**
+ * The product's name, in one place.
+ *
+ * Before this constant existed the product answered to four different names
+ * depending on which surface you were looking at:
+ *
+ * - `Docker Insights` — the login wordmark and the sidebar wordmark
+ * - `Docker Insight` (singular) — its own Settings → About → System Information
+ * - `Container Insights` — `PRODUCT.md`
+ * - `container-insights` — the compose project the app displays back to the
+ *   operator in its own Workloads table
+ *
+ * `Container Insights` is the intended name: it is what `PRODUCT.md` states and
+ * what the shipped compose project is called, so it is the one an operator will
+ * already have seen in `docker ps` output before they ever reach the login page.
+ *
+ * Import this rather than typing the name again. A second literal is how the
+ * fourth name got there.
+ */
+export const PRODUCT_NAME = 'Container Insights';

--- a/frontend/src/shared/lib/utils.test.ts
+++ b/frontend/src/shared/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { escapeRegExp, formatBytes, formatDuration, formatRelativeAge, getImageShortName, truncate, cn } from './utils';
+import { escapeRegExp, formatBytes, formatDate, formatDuration, formatRelativeAge, getImageShortName, truncate, cn, INVALID_DATE_PLACEHOLDER } from './utils';
 
 describe('formatBytes', () => {
   it('should return "0 B" for 0 bytes', () => {
@@ -231,5 +231,36 @@ describe('cn', () => {
 
   it('should handle undefined and null', () => {
     expect(cn('foo', undefined, null, 'bar')).toBe('foo bar');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats a valid ISO timestamp', () => {
+    expect(formatDate('2026-07-26T08:46:00Z')).toMatch(/Jul 26/);
+  });
+
+  it('accepts the SQLite "YYYY-MM-DD HH:MM:SS" shape', () => {
+    expect(formatDate('2026-07-26 08:46:00')).toMatch(/Jul 26/);
+  });
+
+  it('returns "N/A" for null, undefined and empty string', () => {
+    expect(formatDate(null)).toBe('N/A');
+    expect(formatDate(undefined)).toBe('N/A');
+    expect(formatDate('')).toBe('N/A');
+  });
+
+  // The old fallback was the literal string 'Invalid date', which rendered ~20
+  // times in one table on /health when an upstream field arrived in a shape
+  // `new Date()` rejects. A formatter's failure mode must read as "no value",
+  // not as English prose addressed to the operator.
+  it('falls back to a neutral dash — not English prose — for an unparseable value', () => {
+    expect(formatDate('not-a-date')).toBe(INVALID_DATE_PLACEHOLDER);
+    expect(formatDate('not-a-date')).toBe('—');
+    expect(formatDate('not-a-date')).not.toMatch(/invalid/i);
+    expect(formatDate('not-a-date')).not.toMatch(/[a-z]/i);
+  });
+
+  it('uses the same dash for an Invalid Date object', () => {
+    expect(formatDate(new Date('nope'))).toBe(INVALID_DATE_PLACEHOLDER);
   });
 });

--- a/frontend/src/shared/lib/utils.ts
+++ b/frontend/src/shared/lib/utils.ts
@@ -13,6 +13,17 @@ export function formatBytes(bytes: number, decimals = 1): string {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(decimals))} ${sizes[i]}`;
 }
 
+/**
+ * Placeholder rendered when a timestamp cannot be formatted.
+ *
+ * An em dash, not English prose: a formatter's failure mode is shown in a table
+ * cell next to real values, so it must read as "no value" rather than as a
+ * sentence addressed to the operator. `formatDate` used to return the literal
+ * string `Invalid date`, which surfaced ~20 times on a single page when an
+ * upstream field arrived in a shape `new Date()` rejects.
+ */
+export const INVALID_DATE_PLACEHOLDER = '—';
+
 export function formatDate(date: string | Date | null | undefined): string {
   if (!date) return 'N/A';
 
@@ -21,7 +32,7 @@ export function formatDate(date: string | Date | null | undefined): string {
   const dateObj = new Date(dateStr);
 
   // Check if date is valid
-  if (isNaN(dateObj.getTime())) return 'Invalid date';
+  if (isNaN(dateObj.getTime())) return INVALID_DATE_PLACEHOLDER;
 
   return new Intl.DateTimeFormat('en-US', {
     month: 'short',

--- a/packages/ai-intelligence/src/__tests__/correlations.test.ts
+++ b/packages/ai-intelligence/src/__tests__/correlations.test.ts
@@ -294,7 +294,7 @@ describe('Correlation Routes', () => {
       expect(mockChatStream).not.toHaveBeenCalled();
     });
 
-    it('returns fallback insights when LLM fails', async () => {
+    it('returns fallback insights with a single stated reason when the LLM fails', async () => {
       mockFindCorrelatedContainers.mockResolvedValue(samplePairs);
       mockChatStream.mockRejectedValue(new Error('Ollama down'));
 
@@ -308,6 +308,39 @@ describe('Correlation Routes', () => {
       expect(body.insights).toHaveLength(2);
       expect(body.insights[0].narrative).toBeNull();
       expect(body.summary).toBeNull();
+      // One reason for the whole batch, so the UI need not print a failure per row.
+      expect(body.narrativeStatus).toBe('unavailable');
+      expect(body.narrativeUnavailableReason).toContain('LLM_API_URL');
+    });
+
+    it('keys every insight to its pair so a client cannot mismatch narratives', async () => {
+      mockFindCorrelatedContainers.mockResolvedValue(samplePairs);
+      mockChatStream.mockResolvedValue(
+        '1. Coupled through the request path.\n2. Inverse memory relationship.\nSUMMARY: Two correlations.',
+      );
+
+      const res = await app.inject({ method: 'GET', url: '/api/metrics/correlations/insights' });
+      const body = res.json();
+
+      expect(body.insights[0].pairKey).toBe('nginx-proxy|api-server|cpu');
+      expect(body.insights[1].pairKey).toBe('postgres|redis-cache|memory');
+      expect(body.narrativeStatus).toBe('ok');
+      expect(body.narrativeUnavailableReason).toBeNull();
+      // The server states how many pairs it found, so a client slicing its own
+      // top-10 from a filtered list can tell the sets differ.
+      expect(body.pairsTotal).toBe(2);
+    });
+
+    it('reports an unparseable model response once, not once per pair', async () => {
+      mockFindCorrelatedContainers.mockResolvedValue(samplePairs);
+      mockChatStream.mockResolvedValue('I am unable to analyse these correlations.');
+
+      const res = await app.inject({ method: 'GET', url: '/api/metrics/correlations/insights' });
+      const body = res.json();
+
+      expect(body.insights.every((i: { narrative: string | null }) => i.narrative === null)).toBe(true);
+      expect(body.narrativeStatus).toBe('unparsed');
+      expect(body.narrativeUnavailableReason).toContain('could not be matched');
     });
 
     it('serves cached insights on repeat request', async () => {
@@ -418,13 +451,14 @@ describe('parseInsightsResponse', () => {
 2. Postgres and Redis show inverse memory patterns due to cache eviction policies.
 SUMMARY: The stack has two notable correlations worth monitoring.`;
 
-    const { insights, summary } = parseInsightsResponse(response, samplePairs);
+    const { insights, summary, narrativeStatus } = parseInsightsResponse(response, samplePairs);
 
     expect(insights).toHaveLength(2);
     expect(insights[0].narrative).toContain('tightly coupled');
     expect(insights[0].containerA).toBe('nginx-proxy');
     expect(insights[1].narrative).toContain('cache eviction');
     expect(summary).toContain('two notable correlations');
+    expect(narrativeStatus).toBe('ok');
   });
 
   it('handles response without summary', () => {
@@ -438,14 +472,118 @@ SUMMARY: The stack has two notable correlations worth monitoring.`;
     expect(summary).toBeNull();
   });
 
-  it('returns null narrative when line not found', () => {
+  it('returns null narratives and an unparsed status when nothing can be attributed', () => {
     const response = 'Some unstructured response without numbering.';
 
-    const { insights } = parseInsightsResponse(response, samplePairs);
+    const { insights, narrativeStatus, narrativeUnavailableReason } = parseInsightsResponse(response, samplePairs);
 
     expect(insights).toHaveLength(2);
     expect(insights[0].narrative).toBeNull();
     expect(insights[1].narrative).toBeNull();
+    // A single unattributable sentence must NOT be pinned to pair 1 and
+    // presented as its explanation.
+    expect(narrativeStatus).toBe('unparsed');
+    expect(narrativeUnavailableReason).toContain('could not be matched');
+  });
+
+  // ── formatting variations the old `startsWith('1.')` check silently dropped ──
+
+  it('parses `1)` style numbering', () => {
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      '1) Proxy fans out to the API.\n2) Cache pressure moves inversely.',
+      samplePairs,
+    );
+    expect(insights[0].narrative).toBe('Proxy fans out to the API.');
+    expect(insights[1].narrative).toBe('Cache pressure moves inversely.');
+    expect(narrativeStatus).toBe('ok');
+  });
+
+  it('parses bold-markdown numbering', () => {
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      '**1.** Proxy fans out to the API.\n**2.** Cache pressure moves inversely.',
+      samplePairs,
+    );
+    expect(insights[0].narrative).toBe('Proxy fans out to the API.');
+    expect(narrativeStatus).toBe('ok');
+  });
+
+  it('parses `Pair N:` headings', () => {
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      'Pair 1: Proxy fans out to the API.\nPair 2: Cache pressure moves inversely.',
+      samplePairs,
+    );
+    expect(insights[0].narrative).toBe('Proxy fans out to the API.');
+    expect(narrativeStatus).toBe('ok');
+  });
+
+  it('parses a bulleted list positionally when the counts line up', () => {
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      '- Proxy fans out to the API.\n- Cache pressure moves inversely.',
+      samplePairs,
+    );
+    expect(insights[0].narrative).toBe('Proxy fans out to the API.');
+    expect(insights[1].narrative).toBe('Cache pressure moves inversely.');
+    expect(narrativeStatus).toBe('ok');
+  });
+
+  it('parses plain paragraphs positionally when the counts line up', () => {
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      'Proxy fans out to the API.\nCache pressure moves inversely.',
+      samplePairs,
+    );
+    expect(insights[0].narrative).toBe('Proxy fans out to the API.');
+    expect(narrativeStatus).toBe('ok');
+  });
+
+  it('attributes by container name when the model ignored the numbering', () => {
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      'Some preamble about the fleet.\n'
+      + 'postgres and redis-cache trade memory as the cache evicts.\n'
+      + 'nginx-proxy forwards every request to api-server.',
+      samplePairs,
+    );
+    expect(insights[0].narrative).toContain('nginx-proxy forwards');
+    expect(insights[1].narrative).toContain('postgres and redis-cache');
+    expect(narrativeStatus).toBe('ok');
+  });
+
+  it('keeps multi-line explanations attached to their number', () => {
+    const { insights } = parseInsightsResponse(
+      '1. Proxy fans out to the API.\n   Both scale with inbound traffic.\n2. Cache pressure moves inversely.',
+      samplePairs,
+    );
+    expect(insights[0].narrative).toBe('Proxy fans out to the API. Both scale with inbound traffic.');
+  });
+
+  it('reports partial attribution rather than claiming success', () => {
+    const { insights, narrativeStatus, narrativeUnavailableReason } = parseInsightsResponse(
+      '1. Only the first pair was explained.',
+      samplePairs,
+    );
+    expect(insights[0].narrative).toBe('Only the first pair was explained.');
+    expect(insights[1].narrative).toBeNull();
+    expect(narrativeStatus).toBe('partial');
+    expect(narrativeUnavailableReason).toContain('only some pairs');
+  });
+
+  it('reads a bolded SUMMARY heading', () => {
+    const { summary } = parseInsightsResponse(
+      '1. A.\n2. B.\n**SUMMARY:** Two correlations worth watching.',
+      samplePairs,
+    );
+    expect(summary).toBe('Two correlations worth watching.');
+  });
+
+  it('emits a stable pairKey for every insight', () => {
+    const { insights } = parseInsightsResponse('1. A.\n2. B.', samplePairs);
+    expect(insights[0].pairKey).toBe('nginx-proxy|api-server|cpu');
+    expect(insights[1].pairKey).toBe('postgres|redis-cache|memory');
+  });
+
+  it('reports ok for an empty pair list', () => {
+    const { insights, narrativeStatus } = parseInsightsResponse('anything', []);
+    expect(insights).toEqual([]);
+    expect(narrativeStatus).toBe('ok');
   });
 });
 

--- a/packages/ai-intelligence/src/__tests__/correlations.test.ts
+++ b/packages/ai-intelligence/src/__tests__/correlations.test.ts
@@ -66,6 +66,19 @@ const samplePairs: CorrelationPair[] = [
   },
 ];
 
+/** A minimal pair, for attribution tests that only care about the names. */
+function makePair(a: string, b: string, metricType: string): CorrelationPair {
+  return {
+    containerA: { id: `${a}-id`, name: a },
+    containerB: { id: `${b}-id`, name: b },
+    metricType,
+    correlation: 0.9,
+    strength: 'very_strong',
+    direction: 'positive',
+    sampleCount: 100,
+  };
+}
+
 describe('Correlation Routes', () => {
   let app: ReturnType<typeof Fastify>;
 
@@ -526,13 +539,17 @@ SUMMARY: The stack has two notable correlations worth monitoring.`;
     expect(narrativeStatus).toBe('ok');
   });
 
-  it('parses plain paragraphs positionally when the counts line up', () => {
+  it('does NOT read bare prose positionally, even when the counts line up', () => {
+    // Position is evidence only where the model asserted an order. Two prose
+    // lines are equally consistent with [preamble, explanation] as with
+    // [explanation, explanation], and guessing produces a confident sentence
+    // about the wrong containers.
     const { insights, narrativeStatus } = parseInsightsResponse(
       'Proxy fans out to the API.\nCache pressure moves inversely.',
       samplePairs,
     );
-    expect(insights[0].narrative).toBe('Proxy fans out to the API.');
-    expect(narrativeStatus).toBe('ok');
+    expect(insights.every((i) => i.narrative === null)).toBe(true);
+    expect(narrativeStatus).toBe('unparsed');
   });
 
   it('attributes by container name when the model ignored the numbering', () => {
@@ -583,6 +600,129 @@ SUMMARY: The stack has two notable correlations worth monitoring.`;
   it('reports ok for an empty pair list', () => {
     const { insights, narrativeStatus } = parseInsightsResponse('anything', []);
     expect(insights).toEqual([]);
+    expect(narrativeStatus).toBe('ok');
+  });
+
+  // ── no block may be attributed to two pairs ──────────────────────────────
+
+  it('never hands one block to two pairs, even when it names all four containers', () => {
+    // The index pass stores CLEANED text; `lineBlocks` stores it raw. When the
+    // claimed-set was seeded with one form and probed with the other, this
+    // response put a byte-identical sentence on both cards and still reported
+    // `ok` — the exact duplicate-explanation defect this parser replaced.
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      '**1.** nginx-proxy and api-server and postgres and redis-cache all interact through the request path.',
+      samplePairs,
+    );
+
+    expect(insights[0].narrative).toBe(
+      'nginx-proxy and api-server and postgres and redis-cache all interact through the request path.',
+    );
+    expect(insights[1].narrative).toBeNull();
+    expect(insights[0].narrative).not.toBe(insights[1].narrative);
+    expect(narrativeStatus).toBe('partial');
+  });
+
+  it('does not re-use a bullet already claimed by another pair', () => {
+    const { insights } = parseInsightsResponse(
+      '- nginx-proxy, api-server, postgres and redis-cache share one request path.',
+      samplePairs,
+    );
+    const narratives = insights.map((i) => i.narrative).filter(Boolean);
+    expect(new Set(narratives).size).toBe(narratives.length);
+  });
+
+  // ── a preamble is not an explanation ─────────────────────────────────────
+
+  it('refuses to pin a lead-in to pair 1 when the block count coincidentally matches', () => {
+    // Two blocks, two pairs — but the first is a heading, so attributing
+    // positionally would show "Here are the correlations…" as pair 1's
+    // explanation and move the real sentence onto the wrong pair.
+    const { insights, narrativeStatus, narrativeUnavailableReason } = parseInsightsResponse(
+      'Here are the correlations you asked about:\nThe two services scale together under load.',
+      samplePairs,
+    );
+
+    expect(insights[0].narrative).toBeNull();
+    expect(insights[1].narrative).toBeNull();
+    expect(narrativeStatus).toBe('unparsed');
+    expect(narrativeUnavailableReason).toContain('could not be matched');
+  });
+
+  it('withdraws rather than misalign when a stray sentence appears', () => {
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      'Proxy fans out to the API.\nCache pressure moves inversely.\nBoth are worth watching.',
+      samplePairs,
+    );
+
+    expect(insights.every((i) => i.narrative === null)).toBe(true);
+    expect(narrativeStatus).toBe('unparsed');
+  });
+
+  // ── regressions from screening prose by punctuation ──────────────────────
+  // An earlier attempt kept positional attribution for prose and tried to drop
+  // headings by testing for a trailing full stop. Each case below was silently
+  // MISattributed under that rule, and reported `ok`.
+
+  it('does not shift narratives onto the wrong pair when one line lacks a full stop', () => {
+    const three = [
+      makePair('web', 'api', 'cpu'),
+      makePair('db', 'cache', 'memory'),
+      makePair('r1', 'r2', 'cpu'),
+    ];
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      'Proxy fans out to the API.\n'
+      + 'Cache pressure moves inversely\n' // no full stop — was dropped, shifting the rest
+      + 'Both DBs replicate together.\n'
+      + 'Overall the fleet looks healthy.',
+      three,
+    );
+
+    // Pair 2 must not be handed pair 3's sentence, nor pair 3 a closing remark.
+    expect(insights[1].narrative).not.toBe('Both DBs replicate together.');
+    expect(insights[2].narrative).not.toBe('Overall the fleet looks healthy.');
+    expect(narrativeStatus).not.toBe('ok');
+  });
+
+  it('does not drop a narrative merely because markdown wraps it', () => {
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      '**Correlation analysis**\n'
+      + '**Proxy fans out to the API.**\n' // ends in `*` — was judged "not a sentence"
+      + 'Cache pressure moves inversely.\n'
+      + 'Both are worth watching.',
+      samplePairs,
+    );
+
+    expect(insights[0].narrative).not.toBe('Cache pressure moves inversely.');
+    expect(insights[1].narrative).not.toBe('Both are worth watching.');
+    expect(narrativeStatus).not.toBe('ok');
+  });
+
+  it('never gives one pair a block that contains another pair sentence', () => {
+    // `paragraphs` entries are space-joins of the lines in `lineBlocks`, so an
+    // exact-match claimed test let pair 2 take a paragraph containing pair 1's
+    // sentence — two cards asserting overlapping text about different containers.
+    const pairs = [makePair('nginx', 'apisrv', 'cpu'), makePair('postgres', 'redis', 'memory')];
+    const { insights } = parseInsightsResponse(
+      'nginx and apisrv rise together with postgres.\nredis is mostly idle.',
+      pairs,
+    );
+
+    const [a, b] = insights.map((i) => i.narrative);
+    if (a && b) {
+      expect(a.includes(b)).toBe(false);
+      expect(b.includes(a)).toBe(false);
+    }
+  });
+
+  it('still reads an explicitly bulleted list positionally', () => {
+    // A bullet list is the one unnumbered shape where the model asserted order.
+    const { insights, narrativeStatus } = parseInsightsResponse(
+      '- Proxy fans out to the API.\n- Cache pressure moves inversely.',
+      samplePairs,
+    );
+    expect(insights[0].narrative).toBe('Proxy fans out to the API.');
+    expect(insights[1].narrative).toBe('Cache pressure moves inversely.');
     expect(narrativeStatus).toBe('ok');
   });
 });

--- a/packages/ai-intelligence/src/__tests__/incident-store-timestamps.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incident-store-timestamps.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression guard for the "Invalid date" rollup (design critique, P0).
+ *
+ * `getIncidentGroups` used to render its timestamps with a `::text` cast, which
+ * drops the timestamptz OID and therefore bypasses the driver's ISO type parser
+ * (`pg.types.setTypeParser(1184, …)` in core/db/postgres.ts). Rows then carried
+ * Postgres' own text rendering — `2026-07-26 08:46:29.123456+00` — and the
+ * frontend's `formatDate()` (which swaps the first space for a `T`) turned that
+ * into `2026-07-26T08:46:29.123456+00`, an offset shape `new Date()` rejects.
+ * Every row of the Active Incidents rollup printed the literal "Invalid date".
+ *
+ * These tests are DB-free: `toIsoTimestamp` is exercised directly, and
+ * `getIncidentGroups` runs against a fake db so the shape of `top_containers[]`
+ * is asserted without PostgreSQL.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+interface FakeQuery { sql: string; params: unknown[] }
+const queries: FakeQuery[] = [];
+let groupRows: unknown[] = [];
+let topRows: unknown[] = [];
+let facetRows: unknown[] = [];
+
+const fakeDb = {
+  query: vi.fn(async (sql: string, params: unknown[] = []) => {
+    queries.push({ sql, params });
+    if (sql.includes('per_container')) return groupRows;
+    if (sql.includes('representatives')) return topRows;
+    return facetRows;
+  }),
+  queryOne: vi.fn(),
+  execute: vi.fn(),
+};
+
+vi.mock('@dashboard/core/db/app-db-router.js', () => ({
+  getDbForDomain: () => fakeDb,
+}));
+
+import { toIsoTimestamp, getIncidentGroups } from '../services/incident-store.js';
+
+/** The exact string Postgres produces for `timestamptz::text`. */
+const PG_TEXT_TIMESTAMPTZ = '2026-07-26 08:46:29.123456+00';
+
+describe('toIsoTimestamp', () => {
+  it('converts the Postgres ::text rendering that broke the UI into ISO-8601', () => {
+    expect(toIsoTimestamp(PG_TEXT_TIMESTAMPTZ)).toBe('2026-07-26T08:46:29.123Z');
+  });
+
+  it('produces a string the browser Date constructor accepts after formatDate() swaps space for T', () => {
+    // formatDate() in frontend/src/shared/lib/utils.ts does `.replace(' ', 'T')`
+    // before calling new Date(). That is what made the raw Postgres text fail.
+    const raw = toIsoTimestamp(PG_TEXT_TIMESTAMPTZ)!;
+    expect(Number.isNaN(new Date(raw.replace(' ', 'T')).getTime())).toBe(false);
+    // ...and the pre-fix value genuinely fails that same path, so this test
+    // would not have passed before the change.
+    expect(Number.isNaN(new Date(PG_TEXT_TIMESTAMPTZ.replace(' ', 'T')).getTime())).toBe(true);
+  });
+
+  it('passes an ISO string through unchanged in meaning', () => {
+    expect(toIsoTimestamp('2026-07-26T08:46:29.123Z')).toBe('2026-07-26T08:46:29.123Z');
+  });
+
+  it('serialises a Date instance (what the driver returns without a cast)', () => {
+    expect(toIsoTimestamp(new Date('2026-07-26T08:46:29.000Z'))).toBe('2026-07-26T08:46:29.000Z');
+  });
+
+  it('treats a zone-less Postgres timestamp as UTC, matching the driver type parser', () => {
+    expect(toIsoTimestamp('2026-07-26 08:46:29')).toBe('2026-07-26T08:46:29.000Z');
+  });
+
+  it('returns null rather than a broken string for null, empty and unparseable input', () => {
+    expect(toIsoTimestamp(null)).toBeNull();
+    expect(toIsoTimestamp(undefined)).toBeNull();
+    expect(toIsoTimestamp('')).toBeNull();
+    expect(toIsoTimestamp('   ')).toBeNull();
+    expect(toIsoTimestamp('not a timestamp')).toBeNull();
+    expect(toIsoTimestamp(new Date('nope'))).toBeNull();
+    expect(toIsoTimestamp({})).toBeNull();
+  });
+});
+
+describe('getIncidentGroups timestamp shape', () => {
+  beforeEach(() => {
+    queries.length = 0;
+    groupRows = [];
+    topRows = [];
+    facetRows = [];
+    fakeDb.query.mockClear();
+  });
+
+  it('emits ISO-8601 timestamps on groups and top_containers', async () => {
+    groupRows = [{
+      signature: 'anomaly:ml-anomaly:cpu',
+      severity: 'critical',
+      incident_count: 2,
+      alert_count: 5,
+      earliest_at: PG_TEXT_TIMESTAMPTZ,
+      latest_update_at: new Date('2026-07-26T09:00:00.000Z'),
+      container_count: 1,
+      all_names: ['web'],
+    }];
+    topRows = [{
+      signature: 'anomaly:ml-anomaly:cpu',
+      incident_id: 'a1',
+      container_name: 'web',
+      endpoint_id: 1,
+      endpoint_name: 'local',
+      severity: 'critical',
+      created_at: PG_TEXT_TIMESTAMPTZ,
+      incident_ids: ['a1', 'a2'],
+      incident_count: 2,
+      latest_at: PG_TEXT_TIMESTAMPTZ,
+      latest_summary: null,
+      latest_description: null,
+    }];
+
+    const result = await getIncidentGroups({ status: 'active' });
+    const group = result.groups[0];
+    const row = group.top_containers[0];
+
+    expect(row.created_at).toBe('2026-07-26T08:46:29.123Z');
+    expect(row.latest_at).toBe('2026-07-26T08:46:29.123Z');
+    expect(group.earliest_at).toBe('2026-07-26T08:46:29.123Z');
+    expect(group.latest_update_at).toBe('2026-07-26T09:00:00.000Z');
+
+    // Every emitted timestamp must survive `new Date()` — the assertion the UI
+    // silently relied on.
+    for (const value of [row.created_at, row.latest_at, group.earliest_at, group.latest_update_at]) {
+      expect(Number.isNaN(new Date(value!).getTime())).toBe(false);
+    }
+  });
+
+  it('does not cast timestamps to text in SQL (the cast is the root cause)', async () => {
+    await getIncidentGroups({ status: 'active' });
+    const sql = queries.map((q) => q.sql).join('\n');
+    expect(sql).not.toMatch(/created_at\)?::text/);
+    expect(sql).not.toMatch(/updated_at\)?::text/);
+  });
+
+  it('reports an unusable timestamp as null instead of a broken string', async () => {
+    groupRows = [{
+      signature: 'anomaly:ml-anomaly:cpu',
+      severity: 'warning',
+      incident_count: 1,
+      alert_count: 1,
+      earliest_at: null,
+      latest_update_at: null,
+      container_count: 1,
+      all_names: ['web'],
+    }];
+    topRows = [{
+      signature: 'anomaly:ml-anomaly:cpu',
+      incident_id: 'a1',
+      container_name: 'web',
+      endpoint_id: null,
+      endpoint_name: null,
+      severity: 'warning',
+      created_at: null,
+      incident_ids: ['a1'],
+      incident_count: 1,
+      latest_at: 'garbage',
+      latest_summary: null,
+      latest_description: null,
+    }];
+
+    const result = await getIncidentGroups({ status: 'active' });
+    const row = result.groups[0].top_containers[0];
+    expect(row.created_at).toBeNull();
+    expect(row.latest_at).toBeNull();
+    expect(result.groups[0].earliest_at).toBeNull();
+  });
+});

--- a/packages/ai-intelligence/src/__tests__/incidents-groups.test.ts
+++ b/packages/ai-intelligence/src/__tests__/incidents-groups.test.ts
@@ -142,6 +142,23 @@ describe('getIncidentGroups', () => {
     expect(cpu.incident_count).toBe(4);
   });
 
+  it('emits timestamps as ISO-8601 UTC that new Date() accepts', async () => {
+    // Regression: these columns used to be selected with a `::text` cast, which
+    // bypasses the driver's timestamptz parser and yields
+    // `2026-07-26 08:46:29.123456+00` — a shape the UI's formatDate() turns into
+    // Invalid Date. See toIsoTimestamp() in incident-store.ts.
+    const result = await getIncidentGroups({ status: 'active' });
+    const cpu = result.groups.find((g) => g.signature === 'anomaly:ml-anomaly:cpu')!;
+    const isoish = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+    expect(cpu.earliest_at).toMatch(isoish);
+    expect(cpu.latest_update_at).toMatch(isoish);
+    for (const row of cpu.top_containers) {
+      expect(row.created_at).toMatch(isoish);
+      expect(row.latest_at).toMatch(isoish);
+      expect(Number.isNaN(new Date(row.created_at!).getTime())).toBe(false);
+    }
+  });
+
   it('surfaces latest_description from the root-cause insight and latest_summary from the incident', async () => {
     const result = await getIncidentGroups({ status: 'active' });
     const cpu = result.groups.find((g) => g.signature === 'anomaly:ml-anomaly:cpu')!;

--- a/packages/ai-intelligence/src/__tests__/investigation-service.test.ts
+++ b/packages/ai-intelligence/src/__tests__/investigation-service.test.ts
@@ -175,16 +175,18 @@ Hope this helps!`;
       expect(result.root_cause).toBe('Test');
     });
 
-    it('should fall back to raw text with low confidence', () => {
+    it('should fall back to raw text and report no confidence at all', () => {
       const response = 'The container is experiencing high CPU due to a runaway process.';
 
       const result = parseInvestigationResponse(response);
 
       expect(result.root_cause).toBe(response);
       expect(result.contributing_factors).toEqual([]);
+      // 'unknown' says what it is; a number would not.
       expect(result.severity_assessment).toBe('unknown');
       expect(result.recommended_actions).toEqual([]);
-      expect(result.confidence_score).toBe(0.3);
+      // Was 0.3 — a value nothing measured, rendered as a measurement.
+      expect(result.confidence_score).toBeNull();
     });
 
     it('should handle missing fields gracefully', () => {
@@ -198,7 +200,29 @@ Hope this helps!`;
       expect(result.contributing_factors).toEqual([]);
       expect(result.severity_assessment).toBe('unknown');
       expect(result.recommended_actions).toEqual([]);
-      expect(result.confidence_score).toBe(0.5);
+      // Was 0.5, which the UI printed as an authoritative "Confidence: 50%".
+      expect(result.confidence_score).toBeNull();
+    });
+
+    it('keeps a model-supplied 0.5 distinguishable from an absent score', () => {
+      const supplied = parseInvestigationResponse(
+        JSON.stringify({ root_cause: 'x', confidence_score: 0.5 }),
+      );
+      const absent = parseInvestigationResponse(JSON.stringify({ root_cause: 'x' }));
+
+      expect(supplied.confidence_score).toBe(0.5);
+      expect(absent.confidence_score).toBeNull();
+    });
+
+    it('reports a non-numeric or non-finite confidence as null', () => {
+      // The old `typeof === 'number'` check let NaN through as a confidence.
+      expect(
+        parseInvestigationResponse(JSON.stringify({ root_cause: 'x', confidence_score: 'high' }))
+          .confidence_score,
+      ).toBeNull();
+      expect(
+        parseInvestigationResponse('{"root_cause":"x","confidence_score":null}').confidence_score,
+      ).toBeNull();
     });
 
     it('should clamp confidence_score to [0, 1]', () => {
@@ -538,6 +562,32 @@ Hope this helps!`;
           container_name: 'web-app',
         }),
       );
+    });
+
+    it('records no confidence when it aborts for want of evidence', async () => {
+      // With neither logs nor metrics no analysis runs at all, so there is
+      // nothing for a confidence to be the confidence *of*. This path used to
+      // persist 0.1, which the UI rendered as "Confidence: 10%" beside prose
+      // saying the investigation had been aborted.
+      mockGetRecentInvestigationForContainer.mockReturnValue(undefined);
+      mockIsLlmAvailable.mockResolvedValue(true);
+      mockGetContainerLogs.mockResolvedValue('');
+      mockGetMovingAverage.mockReturnValue(undefined);
+      mockGetMetrics.mockReturnValue([]);
+      mockGetContainers.mockResolvedValue([]);
+      mockGetInvestigation.mockReturnValue({ id: 'inv-1', status: 'complete' });
+
+      const insight = makeInsight({ container_id: 'no-evidence-1' });
+      await triggerInvestigation(insight);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const abort = mockUpdateInvestigationStatus.mock.calls.find(
+        ([, , updates]) => updates?.root_cause === 'Insufficient evidence to determine root cause',
+      );
+      expect(abort).toBeDefined();
+      expect(abort![2].confidence_score).toBeNull();
+      // The model was never consulted, so nothing could have supplied a score.
+      expect(mockChatStream).not.toHaveBeenCalled();
     });
 
     it('should skip when insight severity is below INVESTIGATION_MIN_SEVERITY (#697)', async () => {

--- a/packages/ai-intelligence/src/routes/correlations.ts
+++ b/packages/ai-intelligence/src/routes/correlations.ts
@@ -250,6 +250,14 @@ interface ResponseBlocks {
   paragraphs: string[];
   /** One entry per non-empty line, markers stripped. */
   lineBlocks: string[];
+  /**
+   * Blocks the model marked as list items with a `-`/`*`/`•` bullet.
+   *
+   * Tracked separately because these are the only unnumbered blocks whose
+   * ORDER the model asserted. Ordinary prose lines carry no such claim, so
+   * their position is not evidence of anything (see the positional pass).
+   */
+  bulletBlocks: string[];
 }
 
 // `**1.** text`, `1) text`, `2 - text`, `Pair 3: text`, `#4 text`
@@ -268,6 +276,7 @@ function splitResponseBlocks(lines: string[]): ResponseBlocks {
   const indexed = new Map<number, string>();
   const paragraphs: string[] = [];
   const lineBlocks: string[] = [];
+  const bulletBlocks: string[] = [];
 
   let current: { index: number | null; parts: string[] } | null = null;
   const flush = () => {
@@ -296,6 +305,7 @@ function splitResponseBlocks(lines: string[]): ResponseBlocks {
       flush();
       current = { index: null, parts: [asBullet[1]] };
       lineBlocks.push(asBullet[1].trim());
+      bulletBlocks.push(asBullet[1].trim());
       continue;
     }
 
@@ -305,7 +315,7 @@ function splitResponseBlocks(lines: string[]): ResponseBlocks {
   }
   flush();
 
-  return { indexed, paragraphs, lineBlocks };
+  return { indexed, paragraphs, lineBlocks, bulletBlocks };
 }
 
 /** True when a block names both containers of a pair — strong enough to attribute by content. */
@@ -338,13 +348,18 @@ ${pairDescriptions}`;
  *
  *  1. explicit list indices (robust to reordering and to a missing entry),
  *  2. container names appearing in a block (attribution by content),
- *  3. positional blocks, but ONLY when the block count matches the pair count —
- *     otherwise a single unstructured answer would be pinned to pair 1 and
- *     silently presented as its explanation.
+ *  3. position, but ONLY within an explicitly bulleted list of exactly one item
+ *     per pair. Bare prose is never read positionally: an unstructured answer
+ *     would otherwise be pinned to pair 1 and presented as its explanation.
+ *
+ * A block is used at most once, and blocks that overlap one already used are
+ * treated as used, so no two pairs can end up asserting the same sentence.
  *
  * Anything it cannot attribute stays null and is reported through
  * `narrativeStatus` / `narrativeUnavailableReason` so the caller can say why
- * once instead of rendering a failure per row.
+ * once instead of rendering a failure per row. Under-attributing is the
+ * intended direction of failure: a null narrative costs the operator a
+ * sentence, a misattributed one tells them something untrue about a container.
  */
 export function parseInsightsResponse(
   response: string,
@@ -359,7 +374,7 @@ export function parseInsightsResponse(
     : null;
   const narrativeLines = summaryIdx >= 0 ? lines.slice(0, summaryIdx) : lines;
 
-  const { indexed, paragraphs, lineBlocks } = splitResponseBlocks(narrativeLines);
+  const { indexed, paragraphs, lineBlocks, bulletBlocks } = splitResponseBlocks(narrativeLines);
 
   const narratives: Array<string | null> = pairs.map((_, idx) => {
     const block = indexed.get(idx + 1);
@@ -369,27 +384,51 @@ export function parseInsightsResponse(
   // Content-based attribution for anything the index pass missed: a block that
   // names both containers of a pair is evidence, not a guess. Each block is
   // claimed at most once.
-  const claimed = new Set<string>();
-  for (const narrative of narratives) if (narrative) claimed.add(narrative);
+  //
+  // `claimed` is keyed on the CLEANED text, which is also what the index pass
+  // stored. Comparing a raw block against a cleaned narrative never matches, so
+  // a block the index pass had already used (`**1.** …` — raw in `lineBlocks`,
+  // cleaned in `narratives`) could be handed to a second pair as well, putting
+  // the same sentence on two cards and still reporting `ok`. That duplication is
+  // precisely what this module was rewritten to stop.
+  // A block counts as claimed if it overlaps one already used, not merely if it
+  // is byte-identical. `paragraphs` entries are space-joins of the very lines
+  // held individually in `lineBlocks`, so an exact-match test lets a pair be
+  // handed a paragraph that CONTAINS another pair's sentence — two cards then
+  // assert overlapping text about different containers.
+  const claimed: string[] = [];
+  const isClaimed = (cleaned: string) =>
+    claimed.some((c) => c === cleaned || c.includes(cleaned) || cleaned.includes(c));
+  for (const narrative of narratives) if (narrative) claimed.push(narrative);
   pairs.forEach((pair, idx) => {
     if (narratives[idx]) return;
     for (const candidates of [lineBlocks, paragraphs]) {
-      const match = candidates.find((block) => !claimed.has(block) && mentionsBothContainers(block, pair));
-      if (match) {
-        narratives[idx] = cleanNarrative(match);
-        claimed.add(match);
+      for (const block of candidates) {
+        const cleaned = cleanNarrative(block);
+        if (!cleaned || isClaimed(cleaned)) continue;
+        if (!mentionsBothContainers(block, pair)) continue;
+        narratives[idx] = cleaned;
+        claimed.push(cleaned);
         return;
       }
     }
   });
 
-  // Positional fallback — only when a segmentation's block count matches the
-  // pair count exactly, so an unstructured answer is never pinned to pair 1 and
-  // presented as its explanation.
+  // Positional fallback — accepted ONLY for an explicitly marked list.
+  //
+  // Position is evidence only where the model asserted an order. A bulleted
+  // list of exactly one item per pair does assert one; a run of bare prose
+  // does not, and reading it positionally is a guess dressed as an answer. An
+  // earlier attempt kept prose and tried to screen out headings by punctuation,
+  // which was worse than useless: it deleted a blockquote or bolded narrative
+  // from the middle of the list and silently shifted every later sentence onto
+  // the wrong pair, reporting `ok` where the unfiltered code had correctly
+  // returned nothing. Prose that genuinely explains a pair almost always names
+  // its containers, and the content pass above already attributes that on real
+  // evidence.
   const attributedAny = narratives.some((n) => n !== null);
-  if (pairs.length > 0 && !attributedAny) {
-    const positional = [paragraphs, lineBlocks].find((blocks) => blocks.length === pairs.length);
-    positional?.forEach((block, idx) => { narratives[idx] = cleanNarrative(block); });
+  if (pairs.length > 0 && !attributedAny && bulletBlocks.length === pairs.length) {
+    bulletBlocks.forEach((block, idx) => { narratives[idx] = cleanNarrative(block); });
   }
 
   const insights: CorrelationInsight[] = pairs.map((pair, idx) => ({

--- a/packages/ai-intelligence/src/routes/correlations.ts
+++ b/packages/ai-intelligence/src/routes/correlations.ts
@@ -150,7 +150,8 @@ export { sweepExpiredEntries as _sweepExpiredEntries };
 // Simple in-memory cache for LLM insights (15 min TTL)
 const INSIGHTS_TTL = 15 * 60 * 1000;
 export const MAX_INSIGHTS_CACHE = 500;
-const insightsCache = new Map<string, { insights: CorrelationInsight[]; summary: string | null; expiresAt: number }>();
+interface InsightsCacheEntry extends CorrelationInsightsResult { expiresAt: number }
+const insightsCache = new Map<string, InsightsCacheEntry>();
 
 /** Clear the insights cache (for testing) */
 export function clearInsightsCache() {
@@ -163,20 +164,156 @@ export function getInsightsCacheSize(): number {
 }
 
 /** @internal Exported for testing only */
-export function setCachedInsights(key: string, insights: CorrelationInsight[], summary: string | null): void {
+export function setCachedInsights(
+  key: string,
+  insights: CorrelationInsight[],
+  summary: string | null,
+  narrative: Pick<CorrelationInsightsResult, 'narrativeStatus' | 'narrativeUnavailableReason'> = {
+    narrativeStatus: 'ok',
+    narrativeUnavailableReason: null,
+  },
+): void {
   if (insightsCache.size >= MAX_INSIGHTS_CACHE) {
     const firstKey = insightsCache.keys().next().value;
     if (firstKey) insightsCache.delete(firstKey);
   }
-  insightsCache.set(key, { insights, summary, expiresAt: Date.now() + INSIGHTS_TTL });
+  insightsCache.set(key, {
+    insights,
+    summary,
+    narrativeStatus: narrative.narrativeStatus,
+    narrativeUnavailableReason: narrative.narrativeUnavailableReason,
+    expiresAt: Date.now() + INSIGHTS_TTL,
+  });
 }
 
 export interface CorrelationInsight {
+  /**
+   * Stable key for the (containerA, containerB, metric) triple this narrative
+   * belongs to, so a client can join narratives onto its own pair list instead
+   * of relying on array position. Both sides slice their own top-10 from
+   * independently filtered lists, so position is not a safe join key.
+   * Format: `containerA|containerB|metricType`.
+   */
+  pairKey: string;
   containerA: string;
   containerB: string;
   metricType: string;
   correlation: number;
   narrative: string | null;
+}
+
+/**
+ * Why the narratives are missing, when they are.
+ * - `ok`      — every pair got a narrative.
+ * - `partial` — some pairs did; the rest are null.
+ * - `unparsed`— the model answered but nothing could be attributed to a pair.
+ * - `unavailable` — the model call failed.
+ */
+export type NarrativeStatus = 'ok' | 'partial' | 'unparsed' | 'unavailable';
+
+export interface CorrelationInsightsResult {
+  insights: CorrelationInsight[];
+  summary: string | null;
+  narrativeStatus: NarrativeStatus;
+  /**
+   * One operator-facing sentence explaining a non-`ok` status, for the UI to
+   * render ONCE above the list — not once per row. Null when status is `ok`.
+   */
+  narrativeUnavailableReason: string | null;
+}
+
+/** Join key shared with the client. Container names cannot contain `|`. */
+export function correlationPairKey(containerA: string, containerB: string, metricType: string): string {
+  return `${containerA}|${containerB}|${metricType}`;
+}
+
+const NARRATIVE_REASONS: Record<Exclude<NarrativeStatus, 'ok'>, string> = {
+  partial: 'The model returned narratives for only some pairs. The correlation values below are computed from metrics and are unaffected.',
+  unparsed: 'The model returned a response that could not be matched to any container pair. The correlation values below are computed from metrics and are unaffected.',
+  unavailable: 'Could not reach the language model. Check LLM_API_URL and LLM_API_TOKEN under Settings → AI. The correlation values below are computed from metrics and are unaffected.',
+};
+
+/** Strip markdown emphasis / stray list punctuation the model may wrap text in. */
+function cleanNarrative(text: string): string | null {
+  const cleaned = text
+    .replace(/^[\s*_`>#-]+/, '')
+    .replace(/[\s*_`]+$/, '')
+    .trim();
+  // Two characters is not a narrative; treat it as nothing rather than render it.
+  return cleaned.length >= 3 ? cleaned : null;
+}
+
+interface ResponseBlocks {
+  /** Blocks the model numbered explicitly, keyed by that number. */
+  indexed: Map<number, string>;
+  /** Unnumbered blocks, split on blank lines so multi-line paragraphs stay whole. */
+  paragraphs: string[];
+  /** One entry per non-empty line, markers stripped. */
+  lineBlocks: string[];
+}
+
+// `**1.** text`, `1) text`, `2 - text`, `Pair 3: text`, `#4 text`
+const INDEX_MARKER = /^[\s*_`#>-]*(?:pair\s*)?(\d{1,2})\s*[.):\]\-–]\s*(.*)$/i;
+const BULLET_MARKER = /^\s*[-*•]\s+(.*)$/;
+
+/**
+ * Segment a model response three ways so attribution can pick whichever
+ * segmentation actually lines up with the pairs.
+ *
+ * Accepts the ordinary shapes models produce: `1.`, `1)`, `1:`, `1 -`,
+ * `**1.**`, `#1`, `Pair 1:`, `-`/`*`/`•` bullets, and prose. Lines following a
+ * marker without one of their own belong to that marker's block.
+ */
+function splitResponseBlocks(lines: string[]): ResponseBlocks {
+  const indexed = new Map<number, string>();
+  const paragraphs: string[] = [];
+  const lineBlocks: string[] = [];
+
+  let current: { index: number | null; parts: string[] } | null = null;
+  const flush = () => {
+    if (!current) return;
+    const text = current.parts.join(' ').trim();
+    if (text) {
+      if (current.index !== null) indexed.set(current.index, text);
+      else paragraphs.push(text);
+    }
+    current = null;
+  };
+
+  for (const line of lines) {
+    if (!line) { flush(); continue; }
+
+    const asIndexed = INDEX_MARKER.exec(line);
+    if (asIndexed) {
+      flush();
+      current = { index: Number(asIndexed[1]), parts: asIndexed[2] ? [asIndexed[2]] : [] };
+      if (asIndexed[2]) lineBlocks.push(asIndexed[2].trim());
+      continue;
+    }
+
+    const asBullet = BULLET_MARKER.exec(line);
+    if (asBullet) {
+      flush();
+      current = { index: null, parts: [asBullet[1]] };
+      lineBlocks.push(asBullet[1].trim());
+      continue;
+    }
+
+    lineBlocks.push(line);
+    if (current) current.parts.push(line);
+    else current = { index: null, parts: [line] };
+  }
+  flush();
+
+  return { indexed, paragraphs, lineBlocks };
+}
+
+/** True when a block names both containers of a pair — strong enough to attribute by content. */
+function mentionsBothContainers(block: string, pair: CorrelationPair): boolean {
+  const haystack = block.toLowerCase();
+  const a = pair.containerA.name.toLowerCase();
+  const b = pair.containerB.name.toLowerCase();
+  return a.length > 2 && b.length > 2 && haystack.includes(a) && haystack.includes(b);
 }
 
 export function buildCorrelationPrompt(pairs: CorrelationPair[]): string {
@@ -190,34 +327,100 @@ export function buildCorrelationPrompt(pairs: CorrelationPair[]): string {
 ${pairDescriptions}`;
 }
 
+/**
+ * Attribute the model's narratives to correlation pairs.
+ *
+ * The previous implementation matched only a line literally starting with `N.`
+ * or `N)`. Any other formatting — a bulleted list, bold numbering, plain
+ * paragraphs, a leading preamble — nulled every narrative at once, and the UI
+ * printed the same "Insight unavailable" line ten times with no cause. This
+ * version tries, in order of how much evidence it has:
+ *
+ *  1. explicit list indices (robust to reordering and to a missing entry),
+ *  2. container names appearing in a block (attribution by content),
+ *  3. positional blocks, but ONLY when the block count matches the pair count —
+ *     otherwise a single unstructured answer would be pinned to pair 1 and
+ *     silently presented as its explanation.
+ *
+ * Anything it cannot attribute stays null and is reported through
+ * `narrativeStatus` / `narrativeUnavailableReason` so the caller can say why
+ * once instead of rendering a failure per row.
+ */
 export function parseInsightsResponse(
   response: string,
   pairs: CorrelationPair[],
-): { insights: CorrelationInsight[]; summary: string | null } {
-  const lines = response.split('\n').map(l => l.trim()).filter(Boolean);
-  const summaryIdx = lines.findIndex(l => l.toUpperCase().startsWith('SUMMARY:'));
-  const summary = summaryIdx >= 0 ? lines[summaryIdx].replace(/^SUMMARY:\s*/i, '').trim() : null;
+): CorrelationInsightsResult {
+  // Blank lines are kept: they are the only paragraph boundary the model gives us.
+  const lines = response.split('\n').map(l => l.trim());
+  // Tolerate `SUMMARY:`, `**SUMMARY:**`, `## Summary:` etc.
+  const summaryIdx = lines.findIndex(l => /^[\s*_`#>-]*summary\s*:/i.test(l));
+  const summary = summaryIdx >= 0
+    ? cleanNarrative(lines[summaryIdx].replace(/^[\s*_`#>-]*summary\s*:/i, ''))
+    : null;
   const narrativeLines = summaryIdx >= 0 ? lines.slice(0, summaryIdx) : lines;
 
-  const insights: CorrelationInsight[] = pairs.map((pair, idx) => {
-    // Try to find line starting with "N." or "N)"
-    const prefix = `${idx + 1}.`;
-    const prefixAlt = `${idx + 1})`;
-    const matchLine = narrativeLines.find(l => l.startsWith(prefix) || l.startsWith(prefixAlt));
-    const narrative = matchLine
-      ? matchLine.replace(/^\d+[.)]\s*/, '').trim()
-      : null;
+  const { indexed, paragraphs, lineBlocks } = splitResponseBlocks(narrativeLines);
 
-    return {
-      containerA: pair.containerA.name,
-      containerB: pair.containerB.name,
-      metricType: pair.metricType,
-      correlation: pair.correlation,
-      narrative,
-    };
+  const narratives: Array<string | null> = pairs.map((_, idx) => {
+    const block = indexed.get(idx + 1);
+    return block ? cleanNarrative(block) : null;
   });
 
-  return { insights, summary };
+  // Content-based attribution for anything the index pass missed: a block that
+  // names both containers of a pair is evidence, not a guess. Each block is
+  // claimed at most once.
+  const claimed = new Set<string>();
+  for (const narrative of narratives) if (narrative) claimed.add(narrative);
+  pairs.forEach((pair, idx) => {
+    if (narratives[idx]) return;
+    for (const candidates of [lineBlocks, paragraphs]) {
+      const match = candidates.find((block) => !claimed.has(block) && mentionsBothContainers(block, pair));
+      if (match) {
+        narratives[idx] = cleanNarrative(match);
+        claimed.add(match);
+        return;
+      }
+    }
+  });
+
+  // Positional fallback — only when a segmentation's block count matches the
+  // pair count exactly, so an unstructured answer is never pinned to pair 1 and
+  // presented as its explanation.
+  const attributedAny = narratives.some((n) => n !== null);
+  if (pairs.length > 0 && !attributedAny) {
+    const positional = [paragraphs, lineBlocks].find((blocks) => blocks.length === pairs.length);
+    positional?.forEach((block, idx) => { narratives[idx] = cleanNarrative(block); });
+  }
+
+  const insights: CorrelationInsight[] = pairs.map((pair, idx) => ({
+    pairKey: correlationPairKey(pair.containerA.name, pair.containerB.name, pair.metricType),
+    containerA: pair.containerA.name,
+    containerB: pair.containerB.name,
+    metricType: pair.metricType,
+    correlation: pair.correlation,
+    narrative: narratives[idx],
+  }));
+
+  const withNarrative = narratives.filter(Boolean).length;
+  const narrativeStatus: NarrativeStatus = pairs.length === 0 || withNarrative === pairs.length
+    ? 'ok'
+    : withNarrative === 0
+      ? 'unparsed'
+      : 'partial';
+
+  if (narrativeStatus !== 'ok') {
+    log.warn(
+      { pairCount: pairs.length, withNarrative, responsePreview: response.slice(0, 200) },
+      'Correlation narratives could not be fully attributed to pairs',
+    );
+  }
+
+  return {
+    insights,
+    summary,
+    narrativeStatus,
+    narrativeUnavailableReason: narrativeStatus === 'ok' ? null : NARRATIVE_REASONS[narrativeStatus],
+  };
 }
 
 export async function correlationRoutes(fastify: FastifyInstance, opts: CorrelationRoutesOpts) {
@@ -310,7 +513,13 @@ export async function correlationRoutes(fastify: FastifyInstance, opts: Correlat
     const cacheKey = `${safeHours}:${safeMin}`;
     const cached = insightsCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
-      return { insights: cached.insights, summary: cached.summary };
+      return {
+        insights: cached.insights,
+        summary: cached.summary,
+        narrativeStatus: cached.narrativeStatus,
+        narrativeUnavailableReason: cached.narrativeUnavailableReason,
+        pairsTotal: cached.insights.length,
+      };
     }
 
     // Compute correlations (wrapped in statement timeout for expensive pairwise query)
@@ -318,10 +527,14 @@ export async function correlationRoutes(fastify: FastifyInstance, opts: Correlat
       opts.findCorrelatedContainers(safeHours, safeMin, client),
     );
     if (pairs.length === 0) {
-      return { insights: [], summary: null };
+      return { insights: [], summary: null, narrativeStatus: 'ok' as const, narrativeUnavailableReason: null, pairsTotal: 0 };
     }
 
-    // Limit to top 10 pairs for LLM prompt
+    // Limit to top 10 pairs for LLM prompt. `pairsTotal` travels with the
+    // response so a client that sliced its own top-10 from a differently
+    // filtered list can tell that the two lists are not the same set; every
+    // insight also carries `pairKey`, so narratives are joined by identity
+    // rather than by array position.
     const topPairs = pairs.slice(0, 10);
     const prompt = buildCorrelationPrompt(topPairs);
 
@@ -333,20 +546,29 @@ export async function correlationRoutes(fastify: FastifyInstance, opts: Correlat
         'correlation_insights',
       );
 
-      const { insights, summary } = parseInsightsResponse(response.trim(), topPairs);
-      setCachedInsights(cacheKey, insights, summary);
-      return { insights, summary };
+      const parsed = parseInsightsResponse(response.trim(), topPairs);
+      setCachedInsights(cacheKey, parsed.insights, parsed.summary, parsed);
+      return { ...parsed, pairsTotal: pairs.length };
     } catch (err) {
       log.warn({ err }, 'Failed to generate correlation insights');
-      // Return pairs without narratives
+      // Correlations are computed from metrics and stand on their own; return
+      // them with an explicit reason the narratives are missing so the UI can
+      // say it once instead of printing a failure per row.
       const fallbackInsights: CorrelationInsight[] = topPairs.map(p => ({
+        pairKey: correlationPairKey(p.containerA.name, p.containerB.name, p.metricType),
         containerA: p.containerA.name,
         containerB: p.containerB.name,
         metricType: p.metricType,
         correlation: p.correlation,
         narrative: null,
       }));
-      return { insights: fallbackInsights, summary: null };
+      return {
+        insights: fallbackInsights,
+        summary: null,
+        narrativeStatus: 'unavailable' as const,
+        narrativeUnavailableReason: NARRATIVE_REASONS.unavailable,
+        pairsTotal: pairs.length,
+      };
     }
   });
 }

--- a/packages/ai-intelligence/src/services/incident-store.ts
+++ b/packages/ai-intelligence/src/services/incident-store.ts
@@ -185,6 +185,58 @@ export async function resolveIncident(id: string): Promise<void> {
 const TOP_CONTAINERS_PER_GROUP = 10;
 const ALL_NAMES_CAP = 500;
 
+/**
+ * Normalise a PostgreSQL timestamp value into an ISO-8601 UTC string.
+ *
+ * Why this exists: the group queries below used to render their timestamps with
+ * a `::text` cast. That cast changes the wire type from `timestamptz` (OID 1184)
+ * to `text` (OID 25), which bypasses the global
+ * `pg.types.setTypeParser(1184, …)` registered in `core/db/postgres.ts`. Instead
+ * of an ISO string the row then carried Postgres' own text rendering —
+ * `2026-07-26 08:46:29.123456+00`. The frontend's `formatDate()` swaps the first
+ * space for a `T` (a SQLite-era compatibility step), producing
+ * `2026-07-26T08:46:29.123456+00`, and a bare `+00` offset is not valid ISO-8601:
+ * `new Date()` rejects it, so every row of the incident rollup printed the
+ * literal string "Invalid date". `insights.created_at` on the same page rendered
+ * correctly precisely because it is read with `SELECT *` and keeps its
+ * timestamptz OID.
+ *
+ * The casts are gone. This function is the belt-and-braces guarantee that
+ * whatever the driver hands back — a `Date`, an ISO string, or Postgres text —
+ * leaves this module as ISO-8601 UTC, and that an unusable value is reported as
+ * `null` (which the UI can render as a dash) rather than as a broken string the
+ * UI has to fail on.
+ */
+export function toIsoTimestamp(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+  if (typeof value === 'number') {
+    const fromEpoch = new Date(value);
+    return Number.isNaN(fromEpoch.getTime()) ? null : fromEpoch.toISOString();
+  }
+  if (typeof value !== 'string') return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  // Postgres renders `timestamp without time zone` with no offset at all. The
+  // driver's own parser treats that as UTC (see setTypeParser(1114, …)), so we
+  // do the same instead of silently applying the Node process's local zone.
+  const hasZone = /(?:[zZ]|[+-]\d{2}(?::?\d{2})?)$/.test(trimmed);
+  const candidate = hasZone ? trimmed : `${trimmed}Z`;
+
+  const direct = new Date(candidate);
+  if (!Number.isNaN(direct.getTime())) return direct.toISOString();
+
+  // Last resort for `YYYY-MM-DD HH:MM:SS`-style input the engine refused: try
+  // the ISO date/time separator. Done second because a short `+00` offset
+  // parses fine with a space and not at all with a `T`.
+  const isoSeparated = new Date(candidate.replace(' ', 'T'));
+  return Number.isNaN(isoSeparated.getTime()) ? null : isoSeparated.toISOString();
+}
+
 export interface IncidentGroupsOptions {
   status?: 'active' | 'resolved';
   endpoint_id?: number;
@@ -199,8 +251,10 @@ export interface IncidentGroup {
   incident_count: number;
   container_count: number;
   alert_count: number;
-  earliest_at: string;
-  latest_update_at: string;
+  /** ISO-8601 UTC; null when the column is null or unparseable (see `toIsoTimestamp`). */
+  earliest_at: string | null;
+  /** ISO-8601 UTC; null when the column is null or unparseable (see `toIsoTimestamp`). */
+  latest_update_at: string | null;
   top_containers: Array<{
     /** Representative incident (highest-severity, then most-recent) for this container in this group. */
     incident_id: string;
@@ -209,14 +263,18 @@ export interface IncidentGroup {
     endpoint_name: string | null;
     /** Severity of the representative incident. */
     severity: 'critical' | 'warning' | 'info';
-    /** created_at of the representative incident. */
-    created_at: string;
+    /**
+     * created_at of the representative incident, as ISO-8601 UTC.
+     * Null when the column is null or unparseable — never a Postgres-formatted
+     * string, which `new Date()` rejects (see `toIsoTimestamp`).
+     */
+    created_at: string | null;
     /** All active incident ids for (signature, container_name). Length == incident_count. */
     incident_ids: string[];
     /** How many active incidents this container has under this signature. */
     incident_count: number;
-    /** updated_at of the most recently updated incident among incident_ids. */
-    latest_at: string;
+    /** updated_at of the most recently updated incident among incident_ids, as ISO-8601 UTC. */
+    latest_at: string | null;
     /** incidents.summary of the representative incident (LLM-derived, may be null). */
     latest_summary: string | null;
     /** insights.description of the representative incident's root-cause insight (contains metric values, may be null). */
@@ -252,13 +310,16 @@ export async function getIncidentGroups(options: IncidentGroupsOptions = {}): Pr
   // 1. Per-signature aggregate — counts, severity rollup, and name list (capped)
   // We keep the incident-level aggregates (incident_count, alert_count, severity, timestamps)
   // separate from the container expansion to avoid double-counting insight_count.
+  // Timestamps are selected WITHOUT a `::text` cast on purpose: the cast would
+  // drop the timestamptz OID and with it the driver's ISO type parser, handing
+  // the UI a string `new Date()` rejects. See `toIsoTimestamp` above.
   const rawGroups = await db.query<{
     signature: string;
     severity: 'critical' | 'warning' | 'info';
     incident_count: number;
     alert_count: number;
-    earliest_at: string;
-    latest_update_at: string;
+    earliest_at: unknown;
+    latest_update_at: unknown;
     container_count: number;
     all_names: string[];
   }>(`
@@ -272,8 +333,8 @@ export async function getIncidentGroups(options: IncidentGroupsOptions = {}): Pr
              BOOL_OR(severity = 'warning')  AS has_warning,
              COUNT(*)::int                  AS incident_count,
              COALESCE(SUM(insight_count), 0)::int AS alert_count,
-             MIN(created_at)::text          AS earliest_at,
-             MAX(updated_at)::text          AS latest_update_at
+             MIN(created_at)                AS earliest_at,
+             MAX(updated_at)                AS latest_update_at
       FROM base
       GROUP BY signature
     ),
@@ -321,10 +382,10 @@ export async function getIncidentGroups(options: IncidentGroupsOptions = {}): Pr
     endpoint_id: number | null;
     endpoint_name: string | null;
     severity: 'critical' | 'warning' | 'info';
-    created_at: string;
+    created_at: unknown;
     incident_ids: string[];
     incident_count: number;
-    latest_at: string;
+    latest_at: unknown;
     latest_summary: string | null;
     latest_description: string | null;
   }>(`
@@ -366,7 +427,7 @@ export async function getIncidentGroups(options: IncidentGroupsOptions = {}): Pr
       SELECT signature, container_name,
              ARRAY_AGG(incident_id ORDER BY created_at DESC) AS incident_ids,
              COUNT(*)::int AS incident_count,
-             MAX(updated_at)::text AS latest_at
+             MAX(updated_at) AS latest_at
       FROM expanded
       GROUP BY signature, container_name
     ),
@@ -375,7 +436,7 @@ export async function getIncidentGroups(options: IncidentGroupsOptions = {}): Pr
              r.rep_incident_id AS incident_id,
              r.rep_severity AS severity,
              r.endpoint_id, r.endpoint_name,
-             r.rep_created_at::text AS created_at,
+             r.rep_created_at AS created_at,
              g.incident_ids, g.incident_count, g.latest_at,
              r.rep_summary AS latest_summary,
              ins.description AS latest_description,
@@ -416,10 +477,10 @@ export async function getIncidentGroups(options: IncidentGroupsOptions = {}): Pr
       endpoint_id: r.endpoint_id,
       endpoint_name: r.endpoint_name,
       severity: r.severity,
-      created_at: r.created_at,
+      created_at: toIsoTimestamp(r.created_at),
       incident_ids: r.incident_ids,
       incident_count: r.incident_count,
-      latest_at: r.latest_at,
+      latest_at: toIsoTimestamp(r.latest_at),
       latest_summary: r.latest_summary,
       latest_description: r.latest_description,
     });
@@ -433,8 +494,8 @@ export async function getIncidentGroups(options: IncidentGroupsOptions = {}): Pr
     incident_count: g.incident_count,
     container_count: g.container_count,
     alert_count: g.alert_count,
-    earliest_at: g.earliest_at,
-    latest_update_at: g.latest_update_at,
+    earliest_at: toIsoTimestamp(g.earliest_at),
+    latest_update_at: toIsoTimestamp(g.latest_update_at),
     top_containers: topBySig.get(g.signature) ?? [],
     all_container_names: g.all_names ?? [],
     names_truncated: (g.all_names?.length ?? 0) >= ALL_NAMES_CAP && g.container_count > ALL_NAMES_CAP,

--- a/packages/ai-intelligence/src/services/investigation-service.ts
+++ b/packages/ai-intelligence/src/services/investigation-service.ts
@@ -4,6 +4,7 @@ import { getConfig } from '@dashboard/core/config/index.js';
 import { getEffectiveMonitoringConfig } from '@dashboard/core/services/settings-store.js';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { extractLlmJson } from '@dashboard/core/utils/llm-json.js';
+import { clampConfidenceScore } from '@dashboard/core/utils/model-confidence.js';
 import { getContainerLogs, getContainers } from '@dashboard/core/portainer/portainer-client.js';
 import { cachedFetchSWR, getCacheKey, TTL } from '@dashboard/core/portainer/portainer-cache.js';
 import { isLlmAvailable, chatStream } from './llm-client.js';
@@ -60,7 +61,15 @@ export interface ParsedInvestigationResult {
   contributing_factors: string[];
   severity_assessment: string;
   recommended_actions: RecommendedAction[];
-  confidence_score: number;
+  /**
+   * 0–1 when the model supplied a usable score, null when it did not.
+   *
+   * Null rather than a constant is the point: this used to be `0.5` for "the
+   * model said nothing", which the UI rendered as an authoritative
+   * "Confidence: 50%" badge. `severity_assessment` keeps its `'unknown'`
+   * default — that string is honest about itself, a number is not.
+   */
+  confidence_score: number | null;
   ai_summary: string;
 }
 
@@ -71,14 +80,16 @@ export function parseInvestigationResponse(raw: string): ParsedInvestigationResu
     return validateParsedResult(parsed);
   }
 
-  // Fallback: treat raw text as the root cause with low confidence
+  // Fallback: unstructured model output. We have prose and nothing else — the
+  // model stated no confidence, so we report none rather than inventing the
+  // 0.3 that used to be rendered as a measured value.
   const fallbackCause = raw.trim().slice(0, 2000);
   return {
     root_cause: fallbackCause,
     contributing_factors: [],
     severity_assessment: 'unknown',
     recommended_actions: [],
-    confidence_score: 0.3,
+    confidence_score: null,
     ai_summary: fallbackCause.slice(0, 200),
   };
 }
@@ -115,9 +126,9 @@ function validateParsedResult(parsed: Record<string, unknown>): ParsedInvestigat
         .filter((a): a is RecommendedAction => a !== null)
     : [];
 
-  const confidenceScore = typeof parsed.confidence_score === 'number'
-    ? Math.max(0, Math.min(1, parsed.confidence_score))
-    : 0.5;
+  // Null when the model supplied nothing usable — see clampConfidenceScore.
+  // The old `: 0.5` branch also let a NaN through as a confidence.
+  const confidenceScore = clampConfidenceScore(parsed.confidence_score);
 
   const aiSummary = typeof parsed.ai_summary === 'string'
     ? parsed.ai_summary.slice(0, 200)
@@ -364,7 +375,10 @@ async function runInvestigation(investigationId: string, insight: Insight): Prom
         contributing_factors: '[]',
         severity_assessment: 'unknown',
         recommended_actions: '[]',
-        confidence_score: 0.1,
+        // No logs and no metrics were gathered, so no analysis ran. A 0.1
+        // "confidence" here described the confidence of nothing, and sat
+        // beside prose that says the investigation was aborted.
+        confidence_score: null,
         ai_summary: 'Investigation aborted due to insufficient evidence — no logs or metrics available for analysis.',
         analysis_duration_ms: durationMs,
         llm_model: config.LLM_MODEL,

--- a/packages/ai-intelligence/src/services/investigation-store.ts
+++ b/packages/ai-intelligence/src/services/investigation-store.ts
@@ -39,7 +39,14 @@ export async function updateInvestigationStatus(
     contributing_factors?: string;
     severity_assessment?: string;
     recommended_actions?: string;
-    confidence_score?: number;
+    /**
+     * Null means "the model supplied no confidence" and is written through as
+     * SQL NULL — the column is nullable and the loop below tests `!== undefined`,
+     * not truthiness. Do not "simplify" that guard to `if (value)`: a null (or a
+     * legitimate `0`) would then be dropped from the SET list, silently leaving
+     * the previous value in place.
+     */
+    confidence_score?: number | null;
     analysis_duration_ms?: number;
     llm_model?: string;
     ai_summary?: string;

--- a/packages/contracts/src/__tests__/schemas.test.ts
+++ b/packages/contracts/src/__tests__/schemas.test.ts
@@ -156,6 +156,21 @@ describe('NormalizedContainerSchema', () => {
       labels: {}, networks: ['bridge'], networkIPs: { bridge: '172.17.0.2' } };
     expect(NormalizedContainerSchema.parse(raw).networkIPs).toEqual({ bridge: '172.17.0.2' });
   });
+
+  it('preserves the host bind IP on ports (this schema serializes the response)', () => {
+    // parse() strips undeclared keys, so an absent `ip` here means the field
+    // never reaches the client no matter what the normalizer emits — which is
+    // how the container detail table came to hardcode "0.0.0.0".
+    const raw = { id: 'c1', name: 'nginx', image: 'nginx:latest', state: 'running',
+      status: 'Up', endpointId: 1, endpointName: 'local',
+      ports: [
+        { private: 5432, public: 5432, type: 'tcp', ip: '127.0.0.1' },
+        { private: 80, public: 8080, type: 'tcp', ip: '::' },
+      ],
+      created: 1700000000, labels: {}, networks: [], networkIPs: {} };
+    const parsed = NormalizedContainerSchema.parse(raw);
+    expect(parsed.ports.map((p) => p.ip)).toEqual(['127.0.0.1', '::']);
+  });
 });
 
 describe('NormalizedEndpointSchema', () => {
@@ -225,6 +240,26 @@ describe('RemediationAnalysisResultSchema', () => {
     expect(() =>
       RemediationAnalysisResultSchema.parse({ root_cause: 'x', severity: 'info',
         recommended_actions: [], log_analysis: 'x', confidence_score: 1.5 })
+    ).toThrow();
+  });
+
+  it('represents "the model supplied no confidence" as null, not a default', () => {
+    const parsed = RemediationAnalysisResultSchema.parse({ root_cause: 'x', severity: null,
+      recommended_actions: [], log_analysis: 'x', confidence_score: null });
+    expect(parsed.confidence_score).toBeNull();
+    expect(parsed.severity).toBeNull();
+  });
+
+  it('carries the rationale provenance when supplied', () => {
+    const parsed = RemediationAnalysisResultSchema.parse({ root_cause: 'x', severity: 'info',
+      recommended_actions: [], log_analysis: 'x', confidence_score: 0.5, analysis_source: 'llm-analysis' });
+    expect(parsed.analysis_source).toBe('llm-analysis');
+  });
+
+  it('rejects an unknown provenance value', () => {
+    expect(() =>
+      RemediationAnalysisResultSchema.parse({ root_cause: 'x', severity: 'info',
+        recommended_actions: [], log_analysis: 'x', confidence_score: 0.5, analysis_source: 'vibes' })
     ).toThrow();
   });
 });

--- a/packages/contracts/src/interfaces/operations-interface.ts
+++ b/packages/contracts/src/interfaces/operations-interface.ts
@@ -1,9 +1,17 @@
 import type { Insight } from '../schemas/insight.js';
+import type { RationaleSource } from '../schemas/remediation.js';
 
 /** Result of a suggested remediation action. */
 export interface SuggestActionResult {
   actionId: string;
   actionType: string;
+  /**
+   * Where the rationale stored on the action came from. Always `pattern-match`
+   * at suggestion time — the LLM analysis, if any, replaces it asynchronously.
+   */
+  rationaleSource?: RationaleSource;
+  /** Stable id of the keyword rule that matched (see ACTION_PATTERNS). */
+  patternId?: string;
 }
 
 /**

--- a/packages/contracts/src/interfaces/operations-interface.ts
+++ b/packages/contracts/src/interfaces/operations-interface.ts
@@ -8,10 +8,16 @@ export interface SuggestActionResult {
   /**
    * Where the rationale stored on the action came from. Always `pattern-match`
    * at suggestion time — the LLM analysis, if any, replaces it asynchronously.
+   *
+   * Required, not optional: `suggestAction` cannot produce a result without
+   * having matched a pattern, so an optional field would only oblige callers to
+   * null-check something that is never absent — and leave room for a future
+   * implementation to omit the provenance of a rationale, which is the one
+   * thing this field exists to carry.
    */
-  rationaleSource?: RationaleSource;
+  rationaleSource: RationaleSource;
   /** Stable id of the keyword rule that matched (see ACTION_PATTERNS). */
-  patternId?: string;
+  patternId: string;
 }
 
 /**

--- a/packages/contracts/src/schemas/container.ts
+++ b/packages/contracts/src/schemas/container.ts
@@ -4,6 +4,14 @@ export const ContainerPortSchema = z.object({
   private: z.number().optional(),
   public: z.number().optional(),
   type: z.string().optional(),
+  /**
+   * Docker's host-side bind address for the mapping (`0.0.0.0`, `127.0.0.1`,
+   * `::`, …). Required in the response contract: this schema is used as a
+   * Fastify serializer, so an absent field here is silently stripped from the
+   * payload — which is how the UI ended up hardcoding `0.0.0.0`. Undefined when
+   * Docker reported no bind address (exposed but unpublished).
+   */
+  ip: z.string().optional(),
 });
 
 export const NormalizedContainerSchema = z.object({

--- a/packages/contracts/src/schemas/remediation.ts
+++ b/packages/contracts/src/schemas/remediation.ts
@@ -10,12 +10,33 @@ export const RemediationSuggestedActionSchema = z.object({
   rationale: z.string(),
 });
 
+/**
+ * Where a rationale came from. `pattern-match` is a fixed string from the
+ * five-entry regex table in `remediation-service.ts`; `llm-analysis` is model
+ * output. The two render identically today, so the source travels with the
+ * payload and the UI can label it honestly.
+ */
+export const RationaleSourceSchema = z.enum(['pattern-match', 'llm-analysis']);
+export type RationaleSource = z.infer<typeof RationaleSourceSchema>;
+
 export const RemediationAnalysisResultSchema = z.object({
   root_cause: z.string(),
-  severity: SeveritySchema,
+  /**
+   * Null when the model did not supply a severity. A fallback rendered as an
+   * authoritative badge is worse than no badge — the UI must omit it on null
+   * rather than substitute a default.
+   */
+  severity: SeveritySchema.nullable(),
   recommended_actions: z.array(RemediationSuggestedActionSchema),
   log_analysis: z.string(),
-  confidence_score: z.number().min(0).max(1),
+  /**
+   * 0–1 when the model supplied one; null when it did not. Distinguishing the
+   * two is the point: "Confidence: 50%" used to be a hardcoded default dressed
+   * as a measurement.
+   */
+  confidence_score: z.number().min(0).max(1).nullable(),
+  /** Present on stored analyses so the UI can attribute the text. */
+  analysis_source: RationaleSourceSchema.optional(),
 });
 
 export type RemediationSuggestedAction = z.infer<typeof RemediationSuggestedActionSchema>;

--- a/packages/core/src/models/portainer.test.ts
+++ b/packages/core/src/models/portainer.test.ts
@@ -8,6 +8,7 @@ import {
   ImageSchema,
   EndpointArraySchema,
   ContainerArraySchema,
+  containerFromInspect,
 } from './portainer.js';
 
 describe('Portainer Models', () => {
@@ -448,5 +449,61 @@ describe('Portainer Models', () => {
       const result = EndpointArraySchema.safeParse('not an array');
       expect(result.success).toBe(false);
     });
+  });
+});
+
+describe('containerFromInspect port bindings', () => {
+  const base = {
+    Id: 'abc123',
+    Name: '/web',
+    Created: '2026-07-26T08:00:00.000Z',
+    State: { Status: 'running', Running: true },
+    Config: { Image: 'nginx:latest', Labels: {} },
+  };
+
+  it('carries the host bind IP through for each binding', () => {
+    const container = containerFromInspect({
+      ...base,
+      NetworkSettings: {
+        Ports: {
+          '5432/tcp': [{ HostIp: '127.0.0.1', HostPort: '5432' }],
+        },
+      },
+    });
+
+    expect(container.Ports).toEqual([
+      { IP: '127.0.0.1', PrivatePort: 5432, PublicPort: 5432, Type: 'tcp' },
+    ]);
+  });
+
+  it('keeps both bindings of a dual-stack publish instead of dropping one', () => {
+    // Docker lists IPv4 and IPv6 separately. Taking bindings[0] silently hid
+    // one of them; discarding the IP made the survivors indistinguishable.
+    const container = containerFromInspect({
+      ...base,
+      NetworkSettings: {
+        Ports: {
+          '80/tcp': [
+            { HostIp: '0.0.0.0', HostPort: '8080' },
+            { HostIp: '::', HostPort: '8080' },
+          ],
+        },
+      },
+    });
+
+    expect(container.Ports).toHaveLength(2);
+    expect(container.Ports!.map((p) => p.IP)).toEqual(['0.0.0.0', '::']);
+    expect(container.Ports!.every((p) => p.PublicPort === 8080)).toBe(true);
+  });
+
+  it('still reports an exposed but unpublished port', () => {
+    const container = containerFromInspect({
+      ...base,
+      NetworkSettings: { Ports: { '9000/tcp': null } },
+    });
+
+    expect(container.Ports).toEqual([
+      { PrivatePort: 9000, PublicPort: undefined, Type: 'tcp' },
+    ]);
   });
 });

--- a/packages/core/src/models/portainer.ts
+++ b/packages/core/src/models/portainer.ts
@@ -166,16 +166,29 @@ export function containerFromInspect(raw: unknown): Container {
   const createdMs = i.Created ? Date.parse(i.Created) : NaN;
   const created = Number.isFinite(createdMs) ? Math.floor(createdMs / 1000) : 0;
 
+  // One entry per host binding, not per port key. Docker publishes a separate
+  // binding for IPv4 and IPv6, and `HostIp` is what tells them apart — and what
+  // tells a loopback-only publish from a world-facing one. Taking `bindings[0]`
+  // and discarding the IP collapsed both facts. A port with no bindings is
+  // exposed but unpublished and still gets a row.
   const ports = Object.entries(i.NetworkSettings?.Ports ?? {}).flatMap(([key, bindings]) => {
     const [portStr, type] = key.split('/');
     const privatePort = Number(portStr);
     if (!Number.isFinite(privatePort)) return [];
-    const hostPort = bindings?.[0]?.HostPort ? Number(bindings[0].HostPort) : undefined;
-    return [{
-      PrivatePort: privatePort,
-      PublicPort: hostPort !== undefined && Number.isFinite(hostPort) ? hostPort : undefined,
-      Type: type ?? 'tcp',
-    }];
+    const portType = type ?? 'tcp';
+    const list = bindings ?? [];
+    if (list.length === 0) {
+      return [{ PrivatePort: privatePort, PublicPort: undefined, Type: portType }];
+    }
+    return list.map((binding) => {
+      const hostPort = binding?.HostPort ? Number(binding.HostPort) : undefined;
+      return {
+        PrivatePort: privatePort,
+        PublicPort: hostPort !== undefined && Number.isFinite(hostPort) ? hostPort : undefined,
+        Type: portType,
+        ...(binding?.HostIp ? { IP: binding.HostIp } : {}),
+      };
+    });
   });
 
   // Re-parse through ContainerSchema so the returned object is guaranteed to

--- a/packages/core/src/portainer/container-schema-drift.test.ts
+++ b/packages/core/src/portainer/container-schema-drift.test.ts
@@ -18,10 +18,28 @@ describe('NormalizedContainerSchema ⇄ normalizeContainer drift guard', () => {
     const parsed = NormalizedContainerSchema.parse(normalized);
     // If the schema omits a field the normalizer emits, parse() strips it and
     // the key sets diverge — catching the exact class of drift as networkIPs.
-    // Scope: top-level keys only. Drift nested inside `ports[]`/`ContainerPortSchema`
-    // is NOT covered here (those fields are all-optional today, so nothing to strip);
-    // extend this if the port shape ever gains required fields.
     expect(Object.keys(parsed).sort()).toEqual(Object.keys(normalized).sort());
     expect(parsed.networkIPs).toEqual({ bridge: '172.17.0.2' });
+  });
+
+  it('the schema keeps every key inside ports[] too', () => {
+    // This schema is used as a Fastify response serializer, so a field the
+    // schema does not declare is silently stripped from the payload. That is
+    // how the port bind IP went missing and the UI ended up hardcoding
+    // "0.0.0.0"; nested drift is now covered, not just top-level.
+    const normalized = normalizeContainer(
+      {
+        Id: 'abc123', Names: ['/web'], Image: 'nginx:latest', State: 'running',
+        Status: 'Up 2 hours', Created: 1700000000,
+        Ports: [{ IP: '127.0.0.1', PrivatePort: 80, PublicPort: 8080, Type: 'tcp' }],
+        Labels: {},
+      } as never,
+      1,
+      'local',
+    );
+    const parsed = NormalizedContainerSchema.parse(normalized);
+
+    expect(Object.keys(parsed.ports[0]).sort()).toEqual(Object.keys(normalized.ports[0]).sort());
+    expect(parsed.ports[0].ip).toBe('127.0.0.1');
   });
 });

--- a/packages/core/src/portainer/portainer-client.test.ts
+++ b/packages/core/src/portainer/portainer-client.test.ts
@@ -648,9 +648,14 @@ describe('getContainer — Docker inspect normalization (#1387)', () => {
     expect(udp?.PublicPort).toBeUndefined();
     expect(udp?.Type).toBe('udp');
 
+    // The host bind address is part of the mapping — a loopback publish and a
+    // world-facing one must not be indistinguishable downstream.
+    expect(tcp?.IP).toBe('0.0.0.0');
+    expect(udp?.IP).toBeUndefined();
+
     // normalizeContainer consumes the mapped Ports[] — verify it survives.
     const ports = normalizeContainer(c, 4, 'prod').ports;
-    expect(ports).toContainEqual({ private: 80, public: 8080, type: 'tcp' });
+    expect(ports).toContainEqual({ private: 80, public: 8080, type: 'tcp', ip: '0.0.0.0' });
     expect(ports).toContainEqual({ private: 53, public: undefined, type: 'udp' });
   });
 

--- a/packages/core/src/portainer/portainer-normalizers.test.ts
+++ b/packages/core/src/portainer/portainer-normalizers.test.ts
@@ -38,6 +38,51 @@ describe('normalizeContainer', () => {
     expect(result.networks).toEqual(['bridge', 'custom_net']);
   });
 
+  // The UI used to hardcode "0.0.0.0" in its Host IP column because the
+  // normalizer dropped Docker's `IP`. A loopback-only publish and a
+  // world-facing one must not render identically.
+  it('carries the host bind IP through for each published port', () => {
+    const container = makeContainer({
+      Ports: [
+        { IP: '127.0.0.1', PrivatePort: 5432, PublicPort: 5432, Type: 'tcp' },
+        { IP: '0.0.0.0', PrivatePort: 80, PublicPort: 8080, Type: 'tcp' },
+      ],
+    } as Partial<Container>);
+
+    const result = normalizeContainer(container, 1, 'local');
+
+    expect(result.ports).toEqual([
+      { private: 5432, public: 5432, type: 'tcp', ip: '127.0.0.1' },
+      { private: 80, public: 8080, type: 'tcp', ip: '0.0.0.0' },
+    ]);
+  });
+
+  it('keeps the IPv4 and IPv6 bindings of one mapping distinguishable', () => {
+    // Docker publishes these as two entries; without the IP they collapse into
+    // two identical rows and the table looks broken.
+    const container = makeContainer({
+      Ports: [
+        { IP: '0.0.0.0', PrivatePort: 80, PublicPort: 8080, Type: 'tcp' },
+        { IP: '::', PrivatePort: 80, PublicPort: 8080, Type: 'tcp' },
+      ],
+    } as Partial<Container>);
+
+    const result = normalizeContainer(container, 1, 'local');
+
+    expect(result.ports.map((p) => p.ip)).toEqual(['0.0.0.0', '::']);
+  });
+
+  it('omits ip for an exposed but unpublished port', () => {
+    const container = makeContainer({
+      Ports: [{ PrivatePort: 9000, Type: 'tcp' }],
+    } as Partial<Container>);
+
+    const result = normalizeContainer(container, 1, 'local');
+
+    expect(result.ports).toEqual([{ private: 9000, public: undefined, type: 'tcp' }]);
+    expect(result.ports[0].ip).toBeUndefined();
+  });
+
   it('returns empty networkIPs when no networks exist', () => {
     const container = makeContainer({
       NetworkSettings: undefined,

--- a/packages/core/src/portainer/portainer-normalizers.ts
+++ b/packages/core/src/portainer/portainer-normalizers.ts
@@ -51,7 +51,17 @@ export interface NormalizedContainer {
   created: number;
   endpointId: number;
   endpointName: string;
-  ports: Array<{ private: number; public?: number; type: string }>;
+  /**
+   * Published port mappings.
+   *
+   * `ip` is Docker's host-side bind address for the mapping and is deliberately
+   * carried through: whether a port is bound to `127.0.0.1` or `0.0.0.0` is the
+   * most security-relevant fact about it, and it is also what distinguishes the
+   * IPv4 and IPv6 bindings Docker publishes for the same port (which otherwise
+   * render as two identical rows). Undefined when Docker reported no bind
+   * address — an exposed-but-unpublished port.
+   */
+  ports: Array<{ private: number; public?: number; type: string; ip?: string }>;
   networks: string[];
   networkIPs: Record<string, string>;
   labels: Record<string, string>;
@@ -333,6 +343,9 @@ export function normalizeContainer(
       private: p.PrivatePort || 0,
       public: p.PublicPort,
       type: p.Type || 'tcp',
+      // Docker's host bind address. Dropping it made the UI assert a constant
+      // "0.0.0.0" for every mapping, including loopback-only ones.
+      ...(p.IP ? { ip: p.IP } : {}),
     })),
     networks: Object.keys(c.NetworkSettings?.Networks || {}),
     networkIPs: Object.fromEntries(

--- a/packages/core/src/utils/model-confidence.test.ts
+++ b/packages/core/src/utils/model-confidence.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { clampConfidenceScore, parseSeverity } from './model-confidence.js';
+
+describe('clampConfidenceScore', () => {
+  it('passes a usable score through', () => {
+    expect(clampConfidenceScore(0.42)).toBe(0.42);
+    expect(clampConfidenceScore(0)).toBe(0);
+    expect(clampConfidenceScore(1)).toBe(1);
+  });
+
+  it('clamps a badly expressed judgement rather than discarding it', () => {
+    expect(clampConfidenceScore(1.5)).toBe(1);
+    expect(clampConfidenceScore(-2)).toBe(0);
+  });
+
+  it('returns null for anything the model did not supply as a finite number', () => {
+    expect(clampConfidenceScore(undefined)).toBeNull();
+    expect(clampConfidenceScore(null)).toBeNull();
+    expect(clampConfidenceScore('0.8')).toBeNull();
+    expect(clampConfidenceScore(NaN)).toBeNull();
+    expect(clampConfidenceScore(Infinity)).toBeNull();
+    expect(clampConfidenceScore({})).toBeNull();
+  });
+
+  it('keeps a supplied 0.5 distinguishable from an absent score', () => {
+    // The whole point: the old code returned 0.5 for "not supplied", making the
+    // two indistinguishable on screen.
+    expect(clampConfidenceScore(0.5)).toBe(0.5);
+    expect(clampConfidenceScore(undefined)).toBeNull();
+  });
+
+  it('never returns a number for an absent score, at any of the old defaults', () => {
+    for (const legacyDefault of [0.5, 0.35, 0.3, 0.1]) {
+      expect(clampConfidenceScore(undefined)).not.toBe(legacyDefault);
+    }
+  });
+});
+
+describe('parseSeverity', () => {
+  it('passes through the three severities the prompts ask for', () => {
+    expect(parseSeverity('critical')).toBe('critical');
+    expect(parseSeverity('warning')).toBe('warning');
+    expect(parseSeverity('info')).toBe('info');
+  });
+
+  it('returns null instead of defaulting to warning', () => {
+    expect(parseSeverity(undefined)).toBeNull();
+    expect(parseSeverity(null)).toBeNull();
+    expect(parseSeverity('sev1')).toBeNull();
+    expect(parseSeverity('Critical')).toBeNull();
+    expect(parseSeverity(2)).toBeNull();
+  });
+});

--- a/packages/core/src/utils/model-confidence.ts
+++ b/packages/core/src/utils/model-confidence.ts
@@ -1,0 +1,47 @@
+/**
+ * Reading what a language model actually supplied — and saying so when it
+ * supplied nothing.
+ *
+ * The design critique found the same defect in three separate analysers: a
+ * model that omitted its `confidence_score` had one invented for it (`0.5`,
+ * `0.3`, `0.1` depending on the code path), and the UI then rendered that
+ * constant as an authoritative "Confidence: 50%" badge. The number looked like
+ * a measurement, was indistinguishable from one, and nothing had measured
+ * anything.
+ *
+ * `null` is the honest answer, and it lets every caller omit the badge instead
+ * of printing a stand-in. These helpers live in `core` rather than beside any
+ * one analyser because all three consumers — remediation (`@dashboard/operations`),
+ * investigation (`@dashboard/ai`) and PCAP analysis (`@dashboard/security`) —
+ * are in different packages that may not import one another, and three copies
+ * of a rule is how the rule comes back in one of them.
+ */
+
+/** The severities the analysis prompts ask a model to choose between. */
+export type ModelSeverity = 'critical' | 'warning' | 'info';
+
+/**
+ * The model's confidence as a number in 0–1, or `null` when it did not supply a
+ * usable one.
+ *
+ * `Number.isFinite` is load-bearing rather than defensive: a model that emits
+ * `NaN` (or a JSON `"0.8"` string) would otherwise persist a value that renders
+ * as "Confidence: NaN%" or crashes the formatter. Out-of-range numbers are
+ * clamped rather than rejected — the model did express a judgement, it just
+ * expressed it badly.
+ */
+export function clampConfidenceScore(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(1, value));
+}
+
+/**
+ * The model's severity, or `null` when it did not supply a valid one.
+ *
+ * Never falls back to a middle value: a fabricated "warning" badge is read by
+ * an operator as an assessment, and triaging against it wastes the one thing
+ * an incident costs most.
+ */
+export function parseSeverity(value: unknown): ModelSeverity | null {
+  return value === 'critical' || value === 'warning' || value === 'info' ? value : null;
+}

--- a/packages/observability/src/__tests__/metric-correlator-db.test.ts
+++ b/packages/observability/src/__tests__/metric-correlator-db.test.ts
@@ -102,7 +102,13 @@ describe('detectCorrelatedAnomalies (real PG, set-based rewrite)', () => {
     expect(a.containerName).toBe('web');
     expect(a.severity).toBe('critical');
     expect(a.compositeScore).toBeGreaterThanOrEqual(5);
-    expect(a.pattern).toContain('CPU Spike');
+    // The classification is structured now: a stable id plus the z-scores and
+    // threshold that fired it, rather than a fixed English sentence.
+    expect(a.patternMatch?.id).toBe('cpu-only-deviation');
+    expect(a.patternMatch?.zScoreThreshold).toBe(2);
+    expect(a.patternMatch?.triggeredBy[0].type).toBe('cpu');
+    expect(a.pattern).toBe(a.patternMatch?.summary);
+    expect(a.pattern).toContain('cpu z=');
 
     // Only the elevated metric is reported; its z-score reflects the fresh spike.
     expect(a.metrics).toHaveLength(1);

--- a/packages/observability/src/__tests__/metric-correlator.test.ts
+++ b/packages/observability/src/__tests__/metric-correlator.test.ts
@@ -9,6 +9,7 @@ import {
   pearsonCorrelation,
   calculateCompositeScore,
   identifyPattern,
+  PATTERN_Z_SCORE_THRESHOLD,
   scoreSeverity,
   correlationStrength,
 } from '../services/metric-correlator.js';
@@ -57,36 +58,92 @@ describe('metric-correlator', () => {
   });
 
   describe('identifyPattern', () => {
-    it('identifies resource exhaustion', () => {
-      const pattern = identifyPattern([
+    it('classifies both metrics deviating, and reports the z-scores that triggered it', () => {
+      const match = identifyPattern([
         { type: 'cpu', zScore: 3 },
-        { type: 'memory', zScore: 3 },
+        { type: 'memory', zScore: 3.4 },
       ]);
-      expect(pattern).toContain('Resource Exhaustion');
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('cpu-and-memory-deviation');
+      expect(match!.zScoreThreshold).toBe(PATTERN_Z_SCORE_THRESHOLD);
+      expect(match!.triggeredBy).toEqual([
+        { type: 'cpu', zScore: 3 },
+        { type: 'memory', zScore: 3.4 },
+      ]);
+      expect(match!.withinThreshold).toEqual([]);
+      expect(match!.summary).toContain('cpu z=3.00');
+      expect(match!.summary).toContain('memory z=3.40');
     });
 
-    it('identifies memory leak', () => {
-      const pattern = identifyPattern([
-        { type: 'cpu', zScore: 0.5 },
-        { type: 'memory', zScore: 3 },
+    it('classifies memory-only deviation and names CPU as within threshold', () => {
+      const match = identifyPattern([
+        { type: 'cpu', zScore: 0.4 },
+        { type: 'memory', zScore: 3.7 },
       ]);
-      expect(pattern).toContain('Memory Leak');
+      expect(match!.id).toBe('memory-only-deviation');
+      expect(match!.triggeredBy).toEqual([{ type: 'memory', zScore: 3.7 }]);
+      expect(match!.withinThreshold).toEqual([{ type: 'cpu', zScore: 0.4 }]);
+      // The measured numbers must be in the summary — this is what makes two
+      // cards with the same classification distinguishable on screen.
+      expect(match!.summary).toContain('memory z=3.70');
+      expect(match!.summary).toContain('cpu z=0.40');
     });
 
-    it('identifies CPU spike', () => {
-      const pattern = identifyPattern([
+    it('classifies memory_bytes deviation the same way as memory', () => {
+      const match = identifyPattern([
+        { type: 'cpu', zScore: 0.1 },
+        { type: 'memory_bytes', zScore: 2.6 },
+      ]);
+      expect(match!.id).toBe('memory-only-deviation');
+      expect(match!.triggeredBy).toEqual([{ type: 'memory_bytes', zScore: 2.6 }]);
+    });
+
+    it('classifies CPU-only deviation and names memory as within threshold', () => {
+      const match = identifyPattern([
         { type: 'cpu', zScore: 4 },
         { type: 'memory', zScore: 0.5 },
       ]);
-      expect(pattern).toContain('CPU Spike');
+      expect(match!.id).toBe('cpu-only-deviation');
+      expect(match!.triggeredBy).toEqual([{ type: 'cpu', zScore: 4 }]);
+      expect(match!.withinThreshold).toEqual([{ type: 'memory', zScore: 0.5 }]);
+      expect(match!.summary).toContain('cpu z=4.00');
+      expect(match!.summary).toContain('memory z=0.50');
     });
 
-    it('returns null for no known pattern', () => {
-      const pattern = identifyPattern([
+    it('says so when the rule fired with no counterpart sample in the window', () => {
+      const match = identifyPattern([{ type: 'cpu', zScore: 4 }]);
+      expect(match!.id).toBe('cpu-only-deviation');
+      expect(match!.withinThreshold).toEqual([]);
+      expect(match!.summary).toContain('no memory sample this window');
+    });
+
+    it('returns null when no rule matches', () => {
+      const match = identifyPattern([
         { type: 'cpu', zScore: 0.5 },
         { type: 'memory', zScore: 0.5 },
       ]);
-      expect(pattern).toBeNull();
+      expect(match).toBeNull();
+    });
+
+    it('keeps the threshold at the documented value (the maths must not drift)', () => {
+      expect(PATTERN_Z_SCORE_THRESHOLD).toBe(2);
+      // Exactly at the threshold does not fire — the rule is strictly greater.
+      expect(identifyPattern([{ type: 'cpu', zScore: 2 }, { type: 'memory', zScore: 0 }])).toBeNull();
+      expect(identifyPattern([{ type: 'cpu', zScore: 2.01 }, { type: 'memory', zScore: 0 }])!.id)
+        .toBe('cpu-only-deviation');
+    });
+
+    it('carries no diagnostic prose — the classification must not read as inference', () => {
+      const summaries = [
+        identifyPattern([{ type: 'cpu', zScore: 3 }, { type: 'memory', zScore: 3 }])!,
+        identifyPattern([{ type: 'cpu', zScore: 0.5 }, { type: 'memory', zScore: 3 }])!,
+        identifyPattern([{ type: 'cpu', zScore: 4 }, { type: 'memory', zScore: 0.5 }])!,
+      ].flatMap((m) => [m.summary, m.label]);
+
+      for (const text of summaries) {
+        expect(text.toLowerCase()).not.toContain('suggesting');
+        expect(text.toLowerCase()).not.toContain('leak');
+      }
     });
   });
 

--- a/packages/observability/src/__tests__/reports-route.test.ts
+++ b/packages/observability/src/__tests__/reports-route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vites
 import Fastify from 'fastify';
 import { validatorCompiler } from 'fastify-type-provider-zod';
 import { z } from 'zod';
-import { reportsRoutes, clearReportCache, getReportCacheSize, setCachedReport, REPORT_CACHE_MAX_ENTRIES } from '../routes/reports.js';
+import { reportsRoutes, clearReportCache, getReportCacheSize, setCachedReport, REPORT_CACHE_MAX_ENTRIES, evaluateRightSizingRules } from '../routes/reports.js';
 
 // The implementation acquires a pool client per request via pool.connect(),
 // sets statement_timeout, then queries via client.query(). We mirror that here.
@@ -61,6 +61,43 @@ const mockGetRunningIds = vi.fn().mockResolvedValue(null);
 vi.mock('../services/container-lifecycle-store.js', () => ({
   getRunningContainerIds: (...a: unknown[]) => mockGetRunningIds(...a),
 }));
+
+describe('evaluateRightSizingRules', () => {
+  it('returns nothing when every aggregate sits inside the thresholds', () => {
+    expect(evaluateRightSizingRules({ cpu: { avg: 40, p95: 60 }, memory: { avg: 50, p95: 70 } })).toEqual([]);
+  });
+
+  it('carries the rule id, threshold and measured value so identical advice can be grouped', () => {
+    const findings = evaluateRightSizingRules({ cpu: { avg: 2, p95: 4 }, memory: { avg: 50, p95: 70 } });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].id).toBe('cpu-underutilized');
+    expect(findings[0].statistic).toBe('p95');
+    expect(findings[0].comparison).toBe('below');
+    expect(findings[0].threshold).toBe(10);
+    expect(findings[0].unit).toBe('percent');
+    // The measured value is the only thing that differs between two containers
+    // carrying the same recommendation.
+    expect(findings[0].measured).toBe(4);
+  });
+
+  it('keeps the historical one-line string so existing consumers do not break', () => {
+    const findings = evaluateRightSizingRules({ cpu: { avg: 2, p95: 4 }, memory: { avg: 90, p95: 95 } });
+    const issues = findings.map((f) => f.issue);
+    expect(issues).toContain('CPU under-utilized (p95 < 10%) — consider reducing CPU limits');
+    expect(issues).toContain('Memory over-utilized (avg > 85%) — consider increasing memory limits');
+  });
+
+  it('fires all four rules independently', () => {
+    expect(evaluateRightSizingRules({ cpu: { avg: 90, p95: 95 }, memory: { avg: 90, p95: 95 } }).map(f => f.id))
+      .toEqual(['cpu-overutilized', 'memory-overutilized']);
+    expect(evaluateRightSizingRules({ cpu: { avg: 1, p95: 2 }, memory: { avg: 1, p95: 2 } }).map(f => f.id))
+      .toEqual(['cpu-underutilized', 'memory-underutilized']);
+  });
+
+  it('does not fire exactly at a threshold', () => {
+    expect(evaluateRightSizingRules({ cpu: { avg: 80, p95: 10 }, memory: { avg: 85, p95: 20 } })).toEqual([]);
+  });
+});
 
 /** Highest $N referenced anywhere in a SQL string (0 when there are none). */
 function maxPlaceholder(sql: string): number {
@@ -164,6 +201,44 @@ describe('Reports routes', () => {
       expect(body.containers[0].cpu).toBeTruthy();
       expect(body.containers[0].memory).toBeTruthy();
       expect(body.fleetSummary.totalContainers).toBe(1);
+    });
+
+    it('groups identical right-sizing advice with a container count', async () => {
+      // Two containers, both idle: the same recommendation, which the UI used
+      // to print once per container.
+      const agg = (id: string, name: string, metric: string, avg: number) => ({
+        container_id: id, container_name: name, endpoint_id: 1,
+        metric_type: metric, avg_value: avg, min_value: avg, max_value: avg, sample_count: 10,
+      });
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] }) // SET statement_timeout
+        .mockResolvedValueOnce({
+          rows: [
+            agg('c1', 'web', 'cpu', 2), agg('c1', 'web', 'memory', 5),
+            agg('c2', 'api', 'cpu', 3), agg('c2', 'api', 'memory', 6),
+          ],
+        })
+        // one percentile query per (container, metric) row, in order
+        .mockResolvedValueOnce({ rows: [{ p50: 2, p95: 4, p99: 5 }] })   // c1 cpu
+        .mockResolvedValueOnce({ rows: [{ p50: 5, p95: 8, p99: 9 }] })   // c1 memory
+        .mockResolvedValueOnce({ rows: [{ p50: 3, p95: 6, p99: 7 }] })   // c2 cpu
+        .mockResolvedValueOnce({ rows: [{ p50: 6, p95: 9, p99: 10 }] }); // c2 memory
+
+      const res = await app.inject({ method: 'GET', url: '/api/reports/utilization?timeRange=24h' });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.payload);
+
+      // Per-container data is preserved...
+      expect(body.recommendations).toHaveLength(2);
+      expect(body.recommendations[0].findings[0].measured).toBe(4);
+      expect(body.recommendations[1].findings[0].measured).toBe(6);
+
+      // ...and the same advice is stated once, with a count.
+      const cpuRule = body.recommendationSummary.find((r: { id: string }) => r.id === 'cpu-underutilized');
+      expect(cpuRule.container_count).toBe(2);
+      expect(cpuRule.container_names.sort()).toEqual(['api', 'web']);
+      expect(cpuRule.threshold).toBe(10);
+      expect(body.recommendationSummary.every((r: { container_count: number }) => r.container_count > 0)).toBe(true);
     });
 
     it('accepts optional endpointId filter', async () => {

--- a/packages/observability/src/__tests__/reports-route.test.ts
+++ b/packages/observability/src/__tests__/reports-route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vites
 import Fastify from 'fastify';
 import { validatorCompiler } from 'fastify-type-provider-zod';
 import { z } from 'zod';
-import { reportsRoutes, clearReportCache, getReportCacheSize, setCachedReport, REPORT_CACHE_MAX_ENTRIES, evaluateRightSizingRules } from '../routes/reports.js';
+import { reportsRoutes, clearReportCache, getReportCacheSize, setCachedReport, REPORT_CACHE_MAX_ENTRIES, evaluateRightSizingRules, RULE_CONTAINER_NAMES_CAP } from '../routes/reports.js';
 
 // The implementation acquires a pool client per request via pool.connect(),
 // sets statement_timeout, then queries via client.query(). We mirror that here.
@@ -239,6 +239,47 @@ describe('Reports routes', () => {
       expect(cpuRule.container_names.sort()).toEqual(['api', 'web']);
       expect(cpuRule.threshold).toBe(10);
       expect(body.recommendationSummary.every((r: { container_count: number }) => r.container_count > 0)).toBe(true);
+      // A fleet under the cap is not truncated.
+      expect(cpuRule.names_truncated).toBe(false);
+    });
+
+    it('caps the name list on a large fleet while still reporting the true count', async () => {
+      // Four rules each carrying every matching name, in a payload cached for
+      // five minutes across up to REPORT_CACHE_MAX_ENTRIES entries. The cap
+      // bounds the sample; container_count must stay the real total, or the UI
+      // silently under-reports exactly the fleet the cap exists for.
+      const total = RULE_CONTAINER_NAMES_CAP + 25;
+      const aggRows = Array.from({ length: total }, (_, i) => [
+        { container_id: `c${i}`, container_name: `svc-${i}`, endpoint_id: 1,
+          metric_type: 'cpu', avg_value: 2, min_value: 2, max_value: 2, sample_count: 10 },
+        { container_id: `c${i}`, container_name: `svc-${i}`, endpoint_id: 1,
+          metric_type: 'memory', avg_value: 5, min_value: 5, max_value: 5, sample_count: 10 },
+      ]).flat();
+
+      // Chained mockResolvedValueOnce cannot express 1000+ percentile calls;
+      // dispatch on the SQL text instead.
+      let seenAgg = false;
+      mockClientQuery.mockImplementation(async (sql: string) => {
+        if (typeof sql === 'string' && sql.includes('percentile_cont')) {
+          return { rows: [{ p50: 2, p95: 4, p99: 5 }] };
+        }
+        if (!seenAgg && typeof sql === 'string' && sql.includes('avg_value')) {
+          seenAgg = true;
+          return { rows: aggRows };
+        }
+        return { rows: [] };
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/api/reports/utilization?timeRange=24h' });
+      expect(res.statusCode).toBe(200);
+      const cpuRule = JSON.parse(res.payload).recommendationSummary
+        .find((r: { id: string }) => r.id === 'cpu-underutilized');
+
+      expect(cpuRule.container_count).toBe(total);
+      expect(cpuRule.container_names).toHaveLength(RULE_CONTAINER_NAMES_CAP);
+      expect(cpuRule.names_truncated).toBe(true);
+      // The count is the truth, not the array length.
+      expect(cpuRule.container_count).toBeGreaterThan(cpuRule.container_names.length);
     });
 
     it('accepts optional endpointId filter', async () => {

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -108,11 +108,19 @@ export {
 } from './services/infrastructure-service-classifier.js';
 
 // Services — metric correlation
-export type { Queryable, CorrelatedAnomaly, CorrelationPair } from './services/metric-correlator.js';
+export type {
+  Queryable,
+  CorrelatedAnomaly,
+  CorrelationPair,
+  MetricPatternId,
+  MetricPatternMatch,
+  PatternMetricObservation,
+} from './services/metric-correlator.js';
 export {
   pearsonCorrelation,
   calculateCompositeScore,
   identifyPattern,
+  PATTERN_Z_SCORE_THRESHOLD,
   scoreSeverity,
   correlationStrength,
   findCorrelatedContainers,

--- a/packages/observability/src/routes/reports.ts
+++ b/packages/observability/src/routes/reports.ts
@@ -15,6 +15,98 @@ import { createChildLogger } from '@dashboard/core/utils/logger.js';
 
 const log = createChildLogger('reports-routes');
 
+// ---------------------------------------------------------------------------
+// Right-sizing rules
+//
+// Four fixed thresholds. On a real fleet they produce one row per container of
+// which nearly all are byte-identical — 15 rows, 14 the same sentence. The rule
+// is worth keeping; repeating its text once per container is not. Each finding
+// therefore carries the rule `id`, the `threshold` it crossed and the `measured`
+// value, so a client can collapse identical recommendations into one statement
+// plus a count and surface only the containers that genuinely differ.
+// ---------------------------------------------------------------------------
+export type RightSizingRuleId =
+  | 'cpu-underutilized'
+  | 'cpu-overutilized'
+  | 'memory-underutilized'
+  | 'memory-overutilized';
+
+interface RightSizingRule {
+  id: RightSizingRuleId;
+  metric: 'cpu' | 'memory';
+  /** Which aggregate the threshold is applied to. */
+  statistic: 'p95' | 'avg';
+  comparison: 'below' | 'above';
+  threshold: number;
+  unit: 'percent';
+  /** Container-independent statement of the rule, safe to render once per group. */
+  recommendation: string;
+  /** The historical one-line rendering, unchanged so existing consumers keep working. */
+  issue: string;
+}
+
+const RIGHT_SIZING_RULES: RightSizingRule[] = [
+  {
+    id: 'cpu-underutilized',
+    metric: 'cpu',
+    statistic: 'p95',
+    comparison: 'below',
+    threshold: 10,
+    unit: 'percent',
+    recommendation: 'consider reducing CPU limits',
+    issue: 'CPU under-utilized (p95 < 10%) — consider reducing CPU limits',
+  },
+  {
+    id: 'cpu-overutilized',
+    metric: 'cpu',
+    statistic: 'avg',
+    comparison: 'above',
+    threshold: 80,
+    unit: 'percent',
+    recommendation: 'consider increasing CPU limits',
+    issue: 'CPU over-utilized (avg > 80%) — consider increasing CPU limits',
+  },
+  {
+    id: 'memory-underutilized',
+    metric: 'memory',
+    statistic: 'p95',
+    comparison: 'below',
+    threshold: 20,
+    unit: 'percent',
+    recommendation: 'consider reducing memory limits',
+    issue: 'Memory under-utilized (p95 < 20%) — consider reducing memory limits',
+  },
+  {
+    id: 'memory-overutilized',
+    metric: 'memory',
+    statistic: 'avg',
+    comparison: 'above',
+    threshold: 85,
+    unit: 'percent',
+    recommendation: 'consider increasing memory limits',
+    issue: 'Memory over-utilized (avg > 85%) — consider increasing memory limits',
+  },
+];
+
+export interface RightSizingFinding extends RightSizingRule {
+  /** The container's own value for `statistic`, in percent — the one number that differs per row. */
+  measured: number;
+}
+
+/** Evaluate the fixed rules against one container's aggregates. */
+export function evaluateRightSizingRules(
+  stats: { cpu: { avg: number; p95: number }; memory: { avg: number; p95: number } },
+): RightSizingFinding[] {
+  const findings: RightSizingFinding[] = [];
+  for (const rule of RIGHT_SIZING_RULES) {
+    const measured = stats[rule.metric][rule.statistic];
+    const crossed = rule.comparison === 'below' ? measured < rule.threshold : measured > rule.threshold;
+    if (!crossed) continue;
+    findings.push({ ...rule, measured });
+  }
+  return findings;
+}
+
 /** pg pool exhaustion: connection could not be acquired within connectionTimeoutMillis */
 function isPoolTimeoutError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -386,20 +478,55 @@ export async function reportsRoutes(fastify: FastifyInstance) {
         maxMemory: memEntries.length > 0 ? Math.max(...memEntries.map(c => c.memory!.max)) : 0,
       };
 
+      // Per-container data is kept in full; `findings` carries the rule id,
+      // threshold and measured value alongside the legacy `issues` strings so
+      // the client can group identical recommendations instead of printing the
+      // same sentence fifteen times.
       const recommendations = containers
         .filter(c => c.cpu && c.memory)
         .map(c => {
-          const issues: string[] = [];
-          if (c.cpu!.p95 < 10) issues.push('CPU under-utilized (p95 < 10%) — consider reducing CPU limits');
-          if (c.cpu!.avg > 80) issues.push('CPU over-utilized (avg > 80%) — consider increasing CPU limits');
-          if (c.memory!.p95 < 20) issues.push('Memory under-utilized (p95 < 20%) — consider reducing memory limits');
-          if (c.memory!.avg > 85) issues.push('Memory over-utilized (avg > 85%) — consider increasing memory limits');
-          if (issues.length === 0) return null;
-          return { container_id: c.container_id, container_name: c.container_name, service_type: c.service_type, issues };
+          const findings = evaluateRightSizingRules({ cpu: c.cpu!, memory: c.memory! });
+          if (findings.length === 0) return null;
+          return {
+            container_id: c.container_id,
+            container_name: c.container_name,
+            service_type: c.service_type,
+            issues: findings.map(f => f.issue),
+            findings,
+          };
         })
         .filter(Boolean);
 
-      return { timeRange, includeInfrastructure: includeInfrastructureResolved, excludeInfrastructure, containers, fleetSummary, recommendations };
+      // Rollup of how many containers each rule fired on, so the UI can lead
+      // with "12 containers: CPU p95 below 10%" and list only the outliers.
+      const recommendationSummary = RIGHT_SIZING_RULES
+        .map(rule => {
+          const matched = recommendations.filter(
+            (r): r is NonNullable<typeof r> => !!r && r.findings.some(f => f.id === rule.id),
+          );
+          return {
+            id: rule.id,
+            metric: rule.metric,
+            statistic: rule.statistic,
+            comparison: rule.comparison,
+            threshold: rule.threshold,
+            unit: rule.unit,
+            recommendation: rule.recommendation,
+            container_count: matched.length,
+            container_names: matched.map(r => r.container_name),
+          };
+        })
+        .filter(entry => entry.container_count > 0);
+
+      return {
+        timeRange,
+        includeInfrastructure: includeInfrastructureResolved,
+        excludeInfrastructure,
+        containers,
+        fleetSummary,
+        recommendations,
+        recommendationSummary,
+      };
     });
 
     setCachedReport(cacheKey, result);

--- a/packages/observability/src/routes/reports.ts
+++ b/packages/observability/src/routes/reports.ts
@@ -127,6 +127,17 @@ function isStatementTimeoutError(err: unknown): boolean {
 const REPORT_CACHE_TTL_MS = 5 * 60 * 1_000;
 export const REPORT_CACHE_MAX_ENTRIES = 500;
 
+/**
+ * How many container names a single right-sizing rule spells out.
+ *
+ * Mirrors `ALL_NAMES_CAP` in `incident-store.ts`. Four rules, each previously
+ * able to carry every matching container name, in a payload then held for five
+ * minutes across up to `REPORT_CACHE_MAX_ENTRIES` cache entries. The UI only
+ * ever previews six names, so the cap costs nothing visible; `container_count`
+ * stays uncapped so no consumer has to infer the total from the array length.
+ */
+export const RULE_CONTAINER_NAMES_CAP = 500;
+
 interface CacheEntry { payload: unknown; expiresAt: number; timestamp: number }
 const reportCache = new Map<string, CacheEntry>();
 
@@ -512,8 +523,12 @@ export async function reportsRoutes(fastify: FastifyInstance) {
             threshold: rule.threshold,
             unit: rule.unit,
             recommendation: rule.recommendation,
+            // Uncapped: the true number of containers this rule fired on, and
+            // the field the UI must count with. `container_names` is a capped
+            // sample, so counting its length would under-report a large fleet.
             container_count: matched.length,
-            container_names: matched.map(r => r.container_name),
+            container_names: matched.slice(0, RULE_CONTAINER_NAMES_CAP).map(r => r.container_name),
+            names_truncated: matched.length > RULE_CONTAINER_NAMES_CAP,
           };
         })
         .filter(entry => entry.container_count > 0);

--- a/packages/observability/src/services/metric-correlator.ts
+++ b/packages/observability/src/services/metric-correlator.ts
@@ -18,7 +18,14 @@ export interface CorrelatedAnomaly {
     zScore: number;
   }>;
   compositeScore: number;
+  /**
+   * `patternMatch.summary`, or null when no rule fired. Kept as a plain string
+   * for existing consumers; prefer `patternMatch` for anything that wants to
+   * show which rule fired and on what numbers.
+   */
   pattern: string | null;
+  /** The deterministic rule that fired, with the values that triggered it. */
+  patternMatch: MetricPatternMatch | null;
   severity: 'low' | 'medium' | 'high' | 'critical';
   timestamp: string;
 }
@@ -70,33 +77,126 @@ export function calculateCompositeScore(zScores: number[]): number {
   return Math.round(rms * 100) / 100;
 }
 
+/** z-score a metric must exceed for the deviation rules below to count it. */
+export const PATTERN_Z_SCORE_THRESHOLD = 2;
+
+/** Stable ids for the deterministic deviation rules in `identifyPattern`. */
+export type MetricPatternId =
+  | 'cpu-and-memory-deviation'
+  | 'memory-only-deviation'
+  | 'cpu-only-deviation';
+
+export interface PatternMetricObservation {
+  type: string;
+  zScore: number;
+}
+
 /**
- * Identify known patterns from correlated metric anomalies.
+ * The outcome of `identifyPattern` — which rule fired, on which metrics, and at
+ * what threshold.
+ *
+ * This used to be a single hardcoded English sentence per branch ("…suggesting
+ * gradual memory accumulation"), which read as a diagnosis the code had not
+ * made and rendered byte-identically on every card that hit the same branch.
+ * The classification is worth keeping; the prose was not. `summary` now
+ * restates the rule with the measured z-scores so the operator can see the
+ * arithmetic, and `id` / `triggeredBy` / `zScoreThreshold` let the UI render the
+ * rule itself instead of a sentence.
+ */
+export interface MetricPatternMatch {
+  id: MetricPatternId;
+  /** Names what was observed, not what caused it. */
+  label: string;
+  /** The z-score each `triggeredBy` metric had to exceed. */
+  zScoreThreshold: number;
+  /** Metrics that crossed the threshold. */
+  triggeredBy: PatternMetricObservation[];
+  /** Metrics the rule inspected that stayed within the threshold. */
+  withinThreshold: PatternMetricObservation[];
+  /** Restatement of the rule and the numbers it fired on. Not an inference. */
+  summary: string;
+}
+
+function formatObservation(m: PatternMetricObservation): string {
+  return `${m.type} z=${m.zScore.toFixed(2)}`;
+}
+
+function formatObservations(metrics: PatternMetricObservation[]): string {
+  return metrics.map(formatObservation).join(', ');
+}
+
+/**
+ * Classify a container's elevated metrics against three fixed deviation rules.
+ *
+ * Deterministic: a metric counts as deviating when its z-score exceeds
+ * `PATTERN_Z_SCORE_THRESHOLD`. Nothing is inferred about the cause. Returns
+ * null when no rule matches.
  */
 export function identifyPattern(
   metrics: Array<{ type: string; zScore: number }>,
-): string | null {
+): MetricPatternMatch | null {
   const cpuMetric = metrics.find((m) => m.type === 'cpu');
   const memMetric = metrics.find((m) => m.type === 'memory');
   const memBytesMetric = metrics.find((m) => m.type === 'memory_bytes');
 
-  const cpuHigh = cpuMetric && cpuMetric.zScore > 2;
-  const memHigh = memMetric && memMetric.zScore > 2;
-  const memBytesHigh = memBytesMetric && memBytesMetric.zScore > 2;
+  const threshold = PATTERN_Z_SCORE_THRESHOLD;
+  const observed = (m?: { type: string; zScore: number }): PatternMetricObservation[] =>
+    m ? [{ type: m.type, zScore: m.zScore }] : [];
 
-  // Both CPU and memory are anomalous
+  const cpuHigh = !!cpuMetric && cpuMetric.zScore > threshold;
+  const memHigh = !!memMetric && memMetric.zScore > threshold;
+  const memBytesHigh = !!memBytesMetric && memBytesMetric.zScore > threshold;
+
+  const cpuObserved = observed(cpuMetric);
+  const memoryObserved = [...observed(memMetric), ...observed(memBytesMetric)];
+  const memoryTriggered = [
+    ...(memHigh ? observed(memMetric) : []),
+    ...(memBytesHigh ? observed(memBytesMetric) : []),
+  ];
+  const memoryWithin = [
+    ...(memMetric && !memHigh ? observed(memMetric) : []),
+    ...(memBytesMetric && !memBytesHigh ? observed(memBytesMetric) : []),
+  ];
+
+  // Both CPU and memory deviate.
   if (cpuHigh && (memHigh || memBytesHigh)) {
-    return 'Resource Exhaustion: Both CPU and memory are elevated, suggesting a resource-intensive workload or memory leak with CPU thrashing';
+    const triggeredBy = [...cpuObserved, ...memoryTriggered];
+    return {
+      id: 'cpu-and-memory-deviation',
+      label: 'CPU and memory both deviating',
+      zScoreThreshold: threshold,
+      triggeredBy,
+      withinThreshold: memoryWithin,
+      summary: `${formatObservations(triggeredBy)} — both above the z>${threshold} rule threshold`,
+    };
   }
 
-  // Memory high but CPU normal
+  // Memory deviates, CPU stays within the threshold.
   if (!cpuHigh && (memHigh || memBytesHigh)) {
-    return 'Memory Leak Suspected: Memory usage is elevated while CPU remains normal, suggesting gradual memory accumulation';
+    return {
+      id: 'memory-only-deviation',
+      label: 'Memory deviating, CPU within threshold',
+      zScoreThreshold: threshold,
+      triggeredBy: memoryTriggered,
+      withinThreshold: [...cpuObserved, ...memoryWithin],
+      summary: `${formatObservations(memoryTriggered)} above the z>${threshold} rule threshold`
+        + (cpuMetric ? `, ${formatObservation(cpuObserved[0])} within it` : ', no CPU sample this window'),
+    };
   }
 
-  // CPU high but memory normal
+  // CPU deviates, memory stays within the threshold.
   if (cpuHigh && !memHigh && !memBytesHigh) {
-    return 'CPU Spike: CPU usage is elevated while memory remains stable, suggesting a compute-intensive operation or busy loop';
+    return {
+      id: 'cpu-only-deviation',
+      label: 'CPU deviating, memory within threshold',
+      zScoreThreshold: threshold,
+      triggeredBy: cpuObserved,
+      withinThreshold: memoryObserved,
+      summary: `${formatObservation(cpuObserved[0])} above the z>${threshold} rule threshold`
+        + (memoryObserved.length > 0
+          ? `, ${formatObservations(memoryObserved)} within it`
+          : ', no memory sample this window'),
+    };
   }
 
   return null;
@@ -387,7 +487,7 @@ export async function detectCorrelatedAnomalies(
       zScore: s.z_score,
     }));
 
-    const pattern = identifyPattern(metricDetails);
+    const patternMatch = identifyPattern(metricDetails);
     const severity = scoreSeverity(compositeScore);
 
     results.push({
@@ -395,7 +495,8 @@ export async function detectCorrelatedAnomalies(
       containerName,
       metrics: metricDetails,
       compositeScore,
-      pattern,
+      pattern: patternMatch?.summary ?? null,
+      patternMatch,
       severity,
       timestamp: new Date().toISOString(),
     });

--- a/packages/operations/src/__tests__/remediation-service.test.ts
+++ b/packages/operations/src/__tests__/remediation-service.test.ts
@@ -39,6 +39,9 @@ import {
   buildRemediationPrompt,
   isProtectedContainer,
   initRemediationDeps,
+  clampConfidenceScore,
+  parseSeverity,
+  classifyRationaleSource,
 } from '../services/remediation-service.js';
 import * as portainerClient from '@dashboard/core/portainer/portainer-client.js';
 import { cache } from '@dashboard/core/portainer/portainer-cache.js';
@@ -113,7 +116,7 @@ describe('remediation-service', () => {
       endpoint_id: 1,
     } as any);
 
-    expect(result).toEqual({ actionId: 'action-123', actionType: 'INVESTIGATE' });
+    expect(result).toEqual({ actionId: 'action-123', actionType: 'INVESTIGATE', rationaleSource: 'pattern-match', patternId: expect.any(String) });
     expect(mockInsertAction).toHaveBeenCalledWith(expect.objectContaining({ action_type: 'INVESTIGATE' }));
     expect(mockBroadcastNewAction).toHaveBeenCalledTimes(1);
   });
@@ -150,7 +153,7 @@ describe('remediation-service', () => {
       endpoint_id: 1,
     } as any);
 
-    expect(result).toEqual({ actionId: 'action-123', actionType: 'RESTART_CONTAINER' });
+    expect(result).toEqual({ actionId: 'action-123', actionType: 'RESTART_CONTAINER', rationaleSource: 'pattern-match', patternId: expect.any(String) });
     expect(mockHasPendingAction).toHaveBeenCalledWith('container-2', 'RESTART_CONTAINER');
     expect(mockInsertAction).toHaveBeenCalledTimes(1);
   });
@@ -222,7 +225,7 @@ describe('remediation-service', () => {
       endpoint_id: 1,
     } as any);
 
-    expect(result).toEqual({ actionId: 'action-123', actionType: 'INVESTIGATE' });
+    expect(result).toEqual({ actionId: 'action-123', actionType: 'INVESTIGATE', rationaleSource: 'pattern-match', patternId: expect.any(String) });
 
     await flushMicrotasks();
 
@@ -269,7 +272,7 @@ describe('remediation-service', () => {
       endpoint_id: 1,
     } as any);
 
-    expect(result).toEqual({ actionId: 'action-123', actionType: 'RESTART_CONTAINER' });
+    expect(result).toEqual({ actionId: 'action-123', actionType: 'RESTART_CONTAINER', rationaleSource: 'pattern-match', patternId: expect.any(String) });
 
     await flushMicrotasks();
 
@@ -306,7 +309,7 @@ describe('remediation-service', () => {
       endpoint_id: 1,
     } as any);
 
-    expect(result).toEqual({ actionId: 'action-123', actionType: 'RESTART_CONTAINER' });
+    expect(result).toEqual({ actionId: 'action-123', actionType: 'RESTART_CONTAINER', rationaleSource: 'pattern-match', patternId: expect.any(String) });
 
     await flushMicrotasks();
 
@@ -334,7 +337,7 @@ describe('remediation-service', () => {
       endpoint_id: 1,
     } as any);
 
-    expect(result).toEqual({ actionId: 'action-123', actionType: 'RESTART_CONTAINER' });
+    expect(result).toEqual({ actionId: 'action-123', actionType: 'RESTART_CONTAINER', rationaleSource: 'pattern-match', patternId: expect.any(String) });
 
     await flushMicrotasks();
 
@@ -506,6 +509,89 @@ describe('parseRemediationAnalysis', () => {
     const result = parseRemediationAnalysis('unstructured llm response');
     expect(result.root_cause).toContain('unstructured');
     expect(result.recommended_actions).toHaveLength(0);
+  });
+
+  // "Not supplied" must be distinguishable from "the model said 0.5" — the UI
+  // renders confidence as an authoritative badge, so a default must not reach it.
+  it('reports a missing confidence_score as null, not 0.5', () => {
+    const result = parseRemediationAnalysis('{"root_cause":"a","severity":"info","recommended_actions":[],"log_analysis":""}');
+    expect(result.confidence_score).toBeNull();
+  });
+
+  it('reports a missing severity as null, not "warning"', () => {
+    const result = parseRemediationAnalysis('{"root_cause":"a","recommended_actions":[],"log_analysis":"","confidence_score":0.9}');
+    expect(result.severity).toBeNull();
+  });
+
+  it('keeps a supplied confidence of 0.5 distinguishable from an absent one', () => {
+    const supplied = parseRemediationAnalysis('{"root_cause":"a","severity":"info","recommended_actions":[],"log_analysis":"","confidence_score":0.5}');
+    const absent = parseRemediationAnalysis('{"root_cause":"a","severity":"info","recommended_actions":[],"log_analysis":""}');
+    expect(supplied.confidence_score).toBe(0.5);
+    expect(absent.confidence_score).toBeNull();
+  });
+
+  it('supplies no confidence or severity for an unstructured response', () => {
+    const result = parseRemediationAnalysis('the container looks unhealthy to me');
+    expect(result.confidence_score).toBeNull();
+    expect(result.severity).toBeNull();
+  });
+
+  it('marks parsed analyses as llm-analysis', () => {
+    const result = parseRemediationAnalysis('{"root_cause":"a","severity":"info","recommended_actions":[],"log_analysis":"","confidence_score":0.4}');
+    expect(result.analysis_source).toBe('llm-analysis');
+  });
+});
+
+describe('clampConfidenceScore', () => {
+  it('clamps supplied numbers into 0..1', () => {
+    expect(clampConfidenceScore(1.5)).toBe(1);
+    expect(clampConfidenceScore(-2)).toBe(0);
+    expect(clampConfidenceScore(0.42)).toBe(0.42);
+  });
+
+  it('returns null for anything the model did not supply as a finite number', () => {
+    expect(clampConfidenceScore(undefined)).toBeNull();
+    expect(clampConfidenceScore(null)).toBeNull();
+    expect(clampConfidenceScore('0.8')).toBeNull();
+    expect(clampConfidenceScore(NaN)).toBeNull();
+  });
+});
+
+describe('parseSeverity', () => {
+  it('passes through the three valid severities', () => {
+    expect(parseSeverity('critical')).toBe('critical');
+    expect(parseSeverity('warning')).toBe('warning');
+    expect(parseSeverity('info')).toBe('info');
+  });
+
+  it('returns null instead of defaulting to warning', () => {
+    expect(parseSeverity(undefined)).toBeNull();
+    expect(parseSeverity('sev1')).toBeNull();
+  });
+});
+
+describe('classifyRationaleSource', () => {
+  it('labels a plain ACTION_PATTERNS string as pattern-match', () => {
+    expect(classifyRationaleSource('Container is reporting unhealthy status. Restarting may resolve the issue.'))
+      .toBe('pattern-match');
+  });
+
+  it('labels a stored analysis payload as llm-analysis', () => {
+    const stored = JSON.stringify({
+      root_cause: 'pool exhausted',
+      severity: 'warning',
+      recommended_actions: [],
+      log_analysis: '',
+      confidence_score: 0.7,
+      analysis_source: 'llm-analysis',
+    });
+    expect(classifyRationaleSource(stored)).toBe('llm-analysis');
+  });
+
+  it('returns null when there is no rationale to attribute', () => {
+    expect(classifyRationaleSource('')).toBeNull();
+    expect(classifyRationaleSource(null)).toBeNull();
+    expect(classifyRationaleSource(undefined)).toBeNull();
   });
 });
 

--- a/packages/operations/src/services/remediation-service.ts
+++ b/packages/operations/src/services/remediation-service.ts
@@ -31,6 +31,7 @@ export function initRemediationDeps(llm: LLMInterface, metrics: MetricsInterface
 }
 import { broadcastActionUpdate, broadcastNewAction } from '../sockets/remediation.js';
 import { getConfig } from '@dashboard/core/config/index.js';
+import { clampConfidenceScore, parseSeverity } from '@dashboard/core/utils/model-confidence.js';
 
 const log = createChildLogger('remediation-service');
 
@@ -154,22 +155,12 @@ function pickActionPattern(text: string): ActionPattern | null {
   return null;
 }
 
-/**
- * 0–1 when the model supplied a usable number, null when it did not.
- *
- * This used to return the constant 0.5, which the UI rendered as an
- * authoritative "Confidence: 50%" badge — a default presented as a measurement.
- * Null is the honest answer and lets the caller omit the badge entirely.
- */
-export function clampConfidenceScore(value: unknown): number | null {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
-  return Math.max(0, Math.min(1, value));
-}
-
-/** The model's severity, or null when it did not supply a valid one (was: 'warning'). */
-export function parseSeverity(value: unknown): 'critical' | 'warning' | 'info' | null {
-  return value === 'critical' || value === 'warning' || value === 'info' ? value : null;
-}
+// `clampConfidenceScore` / `parseSeverity` moved to @dashboard/core so the
+// investigation and PCAP analysers can share one rule instead of keeping their
+// own copies — they had each kept a `0.5` default, and this file's fix did not
+// reach them. Re-exported because this module's path is the one callers and
+// tests already use.
+export { clampConfidenceScore, parseSeverity };
 
 function parseRecommendedActions(value: unknown): RemediationAnalysisResult['recommended_actions'] {
   if (!Array.isArray(value)) return [];

--- a/packages/operations/src/services/remediation-service.ts
+++ b/packages/operations/src/services/remediation-service.ts
@@ -12,11 +12,11 @@ import {
 import type { Insight } from '@dashboard/core/models/monitoring.js';
 import { eventBus } from '@dashboard/core/services/typed-event-bus.js';
 import { getContainerLogs } from '@dashboard/core/portainer/portainer-client.js';
-import type { LLMInterface, MetricsInterface, RemediationAnalysisResult } from '@dashboard/contracts';
+import type { LLMInterface, MetricsInterface, RationaleSource, RemediationAnalysisResult } from '@dashboard/contracts';
 
 // Re-exported for the historical import path; the canonical shape lives in
 // @dashboard/contracts (#1509).
-export type { RemediationAnalysisResult };
+export type { RemediationAnalysisResult, RationaleSource };
 
 let _llm: LLMInterface | null = null;
 let _metrics: MetricsInterface | null = null;
@@ -35,9 +35,13 @@ import { getConfig } from '@dashboard/core/config/index.js';
 const log = createChildLogger('remediation-service');
 
 type ActionPattern = {
+  /** Stable id for the rule that matched, so the UI can group/label by rule. */
+  id: string;
   keywords: RegExp;
   actionType: string;
   rationale: string;
+  /** Always 'pattern-match' here — these strings are a lookup table, not analysis. */
+  source: RationaleSource;
 };
 
 /** Action types that directly modify container state. */
@@ -72,37 +76,65 @@ export function isProtectedContainer(containerName: string): boolean {
   return protectedNames.some((name) => normalized === name || normalized.startsWith(`${name}-`) || normalized.startsWith(`${name}_`));
 }
 
-const ACTION_PATTERNS: Array<{
-  keywords: RegExp;
-  actionType: string;
-  rationale: string;
-}> = [
+/**
+ * Fixed keyword→action lookup. Every rationale here is a constant this file
+ * ships, not model output — hence `source: 'pattern-match'` on each entry, which
+ * travels to the UI so the two can be told apart on screen.
+ */
+const ACTION_PATTERNS: ActionPattern[] = [
   {
+    id: 'unhealthy-status',
     keywords: /unhealthy|health\s*check\s*fail/i,
     actionType: 'RESTART_CONTAINER',
     rationale: 'Container is reporting unhealthy status. Restarting may resolve the issue.',
+    source: 'pattern-match',
   },
   {
+    id: 'memory-pressure',
     keywords: /oom|out\s*of\s*memory|memory\s*limit/i,
     actionType: 'INVESTIGATE',
     rationale: 'Container may be experiencing memory pressure. Check memory limits and usage patterns before taking action.',
+    source: 'pattern-match',
   },
   {
+    id: 'restart-loop',
     keywords: /restart\s*(loop|count|crash)/i,
     actionType: 'RESTART_CONTAINER',
     rationale: 'Container is in a restart loop. A clean restart may stabilize it.',
+    source: 'pattern-match',
   },
   {
+    id: 'high-cpu',
     keywords: /high\s*cpu|cpu\s*spike|runaway\s*process/i,
     actionType: 'INVESTIGATE',
     rationale: 'High CPU usage detected. Check for runaway processes and review resource allocation before taking action.',
+    source: 'pattern-match',
   },
   {
+    id: 'container-stopped',
     keywords: /stopped|exited|not\s*running/i,
     actionType: 'START_CONTAINER',
     rationale: 'Container appears stopped. Starting it may restore service availability.',
+    source: 'pattern-match',
   },
 ];
+
+/**
+ * Classify where an action's stored `rationale` came from.
+ *
+ * A rationale is either a constant from ACTION_PATTERNS (a plain sentence) or a
+ * serialized {@link RemediationAnalysisResult} written by
+ * `enrichActionWithLlmAnalysis`. Both are rendered under the same bot icon
+ * today; this is the server-side answer to "which one am I looking at".
+ */
+export function classifyRationaleSource(rationale: string | null | undefined): RationaleSource | null {
+  if (!rationale || !rationale.trim()) return null;
+  const parsed = tryParseAnalysisPayload(rationale);
+  if (parsed && typeof parsed.root_cause === 'string') {
+    return parsed.analysis_source === 'pattern-match' ? 'pattern-match' : 'llm-analysis';
+  }
+  return 'pattern-match';
+}
 
 interface RemediationEvidence {
   logs?: string;
@@ -122,13 +154,21 @@ function pickActionPattern(text: string): ActionPattern | null {
   return null;
 }
 
-function clampConfidenceScore(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return 0.5;
+/**
+ * 0–1 when the model supplied a usable number, null when it did not.
+ *
+ * This used to return the constant 0.5, which the UI rendered as an
+ * authoritative "Confidence: 50%" badge — a default presented as a measurement.
+ * Null is the honest answer and lets the caller omit the badge entirely.
+ */
+export function clampConfidenceScore(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
   return Math.max(0, Math.min(1, value));
 }
 
-function parseSeverity(value: unknown): 'critical' | 'warning' | 'info' {
-  return value === 'critical' || value === 'warning' || value === 'info' ? value : 'warning';
+/** The model's severity, or null when it did not supply a valid one (was: 'warning'). */
+export function parseSeverity(value: unknown): 'critical' | 'warning' | 'info' | null {
+  return value === 'critical' || value === 'warning' || value === 'info' ? value : null;
 }
 
 function parseRecommendedActions(value: unknown): RemediationAnalysisResult['recommended_actions'] {
@@ -162,6 +202,7 @@ function validateParsedAnalysis(parsed: Record<string, unknown>): RemediationAna
     recommended_actions: parseRecommendedActions(parsed.recommended_actions),
     log_analysis: logAnalysis,
     confidence_score: clampConfidenceScore(parsed.confidence_score),
+    analysis_source: 'llm-analysis',
   };
 }
 
@@ -171,13 +212,17 @@ export function parseRemediationAnalysis(raw: string): RemediationAnalysisResult
     return validateParsedAnalysis(parsedPayload);
   }
 
+  // Unstructured model output: we have prose and nothing else. Severity and
+  // confidence are null rather than 0.35/'warning' — the model stated neither,
+  // and inventing them puts a number on screen that nothing measured.
   const fallback = raw.trim();
   return {
     root_cause: fallback || 'Unable to determine root cause from current evidence.',
-    severity: 'warning',
+    severity: null,
     recommended_actions: [],
     log_analysis: '',
-    confidence_score: 0.35,
+    confidence_score: null,
+    analysis_source: 'llm-analysis',
   };
 }
 
@@ -272,7 +317,10 @@ async function gatherRemediationEvidence(insight: Insight): Promise<RemediationE
 }
 
 function toStoredAnalysis(analysis: RemediationAnalysisResult): string {
-  return JSON.stringify(analysis);
+  // `analysis_source` is written explicitly so the stored rationale describes
+  // its own provenance, rather than leaving the UI to infer it from the fact
+  // that the string happens to parse as JSON.
+  return JSON.stringify({ ...analysis, analysis_source: 'llm-analysis' satisfies RationaleSource });
 }
 
 /** Stricter retry prompt when the first LLM attempt returns unstructured output. */
@@ -339,7 +387,7 @@ async function enrichActionWithLlmAnalysis(
 
 export async function suggestAction(
   insight: Insight,
-): Promise<{ actionId: string; actionType: string } | null> {
+): Promise<{ actionId: string; actionType: string; rationaleSource: RationaleSource; patternId: string } | null> {
   const textToMatch = `${insight.title} ${insight.description} ${insight.suggested_action || ''}`;
   let pattern = pickActionPattern(textToMatch);
   if (!pattern) return null;
@@ -362,6 +410,7 @@ export async function suggestAction(
     // Downgrade to investigation instead of blocking entirely
     pattern = {
       ...pattern,
+      id: `${pattern.id}-downgraded`,
       actionType: 'INVESTIGATE',
       rationale: `Original suggestion (${pattern.actionType}) was blocked because "${containerName}" is a protected infrastructure container. Investigate the issue manually.`,
     };
@@ -406,7 +455,15 @@ export async function suggestAction(
     log.warn({ err, actionId }, 'Remediation LLM enrichment failed');
   });
 
-  return { actionId, actionType: pattern.actionType };
+  // The rationale stored above is a constant from ACTION_PATTERNS. Say so, so
+  // no caller mistakes it for the model's analysis (which may replace it
+  // asynchronously via enrichActionWithLlmAnalysis).
+  return {
+    actionId,
+    actionType: pattern.actionType,
+    rationaleSource: pattern.source,
+    patternId: pattern.id,
+  };
 }
 
 export async function approveAction(actionId: string, username: string): Promise<boolean> {

--- a/packages/security/src/__tests__/pcap-analysis-service.test.ts
+++ b/packages/security/src/__tests__/pcap-analysis-service.test.ts
@@ -165,9 +165,33 @@ describe('parseAnalysisResponse', () => {
     const raw = 'The traffic looks concerning because of high retransmissions.';
     const result = parseAnalysisResponse(raw);
     expect(result.health_status).toBe('degraded');
-    expect(result.confidence_score).toBe(0.3);
+    // Was 0.3 — a number nothing measured, rendered as a measurement.
+    expect(result.confidence_score).toBeNull();
     expect(result.summary).toContain('retransmissions');
     expect(result.findings).toHaveLength(0);
+  });
+
+  it('reports an absent confidence_score as null rather than 0.5', () => {
+    const raw = JSON.stringify({ health_status: 'healthy', summary: 'test', findings: [] });
+    expect(parseAnalysisResponse(raw).confidence_score).toBeNull();
+  });
+
+  it('keeps a model-supplied 0.5 distinguishable from an absent score', () => {
+    const supplied = parseAnalysisResponse(
+      JSON.stringify({ health_status: 'healthy', summary: 't', findings: [], confidence_score: 0.5 }),
+    );
+    const absent = parseAnalysisResponse(
+      JSON.stringify({ health_status: 'healthy', summary: 't', findings: [] }),
+    );
+    expect(supplied.confidence_score).toBe(0.5);
+    expect(absent.confidence_score).toBeNull();
+  });
+
+  it('reports a non-numeric confidence_score as null', () => {
+    const raw = JSON.stringify({
+      health_status: 'healthy', summary: 'test', findings: [], confidence_score: 'high',
+    });
+    expect(parseAnalysisResponse(raw).confidence_score).toBeNull();
   });
 
   it('validates health_status enum values', () => {

--- a/packages/security/src/models/pcap.ts
+++ b/packages/security/src/models/pcap.ts
@@ -52,7 +52,12 @@ export const PcapAnalysisResultSchema = z.object({
   health_status: z.enum(['healthy', 'degraded', 'critical']),
   summary: z.string(),
   findings: z.array(PcapFindingSchema),
-  confidence_score: z.number().min(0).max(1),
+  /**
+   * 0–1 when the model supplied a score, null when it did not. The two must
+   * stay distinguishable: a constant rendered as "Confidence: 50%" is a default
+   * wearing the clothes of a measurement. The UI omits the badge on null.
+   */
+  confidence_score: z.number().min(0).max(1).nullable(),
 });
 
 export type PcapAnalysisResult = z.infer<typeof PcapAnalysisResultSchema>;

--- a/packages/security/src/services/pcap-analysis-service.ts
+++ b/packages/security/src/services/pcap-analysis-service.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util';
 import { createChildLogger } from '@dashboard/core/utils/logger.js';
 import { getConfig } from '@dashboard/core/config/index.js';
 import { extractLlmJson } from '@dashboard/core/utils/llm-json.js';
+import { clampConfidenceScore } from '@dashboard/core/utils/model-confidence.js';
 import type { LLMInterface } from '@dashboard/contracts';
 import { getCapture, updateCaptureAnalysis } from './pcap-store.js';
 import { getCaptureFilePath } from './pcap-service.js';
@@ -227,12 +228,13 @@ export function parseAnalysisResponse(raw: string): PcapAnalysisResult {
     return validateAnalysisResult(parsed);
   }
 
-  // Fallback
+  // Fallback: unstructured model output. The prose is kept, but the model
+  // stated no confidence, so none is reported rather than inventing 0.3.
   return {
     health_status: 'degraded',
     summary: raw.trim().slice(0, 500),
     findings: [],
-    confidence_score: 0.3,
+    confidence_score: null,
   };
 }
 
@@ -264,9 +266,9 @@ function validateAnalysisResult(parsed: Record<string, unknown>): PcapAnalysisRe
         .filter((f): f is NonNullable<typeof f> => f !== null)
     : [];
 
-  const confidenceScore = typeof parsed.confidence_score === 'number'
-    ? Math.max(0, Math.min(1, parsed.confidence_score))
-    : 0.5;
+  // Null when the model supplied nothing usable — see clampConfidenceScore.
+  // The old `: 0.5` branch also admitted NaN as a confidence.
+  const confidenceScore = clampConfidenceScore(parsed.confidence_score);
 
   return { health_status: healthStatus, summary, findings, confidence_score: confidenceScore };
 }


### PR DESCRIPTION
## What this is

A whole-application design review of all 24 routes, and the fixes for it. The review ran as six
isolated agents (five design-review shards plus a deterministic detector/measurement pass) against
the app running on a live fleet, and produced 173 findings. The critique snapshot is committed at
`.impeccable/critique/` with a recorded baseline of **20/40** on Nielsen's heuristics.

The headline is not "the UI looks generated". It is that **the engineering underneath was
frequently better than the labels on top of it** — z-scores over seasonal baselines, p95 latency
detection, a virtualized log viewer, real BPF presets — under a presentation layer that overclaimed
what it knew. Most of what follows is honest labelling and subtraction, not redesign.

Worth stating up front, because it was tested rather than assumed: the expected copy-slop signature
was largely **absent**. Scanning 36 rendered-text captures for 19 marketing terms, 14 had zero hits
and there were zero exclamation marks in the entire corpus. The problems were structural.

## The four structural causes

**Six hand-maintained copies of the route list had drifted.** The breadcrumb fell through to a
literal `'Dashboard'` on 7 of 20 routes (rendering "Dashboard / Dashboard"), Cmd-K was missing 5
destinations including Log Viewer and Packet Capture — the two an on-call engineer reaches for
first — and the keyboard-shortcuts overlay still advertised labels the nav had renamed. All of them
now derive from `navigation-manifest.ts`, and `navigation-manifest.test.ts` fails if a destination
lacks a breadcrumb label or a palette entry, so the drift cannot silently return.

**`useAutoRefresh` owned interval state and scheduled nothing.** Every consumer had to remember its
own `window.setInterval` effect. One page did — with a comment naming the trap — and six did not,
while `refresh-controls.tsx` renders a pulsing "live" dot whenever `interval > 0`. Six pages
therefore showed a live indicator over a dropdown that scheduled no fetch, and no authenticated page
showed a fetch timestamp, so there was no second signal. On Home, `useContainers` had no
`refetchInterval` at all — the hero's health numbers were frozen at mount. The hook now owns the
timer, and a shared `DataFreshness` stamp makes a stalled poll visible.

**Nothing in the product was an anchor.** Sidebar destinations were `<button>`; clickable table rows
were bare `<tr tabindex="0">` in the shared primitive. So cmd-click, middle-click, copy-link and
open-in-background did not exist anywhere, and assistive tech announced a focusable row rather than a
link to a container. Opening four containers in background tabs — the shape of triage — was
impossible.

**Deterministic rules were labelled as inference.** `identifyPattern` was a three-branch `if/else`
on `zScore > 2` returning one of three fixed sentences, rendered under a Brain icon as "ML-Detected
Anomalies" — which is why two cards on screen carried a byte-identical explanation. A missing
confidence score became the constant `0.5` and was rendered as an authoritative "Confidence: 50%".
**The maths was always sound and is unchanged**; only the framing overclaimed.

## Highest-severity fixes

- **The flagship number contradicted its own page.** `/health` showed "Overall Health Score 100.0%"
  in green beside "14 Critical", because the score reads Docker healthcheck status and cannot see a
  single insight. It is now "Healthcheck pass rate", states its exclusion inline, and the hero slot
  holds an actionable "Needs attention" count.
- **Backup delete had no confirmation of any kind** — one click permanently destroyed a Portainer
  configuration archive, in a product whose positioning is that actions require approval.
- **The remediation execute dialog named nothing** — a fixed string with no container, no action and
  no endpoint, on `variant="default"`, rendering identically for all 28 rows.
- **107 settings rendered at one visual weight**, so `oidc.allow_insecure_transport` ("auth codes and
  tokens travel unencrypted") looked exactly like a cache TTL.
- **A well-written 55-line "not configured" panel was dead code.** `/edge-logs` detected the state
  with `error.message.includes('503')`, but `ApiError.message` carries the server's body text, which
  contains no "503". Operators got a red "Failed to fetch logs" alarm with a Retry that could never
  succeed, for a feature they had simply never switched on.
- **`Host IP` was `cell: () => <span>0.0.0.0</span>`** — a cell function taking no arguments and
  never reading its row, asserting the unsafe answer for every port mapping.
- **Filter chips named a fleet nobody has** (`image:nginx`, `stack:traefik`, `endpoint:prod`). They
  were working controls, which is worse than dead ones: each emptied the table, and the two
  natural-language chips spent a real LLM call. Chips are now derived from loaded containers and
  only emitted when they actually narrow the list.
- **`Invalid date` rendered ~20 times on `/health`** — `getIncidentGroups` cast timestamps with
  `::text`, dropping the `timestamptz` OID and bypassing the global `pg.types` parser.

## Verification

Verified against the running app, not only the source. Rendered-text diff across 36 captures:

| Defect | Before | After |
|---|---|---|
| `Invalid date` on /health | 20 | **0** |
| `Insight unavailable` on /metrics | 10 | **0** |
| `Dashboard / Dashboard` breadcrumbs | 6 routes | **0** |
| `powered by AI` | 23 pages | **0** |
| `ML-Detected Anomalies` | 1 | **0** |
| `Overall Health Score` beside 14 Critical | 1 | **0** |
| `Your intelligent infrastructure companion` | 1 | **0** |
| False `Failed to fetch logs` alarm | 1 | **0** |

- Frontend tests **2251 → 2729 passing**; backend 541 passing, 1 skipped; typecheck and lint
  (including package boundaries) clean.
- Deterministic detector **17 → 14** findings; 5 in both runs are a verified false-positive
  (the standard Tailwind `animate-spin rounded-full border-b-2` spinner idiom).
- `e2e/navigation.spec.ts` and `e2e/containers.spec.ts` updated for the new link semantics and the
  real 404. The old "unknown routes redirect to home" test is now wrong by design — a bad URL used
  to become Home with `replace`, so a stale bookmark landed the operator on a page they had not
  asked for and Back could not recover.

## Not done, deliberately

Three findings need backend work and were **not** faked:

- **Restart count** on the workload list — `/api/containers` carries no metrics and no restart
  count, and `created` is creation time, so it cannot express "recently restarted".
- **Trace `containerId` enrichment** — all 193 traces report `unknown`, which keeps the trace→logs
  deep link permanently gated off.
- **A raw attribute-search param** so the 26 OTEL filter fields can be replaced rather than moved
  one click away. Deleting them without a replacement would have removed working capability.

Also left: `frontend/src/shared/components/forms/nlq-search-bar.tsx` is dead code (nothing imports
it) that still contains the fictional examples — recommended for deletion in a cleanup pass rather
than edited in place.

## Notes for review

- No linked issue — agreed with the repo owner for this change.
- No new env vars, so `docker/.env.example` is unchanged.
- `docs/architecture.md` and `CLAUDE.md` record the four invariants above so the drift cannot be
  reintroduced by someone who did not read this PR.
- Observer-first is intact: no container-mutating action was added, and no backend role gate was
  weakened. Several client-side controls that rendered enabled for every role while the backend
  returned 403 are now gated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
