### PR TITLE
fix(deps): migrate react-router-dom to react-router v8, override hono past its CVE

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.18.0",
+    "react-router": "^8.3.0",
     "recharts": "^3.8.1",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router';
 import { router } from './router';
 import { ThemeProvider } from './providers/theme-provider';
 import { QueryProvider } from './providers/query-provider';

--- a/frontend/src/features/ai-intelligence/components/fleet-health-summary.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/fleet-health-summary.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ShieldAlert, PackageOpen } from 'lucide-react';
 import { FleetHealthSummary, type InsightStats } from './fleet-health-summary';
 import type { HealthStats } from '@/shared/lib/health-score';

--- a/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
+++ b/frontend/src/features/ai-intelligence/components/fleet-health-summary.tsx
@@ -1,5 +1,5 @@
 import { Activity, AlertCircle, AlertTriangle, CheckCircle2, ChevronRight, HelpCircle, Info } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { SkeletonChart } from '@/shared/components/feedback/skeleton';
 import { HealthScoreCard } from '@/shared/components/data-display/health-score-card';
 import {

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.endpoint-overflow.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 import type { IncidentGroupsResponse } from '../hooks/use-incident-groups';

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.expand.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.expand.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.resolve.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.resolve.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.row-detail.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.row-detail.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.row-meta.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.row-meta.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.search-debounce.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.search-debounce.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, act } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.search.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.search.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.show-all.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 import type { IncidentGroupsResponse } from '../hooks/use-incident-groups';

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useCallback, useEffect } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import { ChevronDown, ChevronRight, Layers, Loader2, Inbox } from 'lucide-react';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { useIncidentInsights } from '../hooks/use-incident-insights';

--- a/frontend/src/features/ai-intelligence/components/incident-groups-view.url.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/incident-groups-view.url.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IncidentGroupsView } from './incident-groups-view';
 import type { IncidentGroupsResponse } from '../hooks/use-incident-groups';

--- a/frontend/src/features/ai-intelligence/components/insight-card.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/insight-card.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { InsightCard, type InsightCardProps } from './insight-card';
 import type { AnomalyDimension } from '@dashboard/contracts';
 

--- a/frontend/src/features/ai-intelligence/components/insight-card.tsx
+++ b/frontend/src/features/ai-intelligence/components/insight-card.tsx
@@ -19,7 +19,7 @@ import {
   TrendingUp,
   FileText,
 } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { AnomalyDimension, Severity } from '@dashboard/contracts';
 import { detectionMethodLabel } from '@/features/ai-intelligence/lib/detection-method-labels';
 import { cn, formatDate } from '@/shared/lib/utils';

