### PR TITLE
fix: restore Portainer 2.45 compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,14 @@ npm run test -w frontend   # Frontend only
 
 ## Architecture
 
+**Portainer 2.45 compatibility:** Endpoint reads exclude unused snapshots (list:
+`excludeSnapshots=true`; inspect: `excludeSnapshot=true`). Omitted endpoint `Status`
+is Portainer's zero/unknown value, not an up signal. Docker nil collections are
+normalized at the Zod boundary. Live `/docker/info` uses the shared TLS dispatcher.
+Stack lifecycle vocabulary lives in `@dashboard/contracts` (`STACK_STATUSES`):
+1/2/3/4 map to active/inactive/deploying/error; unknown values remain unknown.
+See `docs/portainer-2.45-compatibility.md` for upstream evidence and verification.
+
 Backend uses npm workspaces under `packages/` with a `core/` kernel (`@dashboard/core`). See `@docs/ai-instructions/architecture.md` for complete directory structure. See `@packages/core/src/CLAUDE.md` for kernel boundaries and security-critical files.
 
 **Portainer data source:** All endpoint container counts, host CPU/memory, and stack totals come from live `/docker/info` calls — Portainer's per-endpoint `Snapshots[]` is **not read**. The pipeline lives in `packages/core/src/portainer/live-fleet.ts` (`enrichEndpointsWithLiveDockerInfo`, `attachStackCounts`, `computeFleetTotals`, `collectFleetOverview`). Up Docker endpoints are `live`; Edge Async (Type 7) and any down or non-Docker endpoint are `unavailable`. `EDGE_LIVE_QUERY_ENABLED=false` is a hard kill-switch — all endpoints become `unavailable` with no fallback. Our `kpi_snapshots`/`monitoring_snapshots` history tables are unchanged; only their inputs are now live.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -48,10 +48,15 @@ JWT_SECRET=generate-a-random-64-char-string
 # Portainer
 # For local development with Portainer on host: http://host.docker.internal:9000
 # For remote Portainer: https://your-portainer.example.com
+# Use the server base URL, without /api. Portainer 2.45 keeps the Docker read routes.
+# The API key's Portainer account still needs access to the monitored environments;
+# a dashboard admin role does not grant additional upstream Portainer permissions.
 PORTAINER_API_URL=http://host.docker.internal:9000
 PORTAINER_API_KEY=your-api-key
 # Set to false only for self-signed certs in trusted environments (CWE-295):
 PORTAINER_VERIFY_SSL=true
+# TLS configuration also applies to live fleet /docker/info queries. Prefer a trusted
+# CA via NODE_EXTRA_CA_CERTS over disabling verification. No new 2.45 env var needed.
 # PORTAINER_CONCURRENCY=30              # max parallel Portainer API calls (default 30)
 # Circuit breaker — trips on 5xx/network errors, ignores 4xx
 # PORTAINER_CB_FAILURE_THRESHOLD=5    # failures before opening circuit

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,18 @@
 # Architecture
 
+## Portainer 2.45 compatibility
+
+Endpoint discovery skips stored snapshots and accepts Portainer's omitted zero-valued
+status without rejecting the entire fleet. The Zod Docker boundary accepts null
+labels, mounts, added capabilities and image tags while retaining strict identity
+validation. Live fleet enrichment shares the main client's pooled TLS dispatcher,
+including custom CA and explicit verification configuration. Stack status values
+3/4 survive normalization as deploying/error through fleet badges, counts and
+filters; the shared vocabulary is in `@dashboard/contracts`.
+
+See [compatibility analysis](portainer-2.45-compatibility.md) for upstream changes,
+regressions, and the remaining live-deployment verification checklist.
+
 This project's architecture documentation is maintained in [docs/ai-instructions/architecture.md](ai-instructions/architecture.md).
 
 For detailed diagrams and data flow, see:

--- a/docs/portainer-2.45-compatibility.md
+++ b/docs/portainer-2.45-compatibility.md
@@ -48,6 +48,9 @@ they are not all newly introduced upstream in 2.45.
 - HTTP 401/403 regressions verify that the client preserves permission denials,
   makes no alternative-path retries, and does not trip other environments' breakers.
 - Targeted frontend fleet/search/status/hook suites: 144 tests pass.
+- The shared stack vocabulary is a runtime import. Vite and Vitest resolve
+  `@dashboard/contracts` to its source entry so clean-checkout dev/tests do not
+  depend on an untracked `dist/` build. A regression loads both actual configs.
 - Production frontend exercised in Chromium at 1440px and 390px with HTTP-boundary
   fixtures: all five lifecycle statuses render; selecting Error shows only the
   matching stack. This is a UI smoke check, not a live Portainer test.