--- a/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.test.tsx
+++ b/frontend/src/features/ai-intelligence/components/llm-latency-breakdown.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LlmLatencyBreakdown, formatWindowLabel } from './llm-latency-breakdown';
 

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 // Stub matchMedia for any motion / media queries
 beforeAll(() => {

--- a/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
+++ b/frontend/src/features/ai-intelligence/pages/ai-monitor.tsx
@@ -37,7 +37,7 @@ import {
   Sigma,
   ThumbsDown,
 } from 'lucide-react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import { isDownState } from '@/shared/lib/container-state';
 
 /**

--- a/frontend/src/features/ai-intelligence/pages/investigation-detail.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/investigation-detail.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { render, screen } from '@testing-library/react';
 
 const mockUseInvestigationDetail = vi.fn();

--- a/frontend/src/features/ai-intelligence/pages/investigation-detail.tsx
+++ b/frontend/src/features/ai-intelligence/pages/investigation-detail.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { ArrowLeft, Brain, Clock, Database, Layers, Server, AlertTriangle, Loader2 } from 'lucide-react';
 import {
   safeParseJson,

--- a/frontend/src/features/ai-intelligence/pages/llm-assistant-streaming.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-assistant-streaming.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 // ---------------------------------------------------------------------------
 // Issue #1494 — streaming performance regression tests.

--- a/frontend/src/features/ai-intelligence/pages/llm-assistant.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-assistant.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import type { Insight } from '@dashboard/contracts';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 // Mock modules before importing component
 vi.mock('@/features/ai-intelligence/hooks/use-llm-chat', () => ({

--- a/frontend/src/features/ai-intelligence/pages/llm-assistant.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-assistant.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useRef, useEffect, useCallback } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { Send, X, Trash2, Bot, User, AlertCircle, Copy, Check, Wrench, CheckCircle2, XCircle, Layers, WifiOff, Loader2 } from 'lucide-react';
 import type { Insight } from '@dashboard/contracts';

--- a/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 // Stub matchMedia for useReducedMotion / useCountUp in KpiCard
 beforeAll(() => {

--- a/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
+++ b/frontend/src/features/ai-intelligence/pages/llm-observability.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { type ColumnDef } from '@tanstack/react-table';
 import { LlmLatencyBreakdown, formatWindowLabel } from '@/features/ai-intelligence/components/llm-latency-breakdown';

--- a/frontend/src/features/containers/components/container-traces-tab.test.tsx
+++ b/frontend/src/features/containers/components/container-traces-tab.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 vi.mock('@/features/observability/hooks/use-red', () => ({
   useRed: vi.fn(),

--- a/frontend/src/features/containers/components/container-traces-tab.tsx
+++ b/frontend/src/features/containers/components/container-traces-tab.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   LineChart,
   Line,

--- a/frontend/src/features/containers/pages/__tests__/fleet-overview-cards.test.tsx
+++ b/frontend/src/features/containers/pages/__tests__/fleet-overview-cards.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import InfrastructurePage from '../fleet-overview';
 
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return { ...actual, useNavigate: () => mockNavigate };
 });
 

--- a/frontend/src/features/containers/pages/__tests__/image-footprint-a11y.test.tsx
+++ b/frontend/src/features/containers/pages/__tests__/image-footprint-a11y.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { axe } from 'vitest-axe';
 import * as axeMatchers from 'vitest-axe/matchers';
 import ImageFootprintPage from '../image-footprint';

--- a/frontend/src/features/containers/pages/container-comparison-redirect.tsx
+++ b/frontend/src/features/containers/pages/container-comparison-redirect.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router';
 
 /**
  * Permanent redirect from the legacy /comparison route to the merged

--- a/frontend/src/features/containers/pages/container-detail.test.tsx
+++ b/frontend/src/features/containers/pages/container-detail.test.tsx
@@ -11,7 +11,7 @@ const state = vi.hoisted(() => ({
   isLoading: false,
 }));
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   useParams: () => ({ endpointId: '1', containerId: 'c1abcdef01234567' }),
   useSearchParams: () => [new URLSearchParams(state.search), mockSetSearchParams],
   useNavigate: () => mockNavigate,

--- a/frontend/src/features/containers/pages/container-detail.tsx
+++ b/frontend/src/features/containers/pages/container-detail.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import { useParams, useSearchParams, useNavigate } from 'react-router';
 import { AlertTriangle, ArrowLeft, Info, ScrollText, Activity, Clock, Wifi, GitBranch } from 'lucide-react';
 import * as Tabs from '@radix-ui/react-tabs';
 import { useContainerDetail } from '@/features/containers/hooks/use-container-detail';

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import InfrastructurePage from './fleet-overview';
 
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return { ...actual, useNavigate: () => mockNavigate };
 });
 

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { type ColumnDef } from '@tanstack/react-table';
 import * as Tabs from '@radix-ui/react-tabs';
 import {

--- a/frontend/src/features/containers/pages/network-topology.test.tsx
+++ b/frontend/src/features/containers/pages/network-topology.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import NetworkTopologyPage, { resolveNetworkMembers } from './network-topology';
 import { useUiStore } from '@/stores/ui-store';
 

--- a/frontend/src/features/containers/pages/network-topology.tsx
+++ b/frontend/src/features/containers/pages/network-topology.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { X, AlertTriangle } from 'lucide-react';
 import { ThemedSelect } from '@/shared/components/ui/themed-select';
 import { useContainers, type Container } from '@/features/containers/hooks/use-containers';

--- a/frontend/src/features/containers/pages/workload-explorer.test.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.test.tsx
@@ -8,7 +8,7 @@ const mockNavigate = vi.fn();
 const mockExportToCsv = vi.fn();
 let mockQueryString = 'endpoint=1&stack=workers';
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   useSearchParams: () => [new URLSearchParams(mockQueryString), mockSetSearchParams],
   useNavigate: () => mockNavigate,
   Link: ({ to, children, ...rest }: { to: string; children?: ReactNode }) => (

--- a/frontend/src/features/containers/pages/workload-explorer.tsx
+++ b/frontend/src/features/containers/pages/workload-explorer.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect, useCallback } from 'react';
-import { useSearchParams, useNavigate, Link } from 'react-router-dom';
+import { useSearchParams, useNavigate, Link } from 'react-router';
 import { type ColumnDef, type RowSelectionState } from '@tanstack/react-table';
 import { AnimatePresence, m, useReducedMotion } from 'framer-motion';
 import { AlertTriangle, Boxes, Download, GitCompareArrows, X } from 'lucide-react';

--- a/frontend/src/features/core/components/layout/app-layout.test.tsx
+++ b/frontend/src/features/core/components/layout/app-layout.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
-import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { RouterProvider, createMemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // --- Mock the heavy shell children to focused stubs. The real Sidebar already

--- a/frontend/src/features/core/components/layout/app-layout.tsx
+++ b/frontend/src/features/core/components/layout/app-layout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { Navigate, Outlet, useLocation, useNavigate, useNavigationType, useOutlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation, useNavigate, useNavigationType, useOutlet } from 'react-router';
 import { useAuth } from '@/providers/auth-provider';
 import { Sidebar } from '@/features/core/components/layout/sidebar';
 import { Header } from '@/features/core/components/layout/header';

--- a/frontend/src/features/core/components/layout/command-palette.test.tsx
+++ b/frontend/src/features/core/components/layout/command-palette.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CommandPalette, pages } from './command-palette';
 

--- a/frontend/src/features/core/components/layout/command-palette.tsx
+++ b/frontend/src/features/core/components/layout/command-palette.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Command } from 'cmdk';
 import {
   Brain,

--- a/frontend/src/features/core/components/layout/header.test.tsx
+++ b/frontend/src/features/core/components/layout/header.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { Header, prefersCommandKey } from './header';
 import { useHeaderContextStore } from '@/stores/header-context-store';
 

--- a/frontend/src/features/core/components/layout/header.tsx
+++ b/frontend/src/features/core/components/layout/header.tsx
@@ -1,4 +1,4 @@
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router';
 import { Sun, Moon, Search, LogOut, User } from 'lucide-react';
 import { useAuth } from '@/providers/auth-provider';
 import { useThemeStore } from '@/stores/theme-store';

--- a/frontend/src/features/core/components/layout/mobile-bottom-nav.test.tsx
+++ b/frontend/src/features/core/components/layout/mobile-bottom-nav.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MobileBottomNav } from './mobile-bottom-nav';
 import {

--- a/frontend/src/features/core/components/layout/mobile-bottom-nav.tsx
+++ b/frontend/src/features/core/components/layout/mobile-bottom-nav.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router';
 import { MoreHorizontal, X } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { useHarborEnabled } from '@/features/security/hooks/use-harbor-vulnerabilities';

--- a/frontend/src/features/core/components/layout/mobile-nav.test.tsx
+++ b/frontend/src/features/core/components/layout/mobile-nav.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MobileBottomNav } from './mobile-bottom-nav';
 

--- a/frontend/src/features/core/components/layout/sidebar.test.tsx
+++ b/frontend/src/features/core/components/layout/sidebar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Sidebar } from './sidebar';
 import { useUiStore } from '@/stores/ui-store';

--- a/frontend/src/features/core/components/layout/sidebar.tsx
+++ b/frontend/src/features/core/components/layout/sidebar.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router';
 import { ChevronRight, ChevronDown } from 'lucide-react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { SidebarLogo } from '@/shared/components/icons/sidebar-logo';

--- a/frontend/src/features/core/components/layout/skip-link.test.tsx
+++ b/frontend/src/features/core/components/layout/skip-link.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { RouterProvider, createMemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SearchProvider } from '@/providers/search-provider';
 

--- a/frontend/src/features/core/lib/navigation-manifest.test.ts
+++ b/frontend/src/features/core/lib/navigation-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import { appRoutes } from '@/router';
 import {
   navDestinations,

--- a/frontend/src/features/core/pages/auth-callback.test.tsx
+++ b/frontend/src/features/core/pages/auth-callback.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import AuthCallbackPage from './auth-callback';
 
 const mockNavigate = vi.fn();
@@ -8,8 +8,8 @@ const mockLoginWithToken = vi.fn();
 const mockApiPost = vi.fn();
 let currentSearch = '';
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/src/features/core/pages/auth-callback.tsx
+++ b/frontend/src/features/core/pages/auth-callback.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { api } from '@/shared/lib/api';
 import { useAuth } from '@/features/core/hooks/use-auth';
 

--- a/frontend/src/features/core/pages/backups.test.tsx
+++ b/frontend/src/features/core/pages/backups.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import BackupsPage from './backups';
 
 function LocationProbe() {

--- a/frontend/src/features/core/pages/backups.tsx
+++ b/frontend/src/features/core/pages/backups.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 
 export default function BackupsPage() {
   const location = useLocation();

--- a/frontend/src/features/core/pages/home.test.tsx
+++ b/frontend/src/features/core/pages/home.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import HomePage from './home';
 
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return { ...actual, useNavigate: () => mockNavigate };
 });
 

--- a/frontend/src/features/core/pages/home.tsx
+++ b/frontend/src/features/core/pages/home.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { AlertTriangle, Star, ShieldAlert, PackageOpen } from 'lucide-react';
 import { useDashboardFull } from '@/features/core/hooks/use-dashboard-full';
 import { useContainers, useFavoriteContainers } from '@/features/containers/hooks/use-containers';

--- a/frontend/src/features/core/pages/login.test.tsx
+++ b/frontend/src/features/core/pages/login.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import LoginPage from './login';
 import { PRODUCT_NAME } from '@/shared/lib/product';
 import {
@@ -14,8 +14,8 @@ const mockUseAuth = vi.fn();
 const mockUseOIDCStatus = vi.fn();
 const mockPrefetchQuery = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/src/features/core/pages/login.tsx
+++ b/frontend/src/features/core/pages/login.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type FormEvent } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router";
 import { createPortal } from "react-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { Eye, EyeOff } from "lucide-react";

--- a/frontend/src/features/core/pages/not-found.test.tsx
+++ b/frontend/src/features/core/pages/not-found.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import NotFound from './not-found';
 
 function renderAt(path: string) {

--- a/frontend/src/features/core/pages/not-found.tsx
+++ b/frontend/src/features/core/pages/not-found.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { FileQuestion, ArrowRight } from 'lucide-react';
 import { EmptyState } from '@/shared/components/feedback/empty-state';
 import { closestDestination, findDestination } from '@/features/core/lib/navigation-manifest';

--- a/frontend/src/features/core/pages/settings.test.tsx
+++ b/frontend/src/features/core/pages/settings.test.tsx
@@ -283,7 +283,7 @@ describe('Settings tab structure', () => {
 
 describe('SettingsPage — auto-save boundary', () => {
   async function renderSettings(initialEntry = '/settings') {
-    const { MemoryRouter } = await import('react-router-dom');
+    const { MemoryRouter } = await import('react-router');
     const SettingsPage = (await import('./settings')).default;
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -465,7 +465,7 @@ describe('SettingsPage — auto-save boundary', () => {
 
 describe('SettingsPage — finding one of 107 keys', () => {
   async function renderSettings() {
-    const { MemoryRouter } = await import('react-router-dom');
+    const { MemoryRouter } = await import('react-router');
     const SettingsPage = (await import('./settings')).default;
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },

--- a/frontend/src/features/core/pages/settings.tsx
+++ b/frontend/src/features/core/pages/settings.tsx
@@ -22,7 +22,7 @@ import { useAuth } from '@/providers/auth-provider';
 import { useThemeStore } from '@/stores/theme-store';
 import { SkeletonText } from '@/shared/components/feedback/skeleton';
 import { toast } from 'sonner';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import {
   DEFAULT_SETTINGS,

--- a/frontend/src/features/observability/components/no-trace-data-callout.test.tsx
+++ b/frontend/src/features/observability/components/no-trace-data-callout.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { NoTraceDataCallout } from './no-trace-data-callout';
 
 describe('NoTraceDataCallout', () => {

--- a/frontend/src/features/observability/components/no-trace-data-callout.tsx
+++ b/frontend/src/features/observability/components/no-trace-data-callout.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Activity, ArrowRight } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 

--- a/frontend/src/features/observability/pages/log-viewer.test.tsx
+++ b/frontend/src/features/observability/pages/log-viewer.test.tsx
@@ -19,7 +19,7 @@ const mockSetSearchParams = vi.fn((updater: URLSearchParams | ((p: URLSearchPara
   }
 });
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   useSearchParams: () => [mockUrlSearch, mockSetSearchParams],
 }));
 

--- a/frontend/src/features/observability/pages/log-viewer.tsx
+++ b/frontend/src/features/observability/pages/log-viewer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useQueries } from '@tanstack/react-query';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {

--- a/frontend/src/features/observability/pages/metrics-dashboard.test.tsx
+++ b/frontend/src/features/observability/pages/metrics-dashboard.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 const mockUseForecasts = vi.fn();
 const mockUseNetworkRates = vi.fn();

--- a/frontend/src/features/observability/pages/metrics-dashboard.tsx
+++ b/frontend/src/features/observability/pages/metrics-dashboard.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { type ColumnDef } from '@tanstack/react-table';
 import {
   AlertTriangle,

--- a/frontend/src/features/observability/pages/reports.test.tsx
+++ b/frontend/src/features/observability/pages/reports.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import ReportsPage from './reports';
 
 const mockExportToCsv = vi.fn();

--- a/frontend/src/features/observability/pages/status-page.test.tsx
+++ b/frontend/src/features/observability/pages/status-page.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ReactNode } from 'react';
 
 // Mock framer-motion before importing component

--- a/frontend/src/features/observability/pages/status-page.tsx
+++ b/frontend/src/features/observability/pages/status-page.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   CheckCircle2,
   AlertTriangle,

--- a/frontend/src/features/observability/pages/trace-explorer.test.tsx
+++ b/frontend/src/features/observability/pages/trace-explorer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ReactElement } from 'react';
 
 function renderWithRouter(ui: ReactElement, route: string = '/traces') {

--- a/frontend/src/features/observability/pages/trace-explorer.tsx
+++ b/frontend/src/features/observability/pages/trace-explorer.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   Search,

--- a/frontend/src/features/operations/pages/remediation.test.tsx
+++ b/frontend/src/features/operations/pages/remediation.test.tsx
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import RemediationPage from './remediation';
 
 const mockNavigate = vi.fn();
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/src/features/operations/pages/remediation.tsx
+++ b/frontend/src/features/operations/pages/remediation.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { type ColumnDef } from '@tanstack/react-table';
 import {

--- a/frontend/src/features/security/components/observed-destinations-panel.test.tsx
+++ b/frontend/src/features/security/components/observed-destinations-panel.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ObservedDestinationsPanel } from './observed-destinations-panel';
 

--- a/frontend/src/features/security/pages/ebpf-coverage.test.tsx
+++ b/frontend/src/features/security/pages/ebpf-coverage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import EbpfCoveragePage, { mergeEndpointCoverage, summarizeCoverage } from './ebpf-coverage';
 import type { CoverageRecord } from '@/features/security/hooks/use-ebpf-coverage';
 

--- a/frontend/src/features/security/pages/harbor-vulnerabilities.test.tsx
+++ b/frontend/src/features/security/pages/harbor-vulnerabilities.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render as rtlRender, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ReactElement } from 'react';
 import HarborVulnerabilitiesPage from './harbor-vulnerabilities';
 

--- a/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
+++ b/frontend/src/features/security/pages/harbor-vulnerabilities.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { type ColumnDef } from '@tanstack/react-table';
 import {
   Shield, ShieldAlert, ShieldCheck, Search, RefreshCw, ArrowRight,

--- a/frontend/src/features/security/pages/security-audit-count.test.tsx
+++ b/frontend/src/features/security/pages/security-audit-count.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { SecurityAuditEntry } from '@/features/security/hooks/use-security-audit';
 import SecurityAuditPage from './security-audit';
 

--- a/frontend/src/features/security/pages/security-audit.test.tsx
+++ b/frontend/src/features/security/pages/security-audit.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ReactElement } from 'react';
 import SecurityAuditPage from './security-audit';
 

--- a/frontend/src/features/security/pages/security-audit.tsx
+++ b/frontend/src/features/security/pages/security-audit.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { type ColumnDef } from '@tanstack/react-table';
 import { ChevronDown, ChevronRight, Search, ShieldAlert, SlidersHorizontal } from 'lucide-react';
 import { useSecurityAudit, type SecurityAuditEntry } from '@/features/security/hooks/use-security-audit';

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from 'react';
-import type { RouteObject } from 'react-router-dom';
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
+import { createBrowserRouter, Navigate } from 'react-router';
 import { AppLayout } from '@/features/core/components/layout/app-layout';
 import { RouteErrorBoundary } from '@/shared/components/feedback/route-error-boundary';
 import { ChunkLoadErrorBoundary } from '@/shared/components/feedback/chunk-load-error-boundary';

--- a/frontend/src/shared/components/charts/endpoint-health-octagons.test.tsx
+++ b/frontend/src/shared/components/charts/endpoint-health-octagons.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EndpointHealthOctagons, getHealthLevel_testable } from './endpoint-health-octagons';
 
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   useNavigate: () => mockNavigate,
   Link: ({ to, children, ...rest }: any) => (
     <a href={to} {...rest}>

--- a/frontend/src/shared/components/charts/endpoint-health-octagons.tsx
+++ b/frontend/src/shared/components/charts/endpoint-health-octagons.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo, useRef, useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { m, useReducedMotion } from 'framer-motion';
 import { cn } from '@/shared/lib/utils';
 import { duration, easing } from '@/shared/lib/motion-tokens';

--- a/frontend/src/shared/components/charts/endpoint-health-treemap.test.tsx
+++ b/frontend/src/shared/components/charts/endpoint-health-treemap.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { EndpointHealthTreemap, getHealthColor_testable } from './endpoint-health-treemap';
 
 // Recharts ResponsiveContainer needs explicit dimensions in jsdom

--- a/frontend/src/shared/components/charts/endpoint-health-treemap.tsx
+++ b/frontend/src/shared/components/charts/endpoint-health-treemap.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useMemo } from 'react';
 import { Treemap, ResponsiveContainer, Tooltip } from 'recharts';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 export interface EndpointHealthTreemapProps {
   endpoints: Array<{

--- a/frontend/src/shared/components/charts/workload-top-bar.test.tsx
+++ b/frontend/src/shared/components/charts/workload-top-bar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { WorkloadTopBar, buildChartData } from './workload-top-bar';
 
 // Mock recharts — keep all real exports, only replace ResponsiveContainer

--- a/frontend/src/shared/components/charts/workload-top-bar.tsx
+++ b/frontend/src/shared/components/charts/workload-top-bar.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 /**
  * A stacked running/stopped bar per series row.

--- a/frontend/src/shared/components/feedback/protected-route.test.tsx
+++ b/frontend/src/shared/components/feedback/protected-route.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { ProtectedRoute } from './protected-route';
 
 const mockUseAuth = vi.fn();

--- a/frontend/src/shared/components/feedback/protected-route.tsx
+++ b/frontend/src/shared/components/feedback/protected-route.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useAuth, type UserRole } from '@/providers/auth-provider';
 
 interface ProtectedRouteProps {

--- a/frontend/src/shared/components/feedback/route-error-boundary.tsx
+++ b/frontend/src/shared/components/feedback/route-error-boundary.tsx
@@ -1,4 +1,4 @@
-import { useRouteError, isRouteErrorResponse, useNavigate } from 'react-router-dom';
+import { useRouteError, isRouteErrorResponse, useNavigate } from 'react-router';
 import { AlertTriangle, RefreshCw, Home, WifiOff, FileQuestion } from 'lucide-react';
 import { useState } from 'react';
 

--- a/frontend/src/shared/components/forms/nlq-search-bar.test.tsx
+++ b/frontend/src/shared/components/forms/nlq-search-bar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { NlqSearchBar } from './nlq-search-bar';
 
 // Mock the useNlQuery hook

--- a/frontend/src/shared/components/forms/nlq-search-bar.tsx
+++ b/frontend/src/shared/components/forms/nlq-search-bar.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Search, Sparkles, Loader2, ArrowRight, AlertCircle, X } from 'lucide-react';
 import { useNlQuery, type NlQueryResult } from '@/features/ai-intelligence/hooks/use-nl-query';
 import { cn } from '@/shared/lib/utils';

--- a/frontend/src/shared/components/forms/workload-smart-search.test.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { Container } from '@/features/containers/hooks/use-containers';
 
 const mockMutate = vi.fn();
@@ -13,8 +13,8 @@ vi.mock('@/features/ai-intelligence/hooks/use-nl-query', () => ({
   }),
 }));
 
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/src/shared/components/forms/workload-smart-search.tsx
+++ b/frontend/src/shared/components/forms/workload-smart-search.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Search, Sparkles, Loader2, ArrowRight, AlertCircle, X, Filter } from 'lucide-react';
 import { useNlQuery, type NlQueryResult } from '@/features/ai-intelligence/hooks/use-nl-query';
 import { cn } from '@/shared/lib/utils';

--- a/frontend/src/shared/components/layout/motion-page.test.tsx
+++ b/frontend/src/shared/components/layout/motion-page.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { MotionPage, MotionStagger, MotionReveal, _resetVisitedPaths } from './motion-page';
 
 // Mock framer-motion to inspect props without running real animations

--- a/frontend/src/shared/components/layout/motion-page.tsx
+++ b/frontend/src/shared/components/layout/motion-page.tsx
@@ -1,5 +1,5 @@
 import { m, useReducedMotion } from 'framer-motion';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { cn } from '@/shared/lib/utils';
 import { pageVariants, transition, easing, duration } from '@/shared/lib/motion-tokens';
 

--- a/frontend/src/shared/components/tables/data-table.test.tsx
+++ b/frontend/src/shared/components/tables/data-table.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { DataTable } from './data-table';
 import type { ColumnDef, OnChangeFn, SortingState } from '@tanstack/react-table';
 import type { ReactElement } from 'react';

--- a/frontend/src/shared/components/tables/data-table.tsx
+++ b/frontend/src/shared/components/tables/data-table.tsx
@@ -16,7 +16,7 @@ import {
   type Updater,
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { cn } from '@/shared/lib/utils';
 import { Checkbox } from '@/shared/components/ui/checkbox';
 import { ArrowUpDown, ChevronLeft, ChevronRight, ArrowUp, ArrowDown } from 'lucide-react';

--- a/frontend/src/shared/hooks/use-url-state.test.ts
+++ b/frontend/src/shared/hooks/use-url-state.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useURLState } from './use-url-state';
 
-// Mock react-router-dom
+// Mock react-router
 const mockSetSearchParams = vi.fn();
 let mockSearchParams = new URLSearchParams();
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   useSearchParams: () => [mockSearchParams, mockSetSearchParams],
 }));
 

--- a/frontend/src/shared/hooks/use-url-state.ts
+++ b/frontend/src/shared/hooks/use-url-state.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useCallback } from 'react';
 
 /**

--- a/frontend/src/test/a11y-pages.test.tsx
+++ b/frontend/src/test/a11y-pages.test.tsx
@@ -15,7 +15,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { axe } from 'vitest-axe';
 import * as axeMatchers from 'vitest-axe/matchers';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -138,7 +138,7 @@ export default defineConfig({
           groups: [
             {
               name: 'react-vendor',
-              test: /node_modules[\\/](?:react|react-dom|scheduler|react-router|react-router-dom)[\\/]/,
+              test: /node_modules[\\/](?:react|react-dom|scheduler|react-router)[\\/]/,
               priority: 30,
             },
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.18.0",
+        "react-router": "^8.3.0",
         "recharts": "^3.8.1",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.0",
@@ -169,6 +169,27 @@
           "optional": true
         },
         "vite": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/react-router": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      },
+      "peerDependencies": {
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
           "optional": true
         }
       }
@@ -3283,12 +3304,12 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -7888,6 +7909,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -14065,44 +14092,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "zod": "^4.3.6",
     "@fastify/swagger-ui": {
       "@fastify/static": "^10.1.2"
-    }
+    },
+    "@hono/node-server": "^2.0.12"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary

- `Security Audit` has been red on `dev` for a while now, independent of any Dependabot bump — every one of the 12 currently-open Dependabot PRs inherits this failure regardless of what dependency it touches, because it's baked into `dev` itself.
- Two production advisories gate `npm audit --omit=dev --audit-level=high`:
  - **react-router** (High, GHSA-qwww-vcr4-c8h2, CSRF bypass) — `react-router-dom` froze at `7.18.1` on npm; v8 was never published under that name. The patched line only exists as the `react-router` package (`8.3.0+`).
  - **@hono/node-server** (moderate, GHSA-frvp-7c67-39w9, path traversal) — transitive via `@modelcontextprotocol/sdk`'s own dependency declaration.

## What changed

1. **react-router migration** (#1618): swapped the `react-router-dom` import specifier to `react-router` across 98 files, and the dependency in `frontend/package.json` (`react-router-dom@^7.18.0` → `react-router@^8.3.0`). Verified directly against the `8.3.0` registry exports map that every API this codebase actually uses — `BrowserRouter`, `createBrowserRouter`, `Routes`, `Route`, `Link`, `NavLink`, `useNavigate`, `useParams`, `useLocation`, `useSearchParams`, `Outlet`, `useOutlet`, `Navigate`, `RouterProvider`, `useRouteError`, `useNavigationType`, `isRouteErrorResponse`, `createMemoryRouter`, `MemoryRouter` — still ships from the main entry point (only the RSC-hydration helpers live under `react-router/dom`), so this is a straight import-path swap, not a `react-router/dom` split.
   - The advisory itself is scoped to RSC mode, which this app doesn't use (plain `createBrowserRouter`/`RouterProvider`, no loaders/actions/RSC APIs) — confirmed by grep before starting.
   - Cleaned up the now-dead `react-router-dom` alternative from the `react-vendor` manual-chunk regex in `vite.config.ts`.
2. **hono override** (#1621): added `"@hono/node-server": "^2.0.12"` to the root `package.json` `overrides`. The only import site of `@modelcontextprotocol/sdk` (`packages/ai-intelligence/src/services/mcp-manager.ts`) uses exclusively client-side transports (`Client`, `StdioClientTransport`, `SSEClientTransport`, `StreamableHTTPClientTransport`) — the vulnerable server-transport code (`@hono/node-server`) is structurally unreachable from those imports, so this override carries no behavioral risk here.

## Verification

- `npm audit --omit=dev --audit-level=high` → **0 vulnerabilities** (was 2: react-router High + hono moderate) — confirmed green in CI on this PR
- `npm ls --all` → clean
- `frontend` typecheck, lint, full test suite (245 files / 2906 tests) → all pass
- `frontend` production build → succeeds, `react-vendor` chunk still groups react/react-dom/scheduler/react-router correctly
- Root `typecheck` (all 9 packages + frontend) and `lint:packages` → clean
- `packages/ai-intelligence` (`@dashboard/ai`) full typecheck passes; `mcp-manager.test.ts` (19/19) passes unchanged, confirming the hono override doesn't touch the client-only code path
- **Manually smoked the app in a real browser** against the already-running dev backend (local Vite dev server on :5273 proxying to the existing dockerized backend on :3051, live Portainer data): unauthenticated redirect to `/login`, login flow, home page, a `<Navigate>` redirect route (`/fleet` → `/infrastructure?tab=fleet`), sidebar client-side `Link` navigation (exercises the `FrozenOutlet`/`useOutlet` transition pattern in `app-layout.tsx` — the highest-risk spot per #1618), the `:endpointId/:containerId` param route into a real container detail page, and `useSearchParams`-driven tab state (`?tab=metrics` rendering the Metrics tab with live charts). Zero console errors throughout; the only console warnings seen were Recharts' known transient "width(-1)/height(-1)" layout-measurement warning, unrelated to routing.

## Test plan

- [x] `npm audit --omit=dev --audit-level=high` clean
- [x] `npm ls --all` clean
- [x] Frontend typecheck/lint/tests/build all pass
- [x] Root typecheck + lint:packages pass
- [x] `mcp-manager` tests pass unchanged
- [x] Manual smoke of golden-path + redirect + param routes + tab query-param state in a real browser

Closes #1618, Closes #1621