--- a/docs/portainer-2.45-compatibility.md
+++ b/docs/portainer-2.45-compatibility.md
@@ -1,0 +1,86 @@
+# Portainer 2.45.0 compatibility investigation
+
+## Evidence and scope
+
+Compared upstream CE tags `2.39.0`, `2.44.0`, and `2.45.0` (commit
+`d79ba726cd54395a54cca5e9180609ce52fa7a4f`). The previous deployed version and
+the failing deployment's responses were not available during local investigation.
+These fixes reproduce concrete contract failures, not a confirmed diagnosis of
+the user's running server. BE-specific behaviour still needs live validation.
+
+## Upstream API changes affecting this client
+
+| Area | Finding | Dashboard handling |
+| --- | --- | --- |
+| Docker proxy | 2.45 tightens authorization of version prefixes and encoded path separators. Existing unversioned read URLs remain valid. | Keep canonical routes and normal API-key authentication; never bypass upstream authorization. |
+| Endpoints | Between 2.39 and 2.45, `Status` became `omitempty`; zero is absent. Empty snapshot/tag arrays can be omitted; older responses can contain null collections. | Accept absent status as zero, not up; normalize null collections. One such endpoint no longer invalidates the entire endpoint list. |
+| Snapshot payloads | `DockerSnapshotRaw.Containers` and `.Images` are arrays, not numeric counts. These are unused by the live fleet pipeline. | Accept the actual shape (and legacy numeric fixtures), and request snapshot exclusion. List uses plural `excludeSnapshots`, inspect singular `excludeSnapshot`. Both flags exist in 2.39 too. |
+| Stack lifecycle | Status 3 means deploying; 4 means deployment error. List/inspect retain the existing top-level stack shape. Git source/workflow fields are additive for this observer client. | Preserve active/inactive/deploying/error/unknown through the shared contract, normalization, badges, counts and filters. |
+| Kubernetes | New native write APIs; stricter namespace authorization and 403 responses on denials. | Existing Kubernetes read proxy routes need no URL migration. Upstream permission denials must remain denials. No new write actions added. |
+
+Sources:
+- [2.45.0 release notes](https://github.com/portainer/portainer/releases/tag/2.45.0)
+- [Endpoint and stack wire types/constants](https://github.com/portainer/portainer/blob/2.45.0/api/portainer.go)
+- [Endpoint list handler](https://github.com/portainer/portainer/blob/2.45.0/api/http/handler/endpoints/endpoint_list.go)
+- [Endpoint inspect handler](https://github.com/portainer/portainer/blob/2.45.0/api/http/handler/endpoints/endpoint_inspect.go)
+- [Docker proxy dispatch](https://github.com/portainer/portainer/blob/2.45.0/api/http/proxy/factory/docker/transport.go)
+- [Stack response compatibility](https://github.com/portainer/portainer/blob/2.45.0/api/http/handler/stacks/response.go)
+
+## Additional integration bugs fixed
+
+- Live fleet `/docker/info` calls previously bypassed the Portainer dispatcher.
+  Consequently a self-signed/custom-CA server could work for container reads but
+  fail for all fleet counts. Both now use the same pool and explicit TLS settings;
+  verification stays enabled by default.
+- Docker's nullable collections could reject otherwise valid container lists
+  (`Labels`, `Mounts`) and dangling-image lists (`RepoTags`). Normalize only these
+  known nullable collections; malformed identity/type values still fail validation.
+- Container inspect accepted `HostConfig.CapAdd: null` but failed when converting
+  back into the list contract. Null capabilities now normalize to an empty list.
+
+These are pre-existing client defects exposed by valid responses/configuration;
+they are not all newly introduced upstream in 2.45.
+
+## Validation
+
+- New compatibility tests first reproduced six failures before implementation.
+- Contracts: 32 tests pass. Core Portainer and model suites: 296 tests pass.
+- HTTP 401/403 regressions verify that the client preserves permission denials,
+  makes no alternative-path retries, and does not trip other environments' breakers.
+- Targeted frontend fleet/search/status/hook suites: 144 tests pass.
+- Production frontend exercised in Chromium at 1440px and 390px with HTTP-boundary
+  fixtures: all five lifecycle statuses render; selecting Error shows only the
+  matching stack. This is a UI smoke check, not a live Portainer test.
+- Full repository `npm run typecheck`: passes.
+- Full production build: passes using Git Bash as npm's script shell on Windows.
+- Backend, frontend, and package ESLint: pass. On Windows the package command
+  needs double-quoted globs; the root Bash gate currently fails on pre-existing
+  CRLF shell scripts. Those unrelated files were not modified.
+- Local live smoke passed against `portainer/portainer-ce:2.45.0`, image digest
+  `sha256:511f3f06c96fe3b993ebeaafde311c1959cae73a7ef825dba6397d51b450dffa`.
+  The production-built client read 1 endpoint, 36 containers, 61 images, 11
+  networks, and an empty stacks list. Docker info (32 CPUs), live fleet info,
+  container inspect, stats, and logs all passed without mocks. Portainer's data
+  was isolated on tmpfs with generated in-memory credentials and a loopback-only
+  HTTP listener. Only the temporary Portainer configuration was created; monitored
+  containers and persistent volumes were not modified.
+- The user's remote deployment, BE/Edge environments, populated stack reads, and
+  full PostgreSQL integration still require deployment/CI verification. The user
+  approved local smoke testing and subsequent deployment verification themselves.
+
+## Live acceptance checklist
+
+1. Confirm previous version, CE/BE edition, exact error, and whether Portainer's
+   own UI can list the affected environments/containers.
+2. From the dashboard runtime, verify the configured server base URL (without
+   `/api`) and TLS trust. Keep API keys out of logs and issue comments.
+3. With the configured key, read `/api/endpoints?excludeSnapshots=true`, a reachable
+   endpoint's `/docker/info`, `/docker/containers/json?all=true`, container inspect,
+   stats/logs, networks/images, and `/api/stacks`. Check HTTP status before schema.
+   A successful public `/api/status` alone does not prove API-key permissions.
+4. A 401/403 requires correcting the upstream account/key/environment permissions;
+   the dashboard admin role does not grant Portainer privileges. Do not work around
+   2.45's authorization hardening with alternative version/encoded paths.
+5. Deploy the patched build through the usual workflow; confirm fleet counts,
+   nullable collection responses, inspect, and deploying/error stack filters.
+   Edge Async remains intentionally unavailable for live Docker queries.

--- a/frontend/src/contracts-resolution.test.ts
+++ b/frontend/src/contracts-resolution.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+import { resolveConfig } from 'vite';
+
+describe('contracts imports on a clean checkout', () => {
+  it.each(['vite.config.ts', 'vitest.config.ts'])('%s resolves the shared vocabulary to source, not unbuilt dist', async (file) => {
+    const root = resolve(import.meta.dirname, '..');
+    const config = await resolveConfig({ root, configFile: resolve(root, file) }, 'serve');
+    const alias = config.resolve.alias.find((entry) => entry.find === '@dashboard/contracts');
+    expect(alias?.replacement).toBe(resolve(root, '../packages/contracts/src/index.ts'));
+  }, 30_000);
+});

--- a/frontend/src/features/containers/components/fleet/status-kpi.tsx
+++ b/frontend/src/features/containers/components/fleet/status-kpi.tsx
@@ -10,6 +10,9 @@ export const ENDPOINT_STATUS_COLORS: Record<string, { dot: string; text: string 
 export const STACK_STATUS_COLORS: Record<string, { dot: string; text: string }> = {
   active: { dot: 'bg-emerald-500', text: 'text-emerald-700 dark:text-emerald-400' },
   inactive: { dot: 'bg-gray-500', text: 'text-gray-700 dark:text-gray-400' },
+  deploying: { dot: 'bg-blue-500', text: 'text-blue-700 dark:text-blue-400' },
+  error: { dot: 'bg-red-500', text: 'text-red-700 dark:text-red-400' },
+  unknown: { dot: 'bg-gray-500', text: 'text-gray-700 dark:text-gray-400' },
 };
 
 export interface StatusKpiPill {
@@ -78,7 +81,7 @@ export function StatusKpi({ pills, ariaLabel }: StatusKpiProps) {
     <div
       role="group"
       aria-label={ariaLabel}
-      className="flex items-center gap-2"
+      className="flex flex-wrap items-center gap-2"
       data-testid="status-kpi"
     >
       <AnimatePresence mode="popLayout">

--- a/frontend/src/features/containers/hooks/use-stacks.ts
+++ b/frontend/src/features/containers/hooks/use-stacks.ts
@@ -1,12 +1,13 @@
 import { useResource } from '@/shared/hooks/use-resource';
 import { STALE_TIMES } from '@/shared/lib/query-constants';
+import type { StackStatus } from '@dashboard/contracts';
 
 export interface Stack {
   id: number;
   name: string;
   type: number;
   endpointId: number;
-  status: 'active' | 'inactive';
+  status: StackStatus;
   createdAt?: number;
   updatedAt?: number;
   envCount: number;

--- a/frontend/src/features/containers/lib/fleet-search-filter.test.ts
+++ b/frontend/src/features/containers/lib/fleet-search-filter.test.ts
@@ -46,6 +46,10 @@ function makeStack(overrides: Partial<StackWithEndpoint> = {}): StackWithEndpoin
 }
 
 describe('parseFleetSearchQuery', () => {
+  it.each(['deploying', 'error', 'unknown'] as const)('can search the %s stack lifecycle state', (status) => {
+    const stack = makeStack({ status });
+    expect(filterStacks([stack, makeStack({ id: 2 })], `status:${status}`)).toEqual([stack]);
+  });
   it('returns empty array for empty string', () => {
     expect(parseFleetSearchQuery('')).toEqual([]);
     expect(parseFleetSearchQuery('   ')).toEqual([]);

--- a/frontend/src/features/containers/lib/fleet-search-filter.ts
+++ b/frontend/src/features/containers/lib/fleet-search-filter.ts
@@ -1,11 +1,12 @@
 import type { Endpoint } from '@/features/containers/hooks/use-endpoints';
+import type { StackStatus } from '@dashboard/contracts';
 
 export interface StackWithEndpoint {
   id: number;
   name: string;
   type: number;
   endpointId: number;
-  status: 'active' | 'inactive';
+  status: StackStatus;
   endpointName: string;
   containerCount?: number;
   envCount: number;

--- a/frontend/src/features/containers/pages/fleet-overview.test.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.test.tsx
@@ -964,6 +964,24 @@ describe('InfrastructurePage — endpoint dropdown filters', () => {
 });
 
 describe('InfrastructurePage — stack dropdown filters', () => {
+  it('counts and filters Portainer deployment/error states without merging them into inactive', () => {
+    mockEndpoints([makeEndpoint()]);
+    mockStacks([
+      makeStack({ id: 1, name: 'deploying-app', status: 'deploying' }),
+      makeStack({ id: 2, name: 'failed-app', status: 'error' }),
+      makeStack({ id: 3, name: 'stopped-app', status: 'inactive' }),
+    ]);
+    renderPageWithInitialParams('/infrastructure?tab=stacks');
+    expect(screen.getByTestId('status-pill-deploying')).toHaveTextContent('Deploying(1)');
+    expect(screen.getByTestId('status-pill-error')).toHaveTextContent('Error(1)');
+    expect(screen.getByTestId('status-pill-inactive')).toHaveTextContent('Inactive(1)');
+    fireEvent.click(screen.getByTestId('status-pill-error'));
+    expect(screen.getByText('failed-app')).toBeInTheDocument();
+    expect(screen.queryByText('deploying-app')).not.toBeInTheDocument();
+    expect(screen.queryByText('stopped-app')).not.toBeInTheDocument();
+    expect(screen.getByTestId('stacks-filtered-count')).toHaveTextContent('1 of 3');
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     useUiStore.setState({ pageViewModes: {} });

--- a/frontend/src/features/containers/pages/fleet-overview.tsx
+++ b/frontend/src/features/containers/pages/fleet-overview.tsx
@@ -1,3 +1,4 @@
+import { STACK_STATUSES } from '@dashboard/contracts';
 import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import * as Tabs from '@radix-ui/react-tabs';
@@ -633,26 +634,14 @@ export default function InfrastructurePage() {
   }, [endpoints, activeEndpointStatusPill, handleEndpointStatusPillChange]);
 
   const stackStatusKpiPills = useMemo<StatusKpiPill[]>(() => {
-    const active = stacksWithEndpoints.filter((s) => s.status === 'active').length;
-    const inactive = stacksWithEndpoints.filter((s) => s.status === 'inactive').length;
-    return [
-      {
-        key: 'active',
-        label: 'Active',
-        count: active,
-        isActive: activeStackStatusPill === 'active',
-        colors: STACK_STATUS_COLORS.active,
-        onClick: () => handleStackStatusPillChange(activeStackStatusPill === 'active' ? undefined : 'active'),
-      },
-      {
-        key: 'inactive',
-        label: 'Inactive',
-        count: inactive,
-        isActive: activeStackStatusPill === 'inactive',
-        colors: STACK_STATUS_COLORS.inactive,
-        onClick: () => handleStackStatusPillChange(activeStackStatusPill === 'inactive' ? undefined : 'inactive'),
-      },
-    ];
+    return STACK_STATUSES.map((status) => ({
+      key: status,
+      label: status.charAt(0).toUpperCase() + status.slice(1),
+      count: stacksWithEndpoints.filter((s) => s.status === status).length,
+      isActive: activeStackStatusPill === status,
+      colors: STACK_STATUS_COLORS[status],
+      onClick: () => handleStackStatusPillChange(activeStackStatusPill === status ? undefined : status),
+    })).filter((pill) => pill.count > 0 || pill.isActive || pill.key === 'active' || pill.key === 'inactive');
   }, [stacksWithEndpoints, activeStackStatusPill, handleStackStatusPillChange]);
 
   // Search-filtered endpoints (dropdown filters applied upstream, then smart search)
@@ -683,11 +672,11 @@ export default function InfrastructurePage() {
   // Dynamic filter options for stacks
   const stackStatusOptions = useMemo(() => {
     if (stacksWithEndpoints.length === 0) return [];
-    const activeCount = stacksWithEndpoints.filter(s => s.status === 'active').length;
-    const inactiveCount = stacksWithEndpoints.filter(s => s.status === 'inactive').length;
     const options = [{ value: ALL_FILTER, label: `All statuses (${stacksWithEndpoints.length})` }];
-    if (activeCount > 0) options.push({ value: 'active', label: `Active (${activeCount})` });
-    if (inactiveCount > 0) options.push({ value: 'inactive', label: `Inactive (${inactiveCount})` });
+    for (const status of STACK_STATUSES) {
+      const count = stacksWithEndpoints.filter((s) => s.status === status).length;
+      if (count > 0) options.push({ value: status, label: `${status.charAt(0).toUpperCase() + status.slice(1)} (${count})` });
+    }
     return options;
   }, [stacksWithEndpoints]);
 

--- a/frontend/src/shared/components/feedback/status-badge.test.tsx
+++ b/frontend/src/shared/components/feedback/status-badge.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from '@testing-library/react';
 import { StatusBadge } from './status-badge';
 
 describe('StatusBadge', () => {
+  it('shows deployment progress as informational, not inactive', () => {
+    render(<StatusBadge status="deploying" />);
+    expect(screen.getByText('deploying')).toHaveClass('bg-blue-100');
+  });
   it('should render the status text', () => {
     render(<StatusBadge status="running" />);
     expect(screen.getByText('running')).toBeInTheDocument();

--- a/frontend/src/shared/components/feedback/status-badge.tsx
+++ b/frontend/src/shared/components/feedback/status-badge.tsx
@@ -5,7 +5,7 @@ type Status = 'running' | 'stopped' | 'paused' | 'unhealthy' | 'healthy' | 'unkn
   'pending' | 'approved' | 'rejected' | 'executing' | 'completed' | 'failed' | 'succeeded' |
   'critical' | 'warning' | 'info' | 'ok' | 'error' |
   'capturing' | 'processing' |
-  'deployed' | 'planned' | 'excluded' |
+  'deployed' | 'deploying' | 'planned' | 'excluded' |
   'not_deployed' | 'unreachable' | 'incompatible';
 
 const statusColors: Record<string, string> = {
@@ -34,6 +34,7 @@ const statusColors: Record<string, string> = {
   capturing: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
   processing: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
   deployed: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400',
+  deploying: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
   planned: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
   excluded: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400',
   not_deployed: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
@@ -67,6 +68,7 @@ const statusDotColors: Record<string, string> = {
   capturing: 'bg-blue-500',
   processing: 'bg-purple-500',
   deployed: 'bg-emerald-500',
+  deploying: 'bg-blue-500',
   planned: 'bg-blue-500',
   excluded: 'bg-gray-500',
   not_deployed: 'bg-blue-500',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -99,6 +99,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
+      '@dashboard/contracts': path.resolve(__dirname, '../packages/contracts/src/index.ts'),
       '@': path.resolve(__dirname, './src'),
     },
   },

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@dashboard/contracts': path.resolve(__dirname, '../packages/contracts/src/index.ts'),
       '@': path.resolve(__dirname, './src'),
     },
   },

--- a/packages/contracts/src/schemas/index.ts
+++ b/packages/contracts/src/schemas/index.ts
@@ -1,6 +1,7 @@
 export * from './insight.js';
 export * from './metric.js';
 export * from './container.js';
+export * from './stack.js';
 export * from './endpoint.js';
 export * from './investigation.js';
 export * from './incident.js';

--- a/packages/contracts/src/schemas/stack.test.ts
+++ b/packages/contracts/src/schemas/stack.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { STACK_STATUSES, StackStatusSchema } from './stack.js';
+
+describe('stack status contract', () => {
+  it('includes every normalized Portainer lifecycle state', () => {
+    expect(STACK_STATUSES).toEqual(['active', 'inactive', 'deploying', 'error', 'unknown']);
+    for (const status of STACK_STATUSES) expect(StackStatusSchema.parse(status)).toBe(status);
+    expect(StackStatusSchema.safeParse('stopped').success).toBe(false);
+  });
+});

--- a/packages/contracts/src/schemas/stack.ts
+++ b/packages/contracts/src/schemas/stack.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod/v4';
+
+/** Shared vocabulary for Portainer stack lifecycle states, including 2.45. */
+export const STACK_STATUSES = ['active', 'inactive', 'deploying', 'error', 'unknown'] as const;
+export const StackStatusSchema = z.enum(STACK_STATUSES);
+export type StackStatus = z.infer<typeof StackStatusSchema>;

--- a/packages/core/src/models/portainer.ts
+++ b/packages/core/src/models/portainer.ts
@@ -5,14 +5,15 @@ export const EndpointSchema = z.object({
   Name: z.string(),
   Type: z.number(),
   URL: z.string(),
-  Status: z.number(),
+  // Portainer 2.45 uses omitempty: absent means Go's zero/unknown, never up.
+  Status: z.number().optional().default(0),
   Snapshots: z.array(z.object({
     DockerSnapshotRaw: z.object({
-      Containers: z.number().nullish(),
+      Containers: z.union([z.number(), z.array(z.record(z.string(), z.unknown()))]).nullish(),
       ContainersRunning: z.number().nullish(),
       ContainersStopped: z.number().nullish(),
       ContainersPaused: z.number().nullish(),
-      Images: z.number().nullish(),
+      Images: z.union([z.number(), z.array(z.record(z.string(), z.unknown()))]).nullish(),
     }).passthrough().nullish(),
     TotalCPU: z.number().nullish(),
     TotalMemory: z.number().nullish(),
@@ -22,8 +23,8 @@ export const EndpointSchema = z.object({
     UnhealthyContainerCount: z.number().nullish(),
     StackCount: z.number().nullish(),
     Time: z.number().nullish(),
-  })).optional().default([]),
-  TagIds: z.array(z.number()).optional().default([]),
+  })).nullish().transform((value) => value ?? []),
+  TagIds: z.array(z.number()).nullish().transform((value) => value ?? []),
   EdgeID: z.string().optional(),
   EdgeKey: z.string().optional(),
   LastCheckInDate: z.number().optional(),
@@ -47,7 +48,7 @@ export const ContainerSchema = z.object({
     PublicPort: z.number().optional(),
     Type: z.string().optional(),
   })).nullish().default([]),
-  Labels: z.record(z.string(), z.string()).optional().default({}),
+  Labels: z.record(z.string(), z.string()).nullish().transform((value) => value ?? {}),
   NetworkSettings: z.object({
     Networks: z.record(z.string(), z.object({
       NetworkID: z.string().optional(),
@@ -62,11 +63,11 @@ export const ContainerSchema = z.object({
     Destination: z.string().optional(),
     Mode: z.string().optional(),
     RW: z.boolean().optional(),
-  })).optional().default([]),
+  })).nullish().transform((value) => value ?? []),
   HostConfig: z.object({
     NetworkMode: z.string().optional(),
     Privileged: z.boolean().optional(),
-    CapAdd: z.array(z.string()).optional(),
+    CapAdd: z.array(z.string()).nullable().transform((value) => value ?? []).optional(),
     PidMode: z.string().optional(),
   }).optional(),
 }).passthrough();
@@ -279,7 +280,7 @@ export const NetworkSchema = z.object({
 
 export const ImageSchema = z.object({
   Id: z.string(),
-  RepoTags: z.array(z.string()).optional().default([]),
+  RepoTags: z.array(z.string()).nullish().transform((value) => value ?? []),
   Size: z.number().optional(),
   Created: z.number().optional(),
 }).passthrough();

--- a/packages/core/src/portainer/edge-live-query.test.ts
+++ b/packages/core/src/portainer/edge-live-query.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock undici fetch — the only external boundary this module crosses.
-vi.mock('undici', () => ({
+vi.mock('undici', async (importOriginal) => ({
+  ...await importOriginal<typeof import('undici')>(),
   fetch: vi.fn(),
 }));
 
@@ -18,6 +19,7 @@ import {
 } from './edge-live-query.js';
 import { cache, waitForInFlight } from './portainer-cache.js';
 import { resetConfig, setConfigForTest } from '../config/index.js';
+import { _resetClientState, getPortainerDispatcher } from './portainer-client.js';
 
 const mockFetch = vi.mocked(undiciFetch);
 
@@ -37,6 +39,7 @@ beforeEach(() => {
   // would hide call-count assertions here.
   setConfigForTest({ CACHE_ENABLED: false, PORTAINER_API_URL: 'http://test.local' });
   _resetEdgeLiveQueryState();
+  _resetClientState();
   mockFetch.mockReset();
 });
 
@@ -49,6 +52,14 @@ function cfg(overrides: Partial<EdgeLiveQueryConfig> = {}): EdgeLiveQueryConfig 
 }
 
 describe('fetchLiveDockerInfo', () => {
+  it.each([true, false])('shares the configured Portainer TLS dispatcher (verify=%s)', async (verify) => {
+    setConfigForTest({ PORTAINER_VERIFY_SSL: verify });
+    const dispatcher = getPortainerDispatcher();
+    mockFetch.mockResolvedValueOnce(mockJsonResponse({ Containers: 1 }));
+    await fetchLiveDockerInfo(7, cfg());
+    expect(mockFetch.mock.calls[0][1]?.dispatcher).toBe(dispatcher);
+  });
+
   it('returns null when disabled and never touches the network', async () => {
     const result = await fetchLiveDockerInfo(7, cfg({ enabled: false }));
     expect(result).toBeNull();

--- a/packages/core/src/portainer/edge-live-query.ts
+++ b/packages/core/src/portainer/edge-live-query.ts
@@ -33,7 +33,7 @@ import { fetch as undiciFetch } from 'undici';
 import { getConfig } from '../config/index.js';
 import { createChildLogger } from '../utils/logger.js';
 import { cache, cachedFetchSWR, getCacheKey } from './portainer-cache.js';
-import { buildApiUrl, buildApiHeaders } from './portainer-client.js';
+import { buildApiUrl, buildApiHeaders, getPortainerDispatcher } from './portainer-client.js';
 
 const log = createChildLogger('edge-live-query');
 
@@ -140,7 +140,7 @@ async function fetchDockerInfoOnce(endpointId: number, timeoutMs: number): Promi
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await undiciFetch(url, { headers, signal: controller.signal });
+    const res = await undiciFetch(url, { headers, signal: controller.signal, dispatcher: getPortainerDispatcher() });
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} ${res.statusText}`);
     }

--- a/packages/core/src/portainer/portainer-client.ts
+++ b/packages/core/src/portainer/portainer-client.ts
@@ -51,7 +51,7 @@ function getCustomCaCert(): Buffer | undefined {
 
 // Connection-pooled dispatcher (used for both SSL-bypass and normal connections)
 let pooledDispatcher: Agent | undefined;
-function getDispatcher(): Agent | undefined {
+export function getPortainerDispatcher(): Agent {
   const config = getConfig();
   if (pooledDispatcher) return pooledDispatcher;
   const ca = getCustomCaCert();
@@ -310,7 +310,7 @@ async function sleep(ms: number) {
 export async function checkPortainerReachable(timeoutMs = 5000): Promise<{ reachable: boolean; ok: boolean }> {
   const url = buildApiUrl('/api/status');
   const headers = buildApiHeaders(false);
-  const dispatcher = getDispatcher();
+  const dispatcher = getPortainerDispatcher();
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -400,7 +400,7 @@ async function portainerFetchInner<T>(
         headers,
         body: body ? JSON.stringify(body) : undefined,
         signal: controller.signal,
-        dispatcher: getDispatcher(),
+        dispatcher: getPortainerDispatcher(),
       });
       clearTimeout(timer);
 
@@ -449,12 +449,13 @@ async function portainerFetchInner<T>(
 
 // Endpoints
 export async function getEndpoints(): Promise<Endpoint[]> {
-  const raw = await portainerFetch<unknown[]>('/api/endpoints');
+  // All fleet measurements come from live Docker reads, not stored snapshots.
+  const raw = await portainerFetch<unknown[]>('/api/endpoints?excludeSnapshots=true');
   return EndpointArraySchema.parse(raw);
 }
 
 export async function getEndpoint(id: number): Promise<Endpoint> {
-  const raw = await portainerFetch<unknown>(`/api/endpoints/${id}`);
+  const raw = await portainerFetch<unknown>(`/api/endpoints/${id}?excludeSnapshot=true`);
   return EndpointSchema.parse(raw);
 }
 
@@ -472,7 +473,7 @@ export async function pingEndpointDocker(endpointId: number): Promise<{ ok: bool
   try {
     const res = await undiciFetch(url, {
       headers,
-      dispatcher: getDispatcher(),
+      dispatcher: getPortainerDispatcher(),
       signal: controller.signal,
     });
     clearTimeout(timer);
@@ -673,7 +674,7 @@ export async function pullImage(endpointId: number, image: string, tag = 'latest
     res = await undiciFetch(url, {
       method: 'POST',
       headers,
-      dispatcher: getDispatcher(),
+      dispatcher: getPortainerDispatcher(),
       signal: controller.signal,
     });
   } catch (err) {
@@ -784,7 +785,7 @@ export async function getContainerLogs(
   try {
     const res = await undiciFetch(url, {
       headers,
-      dispatcher: getDispatcher(),
+      dispatcher: getPortainerDispatcher(),
       signal: controller.signal,
     });
     clearTimeout(timer);
@@ -847,7 +848,7 @@ export async function streamContainerLogs(
   const controller = new AbortController();
   const res = await undiciFetch(url, {
     headers,
-    dispatcher: getDispatcher(),
+    dispatcher: getPortainerDispatcher(),
     signal: controller.signal,
   });
 
@@ -983,7 +984,7 @@ export async function startExec(endpointId: number, execId: string): Promise<voi
     method: 'POST',
     headers,
     body: JSON.stringify({ Detach: true, Tty: false }),
-    dispatcher: getDispatcher(),
+    dispatcher: getPortainerDispatcher(),
   });
 
   if (!res.ok) {
@@ -1020,7 +1021,7 @@ export async function getArchive(
   const url = buildApiUrl(`/api/endpoints/${endpointId}/docker/containers/${containerId}/archive?path=${encodeURIComponent(containerPath)}`);
   const headers = buildApiHeaders();
 
-  const res = await undiciFetch(url, { headers, dispatcher: getDispatcher() });
+  const res = await undiciFetch(url, { headers, dispatcher: getPortainerDispatcher() });
   if (!res.ok) {
     const errorBody = await readErrorBody(res);
     throw new PortainerError(errorBody || `Archive fetch failed: ${res.status}`, classifyError(res.status), res.status);
@@ -1080,7 +1081,7 @@ export async function getEdgeJobTaskLogs(jobId: number, taskId: string): Promise
   const url = buildApiUrl(`/api/edge_jobs/${jobId}/tasks/${taskId}/logs`);
   const headers = buildApiHeaders();
 
-  const res = await undiciFetch(url, { headers, dispatcher: getDispatcher() });
+  const res = await undiciFetch(url, { headers, dispatcher: getPortainerDispatcher() });
   if (!res.ok) {
     const errorBody = await readErrorBody(res);
     throw new PortainerError(errorBody || `Edge job task logs fetch failed: ${res.status}`, classifyError(res.status), res.status);
@@ -1152,7 +1153,7 @@ export async function getPodLogs(
   try {
     const res = await undiciFetch(url, {
       headers,
-      dispatcher: getDispatcher(),
+      dispatcher: getPortainerDispatcher(),
       signal: controller.signal,
     });
     clearTimeout(timer);

--- a/packages/core/src/portainer/portainer-compatibility.test.ts
+++ b/packages/core/src/portainer/portainer-compatibility.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Response, fetch as undiciFetch } from 'undici';
+import { resetConfig, setConfigForTest } from '../config/index.js';
+import { EndpointSchema, ContainerSchema, ImageSchema, containerFromInspect } from '../models/portainer.js';
+import { normalizeEndpoint, normalizeContainer, normalizeStack } from './portainer-normalizers.js';
+import { StackStatusSchema } from '@dashboard/contracts';
+import { _resetClientState, getEndpoints, getEndpoint, getContainers, getImages, getCircuitBreakerStats } from './portainer-client.js';
+
+vi.mock('undici', async (importOriginal) => ({
+  ...await importOriginal<typeof import('undici')>(),
+  fetch: vi.fn(),
+}));
+
+const fetchMock = vi.mocked(undiciFetch);
+const endpoint = { Id: 1, Name: 'docker', Type: 1, URL: 'unix:///var/run/docker.sock' };
+const container = { Id: 'abc123', Names: ['/web'], Image: 'nginx:latest', Created: 1700000000, State: 'running', Status: 'Up' };
+
+beforeEach(() => {
+  resetConfig();
+  setConfigForTest({ PORTAINER_API_URL: 'https://portainer.example.test', CACHE_ENABLED: false });
+  _resetClientState();
+  fetchMock.mockReset();
+});
+afterEach(() => { resetConfig(); _resetClientState(); });
+
+describe('Portainer 2.45 endpoint compatibility', () => {
+  it.each([[1, 'active'], [2, 'inactive'], [3, 'deploying'], [4, 'error'], [99, 'unknown']] as const)('preserves stack lifecycle status %s as %s', (Status, expected) => {
+    const stack = normalizeStack({ Id: 1, Name: 'app', Type: 2, EndpointId: 1, Status, Env: [] });
+    expect(stack.status).toBe(expected);
+    expect(StackStatusSchema.parse(stack.status)).toBe(expected);
+  });
+  it('accepts omitted zero-valued Status without losing the whole fleet or claiming it is up', async () => {
+    fetchMock.mockResolvedValue(Response.json([endpoint, { ...endpoint, Id: 2, Status: 1 }]));
+    const endpoints = await getEndpoints();
+    expect(endpoints.map(normalizeEndpoint).map((ep) => ep.status)).toEqual(['down', 'up']);
+  });
+
+  it('excludes unused snapshots using the distinct list and inspect query parameters', async () => {
+    fetchMock.mockResolvedValueOnce(Response.json([{ ...endpoint, Status: 1 }]))
+      .mockResolvedValueOnce(Response.json({ ...endpoint, Status: 1 }));
+    await getEndpoints();
+    await getEndpoint(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe('https://portainer.example.test/api/endpoints?excludeSnapshots=true');
+    expect(String(fetchMock.mock.calls[1][0])).toBe('https://portainer.example.test/api/endpoints/1?excludeSnapshot=true');
+  });
+
+  it('accepts legacy null collections and real DockerSnapshotRaw arrays', () => {
+    expect(EndpointSchema.parse({ ...endpoint, Status: 1, Snapshots: null, TagIds: null })).toMatchObject({ Snapshots: [], TagIds: [] });
+    expect(EndpointSchema.safeParse({ ...endpoint, Status: 1, Snapshots: [{ DockerSnapshotRaw: { Containers: [container], Images: [{ Id: 'sha256:abc' }] } }] }).success).toBe(true);
+  });
+
+  it('still rejects invalid identity and malformed status rather than hiding schema errors', () => {
+    expect(EndpointSchema.safeParse({ ...endpoint, Id: '1' }).success).toBe(false);
+    expect(EndpointSchema.safeParse({ ...endpoint, Status: 'up' }).success).toBe(false);
+  });
+});
+
+describe('Docker proxy nullable collections', () => {
+  it.each([401, 403])('preserves HTTP %s without retrying alternate proxy routes or tripping the fleet breaker', async (status) => {
+    setConfigForTest({ PORTAINER_CB_FAILURE_THRESHOLD: 1 });
+    fetchMock.mockResolvedValueOnce(Response.json({ message: 'Access denied' }, { status }));
+    await expect(getContainers(1)).rejects.toMatchObject({ kind: 'auth', status });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toBe('https://portainer.example.test/api/endpoints/1/docker/containers/json?all=true');
+    expect(getCircuitBreakerStats()).toMatchObject({ state: 'CLOSED', failures: 0 });
+
+    // A permission denial on one environment must not hide a permitted one.
+    fetchMock.mockResolvedValueOnce(Response.json([container]));
+    await expect(getContainers(2)).resolves.toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not drop a container list when an unlabelled container has nil labels and mounts', async () => {
+    fetchMock.mockResolvedValueOnce(Response.json([{ ...container, Labels: null, Mounts: null }]));
+    const containers = await getContainers(1);
+    expect(normalizeContainer(containers[0], 1, 'docker')).toMatchObject({ name: 'web', labels: {} });
+    expect(containers[0].Mounts).toEqual([]);
+  });
+
+  it('bridges inspect HostConfig.CapAdd=null back into the list contract', () => {
+    const parsed = containerFromInspect({ Id: 'abc123', Name: '/web', Config: { Image: 'nginx', Labels: null }, HostConfig: { CapAdd: null } });
+    expect(parsed.HostConfig?.CapAdd).toEqual([]);
+    expect(ContainerSchema.safeParse(parsed).success).toBe(true);
+  });
+
+  it('keeps dangling images with nil RepoTags', async () => {
+    fetchMock.mockResolvedValueOnce(Response.json([{ Id: 'sha256:abc', RepoTags: null }]));
+    expect(await getImages(1)).toEqual([{ Id: 'sha256:abc', RepoTags: [] }]);
+    expect(ImageSchema.safeParse({ Id: 'sha256:abc', RepoTags: 3 }).success).toBe(false);
+  });
+});

--- a/packages/core/src/portainer/portainer-normalizers.ts
+++ b/packages/core/src/portainer/portainer-normalizers.ts
@@ -1,4 +1,4 @@
-import type { ContainerState } from '@dashboard/contracts';
+import type { ContainerState, StackStatus } from '@dashboard/contracts';
 import type { Endpoint, Container, Stack, Network, K8sPod, K8sDeployment, K8sService, K8sNamespace } from '../models/portainer.js';
 import { isKubernetesEndpoint, isDockerEndpoint } from '../models/portainer.js';
 import { createChildLogger } from '../utils/logger.js';
@@ -80,7 +80,7 @@ export interface NormalizedStack {
   name: string;
   type: number;
   endpointId: number;
-  status: 'active' | 'inactive';
+  status: StackStatus;
   createdAt?: number;
   updatedAt?: number;
   envCount: number;
@@ -366,12 +366,13 @@ export function normalizeContainer(
 }
 
 export function normalizeStack(s: Stack): NormalizedStack {
+  const statuses: Record<number, StackStatus> = { 1: 'active', 2: 'inactive', 3: 'deploying', 4: 'error' };
   return {
     id: s.Id,
     name: s.Name,
     type: s.Type,
     endpointId: s.EndpointId,
-    status: s.Status === 1 ? 'active' : 'inactive',
+    status: statuses[s.Status] ?? 'unknown',
     createdAt: s.CreationDate,
     updatedAt: s.UpdateDate,
     envCount: s.Env?.length || 0,


### PR DESCRIPTION
## Summary
- Accept Portainer's omitted endpoint status and Docker nullable collections without rejecting whole lists or inspect responses.
- Exclude unused snapshots and use the shared TLS dispatcher for live fleet info.
- Preserve deploying/error stack lifecycle states through a shared contract, badges, counts, and filters.
- Keep upstream authorization intact; do not retry 401/403 through alternative routes.

Closes #1694

## Validation
- Live read-only smoke with portainer/portainer-ce:2.45.0: endpoint list/detail, 36 containers, 61 images, 11 networks, empty stacks list, Docker info/live fleet counts, inspect, stats, and logs all pass.
- Temporary Portainer used loopback HTTP, tmpfs data, generated in-memory credentials, and a read-only socket mount. Removed after testing; monitored workloads and persistent volumes untouched.
- Full typecheck and all 2,942 frontend tests pass via the pre-push hook (supported Node 24.19; two workers to avoid local CPU contention).
- 32 contracts and 296 core Portainer/model tests pass.
- Production build and backend/frontend/package ESLint pass.
- Desktop/mobile Chromium smoke for all stack lifecycle states and filtering passes.

## Notes
- Maintainer will verify their remote deployment after merge. CE local validation does not claim BE/Edge or populated-stack live coverage.
- Root shell lint is affected locally by pre-existing CRLF shell scripts; CI's Linux checkout will run the gate normally.
- No secrets, unrelated workspace files, or container-mutating features included.